### PR TITLE
feat(hub): Restrict solo TCP access and trust reverse proxies

### DIFF
--- a/NOTICE.html
+++ b/NOTICE.html
@@ -187,6 +187,7 @@ body {
 <li><a href="#githubcomprometheusclient_model-v063">github.com/prometheus/client_model v0.6.3</a></li>
 <li><a href="#githubcomprometheuscommon-v0701">github.com/prometheus/common v0.70.1</a></li>
 <li><a href="#githubcomprometheusprocfs-v0211">github.com/prometheus/procfs v0.21.1</a></li>
+<li><a href="#githubcomrealclientiprealclientip-go-v101-020260615104152-545b12e0e8c7">github.com/realclientip/realclientip-go v1.0.1-0.20260615104152-545b12e0e8c7</a></li>
 <li><a href="#githubcomremyoudomphengbigfft-v000-20230129092748-24d4a6f8daec">github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec</a></li>
 <li><a href="#githubcomsethvargogo-retry-v040">github.com/sethvargo/go-retry v0.4.0</a></li>
 <li><a href="#githubcomshirougopsutilv4-v4267">github.com/shirou/gopsutil/v4 v4.26.7</a></li>
@@ -207,6 +208,7 @@ body {
 <li><a href="#goopentelemetryiooteltrace-v1440">go.opentelemetry.io/otel/trace v1.44.0</a></li>
 <li><a href="#gouberorgmultierr-v1110">go.uber.org/multierr v1.11.0</a></li>
 <li><a href="#goyamlinyamlv3-v305">go.yaml.in/yaml/v3 v3.0.5</a></li>
+<li><a href="#go4orgnetipx-v000-20260823151212-3075585bcbeb">go4.org/netipx v0.0.0-20260823151212-3075585bcbeb</a></li>
 <li><a href="#golangorgxcrypto-v0550">golang.org/x/crypto v0.55.0</a></li>
 <li><a href="#golangorgxmod-v0400">golang.org/x/mod v0.40.0</a></li>
 <li><a href="#golangorgxnet-v0580">golang.org/x/net v0.58.0</a></li>
@@ -8761,6 +8763,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    See the License for the specific language governing permissions and
    limitations under the License.
 </code></pre>
+<h3 id="githubcomrealclientiprealclientip-go-v101-020260615104152-545b12e0e8c7">github.com/realclientip/realclientip-go v1.0.1-0.20260615104152-545b12e0e8c7</h3>
+<pre><code>BSD Zero Clause License
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+</code></pre>
 <h3 id="githubcomremyoudomphengbigfft-v000-20230129092748-24d4a6f8daec">github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec</h3>
 <pre><code>Copyright (c) 2012 The Go Authors. All rights reserved.
 
@@ -10673,6 +10689,35 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+</code></pre>
+<h3 id="go4orgnetipx-v000-20260823151212-3075585bcbeb">go4.org/netipx v0.0.0-20260823151212-3075585bcbeb</h3>
+<pre><code>Copyright (c) 2020 The Inet.af AUTHORS. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Tailscale Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </code></pre>
 <h3 id="golangorgxcrypto-v0550">golang.org/x/crypto v0.55.0</h3>
 <pre><code>Copyright 2009 The Go Authors.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -91,6 +91,7 @@ For the latest version, see [NOTICE.md on GitHub](https://github.com/leapmux/lea
 - [github.com/prometheus/client_model v0.6.3](#githubcomprometheusclient_model-v063)
 - [github.com/prometheus/common v0.70.1](#githubcomprometheuscommon-v0701)
 - [github.com/prometheus/procfs v0.21.1](#githubcomprometheusprocfs-v0211)
+- [github.com/realclientip/realclientip-go v1.0.1-0.20260615104152-545b12e0e8c7](#githubcomrealclientiprealclientip-go-v101-020260615104152-545b12e0e8c7)
 - [github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec](#githubcomremyoudomphengbigfft-v000-20230129092748-24d4a6f8daec)
 - [github.com/sethvargo/go-retry v0.4.0](#githubcomsethvargogo-retry-v040)
 - [github.com/shirou/gopsutil/v4 v4.26.7](#githubcomshirougopsutilv4-v4267)
@@ -111,6 +112,7 @@ For the latest version, see [NOTICE.md on GitHub](https://github.com/leapmux/lea
 - [go.opentelemetry.io/otel/trace v1.44.0](#goopentelemetryiooteltrace-v1440)
 - [go.uber.org/multierr v1.11.0](#gouberorgmultierr-v1110)
 - [go.yaml.in/yaml/v3 v3.0.5](#goyamlinyamlv3-v305)
+- [go4.org/netipx v0.0.0-20260823151212-3075585bcbeb](#go4orgnetipx-v000-20260823151212-3075585bcbeb)
 - [golang.org/x/crypto v0.55.0](#golangorgxcrypto-v0550)
 - [golang.org/x/mod v0.40.0](#golangorgxmod-v0400)
 - [golang.org/x/net v0.58.0](#golangorgxnet-v0580)
@@ -8916,6 +8918,23 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
    limitations under the License.
 ```
 
+### github.com/realclientip/realclientip-go v1.0.1-0.20260615104152-545b12e0e8c7
+
+```
+BSD Zero Clause License
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+```
+
 ### github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec
 
 ```
@@ -10887,6 +10906,38 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```
+
+### go4.org/netipx v0.0.0-20260823151212-3075585bcbeb
+
+```
+Copyright (c) 2020 The Inet.af AUTHORS. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Tailscale Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
 ### golang.org/x/crypto v0.55.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The binary runs in several modes:
 
 | Command | Description |
 |---------|-------------|
-| `leapmux solo` | Hub + Worker on `127.0.0.1:4327`, no login, single-user |
+| `leapmux solo` | Hub + Worker, single-user; local IPC needs no credential and TCP starts with password setup |
 | `leapmux hub` | Central service only (auth, relay, database) |
 | `leapmux worker` | Connects to a remote Hub |
 | `leapmux dev` | Hub + Worker on all interfaces, login required |

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Each `dev` target generates code and builds prerequisites, then launches `mprocs
 | Command | Processes | Description |
 |---------|-----------|-------------|
 | `task dev` | Go backend (`leapmux dev`) + Bun frontend dev server | Full-featured dev mode on all interfaces, login required |
-| `task dev-solo` | Go backend (`leapmux solo`) + Bun frontend dev server | Localhost-only, no login, single-user |
+| `task dev-solo` | Go backend (`leapmux solo`) + Bun frontend dev server | Localhost-only, single-user; the browser sets the first `solo` password |
 | `task dev-desktop` | Bun frontend dev server + Tauri desktop app | Desktop app development (builds sidecar first) |
 
 ## Development

--- a/backend/cmd/leapmux/recover_test.go
+++ b/backend/cmd/leapmux/recover_test.go
@@ -675,10 +675,9 @@ func TestCLI_BootstrapCreateAdmin(t *testing.T) {
 // that every other creation path applies.
 //
 // This one is OFFLINE, so nothing stands behind it. A row named "solo" in
-// a non-solo database is auto-authenticated for every request the moment
-// the same data dir is opened with `leapmux solo`: the interceptor's solo
-// short-circuit returns that identity before the email gate and before the
-// admin gate, with no credential at all.
+// a non-solo database becomes the synthetic local IPC identity when the same
+// data directory opens with `leapmux solo`. The interceptor returns that
+// identity before the email and admin checks.
 func TestCLI_BootstrapCreateAdmin_RefusesAReservedUsername(t *testing.T) {
 	for _, name := range []string{"solo", "SOLO", " Solo "} {
 		dir := setupTestDataDir(t)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -34,9 +34,11 @@ require (
 	github.com/pressly/goose/v3 v3.27.3
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.3
+	github.com/realclientip/realclientip-go v1.0.1-0.20260615104152-545b12e0e8c7
 	github.com/stretchr/testify v1.12.1
 	github.com/testcontainers/testcontainers-go v0.44.0
 	go.yaml.in/yaml/v3 v3.0.5
+	go4.org/netipx v0.0.0-20260823151212-3075585bcbeb
 	golang.org/x/crypto v0.55.0
 	golang.org/x/net v0.58.0
 	golang.org/x/oauth2 v0.36.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -551,6 +551,8 @@ github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 h1:M8mH9eK4OUR4l
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567/go.mod h1:DWNGW8A4Y+GyBgPuaQJuWiy0XYftx4Xm/y5Jqk9I6VQ=
 github.com/raeperd/recvcheck v0.3.0 h1:PM+XYvyxIj3bo+kobJfFTdTuU3Lmfu96mKDbyHDbRt8=
 github.com/raeperd/recvcheck v0.3.0/go.mod h1:PZNwG+HztFYMH2ZPq0Hu3QgkV2yiA6VrtNz9c1fXWJo=
+github.com/realclientip/realclientip-go v1.0.1-0.20260615104152-545b12e0e8c7 h1:WPeyNSaEGK2AMT1SBSGnzZqM0XaUkMTtg8rUdjHxlCk=
+github.com/realclientip/realclientip-go v1.0.1-0.20260615104152-545b12e0e8c7/go.mod h1:9IDC+QZqpbnpDay41+NYetCPNVPRrzAiGowmLYor7Ns=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
@@ -730,6 +732,8 @@ go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
+go4.org/netipx v0.0.0-20260823151212-3075585bcbeb h1:XBM4hvfwGAttkkiTIFfeigdfcL1xIfdKXqFdgiHGtDs=
+go4.org/netipx v0.0.0-20260823151212-3075585bcbeb/go.mod h1:PLyyIXexvUFg3Owu6p/WfdlivPbZJsZdgWZlrGope/Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/backend/hub/listeners.go
+++ b/backend/hub/listeners.go
@@ -686,9 +686,9 @@ func (r listenReporter) PrimaryListenAddr() string {
 // The panel already asks for the password before it will apply such an
 // address, but a client-side rule is not enforcement: `leapmux control admin
 // settings set extra_listen_addresses '{"addresses":["0.0.0.0:4327"]}'` is a
-// write like any other, the key is HOT, and a credential-free solo caller is
-// admitted to write it -- so one command published an unauthenticated
-// administrator on the LAN, with no refusal and no warning. Before this
+// write like any other, the key is hot, and local IPC can write it without a
+// credential. One command could then publish the first-password setup flow on
+// the LAN, where another caller could claim the account. Before this
 // feature the same exposure needed `-listen 0.0.0.0:4327` on the command line,
 // which printed the startup warning.
 //
@@ -730,7 +730,7 @@ func refuseUnguardedExposure(soloMode bool, gate *auth.SoloGate) func(*settings.
 		}
 		return fmt.Errorf(
 			"extra_listen_addresses %v would answer other machines while the %q account has no password, "+
-				"so anyone who reached the port would hold the administrator; set the password first",
+				"so the first caller could claim the account; set the password first",
 			exposed, usernames.Solo)
 	}
 }

--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -454,8 +454,8 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 		// The auth policy (cookie name, verification gate, session
 		// duration) is DB-backed and hot: re-resolved per use so an admin
 		// change applies to the next request.
-		Policy: func() auth.Policy {
-			return auth.PolicyFromSettings(setMgr.Snapshot(context.Background()))
+		Policy: func(ctx context.Context) auth.Policy {
+			return auth.PolicyFromSettings(ctx, setMgr.Snapshot(ctx))
 		},
 	})
 	acquired.authContexts = authContexts
@@ -611,8 +611,8 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	// The cookie-name policy resolves per connection, so a secure_cookies
 	// change applies to the next socket (existing sockets keep the name
 	// they authenticated under).
-	secureCookies := func() bool {
-		return settings.KeySecureCookies.Of(setMgr.Snapshot(context.Background()))
+	secureCookies := func(ctx context.Context) bool {
+		return settings.SecureCookiesFor(ctx, setMgr.Snapshot(ctx))
 	}
 	channelRelay := service.NewChannelRelayHandler(st, wMgr, cMgr, authContexts, soloUser, secureCookies, relayQueuePool).
 		WithTokenValidator(tokenValidator).
@@ -818,7 +818,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 		// and Referrer-Policy protect every response, and the hub renders HTML
 		// outside the frontend handler (the device-code and PKCE callback
 		// pages), which deserve the same treatment as the app document.
-		Handler: requestsource.Middleware(setMgr,
+		Handler: requestsource.Middleware(requestsource.RangesFromSettings(setMgr),
 			logging.HTTPMiddleware(metrics.HTTPMiddleware(httpsec.Middleware(csp, mux)))),
 		// Limits reading request HEADERS on HTTP/1.1 connections (the
 		// slowloris guard). It must NOT govern h2c connections, whose streams
@@ -846,9 +846,13 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 			}
 			return handlerCtx
 		},
-		// The peer address, for the address-keyed budgets that guard the
-		// unauthenticated endpoints. ConnContext derives from BaseContext, so
-		// a local IPC connection carries both marks.
+		// The UNCHANGED address of the accepted connection. It is the fallback
+		// key for the address-keyed budgets that guard the unauthenticated
+		// endpoints: the request-source middleware prefers the verified client
+		// IP, and this is what the budget uses when no header could name one.
+		// No header can set it, so a caller cannot move itself between
+		// budgets. ConnContext derives from BaseContext, so a local IPC
+		// connection carries this mark and the local-IPC one.
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
 			return peer.WithTransportAddr(ctx, c.RemoteAddr())
 		},

--- a/backend/hub/server.go
+++ b/backend/hub/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/notifier"
 	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/ratelimit"
+	"github.com/leapmux/leapmux/internal/hub/requestsource"
 	"github.com/leapmux/leapmux/internal/hub/revocationwatcher"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/settings"
@@ -817,7 +818,8 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 		// and Referrer-Policy protect every response, and the hub renders HTML
 		// outside the frontend handler (the device-code and PKCE callback
 		// pages), which deserve the same treatment as the app document.
-		Handler: logging.HTTPMiddleware(metrics.HTTPMiddleware(httpsec.Middleware(csp, mux))),
+		Handler: requestsource.Middleware(setMgr,
+			logging.HTTPMiddleware(metrics.HTTPMiddleware(httpsec.Middleware(csp, mux)))),
 		// Limits reading request HEADERS on HTTP/1.1 connections (the
 		// slowloris guard). It must NOT govern h2c connections, whose streams
 		// outlive any header deadline. net/http disarms this deadline itself at
@@ -848,7 +850,7 @@ func NewServer(cfg *config.Config, opts ...ServerOption) (*Server, error) {
 		// unauthenticated endpoints. ConnContext derives from BaseContext, so
 		// a local IPC connection carries both marks.
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
-			return peer.WithRemoteAddr(ctx, c.RemoteAddr())
+			return peer.WithTransportAddr(ctx, c.RemoteAddr())
 		},
 		Protocols: protocols,
 		HTTP2: &http.HTTP2Config{

--- a/backend/hub/server_extra_listeners_test.go
+++ b/backend/hub/server_extra_listeners_test.go
@@ -245,9 +245,9 @@ func TestServer_StoredAddressesBindAgainOnTheNextStart(t *testing.T) {
 // password, and that refusal has to hold for every writer.
 //
 // `leapmux control admin settings set extra_listen_addresses` is a write like
-// any other, the key is HOT, and a credential-free solo caller is admitted to
-// make it -- so without a server-side rule one command published an
-// unauthenticated administrator on the LAN, with no refusal and no warning.
+// any other. Without a server-side rule, local IPC could publish the setup
+// flow on the LAN before it set a password. A remote caller could then claim
+// the account.
 func TestServer_RefusesAnExposingAddressWithNoPassword(t *testing.T) {
 	port := freePorts(t, 1)[0]
 	base := "127.0.0.1:" + strconv.Itoa(port)

--- a/backend/hub/server_local_ipc_test.go
+++ b/backend/hub/server_local_ipc_test.go
@@ -83,8 +83,15 @@ func TestServer_TCPInitialSoloPasswordCreatesVerifiedSession(t *testing.T) {
 	assert.Equal(t, usernames.Solo, response.Msg.GetUser().GetUsername())
 
 	setCookie := response.Header().Get("Set-Cookie")
-	assert.NotContains(t, setCookie, "; Secure",
-		"forwarded HTTPS must not change the explicit secure_cookies setting")
+	// The trusted proxy verified HTTPS for this request, so the cookie is
+	// Secure and takes the __Host- name without anybody setting
+	// `secure_cookies`. The hub terminates no TLS itself, so the proxy's
+	// answer is the only way it can know -- and an operator who had to set the
+	// key by hand got a cookie with no Secure attribute until they did.
+	assert.Contains(t, setCookie, "; Secure",
+		"a trusted proxy that verified HTTPS turns the cookie policy on")
+	assert.Contains(t, setCookie, "__Host-",
+		"the secure policy also selects the __Host- prefixed name")
 	cookieResponse := &http.Response{Header: http.Header{"Set-Cookie": []string{setCookie}}}
 	cookies := cookieResponse.Cookies()
 	require.Len(t, cookies, 1)

--- a/backend/hub/server_local_ipc_test.go
+++ b/backend/hub/server_local_ipc_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/password"
+	"github.com/leapmux/leapmux/internal/hub/requestsource"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/usernames"
 	"github.com/leapmux/leapmux/locallisten"
@@ -50,6 +52,58 @@ func listSettings(c leapmuxv1connect.AdminSettingsServiceClient) error {
 	return err
 }
 
+// A passwordless solo TCP connection can claim the account by setting its
+// first password. It must not receive the synthetic administrator before that
+// write. Otherwise, any caller that reaches the port can call every protected
+// RPC without first taking responsibility for the account.
+func TestServer_PasswordlessSoloTCPRejectsAdministratorRPC(t *testing.T) {
+	base := "127.0.0.1:" + strconv.Itoa(freePorts(t, 1)[0])
+	startTestServer(t, &config.Config{Listen: base, SoloMode: true})
+	requireAnswers(t, base)
+
+	err := listSettings(tcpClient(base))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestServer_TCPInitialSoloPasswordCreatesVerifiedSession(t *testing.T) {
+	base := "127.0.0.1:" + strconv.Itoa(freePorts(t, 1)[0])
+	srv := startTestServer(t, &config.Config{Listen: base, SoloMode: true})
+	requireAnswers(t, base)
+	require.NoError(t, srv.settings.Update(context.Background(), requestsource.KeyTrustedProxyRanges,
+		json.RawMessage(`["127.0.0.1"]`)))
+
+	request := connect.NewRequest(&leapmuxv1.SetInitialSoloPasswordRequest{
+		Password: "correct-horse-battery-staple",
+	})
+	request.Header().Set("Forwarded", "for=198.51.100.7;proto=https")
+	request.Header().Set("User-Agent", "setup-browser")
+	response, err := tcpAuthClient(base).SetInitialSoloPassword(context.Background(), request)
+	require.NoError(t, err)
+	assert.Equal(t, usernames.Solo, response.Msg.GetUser().GetUsername())
+
+	setCookie := response.Header().Get("Set-Cookie")
+	assert.NotContains(t, setCookie, "; Secure",
+		"forwarded HTTPS must not change the explicit secure_cookies setting")
+	cookieResponse := &http.Response{Header: http.Header{"Set-Cookie": []string{setCookie}}}
+	cookies := cookieResponse.Cookies()
+	require.Len(t, cookies, 1)
+	session, err := srv.store.Sessions().GetByID(context.Background(), cookies[0].Value, time.Now().UTC())
+	require.NoError(t, err)
+	assert.Equal(t, "198.51.100.7", session.IPAddress)
+	assert.Equal(t, "setup-browser", session.UserAgent)
+
+	adminRequest := connect.NewRequest(&leapmuxv1.ListSettingsRequest{})
+	adminRequest.Header().Set("Cookie", cookies[0].Name+"="+cookies[0].Value)
+	_, err = tcpClient(base).ListSettings(context.Background(), adminRequest)
+	require.NoError(t, err, "the returned session must authorize the next protected RPC")
+
+	_, err = tcpAuthClient(base).SetInitialSoloPassword(context.Background(), connect.NewRequest(
+		&leapmuxv1.SetInitialSoloPasswordRequest{Password: "another-correct-password"}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
 // The local IPC socket is the ONE credential-free transport, and the desktop
 // app rests entirely on it: it reaches its own hub over that socket and has no
 // way to present a password, so a hub that asked it for one would be unusable
@@ -70,17 +124,19 @@ func TestServer_TheLocalSocketStaysCredentialFreeWhenTCPStopsBeing(t *testing.T)
 	srv := startTestServer(t, &config.Config{Listen: base, SoloMode: true})
 	requireAnswers(t, base)
 
-	// The bootstrap state: neither transport asks for anything.
+	// Local IPC receives the synthetic account before setup. TCP can call only
+	// the public initial-password procedure.
 	require.NoError(t, listSettings(localIPCClient(t, srv)),
 		"the local socket must admit the desktop app before a password exists")
-	require.NoError(t, listSettings(tcpClient(base)),
-		"TCP must stay credential-free while the account has no password, or the first password could never be set from a browser")
+	err := listSettings(tcpClient(base))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 
 	setSoloPasswordDirect(t, srv.store)
 
 	// TCP arms itself with no restart: the gate re-reads the account while its
 	// latch is false.
-	err := listSettings(tcpClient(base))
+	err = listSettings(tcpClient(base))
 	require.Error(t, err, "TCP must ask for a sign-in once the account holds a password")
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 

--- a/backend/hub/server_settings_rules_test.go
+++ b/backend/hub/server_settings_rules_test.go
@@ -29,14 +29,14 @@ import (
 // it reached the wiring it exists to pin. The helper also answers the reason
 // the hand-built path avoided t.TempDir(): it roots the socket in a short temp
 // directory, so the path stays inside macOS's 104-byte sun_path limit.
-func startTestServer(t *testing.T, cfg *config.Config) *Server {
+func startTestServer(t *testing.T, cfg *config.Config, opts ...ServerOption) *Server {
 	t.Helper()
 
 	cfg.DataDir = t.TempDir()
 	cfg.LocalListen = locallistentest.UniqueListenURL(t, "lmx-hub-test")
 	cfg.Storage = config.StorageConfig{Type: config.StorageTypeSQLite}
 
-	srv, err := NewServer(cfg)
+	srv, err := NewServer(cfg, opts...)
 	require.NoError(t, err)
 
 	serveCtx, cancel := context.WithCancel(context.Background())

--- a/backend/hub/server_trusted_proxy_test.go
+++ b/backend/hub/server_trusted_proxy_test.go
@@ -20,7 +20,13 @@ func TestServer_AppliesTrustedProxyIdentityOutsideTheHandlerStack(t *testing.T) 
 	base := "127.0.0.1:" + strconv.Itoa(freePorts(t, 1)[0])
 	frontend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Test-Client-IP", peer.ClientIP(r.Context()))
-		w.Header().Set("X-Test-Scheme", r.URL.Scheme)
+		// The CONTEXT, not r.URL.Scheme: the middleware records the verified
+		// protocol where every consumer reads it and leaves the URL alone.
+		scheme := "http"
+		if peer.IsHTTPS(r.Context()) {
+			scheme = "https"
+		}
+		w.Header().Set("X-Test-Scheme", scheme)
 		w.Header().Set("X-Test-Remote-Addr", r.RemoteAddr)
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/backend/hub/server_trusted_proxy_test.go
+++ b/backend/hub/server_trusted_proxy_test.go
@@ -1,0 +1,54 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/config"
+	"github.com/leapmux/leapmux/internal/hub/peer"
+	"github.com/leapmux/leapmux/internal/hub/requestsource"
+)
+
+func TestServer_AppliesTrustedProxyIdentityOutsideTheHandlerStack(t *testing.T) {
+	base := "127.0.0.1:" + strconv.Itoa(freePorts(t, 1)[0])
+	frontend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Test-Client-IP", peer.ClientIP(r.Context()))
+		w.Header().Set("X-Test-Scheme", r.URL.Scheme)
+		w.Header().Set("X-Test-Remote-Addr", r.RemoteAddr)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := startTestServer(t, &config.Config{Listen: base}, WithFrontendHandler(frontend))
+	requireAnswers(t, base)
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	request := func() *http.Request {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+base+"/", nil)
+		require.NoError(t, err)
+		req.Header.Set("Forwarded", "for=198.51.100.7;proto=https")
+		return req
+	}
+
+	direct, err := client.Do(request())
+	require.NoError(t, err)
+	require.NoError(t, direct.Body.Close())
+	assert.Equal(t, "127.0.0.1", direct.Header.Get("X-Test-Client-IP"))
+	assert.Equal(t, "http", direct.Header.Get("X-Test-Scheme"))
+	assert.Contains(t, direct.Header.Get("X-Test-Remote-Addr"), "127.0.0.1:")
+
+	require.NoError(t, srv.settings.Update(context.Background(), requestsource.KeyTrustedProxyRanges,
+		json.RawMessage(`["127.0.0.1"]`)))
+	proxied, err := client.Do(request())
+	require.NoError(t, err)
+	require.NoError(t, proxied.Body.Close())
+	assert.Equal(t, "198.51.100.7", proxied.Header.Get("X-Test-Client-IP"))
+	assert.Equal(t, "https", proxied.Header.Get("X-Test-Scheme"))
+	assert.Contains(t, proxied.Header.Get("X-Test-Remote-Addr"), "127.0.0.1:",
+		"request-source handling must not replace the physical peer")
+}

--- a/backend/internal/cli/control/client.go
+++ b/backend/internal/cli/control/client.go
@@ -198,12 +198,12 @@ func NewClient(hubURL string) (*Client, error) {
 }
 
 // NewClientOrAnonymous constructs a hub client that falls back to an
-// EMPTY credential when none is STORED. The hub — not the CLI — enforces
-// authentication: against a solo hub the interceptor authenticates every
-// request as the solo user regardless of headers, so `control admin`
-// works there with no login (solo cannot complete a login flow at all);
-// against any other hub the credential-less request simply answers
-// unauthenticated.
+// EMPTY credential when none is STORED. The hub -- not the CLI -- enforces
+// authentication. A solo hub authenticates its LOCAL IPC socket as the solo
+// user with no credential, so `control admin` works there with no login.
+// Every other connection, a solo hub's TCP addresses included, answers
+// unauthenticated to a credential-less request; run
+// `leapmux control auth login --hub <url>` first.
 //
 // Only ErrNotLoggedIn takes that fallback. A credential file that exists
 // but cannot be read or parsed is a fault the operator must see: running

--- a/backend/internal/cli/control/cmd/admin.go
+++ b/backend/internal/cli/control/cmd/admin.go
@@ -55,10 +55,9 @@ func requireAdminClient(hubFlag string) (*control.Client, error) {
 		return nil, control.EmitError("invalid_request",
 			"no hub address; pass --hub <url> or set LEAPMUX_HUB. For a hub that needs a credential, run `leapmux control auth login --hub <url>` first.")
 	}
-	// Anonymous fallback: a solo hub authenticates every request as the
-	// local user, and solo cannot complete a login flow at all — the hub
-	// enforces the admin gate, so a credential-less call against a
-	// non-solo hub simply answers unauthenticated.
+	// Anonymous fallback supports a solo hub's local IPC socket. A TCP address
+	// needs a session. The hub enforces the admin gate, so a credential-less
+	// call against any other connection answers unauthenticated.
 	c, err := control.NewClientOrAnonymous(hubFlag)
 	if err != nil {
 		return nil, control.EmitErrorWith("not_logged_in", err)

--- a/backend/internal/cli/control/cmd/auth.go
+++ b/backend/internal/cli/control/cmd/auth.go
@@ -154,11 +154,10 @@ func requireClient(hubFlag string) (*control.Client, error) {
 // --device-code) when the local listener can't be reached from a
 // browser.
 //
-// A solo hub needs no login to USE, because it authenticates every request as
-// its one account. It still authorizes apps: the solo rung yields to a
-// presented lmx_ bearer, so a credential minted here binds its scope there --
-// which is how an agent on a solo machine holds file:read and nothing more.
-// Both flows complete, because the consent stages accept the solo account.
+// A solo hub needs no login over local IPC. Its TCP addresses use ordinary
+// sessions after first-password setup. Solo still authorizes apps: the solo
+// rung yields to a presented lmx_ bearer, so a credential minted here binds
+// its scope there.
 func RunAuthLogin(rawCtx any, args []string) error {
 	cmd := asCtx(rawCtx)
 	var hub, deviceName, scopeFlag string

--- a/backend/internal/hub/auth/admin_gate_test.go
+++ b/backend/internal/hub/auth/admin_gate_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/bootstrap"
 	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/oauthapp"
+	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/servicetest"
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -265,7 +267,11 @@ func TestAdminGate_SoloModeAutoAdmin(t *testing.T) {
 	adminPath, adminHandler := leapmuxv1connect.NewAdminSettingsServiceHandler(adminSvc, interceptors)
 	mux.Handle(adminPath, adminHandler)
 
-	server := httptest.NewServer(mux)
+	server := httptest.NewUnstartedServer(mux)
+	server.Config.BaseContext = func(net.Listener) context.Context {
+		return peer.WithLocalIPC(context.Background())
+	}
+	server.Start()
 	t.Cleanup(server.Close)
 
 	client := leapmuxv1connect.NewAdminSettingsServiceClient(server.Client(), server.URL)

--- a/backend/internal/hub/auth/auth.go
+++ b/backend/internal/hub/auth/auth.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/leapmux/leapmux/internal/authscope"
 	pwdhash "github.com/leapmux/leapmux/internal/hub/password"
+	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/usernames"
 	"github.com/leapmux/leapmux/internal/util/id"
@@ -192,9 +193,9 @@ type UserInfo struct {
 
 // SoloAuthenticated reports whether this is solo mode's synthetic user.
 //
-// Solo mode authenticates every request as one bootstrapped account with no
-// session row and no credential row, so the questions the credential-shaped
-// rules ask have no answer for it. The elevation rule is the one that matters:
+// Solo mode authenticates local IPC as one bootstrapped account with no
+// session row and no credential row, so credential-shaped rules have no row to
+// inspect. The elevation rule is the one that matters:
 // there is no sign-in, so there is no ceremony to prove a factor with, and a
 // gate that demanded one would refuse the whole hub-administration surface for
 // ever. The predicate lives here, on the identity itself, so a rule states its
@@ -472,7 +473,6 @@ func Login(ctx context.Context, st store.Store, username, password string, lifet
 // SessionMeta holds optional metadata for session creation.
 type SessionMeta struct {
 	UserAgent string
-	IPAddress string
 }
 
 // CreateSession creates a new user session and returns the session ID and
@@ -495,10 +495,10 @@ func CreateSession(ctx context.Context, st store.Store, userID userid.UserID, li
 		ID:        sessionID,
 		UserID:    userID,
 		ExpiresAt: expiresAt,
+		IPAddress: peer.ClientIP(ctx),
 	}
 	if len(meta) > 0 {
 		params.UserAgent = meta[0].UserAgent
-		params.IPAddress = meta[0].IPAddress
 	}
 	if err := st.Sessions().Create(ctx, params); err != nil {
 		return "", time.Time{}, fmt.Errorf("create session: %w", err)

--- a/backend/internal/hub/auth/auth_test.go
+++ b/backend/internal/hub/auth/auth_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/oauthapp"
 	"github.com/leapmux/leapmux/internal/hub/password"
+	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/hub/store/storetest"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
@@ -105,6 +106,21 @@ func TestCreateSession_NonPositiveLifetimeFallsBackToDefault(t *testing.T) {
 		require.NoError(t, err)
 		hubtestutil.AssertSessionLifetime(t, before, time.Hour, expiresAt)
 	})
+}
+
+func TestCreateSession_RecordsVerifiedClientIP(t *testing.T) {
+	t.Parallel()
+	ctx := peer.WithClientIP(context.Background(), "2001:0db8::7")
+	st := hubtestutil.OpenTestStore(t)
+	hubtestutil.CreateTestAdmin(t, st)
+	user, err := st.Users().GetByUsername(ctx, hubtestutil.TestAdminUsername)
+	require.NoError(t, err)
+
+	sessionID, _, err := auth.CreateSession(ctx, st, userid.MustNew(user.ID), time.Hour)
+	require.NoError(t, err)
+	session, err := st.Sessions().GetByID(ctx, sessionID, time.Now().UTC())
+	require.NoError(t, err)
+	assert.Equal(t, "2001:db8::7", session.IPAddress)
 }
 
 // Workspace access is owner-only: no other user may read someone else's workspace.

--- a/backend/internal/hub/auth/bearer_cache_gen_test.go
+++ b/backend/internal/hub/auth/bearer_cache_gen_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
+	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	"github.com/leapmux/leapmux/internal/util/userid"
 )
@@ -596,7 +597,7 @@ func TestSoloAuthenticationAdvancesPastUserRevocation(t *testing.T) {
 	cache := &AuthContextRegistry{state: state}
 
 	cache.RevokeUserAuthContextAtGeneration("solo", 2)
-	ctx, refresh, err := a.authenticate(context.Background(), "/private", "", "", a.currentPolicy())
+	ctx, refresh, err := a.authenticate(peer.WithLocalIPC(context.Background()), "/private", "", "", a.currentPolicy())
 	require.NoError(t, err)
 	assert.Equal(t, sessionRefresh{}, refresh, "solo mode holds no session cookie to refresh")
 	current := GetUser(ctx)
@@ -667,6 +668,7 @@ func TestAuthenticateHTTPRefreshesSyntheticUserGeneration(t *testing.T) {
 	contexts := &AuthContextRegistry{state: &authState{}}
 	contexts.RevokeUserAuthContextAtGeneration("solo", 2)
 	req := httptest.NewRequest("GET", "/ws/channel", nil)
+	req = req.WithContext(peer.WithLocalIPC(req.Context()))
 
 	user, err := AuthenticateHTTP(context.Background(), req, HTTPAuthOpts{
 		SoloUser: &UserInfo{ID: userid.MustNew("solo"), UserAuthGeneration: 1},

--- a/backend/internal/hub/auth/bearer_cache_gen_test.go
+++ b/backend/internal/hub/auth/bearer_cache_gen_test.go
@@ -319,7 +319,7 @@ func TestAuthenticateUsesTouchedSessionExpiry(t *testing.T) {
 
 	ctx, refresh, err := a.authenticate(
 		context.Background(), "/private",
-		CookieName+"=session", "", a.currentPolicy(),
+		CookieName+"=session", "", a.currentPolicy(context.Background()),
 	)
 	require.NoError(t, err)
 	user := GetUser(ctx)
@@ -353,7 +353,7 @@ func TestZeroRowTouchDoesNotExtendSessionExpiry(t *testing.T) {
 
 	ctx, refresh, err := a.authenticate(
 		context.Background(), "/private",
-		CookieName+"=session", "", a.currentPolicy(),
+		CookieName+"=session", "", a.currentPolicy(context.Background()),
 	)
 	require.NoError(t, err)
 	user := GetUser(ctx)
@@ -597,7 +597,7 @@ func TestSoloAuthenticationAdvancesPastUserRevocation(t *testing.T) {
 	cache := &AuthContextRegistry{state: state}
 
 	cache.RevokeUserAuthContextAtGeneration("solo", 2)
-	ctx, refresh, err := a.authenticate(peer.WithLocalIPC(context.Background()), "/private", "", "", a.currentPolicy())
+	ctx, refresh, err := a.authenticate(peer.WithLocalIPC(context.Background()), "/private", "", "", a.currentPolicy(context.Background()))
 	require.NoError(t, err)
 	assert.Equal(t, sessionRefresh{}, refresh, "solo mode holds no session cookie to refresh")
 	current := GetUser(ctx)

--- a/backend/internal/hub/auth/cookie_internal_test.go
+++ b/backend/internal/hub/auth/cookie_internal_test.go
@@ -200,10 +200,10 @@ func TestTouchThresholdAlwaysLeavesRoomToSlide(t *testing.T) {
 // end the session before the configured duration passed since the last request.
 func TestSlideDurationCoversTouchThrottle(t *testing.T) {
 	for _, configured := range []time.Duration{0, -time.Hour, MinSessionDuration, time.Hour, 30 * 24 * time.Hour} {
-		a := &authInterceptor{policy: func() Policy { return Policy{SessionDuration: configured} }}
-		assert.Equal(t, sessionLifetime(configured)+touchThreshold(configured), a.slideDuration(a.currentPolicy()),
+		a := &authInterceptor{policy: func(context.Context) Policy { return Policy{SessionDuration: configured} }}
+		assert.Equal(t, sessionLifetime(configured)+touchThreshold(configured), a.slideDuration(a.currentPolicy(context.Background())),
 			"configured=%s", configured)
-		assert.Greater(t, a.slideDuration(a.currentPolicy()), sessionLifetime(configured), "configured=%s", configured)
+		assert.Greater(t, a.slideDuration(a.currentPolicy(context.Background())), sessionLifetime(configured), "configured=%s", configured)
 	}
 }
 
@@ -213,8 +213,8 @@ func TestSlideDurationCoversTouchThrottle(t *testing.T) {
 func TestSessionExpiryMatchesTheSlide(t *testing.T) {
 	for _, configured := range []time.Duration{0, MinSessionDuration, DefaultSessionDuration} {
 		now := time.Now()
-		a := &authInterceptor{policy: func() Policy { return Policy{SessionDuration: configured} }}
-		assert.Equal(t, now.Add(a.slideDuration(a.currentPolicy())).UTC(), sessionExpiry(now, configured),
+		a := &authInterceptor{policy: func(context.Context) Policy { return Policy{SessionDuration: configured} }}
+		assert.Equal(t, now.Add(a.slideDuration(a.currentPolicy(context.Background()))).UTC(), sessionExpiry(now, configured),
 			"configured=%s", configured)
 	}
 }
@@ -239,10 +239,10 @@ func TestMinSessionDurationBoundsTheOvershoot(t *testing.T) {
 // configured otherwise.
 func TestSweepDropsLastTouchOnceTheThrottleWindowPassed(t *testing.T) {
 	a := &authInterceptor{
-		policy: func() Policy { return Policy{SessionDuration: DefaultSessionDuration} },
+		policy: func(context.Context) Policy { return Policy{SessionDuration: DefaultSessionDuration} },
 		state:  &authState{},
 	}
-	threshold := a.touchThreshold(a.currentPolicy())
+	threshold := a.touchThreshold(a.currentPolicy(context.Background()))
 
 	a.state.lastTouch.Store("fresh", time.Now())
 	a.state.lastTouch.Store("stale", time.Now().Add(-threshold-time.Minute))
@@ -270,18 +270,18 @@ func TestValidateSessionDuration(t *testing.T) {
 // alone) would sign every user out through the day.
 func TestSlideDurationFallsBackToDefault(t *testing.T) {
 	a := &authInterceptor{}
-	assert.Equal(t, DefaultSessionDuration+sessionTouchThreshold, a.slideDuration(a.currentPolicy()))
+	assert.Equal(t, DefaultSessionDuration+sessionTouchThreshold, a.slideDuration(a.currentPolicy(context.Background())))
 }
 
 // The configured duration, not the default, is what a slide writes.
 func TestSlideDurationHonoursConfiguredValue(t *testing.T) {
 	configured := 36 * time.Hour
 	interceptor, registry := NewInterceptor(InterceptorOptions{
-		Policy: func() Policy { return Policy{SessionDuration: configured} },
+		Policy: func(context.Context) Policy { return Policy{SessionDuration: configured} },
 	})
 	t.Cleanup(registry.Stop)
 
-	assert.Equal(t, configured+sessionTouchThreshold, interceptor.(*authInterceptor).slideDuration(interceptor.(*authInterceptor).currentPolicy()))
+	assert.Equal(t, configured+sessionTouchThreshold, interceptor.(*authInterceptor).slideDuration(interceptor.(*authInterceptor).currentPolicy(context.Background())))
 }
 
 // TestPolicyResolvedOncePerRequest pins the request-path cost contract:
@@ -292,7 +292,7 @@ func TestSlideDurationHonoursConfiguredValue(t *testing.T) {
 func TestPolicyResolvedOncePerRequest(t *testing.T) {
 	var calls int
 	inc := &authInterceptor{
-		policy: func() Policy {
+		policy: func(context.Context) Policy {
 			calls++
 			return Policy{}
 		},

--- a/backend/internal/hub/auth/empty_userid_test.go
+++ b/backend/internal/hub/auth/empty_userid_test.go
@@ -478,7 +478,7 @@ func TestIdentityStructTypes_ScopesToOptionsStructs(t *testing.T) {
 	assert.True(t, carries["HTTPAuthOpts"], "it declares SoloUser *UserInfo")
 	assert.True(t, carries["UserInfo"], "it declares ID userid.UserID")
 	assert.False(t, carries["AuthContextRegistry"], "it reaches a *UserInfo only through internal state")
-	assert.False(t, carries["SessionMeta"], "it carries a user agent and an IP address, no identity")
+	assert.False(t, carries["SessionMeta"], "it carries a user agent, no identity")
 }
 
 func TestCarriesNamedStruct(t *testing.T) {

--- a/backend/internal/hub/auth/http.go
+++ b/backend/internal/hub/auth/http.go
@@ -118,9 +118,7 @@ func (o HTTPAuthOpts) soloGate() *SoloGate {
 // safe and stays, so a session issued under TLS still validates after the
 // operator turns the setting off.
 func AuthenticateHTTP(ctx context.Context, r *http.Request, opts HTTPAuthOpts) (*UserInfo, error) {
-	// The solo rung admits the callers SoloGate allows -- the local IPC
-	// socket, and any transport while the account holds no password -- and
-	// YIELDS to a presented bearer.
+	// The solo rung admits local IPC and yields to a presented bearer.
 	//
 	// A caller that presents an lmx_ bearer is ASKING to be its app: it
 	// accepted a narrower grant on a consent screen, and answering "you are

--- a/backend/internal/hub/auth/interceptor.go
+++ b/backend/internal/hub/auth/interceptor.go
@@ -297,9 +297,9 @@ type Policy struct {
 // snapshot. The hub's interceptor closure and the service tests share
 // this one mapping, so a new Policy field is wired in exactly one place
 // and a test cannot enforce a policy the hub computes differently.
-func PolicyFromSettings(snap *settings.Snapshot) Policy {
+func PolicyFromSettings(ctx context.Context, snap *settings.Snapshot) Policy {
 	return Policy{
-		SecureCookies:             settings.KeySecureCookies.Of(snap),
+		SecureCookies:             settings.SecureCookiesFor(ctx, snap),
 		EmailVerificationRequired: settings.EmailVerificationEffective(snap),
 		SessionDuration:           settings.SessionDuration(snap),
 	}
@@ -309,7 +309,7 @@ func PolicyFromSettings(snap *settings.Snapshot) Policy {
 // on both unary and streaming RPCs.
 type authInterceptor struct {
 	store          store.Store
-	policy         func() Policy
+	policy         func(context.Context) Policy
 	soloUser       *UserInfo
 	tokenValidator *TokenValidator
 	// state holds the shared caches, lease registry, and revocation ledger.
@@ -350,7 +350,7 @@ type InterceptorOptions struct {
 	// verification requirement, session duration). Nil keeps the zero Policy:
 	// plain cookie names, no verification requirement, and the default
 	// session duration.
-	Policy func() Policy
+	Policy func(context.Context) Policy
 	// SoloGate decides which solo callers may skip credentials. Nil builds one
 	// over Store, so the RULE never depends on the caller remembering to pass
 	// it -- only the latch does, and a hub shares one gate with
@@ -961,7 +961,7 @@ func (c *AuthContextRegistry) Stop() {
 
 func (a *authInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-		p := a.currentPolicy()
+		p := a.currentPolicy(ctx)
 		ctx, refresh, err := a.authenticate(ctx, req.Spec().Procedure, req.Header().Get("Cookie"), req.Header().Get("Authorization"), p)
 		if err != nil {
 			// authenticate rejects an authenticated request too -- an unverified
@@ -995,7 +995,7 @@ func (a *authInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) 
 
 func (a *authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
-		p := a.currentPolicy()
+		p := a.currentPolicy(ctx)
 		ctx, refresh, err := a.authenticate(ctx, conn.Spec().Procedure, conn.RequestHeader().Get("Cookie"), conn.RequestHeader().Get("Authorization"), p)
 		// Before the handler runs, not after: the response header of a stream
 		// goes out with the first message, and a long-lived stream sends that
@@ -1127,11 +1127,11 @@ func (a *authInterceptor) authorize(procedure string, userInfo *UserInfo, p Poli
 // zero value. The wrappers pass the result through the call chain, so
 // one request resolves the (mutex-guarded, snapshot-backed) policy
 // exactly once instead of re-reading it at every consumer.
-func (a *authInterceptor) currentPolicy() Policy {
+func (a *authInterceptor) currentPolicy(ctx context.Context) Policy {
 	if a.policy == nil {
 		return Policy{}
 	}
-	return a.policy()
+	return a.policy(ctx)
 }
 
 // enforceEmailVerification rejects a request from an unverified, non-admin user
@@ -1499,7 +1499,12 @@ const touchSweepInterval = 10 * time.Minute
 // delete is unconditional -- see below).
 func (a *authInterceptor) sweepCachesOnce() {
 	now := time.Now()
-	touchCutoff := now.Add(-a.touchThreshold(a.currentPolicy()))
+	// A BACKGROUND context, because this sweep serves no request. It reads the
+	// two session-duration fields only; the per-request half of the policy (the
+	// cookie name, which a trusted proxy's verified protocol can turn secure)
+	// has no meaning without a request and is not consulted here.
+	policy := a.currentPolicy(context.Background())
+	touchCutoff := now.Add(-a.touchThreshold(policy))
 	a.state.lastTouch.Range(func(key, value any) bool {
 		if value.(time.Time).Before(touchCutoff) {
 			a.state.deleteStaleLastTouch(key, value)
@@ -1562,7 +1567,7 @@ func (a *authInterceptor) sweepCachesOnce() {
 	// uses an unconditional Delete (no CAS), so a lock-free scan could drop a fresh
 	// re-revocation mark stored for the same key in the scan->delete gap -- a
 	// security regression. These maps are also far smaller than the caches.
-	revocationCutoff := now.Add(-a.slideDuration(a.currentPolicy()))
+	revocationCutoff := now.Add(-a.slideDuration(policy))
 	sweepRevocationMarks(&a.state.sessionRevocations, revocationCutoff)
 	sweepRevocationMarks(&a.state.userRevocations, revocationCutoff)
 	sweepRevocationMarks(&a.state.userInvalidations, revocationCutoff)

--- a/backend/internal/hub/auth/interceptor.go
+++ b/backend/internal/hub/auth/interceptor.go
@@ -43,11 +43,12 @@ import (
 // so a rename in the proto definition turns a typo here into a build
 // error instead of a silent auth bypass.
 var publicProcedures = map[string]bool{
-	leapmuxv1connect.AuthServiceLoginProcedure:               true,
-	leapmuxv1connect.AuthServiceSignUpProcedure:              true,
-	leapmuxv1connect.AuthServiceGetSystemInfoProcedure:       true,
-	leapmuxv1connect.WorkerConnectorServiceRegisterProcedure: true,
-	leapmuxv1connect.WorkerConnectorServiceConnectProcedure:  true,
+	leapmuxv1connect.AuthServiceLoginProcedure:                  true,
+	leapmuxv1connect.AuthServiceSetInitialSoloPasswordProcedure: true,
+	leapmuxv1connect.AuthServiceSignUpProcedure:                 true,
+	leapmuxv1connect.AuthServiceGetSystemInfoProcedure:          true,
+	leapmuxv1connect.WorkerConnectorServiceRegisterProcedure:    true,
+	leapmuxv1connect.WorkerConnectorServiceConnectProcedure:     true,
 	// Same worker auth_token as Connect, on a plain unary RPC rather than the
 	// stream. The worker's orphan reconciler is the only caller, and it is what
 	// converges a worker after a close or a cross-workspace move that landed
@@ -1031,12 +1032,9 @@ func headerPresentsLeapMuxBearer(authHeader string) bool {
 func (a *authInterceptor) authenticate(ctx context.Context, procedure, cookieHeader, authHeader string, p Policy) (context.Context, sessionRefresh, error) {
 	var noRefresh sessionRefresh
 
-	// Solo mode authenticates every procedure -- public or not -- as the
-	// synthetic user, and short-circuits the cookie path, for the callers
-	// SoloGate.CredentialFree admits: the local IPC socket, and any transport
-	// while the account holds no password. A TCP caller on a hub whose account
-	// HAS a password falls through to the ordinary cookie and bearer rungs
-	// below and signs in like any other account.
+	// Solo mode authenticates local IPC as the synthetic user and short-circuits
+	// the cookie path. Every TCP caller uses a public setup procedure or an
+	// ordinary cookie or bearer.
 	//
 	// It YIELDS to a presented lmx_ bearer, which is what makes the scope model
 	// work on a solo hub. The admitted caller carries an unscoped grant; a

--- a/backend/internal/hub/auth/interceptor_refresh_internal_test.go
+++ b/backend/internal/hub/auth/interceptor_refresh_internal_test.go
@@ -26,7 +26,7 @@ func slidingInterceptor(t *testing.T, sessionDuration time.Duration) *authInterc
 	return &authInterceptor{
 		store:  sessionValidationOverrideStore{sessions: sessions},
 		state:  &authState{},
-		policy: func() Policy { return Policy{SessionDuration: sessionDuration} },
+		policy: func(context.Context) Policy { return Policy{SessionDuration: sessionDuration} },
 	}
 }
 
@@ -47,11 +47,11 @@ func TestTouchSession_StoreErrorIsThrottledLikeAnySlide(t *testing.T) {
 	a := &authInterceptor{
 		store:  sessionValidationOverrideStore{sessions: sessions},
 		state:  &authState{},
-		policy: func() Policy { return Policy{SessionDuration: 36 * time.Hour} },
+		policy: func(context.Context) Policy { return Policy{SessionDuration: 36 * time.Hour} },
 	}
 
-	first := a.touchSession(context.Background(), "session", nil, a.currentPolicy())
-	second := a.touchSession(context.Background(), "session", nil, a.currentPolicy())
+	first := a.touchSession(context.Background(), "session", nil, a.currentPolicy(context.Background()))
+	second := a.touchSession(context.Background(), "session", nil, a.currentPolicy(context.Background()))
 
 	assert.True(t, first.IsZero(), "a failed touch slid nothing")
 	assert.True(t, second.IsZero())
@@ -139,7 +139,9 @@ func TestWrapUnary_HandlerErrorStillCarriesRefresh(t *testing.T) {
 // deadline, for as long as the user kept being refused.
 func TestWrapUnary_EmailVerificationDenialCarriesRefresh(t *testing.T) {
 	a := slidingInterceptor(t, 36*time.Hour)
-	a.policy = func() Policy { return Policy{SessionDuration: 36 * time.Hour, EmailVerificationRequired: true} }
+	a.policy = func(context.Context) Policy {
+		return Policy{SessionDuration: 36 * time.Hour, EmailVerificationRequired: true}
+	}
 
 	resp, err := a.WrapUnary(func(context.Context, connect.AnyRequest) (connect.AnyResponse, error) {
 		return nil, errors.New("the handler must not run")

--- a/backend/internal/hub/auth/interceptor_test.go
+++ b/backend/internal/hub/auth/interceptor_test.go
@@ -101,7 +101,7 @@ func TestInterceptor_PrivateProcedure_ValidCookie(t *testing.T) {
 	assert.True(t, resp.Msg.GetUser().GetIsAdmin())
 }
 
-func TestInterceptor_SoloMode_AutoAuthenticated(t *testing.T) {
+func TestInterceptor_SoloModeRejectsPasswordlessTCP(t *testing.T) {
 	st := hubtestutil.OpenTestStore(t)
 
 	// Bootstrap in solo mode creates a user named "solo".
@@ -123,11 +123,9 @@ func TestInterceptor_SoloMode_AutoAuthenticated(t *testing.T) {
 
 	client := leapmuxv1connect.NewAuthServiceClient(server.Client(), server.URL)
 
-	// In solo mode, private endpoints should work without any cookie.
-	resp, err := client.GetCurrentUser(context.Background(), connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{}))
-	require.NoError(t, err)
-	assert.Equal(t, "solo", resp.Msg.GetUser().GetUsername())
-	assert.True(t, resp.Msg.GetUser().GetIsAdmin())
+	_, err = client.GetCurrentUser(context.Background(), connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 }
 
 // TestInterceptor_SoloMode_YieldsToAPresentedBearer pins the solo decision on

--- a/backend/internal/hub/auth/procedure_scopes.go
+++ b/backend/internal/hub/auth/procedure_scopes.go
@@ -131,6 +131,7 @@ var procedureScopes = map[string]ScopeRequirement{
 	// Almost all of it bootstraps a session, so it is public. The two that need
 	// a caller are classified on what they do WITH one.
 	leapmuxv1connect.AuthServiceLoginProcedure:                           ScopePublic,
+	leapmuxv1connect.AuthServiceSetInitialSoloPasswordProcedure:          ScopePublic,
 	leapmuxv1connect.AuthServiceSignUpProcedure:                          ScopePublic,
 	leapmuxv1connect.AuthServiceGetSystemInfoProcedure:                   ScopePublic,
 	leapmuxv1connect.AuthServiceGetOAuthProvidersProcedure:               ScopePublic,

--- a/backend/internal/hub/auth/public_procedures_test.go
+++ b/backend/internal/hub/auth/public_procedures_test.go
@@ -38,6 +38,7 @@ var publicProcedureRationale = map[string]string{
 	// Unauthenticated by design: these are how a caller ACQUIRES a credential,
 	// so requiring one would be circular.
 	leapmuxv1connect.AuthServiceLoginProcedure:                           "credential-acquiring: verifies username/password itself",
+	leapmuxv1connect.AuthServiceSetInitialSoloPasswordProcedure:          "credential-acquiring: atomically claims a passwordless solo account and creates a session",
 	leapmuxv1connect.AuthServiceSignUpProcedure:                          "credential-acquiring: requires the signup-enabled config and the first-admin rules",
 	leapmuxv1connect.AuthServiceGetSystemInfoProcedure:                   "discloses only pre-login system facts (auth modes, setup state)",
 	leapmuxv1connect.AuthServiceGetOAuthProvidersProcedure:               "discloses only which OAuth providers are configured, pre-login",

--- a/backend/internal/hub/auth/solo_gate.go
+++ b/backend/internal/hub/auth/solo_gate.go
@@ -61,11 +61,10 @@ type SoloGate struct {
 	//
 	// While it is false, GetSystemInfo reads the store for each request, and
 	// SetInitialSoloPassword is the path that ends that state. The read is one
-	// indexed read of a table with one row, in the process that owns the
-	// database, and it is what makes a password set through any other path arm
-	// the rule on the very next request. A caller that needs the answer
-	// SEVERAL times in one request reads it once and passes it down;
-	// GetSystemInfo does.
+	// indexed read of a table with one row. It runs in the process that owns
+	// the database. Thus a password set through any other path arms the rule on
+	// the very next request. A caller that needs the answer SEVERAL times in
+	// one request reads it once and passes it down; GetSystemInfo does.
 	passwordSet atomic.Bool
 }
 
@@ -80,13 +79,26 @@ func NewSoloGate(solo bool, st store.Store) *SoloGate {
 	return &SoloGate{solo: solo, store: st}
 }
 
+// SoloMode reports whether this hub runs in solo mode.
+//
+// It exists so no caller has to spell `cfg.SoloMode` beside a gate answer.
+// That is the whole reason the mode lives on this type: a second spelling of
+// the rule is a second thing to keep in step, and GetSystemInfo is where the
+// two drifted apart before.
+func (g *SoloGate) SoloMode() bool {
+	return g != nil && g.solo
+}
+
 // CredentialFree reports whether the request arrived through local IPC on a
 // solo hub. The password state does not affect this decision.
+//
+// A NIL gate counts as solo, because a nil gate is a test that wired none and
+// the local IPC marker is then the whole rule. PasswordSet answers false for
+// the same nil gate, which is the opposite polarity and deliberate: an absent
+// gate can admit the socket it can see, but it must never claim a password it
+// cannot read.
 func (g *SoloGate) CredentialFree(ctx context.Context) bool {
-	if g == nil {
-		return peer.IsLocalIPC(ctx)
-	}
-	if !g.solo {
+	if g != nil && !g.solo {
 		return false
 	}
 	return peer.IsLocalIPC(ctx)

--- a/backend/internal/hub/auth/solo_gate.go
+++ b/backend/internal/hub/auth/solo_gate.go
@@ -59,13 +59,13 @@ type SoloGate struct {
 	// request. A setter beside that read would be a second way in for a value
 	// with one source, and it could save at most the one read that sets it.
 	//
-	// While it is false, GetSystemInfo reads the store for each request. The
-	// first-password procedure changes this state. It is one indexed read of a
-	// table with one row, in
-	// the process that owns the database, and it is what makes a password set
-	// through any other path arm the rule on the very next request. A caller
-	// that needs the answer SEVERAL times in one request reads it once and
-	// passes it down; GetSystemInfo does.
+	// While it is false, GetSystemInfo reads the store for each request, and
+	// SetInitialSoloPassword is the path that ends that state. The read is one
+	// indexed read of a table with one row, in the process that owns the
+	// database, and it is what makes a password set through any other path arm
+	// the rule on the very next request. A caller that needs the answer
+	// SEVERAL times in one request reads it once and passes it down;
+	// GetSystemInfo does.
 	passwordSet atomic.Bool
 }
 

--- a/backend/internal/hub/auth/solo_gate.go
+++ b/backend/internal/hub/auth/solo_gate.go
@@ -11,8 +11,8 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/usernames"
 )
 
-// SoloGate decides whether a caller may be authenticated as the solo user with
-// NO credentials at all.
+// SoloGate decides whether a caller may use the solo account without a
+// credential.
 //
 // It is a type rather than a method because two authentication ladders ask the
 // question and must answer alike: the ConnectRPC interceptor, and
@@ -20,18 +20,9 @@ import (
 // so the latch below is shared and the answer cannot differ between a request
 // and the socket it opens.
 //
-// THE RULE, in two cases:
-//
-//   - The LOCAL IPC socket, always. A unix socket is reachable only from this
-//     machine, its file mode restricts it to this user, and it is how the
-//     desktop app reaches its own hub. There is no third party to authenticate.
-//   - Any transport while the account holds NO PASSWORD. This is the bootstrap
-//     state: a hub run outside the desktop app is reached from a browser over
-//     TCP and nothing else, so refusing here would leave no way to set the
-//     first password.
-//
-// Once the account has a password, every TCP address asks for it -- the one
-// -listen gives, 127.0.0.1 included, and every extra address alike.
+// Only local IPC receives credential-free access. A TCP caller can use the
+// public first-password procedure while the account has no password. It cannot
+// use the synthetic solo administrator.
 //
 // Loopback buys no exemption, and that is deliberate. When an operator adds
 // `*:4327` to a hub already serving `127.0.0.1:4327`, the two MERGE into one
@@ -68,11 +59,9 @@ type SoloGate struct {
 	// request. A setter beside that read would be a second way in for a value
 	// with one source, and it could save at most the one read that sets it.
 	//
-	// While it is false the store is read per request, and that state does NOT
-	// end on its own: a hub kept on loopback is never asked for a password --
-	// soloPasswordSetupRequired demands one only for an address another
-	// machine can reach -- so the default `leapmux solo` pays the read for the
-	// life of the process. It is one indexed read of a table with one row, in
+	// While it is false, GetSystemInfo reads the store for each request. The
+	// first-password procedure changes this state. It is one indexed read of a
+	// table with one row, in
 	// the process that owns the database, and it is what makes a password set
 	// through any other path arm the rule on the very next request. A caller
 	// that needs the answer SEVERAL times in one request reads it once and
@@ -85,42 +74,14 @@ type SoloGate struct {
 // A gate that is NOT solo refuses every caller and reports no password. There
 // is no solo account on such a hub and no rule for it to decide.
 //
-// A NIL store gives a gate that admits the local IPC socket and refuses every
-// other transport: it cannot read the account, and a gate that cannot read the
-// account must not hand out the administrator. See CredentialFree.
+// A nil store still admits local IPC. PasswordSet reports false because it
+// cannot read the solo account.
 func NewSoloGate(solo bool, st store.Store) *SoloGate {
 	return &SoloGate{solo: solo, store: st}
 }
 
-// CredentialFree reports whether this request may be authenticated as the solo
-// user without presenting anything.
-//
-// ONE RULE: only a gate that can read the account admits anybody. A nil gate
-// and a gate over a nil store both answer FALSE, because neither can tell
-// whether a password exists, and "I cannot tell" must never mean "come in as
-// the administrator". Answering true instead put the fail-open combination one
-// forgotten field away -- `HTTPAuthOpts` carries SoloUser, SoloGate and Store
-// independently, so a caller that set the first and neither of the others got
-// a gate that knew nothing and admitted everything. This makes that
-// unreachable by construction rather than by an audit of the call sites.
-//
-// The LOCAL IPC test answers first, and it must. A unix socket is reachable
-// only from this machine and its file mode restricts it to this user, so the
-// desktop app is admitted whatever the gate can or cannot read -- a broken
-// database, or a hub that never configured one, cannot lock it out of its own
-// hub.
-//
-// PasswordSet fails the other way for the same gate: it answers false, because
-// "no password" is what an unconfigured gate honestly knows. The two are not
-// symmetric on purpose -- one decides an admission and the other reports a
-// fact, and the safe answer differs.
-//
-// A gate that is not SOLO refuses before any of this, the local socket
-// included: `leapmux hub` has no solo account and no credential-free rung, so
-// the desktop app there signs in like every other client. A NIL gate is the
-// different case -- nobody configured anything, so it keeps the local socket
-// rather than locking the desktop app out of a hub that stated solo mode and
-// nothing else.
+// CredentialFree reports whether the request arrived through local IPC on a
+// solo hub. The password state does not affect this decision.
 func (g *SoloGate) CredentialFree(ctx context.Context) bool {
 	if g == nil {
 		return peer.IsLocalIPC(ctx)
@@ -128,13 +89,7 @@ func (g *SoloGate) CredentialFree(ctx context.Context) bool {
 	if !g.solo {
 		return false
 	}
-	if peer.IsLocalIPC(ctx) {
-		return true
-	}
-	if g.store == nil {
-		return false
-	}
-	return !g.accountHasPassword(ctx)
+	return peer.IsLocalIPC(ctx)
 }
 
 // accountHasPassword reads the latch, falling back to the store.
@@ -187,35 +142,4 @@ func (g *SoloGate) PasswordSet(ctx context.Context) bool {
 		return false
 	}
 	return g.accountHasPassword(ctx)
-}
-
-// CredentialFreeAndPasswordSet answers BOTH questions from one store read.
-//
-// GetSystemInfo reports three solo facts and every one of them rests on the
-// same row. Asking through CredentialFree and PasswordSet separately costs a
-// read each while the latch is false -- which is the whole life of a hub that
-// never sets a password -- so the public, unauthenticated call every page load
-// makes paid three round trips for one fact.
-//
-// It reads the store BEFORE the local-IPC test, unlike CredentialFree, and
-// that costs the desktop app nothing: the caller wants the password answer as
-// well, so the read happens either way. The property CredentialFree protects
-// still holds, because an unreadable store answers "has a password" and the
-// local socket is admitted on top of that answer rather than behind it.
-//
-// A gate that cannot read the account answers exactly as CredentialFree does:
-// the local socket comes in, nothing else does, and the password is reported
-// absent.
-func (g *SoloGate) CredentialFreeAndPasswordSet(ctx context.Context) (credentialFree, passwordSet bool) {
-	if g == nil {
-		return peer.IsLocalIPC(ctx), false
-	}
-	if !g.solo {
-		return false, false
-	}
-	if g.store == nil {
-		return peer.IsLocalIPC(ctx), false
-	}
-	passwordSet = g.accountHasPassword(ctx)
-	return peer.IsLocalIPC(ctx) || !passwordSet, passwordSet
 }

--- a/backend/internal/hub/auth/solo_gate_test.go
+++ b/backend/internal/hub/auth/solo_gate_test.go
@@ -42,13 +42,13 @@ func setSoloPassword(t *testing.T, st store.Store) {
 // tcpCtx is a request that arrived over TCP, whatever the address. Loopback is
 // included on purpose: it buys no exemption.
 func tcpCtx(ip string) context.Context {
-	return peer.WithRemoteAddr(context.Background(),
+	return peer.WithTransportAddr(context.Background(),
 		&net.TCPAddr{IP: net.ParseIP(ip), Port: 51234})
 }
 
 // ipcCtx is a request that arrived on the local IPC socket.
 func ipcCtx() context.Context {
-	return peer.WithRemoteAddr(peer.WithLocalIPC(context.Background()),
+	return peer.WithTransportAddr(peer.WithLocalIPC(context.Background()),
 		&net.UnixAddr{Name: "/tmp/hub.sock", Net: "unix"})
 }
 
@@ -68,11 +68,9 @@ func TestSoloGate_CredentialFree(t *testing.T) {
 		// can open.
 		{"local IPC, password set", true, ipcCtx(), true},
 
-		// The bootstrap state. A hub outside the desktop app is reached from a
-		// browser over TCP and nothing else, so refusing here would leave no
-		// way to set the first password.
-		{"TCP loopback, no password", false, tcpCtx("127.0.0.1"), true},
-		{"TCP LAN, no password", false, tcpCtx("192.168.1.24"), true},
+		// TCP can use only the public initial-password procedure before setup.
+		{"TCP loopback, no password", false, tcpCtx("127.0.0.1"), false},
+		{"TCP LAN, no password", false, tcpCtx("192.168.1.24"), false},
 
 		// Once a password exists, EVERY TCP address asks for it. Loopback is
 		// the case that changed, and it is the point: a merged `*:4327` socket
@@ -83,7 +81,7 @@ func TestSoloGate_CredentialFree(t *testing.T) {
 		{"TCP LAN, password set", true, tcpCtx("192.168.1.24"), false},
 
 		// An unmarked context is not local IPC, so it follows the TCP rows.
-		{"unmarked, no password", false, context.Background(), true},
+		{"unmarked, no password", false, context.Background(), false},
 		{"unmarked, password set", true, context.Background(), false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -109,8 +107,8 @@ func TestSoloGate_ReadsTheHashAndNotTheColumn(t *testing.T) {
 	require.True(t, user.FirstCredentialExempt, "precondition: the bootstrap claims a password")
 	require.False(t, password.IsUsable(user.PasswordHash), "precondition: no hash backs the claim")
 
-	assert.True(t, auth.NewSoloGate(true, st).CredentialFree(tcpCtx("127.0.0.1")),
-		"a hub with no usable password must stay reachable, whatever the column says")
+	assert.False(t, auth.NewSoloGate(true, st).CredentialFree(tcpCtx("127.0.0.1")),
+		"a TCP caller must use the restricted setup procedure")
 	assert.False(t, auth.NewSoloGate(true, st).PasswordSet(context.Background()))
 }
 
@@ -121,7 +119,7 @@ func TestSoloGate_SeesAPasswordWrittenAfterItRead(t *testing.T) {
 	st := soloStore(t)
 	gate := auth.NewSoloGate(true, st)
 
-	require.True(t, gate.CredentialFree(tcpCtx("127.0.0.1")), "precondition: no password yet")
+	require.False(t, gate.CredentialFree(tcpCtx("127.0.0.1")), "TCP never receives synthetic solo access")
 
 	setSoloPassword(t, st)
 	assert.False(t, gate.CredentialFree(tcpCtx("127.0.0.1")),
@@ -167,13 +165,6 @@ func TestSoloGate_ThatCannotReadTheAccountAdmitsOnlyTheLocalSocket(t *testing.T)
 			assert.False(t, gate.PasswordSet(context.Background()),
 				"no password is what an unconfigured gate honestly knows")
 
-			free, set := gate.CredentialFreeAndPasswordSet(tcpCtx("127.0.0.1"))
-			assert.False(t, free)
-			assert.False(t, set)
-			free, set = gate.CredentialFreeAndPasswordSet(ipcCtx())
-			assert.True(t, free)
-			assert.False(t, set)
-
 		})
 	}
 }
@@ -196,32 +187,8 @@ func TestSoloGate_AnAbsentAccountHoldsNoPassword(t *testing.T) {
 	gate := auth.NewSoloGate(true, st)
 	assert.False(t, gate.PasswordSet(context.Background()),
 		"an account that does not exist cannot hold a password")
-	assert.True(t, gate.CredentialFree(tcpCtx("127.0.0.1")),
-		"a missing account must not demand a password nobody can present")
-}
-
-// GetSystemInfo reports three solo facts that all rest on one row, so it reads
-// them together. The two answers must agree with the single-question methods,
-// or the app's view of the connection and the hub's own rule could differ.
-func TestSoloGate_CredentialFreeAndPasswordSet(t *testing.T) {
-	t.Parallel()
-	st := soloStore(t)
-
-	gate := auth.NewSoloGate(true, st)
-	free, set := gate.CredentialFreeAndPasswordSet(tcpCtx("127.0.0.1"))
-	assert.True(t, free)
-	assert.False(t, set)
-
-	setSoloPassword(t, st)
-	free, set = gate.CredentialFreeAndPasswordSet(tcpCtx("127.0.0.1"))
-	assert.False(t, free, "TCP asks for the password the account now holds")
-	assert.True(t, set)
-
-	// The local socket stays credential-free on the same answer.
-	free, set = gate.CredentialFreeAndPasswordSet(ipcCtx())
-	assert.True(t, free, "the desktop app cannot present a password and must not be asked")
-	assert.True(t, set)
-
+	assert.False(t, gate.CredentialFree(tcpCtx("127.0.0.1")),
+		"a missing account does not grant synthetic access over TCP")
 }
 
 // A gate for a hub that is NOT solo answers no to everything, and reads
@@ -244,10 +211,6 @@ func TestSoloGate_OutsideSoloModeAnswersNoAndReadsNothing(t *testing.T) {
 		"a hub with no solo rung admits nobody through it, the local socket included")
 	assert.False(t, gate.PasswordSet(context.Background()),
 		"there is no solo account to hold a password")
-
-	free, set := gate.CredentialFreeAndPasswordSet(tcpCtx("127.0.0.1"))
-	assert.False(t, free)
-	assert.False(t, set)
 
 	assert.Zero(t, st.soloLookups.Load(), "a hub with no solo account must not look one up")
 }

--- a/backend/internal/hub/auth/solo_rung_test.go
+++ b/backend/internal/hub/auth/solo_rung_test.go
@@ -107,17 +107,17 @@ func (f soloRungFixture) setSoloPassword(t *testing.T) {
 	}))
 }
 
-// The bootstrap state: TCP is credential-free, because a hub reached from a
-// browser over TCP and nothing else would otherwise have no way to set its
-// first password.
-func TestSoloRung_TCPIsCredentialFreeWhileTheAccountHasNoPassword(t *testing.T) {
+// A passwordless TCP caller can use only the public initial-password RPC. The
+// ordinary authentication ladders must not grant the synthetic administrator.
+func TestSoloRung_TCPNeedsCredentialsBeforeTheAccountHasAPassword(t *testing.T) {
 	f := newSoloRungFixture(t)
 
-	require.NoError(t, f.connectCall(nil), "the Connect ladder must admit a bare TCP caller")
+	err := f.connectCall(nil)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 
-	user, err := f.httpCall(nil)
-	require.NoError(t, err, "the HTTP ladder must admit the same caller")
-	assert.True(t, user.SoloAuthenticated())
+	_, httpErr := f.httpCall(nil)
+	require.Error(t, httpErr)
 }
 
 // The rule arms itself the moment the password lands, in both ladders and with

--- a/backend/internal/hub/captcha/interceptor.go
+++ b/backend/internal/hub/captcha/interceptor.go
@@ -76,6 +76,22 @@ var protectedProcedures = map[string]protectedProcedure{
 	leapmuxv1connect.UserServiceResendVerificationEmailProcedure:     {action: contracts.CaptchaActionResendVerification},
 }
 
+// IsProtected reports whether a captcha guards this procedure.
+//
+// It exists for the rate-limit package's coverage tripwire, which walks the
+// proto descriptors for every procedure that carries a secret and demands that
+// SOMETHING limit each one. A captcha and a budget are the two answers, so the
+// walk must be able to ask this question. Restating the table there would give
+// the tripwire a second copy to drift from, which is the one thing a tripwire
+// must not have.
+//
+// The table is not exported itself, because a caller that ranged over it could
+// act on the action tokens, and those belong to the interceptor.
+func IsProtected(procedure string) bool {
+	_, ok := protectedProcedures[procedure]
+	return ok
+}
+
 // NewInterceptor returns a unary interceptor enforcing captcha + honeypot
 // verification on the protected procedures. It must run BEFORE the auth
 // interceptor's handler pass-through reaches the expensive handler logic.

--- a/backend/internal/hub/captcha/protected_procedures_test.go
+++ b/backend/internal/hub/captcha/protected_procedures_test.go
@@ -44,7 +44,7 @@ var protectedAuthenticatedRationale = map[string]string{
 // passes the auth package's rationale test, and ships the procedure
 // unprotected.
 var captchaExemptRationale = map[string]string{
-	leapmuxv1connect.AuthServiceSetInitialSoloPasswordProcedure:             "solo disables captcha, and the first successful write closes this procedure",
+	leapmuxv1connect.AuthServiceSetInitialSoloPasswordProcedure:             "solo disables captcha; ratelimit.OpSoloPasswordSetup caps its Argon2 hash by address instead",
 	leapmuxv1connect.AuthServiceGetSystemInfoProcedure:                      "cheap pre-login read",
 	leapmuxv1connect.AuthServiceGetOAuthProvidersProcedure:                  "cheap pre-login read",
 	leapmuxv1connect.AuthServiceGetPendingOAuthSignupProcedure:              "read keyed by a single-use pending id; no expensive action",

--- a/backend/internal/hub/captcha/protected_procedures_test.go
+++ b/backend/internal/hub/captcha/protected_procedures_test.go
@@ -44,6 +44,7 @@ var protectedAuthenticatedRationale = map[string]string{
 // passes the auth package's rationale test, and ships the procedure
 // unprotected.
 var captchaExemptRationale = map[string]string{
+	leapmuxv1connect.AuthServiceSetInitialSoloPasswordProcedure:             "solo disables captcha, and the first successful write closes this procedure",
 	leapmuxv1connect.AuthServiceGetSystemInfoProcedure:                      "cheap pre-login read",
 	leapmuxv1connect.AuthServiceGetOAuthProvidersProcedure:                  "cheap pre-login read",
 	leapmuxv1connect.AuthServiceGetPendingOAuthSignupProcedure:              "read keyed by a single-use pending id; no expensive action",

--- a/backend/internal/hub/peer/peer.go
+++ b/backend/internal/hub/peer/peer.go
@@ -18,12 +18,14 @@ package peer
 import (
 	"context"
 	"net"
-	"strings"
+	"net/netip"
 )
 
 type localIPCKey struct{}
 
-type remoteAddrKey struct{}
+type transportAddrKey struct{}
+
+type clientIPKey struct{}
 
 // WithLocalIPC marks the context as belonging to the local IPC listener --
 // the unix domain socket on Unix, the named pipe on Windows.
@@ -46,47 +48,33 @@ func IsLocalIPC(ctx context.Context) bool {
 	return v
 }
 
-// WithRemoteAddr records one connection's peer address, from the
-// http.Server's ConnContext.
-func WithRemoteAddr(ctx context.Context, addr net.Addr) context.Context {
+// WithTransportAddr records the unchanged address of the accepted connection.
+func WithTransportAddr(ctx context.Context, addr net.Addr) context.Context {
 	if addr == nil {
 		return ctx
 	}
-	return context.WithValue(ctx, remoteAddrKey{}, addr)
+	return context.WithValue(ctx, transportAddrKey{}, addr)
 }
 
-// RemoteAddr returns the recorded peer address, and whether one was recorded.
-func RemoteAddr(ctx context.Context) (net.Addr, bool) {
-	addr, ok := ctx.Value(remoteAddrKey{}).(net.Addr)
+// TransportAddr returns the unchanged connection address.
+func TransportAddr(ctx context.Context) (net.Addr, bool) {
+	addr, ok := ctx.Value(transportAddrKey{}).(net.Addr)
 	return addr, ok
 }
 
-// RemoteHost returns the peer's host with the port removed, or "" when no
-// address was recorded.
-func RemoteHost(ctx context.Context) string {
-	addr, ok := RemoteAddr(ctx)
-	if !ok {
-		return ""
+// WithClientIP records the verified client IP. Invalid values become an
+// unknown client instead of entering request identity state.
+func WithClientIP(ctx context.Context, value string) context.Context {
+	addr, err := netip.ParseAddr(value)
+	if err != nil || addr.Zone() != "" || addr.IsUnspecified() {
+		return context.WithValue(ctx, clientIPKey{}, "")
 	}
-	return HostOf(addr.String())
+	return context.WithValue(ctx, clientIPKey{}, addr.Unmap().String())
 }
 
-// HostOf reduces one address to the host a budget is keyed on.
-//
-// The port goes because a client picks a fresh one for every connection, so a
-// budget keyed on it would give each request a budget of its own. The brackets
-// go so one IPv6 peer reads as one host whichever way its address was
-// rendered.
-//
-// It is exported because TWO entry points reach an address differently -- the
-// plain-HTTP door reads r.RemoteAddr, and the Connect interceptor reads the
-// peer the http.Server stamped on the context -- and they must reduce it the
-// same way or one caller holds two budgets. That invariant was stated in a
-// comment beside two identical copies of these three lines; it is one function
-// now.
-func HostOf(addr string) string {
-	if host, _, err := net.SplitHostPort(addr); err == nil {
-		addr = host
-	}
-	return strings.Trim(addr, "[]")
+// ClientIP returns the verified client IP, or an empty string when the request
+// source could not identify one.
+func ClientIP(ctx context.Context) string {
+	value, _ := ctx.Value(clientIPKey{}).(string)
+	return value
 }

--- a/backend/internal/hub/peer/peer.go
+++ b/backend/internal/hub/peer/peer.go
@@ -2,11 +2,17 @@
 // answer two questions the request body cannot: did this arrive on the hub's
 // local IPC listener, and what address is it from?
 //
-// Both marks are placed once, by the http.Server, and every consumer reads
-// them from the context. That is what lets the ConnectRPC interceptor and the
-// WebSocket authenticator answer alike: a Connect handler holds a context and
-// a WebSocket handler holds an *http.Request whose context descends from the
-// same connection.
+// The package holds FOUR marks, and they have two writers. The http.Server
+// places the local-IPC mark and the transport address, one per listener and
+// one per connection. The request-source middleware places the verified client
+// IP and the verified protocol, per request, because both answers need the
+// forwarding headers and the trusted-proxy setting, which the server knows
+// nothing about.
+//
+// Every consumer reads them from the context. That is what lets the ConnectRPC
+// interceptor and the WebSocket authenticator answer alike: a Connect handler
+// holds a context and a WebSocket handler holds an *http.Request whose context
+// descends from the same connection.
 //
 // THE POLARITY IS DELIBERATE. An unmarked context reports "not local IPC" and
 // an empty address. Every mark is added by production wiring that a test can
@@ -26,6 +32,8 @@ type localIPCKey struct{}
 type transportAddrKey struct{}
 
 type clientIPKey struct{}
+
+type httpsKey struct{}
 
 // WithLocalIPC marks the context as belonging to the local IPC listener --
 // the unix domain socket on Unix, the named pipe on Windows.
@@ -64,9 +72,17 @@ func TransportAddr(ctx context.Context) (net.Addr, bool) {
 
 // WithClientIP records the verified client IP. Invalid values become an
 // unknown client instead of entering request identity state.
+//
+// A ZONE is kept, and only the transport peer can supply one. Every
+// header-derived address is refused a zone by the parser that reads it, so a
+// zoned value here came from the accepted connection, where the zone is part
+// of the identity: two link-local peers on different interfaces carry the same
+// address, and dropping the zone would merge them. Refusing the whole address
+// instead put every link-local client into the shared unknown budget and wrote
+// an empty address on their session rows.
 func WithClientIP(ctx context.Context, value string) context.Context {
 	addr, err := netip.ParseAddr(value)
-	if err != nil || addr.Zone() != "" || addr.IsUnspecified() {
+	if err != nil || addr.IsUnspecified() {
 		return context.WithValue(ctx, clientIPKey{}, "")
 	}
 	return context.WithValue(ctx, clientIPKey{}, addr.Unmap().String())
@@ -76,5 +92,26 @@ func WithClientIP(ctx context.Context, value string) context.Context {
 // source could not identify one.
 func ClientIP(ctx context.Context) string {
 	value, _ := ctx.Value(clientIPKey{}).(string)
+	return value
+}
+
+// WithHTTPS records that the request reached the hub over TLS.
+//
+// The hub terminates no TLS itself, so the only way this is true is a trusted
+// reverse proxy that terminated it and said so. The request-source middleware
+// is the one writer, and it sets this only after the transport peer passed the
+// trust test -- a caller-controlled header can never reach it.
+//
+// The POLARITY matches the rest of this package: an unmarked context reports
+// plain HTTP. A missed mark then costs a cookie its Secure attribute, which is
+// the direction that fails safe against a mark the wiring forgot.
+func WithHTTPS(ctx context.Context, https bool) context.Context {
+	return context.WithValue(ctx, httpsKey{}, https)
+}
+
+// IsHTTPS reports whether a trusted proxy verified that this request reached
+// the hub over TLS.
+func IsHTTPS(ctx context.Context) bool {
+	value, _ := ctx.Value(httpsKey{}).(bool)
 	return value
 }

--- a/backend/internal/hub/peer/peer_test.go
+++ b/backend/internal/hub/peer/peer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/leapmux/leapmux/internal/hub/peer"
 )
@@ -17,9 +18,9 @@ func TestUnmarkedContextGrantsNothing(t *testing.T) {
 	ctx := context.Background()
 
 	assert.False(t, peer.IsLocalIPC(ctx), "an unmarked context must not read as local IPC")
-	_, ok := peer.RemoteAddr(ctx)
+	_, ok := peer.TransportAddr(ctx)
 	assert.False(t, ok)
-	assert.Equal(t, "", peer.RemoteHost(ctx))
+	assert.Equal(t, "", peer.ClientIP(ctx))
 }
 
 func TestIsLocalIPC(t *testing.T) {
@@ -35,7 +36,7 @@ func TestIsLocalIPC(t *testing.T) {
 		&net.TCPAddr{IP: net.ParseIP("::1"), Port: 4327},
 		&net.TCPAddr{IP: net.ParseIP("192.168.1.24"), Port: 4327},
 	} {
-		ctx := peer.WithRemoteAddr(context.Background(), addr)
+		ctx := peer.WithTransportAddr(context.Background(), addr)
 		assert.Falsef(t, peer.IsLocalIPC(ctx), "%s must not read as local IPC", addr)
 	}
 }
@@ -44,77 +45,37 @@ func TestIsLocalIPC(t *testing.T) {
 // address, and recording an address never implies the transport.
 func TestMarksCompose(t *testing.T) {
 	t.Parallel()
-	ctx := peer.WithRemoteAddr(peer.WithLocalIPC(context.Background()),
+	ctx := peer.WithTransportAddr(peer.WithLocalIPC(context.Background()),
 		&net.UnixAddr{Name: "/tmp/hub.sock", Net: "unix"})
 
 	assert.True(t, peer.IsLocalIPC(ctx))
-	addr, ok := peer.RemoteAddr(ctx)
+	addr, ok := peer.TransportAddr(ctx)
 	assert.True(t, ok)
 	assert.Equal(t, "/tmp/hub.sock", addr.String())
 }
 
-func TestWithRemoteAddr_IgnoresNil(t *testing.T) {
+func TestWithTransportAddr_IgnoresNil(t *testing.T) {
 	t.Parallel()
-	ctx := peer.WithRemoteAddr(context.Background(), nil)
-	_, ok := peer.RemoteAddr(ctx)
+	ctx := peer.WithTransportAddr(context.Background(), nil)
+	_, ok := peer.TransportAddr(ctx)
 	assert.False(t, ok, "a nil address must record nothing rather than a typed nil")
 }
 
-func TestRemoteHost(t *testing.T) {
+func TestClientIP_IsSeparateAndCanonical(t *testing.T) {
 	t.Parallel()
-	for _, tc := range []struct {
-		name string
-		addr net.Addr
-		want string
-	}{
-		{"IPv4 drops the port", &net.TCPAddr{IP: net.ParseIP("192.168.1.24"), Port: 51234}, "192.168.1.24"},
-		{"IPv6 drops the port and the brackets", &net.TCPAddr{IP: net.ParseIP("2001:db8::1"), Port: 51234}, "2001:db8::1"},
-		{"loopback keeps its address", &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 51234}, "127.0.0.1"},
-		// A unix address carries no port, so the split fails and the whole
-		// name is the host. Every desktop connection then shares one budget,
-		// which is right: they are all the same person.
-		{"a unix socket path is the host", &net.UnixAddr{Name: "/tmp/hub.sock", Net: "unix"}, "/tmp/hub.sock"},
-		{"an empty unix address is empty", &net.UnixAddr{Net: "unix"}, ""},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			ctx := peer.WithRemoteAddr(context.Background(), tc.addr)
-			assert.Equal(t, tc.want, peer.RemoteHost(ctx))
-		})
-	}
+	ctx := peer.WithTransportAddr(context.Background(),
+		&net.TCPAddr{IP: net.ParseIP("10.0.0.4"), Port: 4327})
+	ctx = peer.WithClientIP(ctx, "2001:0db8::7")
+
+	transport, ok := peer.TransportAddr(ctx)
+	require.True(t, ok)
+	assert.Equal(t, "10.0.0.4:4327", transport.String())
+	assert.Equal(t, "2001:db8::7", peer.ClientIP(ctx))
 }
 
-// The two ports of one client must share a budget, or a rate limit counts
-// nothing: a caller opens a fresh connection per attempt.
-func TestRemoteHost_IsStableAcrossPorts(t *testing.T) {
+func TestClientIP_RejectsInvalidValues(t *testing.T) {
 	t.Parallel()
-	first := peer.RemoteHost(peer.WithRemoteAddr(context.Background(),
-		&net.TCPAddr{IP: net.ParseIP("192.168.1.24"), Port: 51234}))
-	second := peer.RemoteHost(peer.WithRemoteAddr(context.Background(),
-		&net.TCPAddr{IP: net.ParseIP("192.168.1.24"), Port: 51235}))
-
-	assert.Equal(t, first, second)
-}
-
-// The two entry points must reduce an address the same way, or one caller
-// holds two budgets and the sign-in limit counts neither of them properly.
-//
-// ratelimit.clientAddressKey reads r.RemoteAddr and RemoteHost reads the peer
-// the http.Server stamped; both go through HostOf, and this pins that the one
-// reduction handles every shape either of them can see.
-func TestHostOf(t *testing.T) {
-	for _, tc := range []struct{ in, want string }{
-		{"192.168.1.24:51234", "192.168.1.24"},
-		{"[2001:db8::1]:51234", "2001:db8::1"},
-		{"[fe80::1%en0]:51234", "fe80::1%en0"},
-		// No port at all: a unix socket path, or an address a transport
-		// rendered without one.
-		{"/tmp/hub.sock", "/tmp/hub.sock"},
-		{"192.168.1.24", "192.168.1.24"},
-		{"", ""},
-	} {
-		t.Run(tc.in, func(t *testing.T) {
-			assert.Equal(t, tc.want, peer.HostOf(tc.in))
-		})
+	for _, value := range []string{"", "unknown", "192.0.2.1:443", "fe80::1%en0", "0.0.0.0", "::"} {
+		assert.Empty(t, peer.ClientIP(peer.WithClientIP(context.Background(), value)), value)
 	}
 }

--- a/backend/internal/hub/peer/peer_test.go
+++ b/backend/internal/hub/peer/peer_test.go
@@ -75,7 +75,33 @@ func TestClientIP_IsSeparateAndCanonical(t *testing.T) {
 
 func TestClientIP_RejectsInvalidValues(t *testing.T) {
 	t.Parallel()
-	for _, value := range []string{"", "unknown", "192.0.2.1:443", "fe80::1%en0", "0.0.0.0", "::"} {
+	for _, value := range []string{"", "unknown", "192.0.2.1:443", "0.0.0.0", "::"} {
 		assert.Empty(t, peer.ClientIP(peer.WithClientIP(context.Background(), value)), value)
 	}
+}
+
+// A ZONE is kept, and only the transport peer can supply one: every
+// header-derived address is refused a zone by the parser that reads it. On a
+// link-local address the zone is part of the identity, so dropping it would
+// merge two peers on different interfaces into one budget -- and refusing the
+// address outright, which this used to do, put every link-local client into
+// the shared unknown budget and wrote an empty address on their session rows.
+func TestClientIP_KeepsAZone(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "fe80::1%en0",
+		peer.ClientIP(peer.WithClientIP(context.Background(), "fe80::1%en0")))
+	assert.NotEqual(t,
+		peer.ClientIP(peer.WithClientIP(context.Background(), "fe80::1%en0")),
+		peer.ClientIP(peer.WithClientIP(context.Background(), "fe80::1%en1")),
+		"two interfaces must not share one budget")
+}
+
+// The POLARITY, which is the whole reason this mark is safe to derive from a
+// header. An unmarked context reports plain HTTP, so wiring that forgets the
+// middleware costs a cookie its Secure attribute rather than granting one.
+func TestIsHTTPS_DefaultsToPlain(t *testing.T) {
+	t.Parallel()
+	assert.False(t, peer.IsHTTPS(context.Background()), "an unmarked context is not HTTPS")
+	assert.False(t, peer.IsHTTPS(peer.WithHTTPS(context.Background(), false)))
+	assert.True(t, peer.IsHTTPS(peer.WithHTTPS(context.Background(), true)))
 }

--- a/backend/internal/hub/ratelimit/http.go
+++ b/backend/internal/hub/ratelimit/http.go
@@ -3,7 +3,9 @@ package ratelimit
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/netip"
 
 	"github.com/leapmux/leapmux/internal/hub/peer"
 )
@@ -39,7 +41,7 @@ func AllowHTTP(ctx context.Context, m *Manager, op Operation, r *http.Request) b
 	if m == nil {
 		return true
 	}
-	allowed, _, err := m.allowWindowed(ctx, op, clientAddressKey(r))
+	allowed, _, err := m.allowWindowed(ctx, op, anonymousBudgetKey(r.Context()))
 	if err != nil {
 		slog.WarnContext(ctx, "rate limit unavailable for an anonymous OAuth endpoint; admitting",
 			"operation", string(op), "err", err)
@@ -48,23 +50,76 @@ func AllowHTTP(ctx context.Context, m *Manager, op Operation, r *http.Request) b
 	return allowed
 }
 
-// clientAddressKey is the budget key for an anonymous caller: its IP address.
+// anonymousBudgetKey renders one anonymous caller's budget key.
 //
-// The request-source middleware verifies this value against the unchanged
-// transport peer before it records it. An unknown client shares one budget.
-func clientAddressKey(r *http.Request) string {
-	return AddressBudgetKey(peer.ClientIP(r.Context()))
+// It answers from the VERIFIED client IP when the request-source middleware
+// could name one, and from the unchanged TRANSPORT PEER when it could not.
+// Both entry points -- the plain-HTTP door and the Connect interceptor -- call
+// this one function, so a caller can never hold two budgets.
+//
+// The fallback is what keeps the shared bucket honest, and it is not a
+// weakening: the transport peer is the address the kernel accepted the
+// connection from, so no header can set it and no proxy can forge it. Without
+// the fallback, EVERY request the middleware refuses to name lands in one
+// bucket -- a malformed forwarding header from behind a trusted proxy, a
+// chain whose addresses are all trusted, a `for=unknown` node, and an IPv6
+// link-local peer, which needs no configuration at all. That bucket also
+// holds the local IPC socket, so a remote caller could spend the desktop
+// app's window: 600 requests in ten minutes exhausts OpOAuthAnonymous, and
+// `leapmux control` is then refused on the machine's own socket.
+//
+// The client IP stays the PREFERRED key, so a real proxy deployment still
+// budgets per client rather than per proxy.
+//
+// A caller with neither -- the local IPC socket, whose accepted connection
+// carries no IP address, and a test transport -- shares one budget. That is
+// the population the shared bucket was always for.
+func anonymousBudgetKey(ctx context.Context) string {
+	if clientIP := peer.ClientIP(ctx); clientIP != "" {
+		return AddressBudgetKey(clientIP)
+	}
+	return AddressBudgetKey(transportHost(ctx))
+}
+
+// transportHost is the host of the accepted connection's address, or an empty
+// string when it has none.
+//
+// A unix socket and a named pipe both reach this: the first carries no address
+// at all, and the second carries a pipe path rather than a host. Neither can
+// be reached from the network, which is why both belong in the shared bucket.
+func transportHost(ctx context.Context) string {
+	addr, ok := peer.TransportAddr(ctx)
+	if !ok {
+		return ""
+	}
+	tcp, ok := addr.(*net.TCPAddr)
+	if !ok || tcp.IP == nil {
+		return ""
+	}
+	host, err := netip.ParseAddr(tcp.IP.String())
+	if err != nil {
+		return ""
+	}
+	// The ZONE stays. On a link-local address it is part of the identity: two
+	// peers on different interfaces can carry the same address, and merging
+	// them would put them in one budget.
+	if tcp.Zone != "" {
+		host = host.WithZone(tcp.Zone)
+	}
+	return host.Unmap().String()
 }
 
 // AddressBudgetKey renders one anonymous caller's budget key from its host.
 //
-// It is exported because the HTTP and Connect entry points must render the
-// same verified client IP as the same key.
+// It is exported because `AllowHTTP`'s callers outside this package name the
+// unknown bucket in their own tests. Inside the package every budget goes
+// through anonymousBudgetKey, which is the one place that decides what a host
+// is.
 func AddressBudgetKey(host string) string {
 	if host == "" {
-		// An unaddressed caller (a test transport, a unix socket) shares one
-		// budget under a name no address can collide with, rather than each
-		// getting an unlimited one.
+		// An unaddressed caller (a test transport, a unix socket, a Windows
+		// named pipe) shares one budget under a name no address can collide
+		// with, rather than each getting an unlimited one.
 		return "anonymous:unknown"
 	}
 	return "anonymous:" + host

--- a/backend/internal/hub/ratelimit/http.go
+++ b/backend/internal/hub/ratelimit/http.go
@@ -50,31 +50,16 @@ func AllowHTTP(ctx context.Context, m *Manager, op Operation, r *http.Request) b
 
 // clientAddressKey is the budget key for an anonymous caller: its IP address.
 //
-// The REMOTE ADDRESS of the connection, never a forwarded header. A header is
-// caller-controlled, so keying on one would let an attacker mint a fresh budget
-// per request by varying it -- which is worse than no limit, because it also
-// lets them exhaust a victim's budget by claiming the victim's address.
-//
-// A hub behind a reverse proxy therefore sees the proxy's address and shares
-// one budget across every client behind it. That is the honest reading of what
-// the hub can actually verify, and the budget is sized for it: these endpoints
-// are polled, not held open, so the default admits a large multiple of what one
-// real client needs.
-//
-// The port is stripped, because a client picks a fresh one per connection and
-// keying on it would give every request its own budget.
+// The request-source middleware verifies this value against the unchanged
+// transport peer before it records it. An unknown client shares one budget.
 func clientAddressKey(r *http.Request) string {
-	addr := r.RemoteAddr
-	return AddressBudgetKey(peer.HostOf(addr))
+	return AddressBudgetKey(peer.ClientIP(r.Context()))
 }
 
 // AddressBudgetKey renders one anonymous caller's budget key from its host.
 //
-// It is exported because the two entry points reach the host differently: the
-// plain-HTTP door reads r.RemoteAddr, and the Connect interceptor reads the
-// peer the http.Server stamped on the context. Both must produce the SAME key,
-// or one caller would hold two budgets and neither would limit it. peer.HostOf
-// is the shared reduction that makes the two agree.
+// It is exported because the HTTP and Connect entry points must render the
+// same verified client IP as the same key.
 func AddressBudgetKey(host string) string {
 	if host == "" {
 		// An unaddressed caller (a test transport, a unix socket) shares one

--- a/backend/internal/hub/ratelimit/http_test.go
+++ b/backend/internal/hub/ratelimit/http_test.go
@@ -9,7 +9,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/peer"
 )
+
+func requestWithClientIP(method, path, clientIP string) *http.Request {
+	req := httptest.NewRequest(method, path, nil)
+	return req.WithContext(peer.WithClientIP(req.Context(), clientIP))
+}
 
 // TestAllowHTTPCountsEveryRequestAgainstOneAddress pins the difference from the
 // interceptor: this budget caps the RATE at which one address may drive an
@@ -19,7 +26,7 @@ func TestAllowHTTPCountsEveryRequestAgainstOneAddress(t *testing.T) {
 	m := newTestManager(t)
 	upsertLimit(t, m, OpOAuthAnonymous, true, 2, 600)
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
+	req := requestWithClientIP(http.MethodPost, "/oauth/token", "203.0.113.7")
 	req.RemoteAddr = "203.0.113.7:51234"
 
 	assert.True(t, AllowHTTP(context.Background(), m, OpOAuthAnonymous, req))
@@ -29,25 +36,23 @@ func TestAllowHTTPCountsEveryRequestAgainstOneAddress(t *testing.T) {
 
 	// A DIFFERENT address has its own budget, so one noisy caller cannot lock
 	// everybody else out.
-	other := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
+	other := requestWithClientIP(http.MethodPost, "/oauth/token", "203.0.113.8")
 	other.RemoteAddr = "203.0.113.8:51234"
 	assert.True(t, AllowHTTP(context.Background(), m, OpOAuthAnonymous, other))
 }
 
-// TestAllowHTTPKeysOnTheConnectionAddressAndNotAHeader is the security
-// property: keying on a forwarded header would let an attacker mint a fresh
-// budget per request by varying it -- worse than no limit, because it also lets
-// them exhaust a victim's budget by claiming the victim's address.
-func TestAllowHTTPKeysOnTheConnectionAddressAndNotAHeader(t *testing.T) {
+// The limiter reads only the verified client IP from context. Raw forwarding
+// headers cannot change the budget after request-source verification.
+func TestAllowHTTPUsesVerifiedClientIPAndNotRawHeaders(t *testing.T) {
 	m := newTestManager(t)
 	upsertLimit(t, m, OpOAuthAnonymous, true, 1, 600)
 
-	first := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
+	first := requestWithClientIP(http.MethodPost, "/oauth/token", "203.0.113.7")
 	first.RemoteAddr = "203.0.113.7:1"
 	first.Header.Set("X-Forwarded-For", "10.0.0.1")
 	require.True(t, AllowHTTP(context.Background(), m, OpOAuthAnonymous, first))
 
-	second := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
+	second := requestWithClientIP(http.MethodPost, "/oauth/token", "203.0.113.7")
 	second.RemoteAddr = "203.0.113.7:2"
 	second.Header.Set("X-Forwarded-For", "10.0.0.2")
 	assert.False(t, AllowHTTP(context.Background(), m, OpOAuthAnonymous, second),
@@ -59,7 +64,7 @@ func TestAllowHTTPKeysOnTheConnectionAddressAndNotAHeader(t *testing.T) {
 // client authenticates at all, so a settings blip that locked every app out of
 // every hub would be a worse outage than the unthrottled window it prevents.
 func TestAllowHTTPAdmitsWhenUnconfigured(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
+	req := requestWithClientIP(http.MethodPost, "/oauth/token", "203.0.113.7")
 	req.RemoteAddr = "203.0.113.7:1"
 	assert.True(t, AllowHTTP(context.Background(), nil, OpOAuthAnonymous, req),
 		"a nil manager admits: a test wires none, and a hub always has one")
@@ -81,7 +86,7 @@ func TestAllowHTTPWindowActuallyResets(t *testing.T) {
 	m := newTestManager(t)
 	upsertLimit(t, m, OpOAuthAnonymous, true, 2, 600)
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
+	req := requestWithClientIP(http.MethodPost, "/oauth/token", "203.0.113.7")
 	req.RemoteAddr = "203.0.113.7:51234"
 
 	assert.True(t, AllowHTTP(context.Background(), m, OpOAuthAnonymous, req))
@@ -94,18 +99,14 @@ func TestAllowHTTPWindowActuallyResets(t *testing.T) {
 		"one window later the budget starts over")
 }
 
-// TestClientAddressKeyStripsThePortAndBracket pins the key shape. A client
-// picks a fresh port per connection, so keying on it would give every request
-// its own budget -- exactly the hole the header rule above closes.
-func TestClientAddressKeyStripsThePortAndBracket(t *testing.T) {
-	for addr, want := range map[string]string{
-		"203.0.113.7:51234":  "anonymous:203.0.113.7",
-		"[2001:db8::1]:4327": "anonymous:2001:db8::1",
-		"203.0.113.7":        "anonymous:203.0.113.7",
-		"":                   "anonymous:unknown",
+// The verified value is already a canonical IP without a port.
+func TestClientAddressKeyUsesVerifiedClientIP(t *testing.T) {
+	for clientIP, want := range map[string]string{
+		"203.0.113.7": "anonymous:203.0.113.7",
+		"2001:db8::1": "anonymous:2001:db8::1",
+		"":            "anonymous:unknown",
 	} {
-		req := httptest.NewRequest(http.MethodPost, "/oauth/token", nil)
-		req.RemoteAddr = addr
-		assert.Equalf(t, want, clientAddressKey(req), "address %q", addr)
+		req := requestWithClientIP(http.MethodPost, "/oauth/token", clientIP)
+		assert.Equalf(t, want, clientAddressKey(req), "client IP %q", clientIP)
 	}
 }

--- a/backend/internal/hub/ratelimit/http_test.go
+++ b/backend/internal/hub/ratelimit/http_test.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -99,14 +100,59 @@ func TestAllowHTTPWindowActuallyResets(t *testing.T) {
 		"one window later the budget starts over")
 }
 
-// The verified value is already a canonical IP without a port.
-func TestClientAddressKeyUsesVerifiedClientIP(t *testing.T) {
+// The verified value is already a canonical IP without a port, and it is the
+// PREFERRED key: a request that carries one never falls back.
+func TestAnonymousBudgetKeyUsesVerifiedClientIP(t *testing.T) {
 	for clientIP, want := range map[string]string{
 		"203.0.113.7": "anonymous:203.0.113.7",
 		"2001:db8::1": "anonymous:2001:db8::1",
-		"":            "anonymous:unknown",
 	} {
 		req := requestWithClientIP(http.MethodPost, "/oauth/token", clientIP)
-		assert.Equalf(t, want, clientAddressKey(req), "client IP %q", clientIP)
+		assert.Equalf(t, want, anonymousBudgetKey(req.Context()), "client IP %q", clientIP)
 	}
+}
+
+// The FALLBACK, and the property that makes the shared bucket safe: when the
+// middleware could name no client, the budget keys on the address the kernel
+// accepted the connection from. Without it every request the middleware
+// refuses to name shares ONE bucket with the local IPC socket, so a remote
+// caller could spend the desktop app's window.
+func TestAnonymousBudgetKeyFallsBackToTheTransportPeer(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		addr net.Addr
+		want string
+	}{
+		{"an IPv4 peer", &net.TCPAddr{IP: net.ParseIP("198.51.100.9"), Port: 51234}, "anonymous:198.51.100.9"},
+		{"an IPv6 peer", &net.TCPAddr{IP: net.ParseIP("2001:db8::9"), Port: 51234}, "anonymous:2001:db8::9"},
+		// The zone stays: two link-local peers on different interfaces are
+		// different callers and must not share one budget.
+		{"a link-local peer", &net.TCPAddr{IP: net.ParseIP("fe80::1"), Zone: "en0", Port: 51234}, "anonymous:fe80::1%en0"},
+		// The local IPC socket carries no address, so it stays in the shared
+		// bucket, which is the population that bucket was always for.
+		{"a unix socket", &net.UnixAddr{Net: "unix"}, "anonymous:unknown"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := peer.WithClientIP(peer.WithTransportAddr(context.Background(), test.addr), "")
+			assert.Equal(t, test.want, anonymousBudgetKey(ctx))
+		})
+	}
+}
+
+// A request with NEITHER mark shares the unknown bucket. A test transport is
+// the reachable case.
+func TestAnonymousBudgetKeyWithNoMarksIsUnknown(t *testing.T) {
+	assert.Equal(t, "anonymous:unknown", anonymousBudgetKey(context.Background()))
+}
+
+// The fallback must not be reachable from a header. A caller that could move
+// itself between budgets would defeat both of them.
+func TestAnonymousBudgetKeyIgnoresHeaders(t *testing.T) {
+	addr := &net.TCPAddr{IP: net.ParseIP("198.51.100.9"), Port: 51234}
+	ctx := peer.WithClientIP(peer.WithTransportAddr(context.Background(), addr), "")
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", nil).WithContext(ctx)
+	req.Header.Set("X-Forwarded-For", "10.0.0.1")
+	req.Header.Set("Forwarded", "for=10.0.0.2")
+	assert.Equal(t, "anonymous:198.51.100.9", anonymousBudgetKey(req.Context()),
+		"a forwarding header must not reach the fallback key")
 }

--- a/backend/internal/hub/ratelimit/ratelimit.go
+++ b/backend/internal/hub/ratelimit/ratelimit.go
@@ -771,7 +771,7 @@ func NewInterceptor(m *Manager) connect.UnaryInterceptorFunc {
 // this feature creates.
 func budgetKeyFor(ctx context.Context, m *Manager, spec procedureSpec) (string, bool) {
 	if defaults[spec.op].keyByAddress {
-		return AddressBudgetKey(peer.RemoteHost(ctx)), true
+		return AddressBudgetKey(peer.ClientIP(ctx)), true
 	}
 	user := auth.GetUser(ctx)
 	if user == nil || user.SoloAuthenticated() {

--- a/backend/internal/hub/ratelimit/ratelimit.go
+++ b/backend/internal/hub/ratelimit/ratelimit.go
@@ -18,7 +18,6 @@ import (
 
 	leapmuxv1connect "github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/hub/auth"
-	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/settings"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
 	"github.com/leapmux/leapmux/internal/util/windowed"
@@ -99,8 +98,8 @@ const (
 	// package through AllowHTTP instead.
 	//
 	// It is keyed by CLIENT ADDRESS rather than by user, because there is no
-	// user. See clientAddressKey for what that costs behind a proxy, and why
-	// the budget is sized the way it is.
+	// user. See anonymousBudgetKey for which address that is, and why the
+	// budget is sized the way it is.
 	//
 	// The budget is deliberately generous: a device-code client polls every
 	// five seconds for up to ten minutes, which is 120 requests for ONE
@@ -143,14 +142,37 @@ const (
 	// window, so a person who mistypes twice and then signs in is not held
 	// against their next sign-in.
 	//
-	// The address is the one the hub itself sees, never a forwarded header;
-	// clientAddressKey states why. So a hub behind a reverse proxy shares ONE
-	// budget across every client behind it, and ten failures from anywhere
-	// pause sign-in for all of them. That is the cost of counting only what
-	// the hub can verify, and the operator's answer is the budget key an
-	// administrator can raise, or a sign-in limit in the proxy, which knows
-	// the real client address. The admin-cli chapter says so.
+	// The address is the VERIFIED one, and anonymousBudgetKey states how it is
+	// chosen. A hub that trusts no proxy sees the transport peer, so each
+	// client holds its own budget. A hub that trusts one reads the forwarding
+	// header from that peer alone, so each client behind the proxy still holds
+	// its own. A hub behind an UNCONFIGURED proxy shares one budget across
+	// every client behind it, and ten failures from anywhere pause sign-in for
+	// all of them: the operator's answer is `trusted_proxy_ranges`, a budget an
+	// administrator raises, or a sign-in limit in the proxy. The admin-cli
+	// chapter says so.
 	OpLoginAnonymous Operation = "login_anonymous"
+
+	// OpSoloPasswordSetup limits AuthService.SetInitialSoloPassword, keyed by
+	// CLIENT ADDRESS because the caller is unauthenticated by construction.
+	//
+	// The procedure is PUBLIC and it runs an Argon2 hash. Argon2id costs the
+	// hub 19 MiB and tens of milliseconds for each call. Nothing else stands
+	// in front of it: captcha is off in solo mode by construction, and the
+	// account-has-no-password test that ends the procedure refuses nothing
+	// until the first call succeeds. So the window before a password exists
+	// is a window in which an unauthenticated caller drives memory-hard
+	// hashing at request speed. That window is the exact state
+	// `leapmux solo -listen 0.0.0.0:4327` warns about.
+	//
+	// It counts ADMITTED REQUESTS rather than failures, like OpOAuthAnonymous.
+	// The cost here is the hash, not a wrong answer, and the caller CHOOSES
+	// the password rather than guessing one -- so there is no credential
+	// failure to count, and a failures-only window would never fill.
+	//
+	// It stays ENFORCED in solo mode, and its settings key stays visible
+	// there, because solo is the only mode that serves this procedure at all.
+	OpSoloPasswordSetup Operation = "solo_password_setup"
 )
 
 // Limits is one operation's effective budget.
@@ -303,6 +325,39 @@ var defaults = map[Operation]opSpec{
 		// pour user IDs and addresses into the same window.
 		keyByAddress: true,
 	},
+	OpSoloPasswordSetup: {
+		// Ten in fifteen minutes. An operator sets the first password once,
+		// and a mistyped confirmation costs nothing here, because the
+		// frontend compares the two fields before it calls. Ten leaves room
+		// for a reload and a retry; it caps an attacker at forty Argon2
+		// hashes an hour from one address instead of request speed.
+		limits: Limits{MaxAttempts: 10, WindowSeconds: 900},
+		// Nothing here verifies a secret. The caller CHOOSES the password,
+		// so no answer can be wrong and no failure window would ever fill.
+		isCredentialFailure: func(error) bool { return false },
+		// Counts every request that REACHED the hash, because the hash is
+		// what costs.
+		countsProceededRequests: true,
+		// The refusals that land BEFORE the hash cost nothing, and they must
+		// not consume the window: FailedPrecondition is "not a solo hub" and
+		// "the account already has a password", InvalidArgument is a password
+		// the validator rejects. If they counted, a caller could spend an
+		// operator's whole budget with garbage that never hashed, and the
+		// operator would meet a refusal on the one screen the hub offers
+		// them. Everything else -- a success, or a failure from the hash or
+		// the transaction -- paid the cost and counts.
+		proceedsToBudget: func(err error) bool {
+			code := connect.CodeOf(err)
+			return code != connect.CodeFailedPrecondition && code != connect.CodeInvalidArgument
+		},
+		// Keyed by ADDRESS: this caller has no user yet. It is also the one
+		// unauthenticated procedure a solo hub adds, so the address budget is
+		// the only budget that can hold it.
+		keyByAddress: true,
+		// Solo-only, so an operator who publishes a solo hub must be able to
+		// reach this key. Hiding it in solo would hide it everywhere.
+		hiddenInSolo: false,
+	},
 }
 
 // limitKeys holds one settings key per catalogued operation, derived from
@@ -433,6 +488,10 @@ var procedureOperations = map[string]procedureSpec{
 	// The one UNAUTHENTICATED procedure with a secret to guess. Keyed by
 	// address, counted on failure, cleared on success; see OpLoginAnonymous.
 	leapmuxv1connect.AuthServiceLoginProcedure: {op: OpLoginAnonymous, provesCredential: true},
+	// The other UNAUTHENTICATED procedure that runs an Argon2 hash. It proves
+	// no credential -- the caller chooses the password rather than guessing
+	// one -- so it counts admitted requests instead. See OpSoloPasswordSetup.
+	leapmuxv1connect.AuthServiceSetInitialSoloPasswordProcedure: {op: OpSoloPasswordSetup},
 }
 
 // effectiveLimit is the resolved per-operation policy.
@@ -771,7 +830,7 @@ func NewInterceptor(m *Manager) connect.UnaryInterceptorFunc {
 // this feature creates.
 func budgetKeyFor(ctx context.Context, m *Manager, spec procedureSpec) (string, bool) {
 	if defaults[spec.op].keyByAddress {
-		return AddressBudgetKey(peer.ClientIP(ctx)), true
+		return anonymousBudgetKey(ctx), true
 	}
 	user := auth.GetUser(ctx)
 	if user == nil || user.SoloAuthenticated() {

--- a/backend/internal/hub/ratelimit/ratelimit_solo_test.go
+++ b/backend/internal/hub/ratelimit/ratelimit_solo_test.go
@@ -31,6 +31,11 @@ func TestHiddenInSoloIsADeliberatePerOperationAnswer(t *testing.T) {
 		// would leave a published solo hub with no throttle an operator could
 		// even see.
 		OpLoginAnonymous: false,
+		// Solo is the ONLY mode that serves SetInitialSoloPassword at all, so
+		// hiding this key in solo would hide it everywhere. It is also the one
+		// throttle on an unauthenticated Argon2 hash: captcha is off in solo
+		// by construction.
+		OpSoloPasswordSetup: false,
 	}
 	for _, op := range KnownOperations() {
 		want, recorded := expected[op]

--- a/backend/internal/hub/ratelimit/ratelimit_test.go
+++ b/backend/internal/hub/ratelimit/ratelimit_test.go
@@ -18,6 +18,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	leapmuxv1connect "github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/hub/auth"
+	"github.com/leapmux/leapmux/internal/hub/captcha"
 	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/settings"
 	"github.com/leapmux/leapmux/internal/hub/store/sqlite"
@@ -490,8 +491,9 @@ func TestExpensiveMutationsAreRouted(t *testing.T) {
 		leapmuxv1connect.UserServiceDeletePasskeyProcedure:             false,
 		leapmuxv1connect.UserServiceDeactivatePasskeyAuthProcedure:     false,
 	}
-	// +2: the mail RPC and Login, each asserted on its own below.
-	assert.Len(t, procedureOperations, len(proving)+2,
+	// +3: the mail RPC, Login, and the solo first-password setup, each
+	// asserted on its own below.
+	assert.Len(t, procedureOperations, len(proving)+3,
 		"a procedure added to or removed from the routing map must be reflected here")
 	for procedure, provesCredential := range proving {
 		spec, ok := procedureOperations[procedure]
@@ -523,6 +525,33 @@ func TestExpensiveMutationsAreRouted(t *testing.T) {
 	assert.True(t, defaults[OpLoginAnonymous].keyByAddress, "an unauthenticated caller has no user to key on")
 	assert.False(t, defaults[OpLoginAnonymous].hiddenInSolo,
 		"a solo hub has no captcha in front of Login, so this budget is the only thing limiting it")
+
+	// The other UNAUTHENTICATED procedure that runs an Argon2 hash. It proves
+	// nothing -- the caller chooses the password -- so a failures window would
+	// never fill and only a proceeded-request count caps it.
+	setupSpec, routed := procedureOperations[leapmuxv1connect.AuthServiceSetInitialSoloPasswordProcedure]
+	require.True(t, routed,
+		"SetInitialSoloPassword is public and runs Argon2; unrouted it hashes at request speed")
+	assert.Equal(t, OpSoloPasswordSetup, setupSpec.op)
+	assert.False(t, setupSpec.provesCredential, "the caller chooses this password rather than guessing it")
+	assert.True(t, defaults[OpSoloPasswordSetup].keyByAddress, "an unauthenticated caller has no user to key on")
+	assert.True(t, defaults[OpSoloPasswordSetup].countsProceededRequests,
+		"no answer here can be wrong, so a failures window would never fill")
+	require.NotNil(t, defaults[OpSoloPasswordSetup].proceedsToBudget,
+		"a proceeded-counting operation must classify its outcomes")
+	assert.False(t, defaults[OpSoloPasswordSetup].hiddenInSolo,
+		"solo is the only mode that serves this procedure, so hiding the key in solo hides it everywhere")
+	// The pre-hash refusals cost nothing and must not spend the window, or a
+	// caller could exhaust the operator's budget with garbage that never
+	// hashed.
+	proceeds := defaults[OpSoloPasswordSetup].proceedsToBudget
+	assert.False(t, proceeds(connect.NewError(connect.CodeFailedPrecondition, errors.New("already set"))),
+		"a refusal before the hash costs nothing")
+	assert.False(t, proceeds(connect.NewError(connect.CodeInvalidArgument, errors.New("weak password"))),
+		"a password the validator rejects never reaches the hash")
+	assert.True(t, proceeds(nil), "a success ran the hash")
+	assert.True(t, proceeds(connect.NewError(connect.CodeInternal, errors.New("store failed"))),
+		"a failure after the hash still paid for it")
 
 	// The negative half, and it is the half OpElevation's doc has to keep
 	// true. UnlinkOAuthProvider is an elevation-admitted mutation, so a
@@ -574,7 +603,7 @@ func TestPanickingHandlerReleasesReservation(t *testing.T) {
 }
 
 func TestKnownOperationsSortedAndEffectiveLimitsOverlay(t *testing.T) {
-	assert.Equal(t, []Operation{OpElevation, OpEmailChange, OpLoginAnonymous, OpOAuthAnonymous}, KnownOperations())
+	assert.Equal(t, []Operation{OpElevation, OpEmailChange, OpLoginAnonymous, OpOAuthAnonymous, OpSoloPasswordSetup}, KnownOperations())
 
 	// No row: defaults, enabled.
 	m := newTestManager(t)
@@ -739,9 +768,39 @@ func TestElevationBudgetIsSharedByBothFactorPaths(t *testing.T) {
 // finishes with, and every passkey procedure carries it. Without that entry
 // the walk covers ElevateSession alone -- and it would say so silently,
 // because a shorter walk still passes.
+//
+// `password` and `new_password` are on the list because a procedure that
+// ACCEPTS a password hashes it, and an Argon2 hash is expensive to repeat
+// whether or not the caller had to guess the value. SetInitialSoloPassword
+// shipped unrouted because the walk covered `user.proto` alone and matched
+// neither name.
 var credentialBearingFields = map[string]bool{
 	"current_password": true,
 	"credential_json":  true,
+	"password":         true,
+	"new_password":     true,
+}
+
+// credentialWalkFiles are the proto files the walk covers. Both carry
+// procedures that verify or hash a secret, and a file left out of this list
+// is a whole service the tripwire cannot see. `auth.proto` was missing, which
+// is how SetInitialSoloPassword shipped unrouted.
+var credentialWalkFiles = []string{"leapmux/v1/user.proto", "leapmux/v1/auth.proto"}
+
+// ceremonyFinishExemptions are the credential-bearing procedures that neither
+// a budget nor a captcha guards, and the reason each one needs neither.
+//
+// All of them are the FINISH stage of a ceremony. A Finish can only spend a
+// short-lived session that its own Begin minted, and the Begin carries the
+// captcha, so the toll is already paid upstream and a Finish an attacker
+// repeats has nothing to spend. The captcha package states the same
+// exemptions in captchaExemptRationale; this map is the rate-limit side of
+// the same decision, and a NEW credential-bearing procedure still fails the
+// walk unless somebody adds it here on purpose.
+var ceremonyFinishExemptions = map[string]string{
+	leapmuxv1connect.AuthServiceFinishPasskeyLoginProcedure:           "consumes a short-lived ceremony session; the captcha'd Begin did the expensive work",
+	leapmuxv1connect.AuthServiceFinishPasskeySignUpProcedure:          "consumes a short-lived ceremony session; the captcha'd Begin did the expensive work",
+	leapmuxv1connect.AuthServiceFinishAccountRecoveryPasskeyProcedure: "consumes a short-lived ceremony session the captcha'd Begin minted",
 }
 
 // TestCredentialConsumingProceduresAreRouted walks the live user.proto
@@ -751,36 +810,44 @@ var credentialBearingFields = map[string]bool{
 // unlimited retries while its siblings are capped, and only a descriptor
 // walk catches the forgotten direction.
 func TestCredentialConsumingProceduresAreRouted(t *testing.T) {
-	fd, err := protoregistry.GlobalFiles.FindFileByPath("leapmux/v1/user.proto")
-	require.NoError(t, err, "user.proto descriptor must be registered; import the generated pb package")
-	services := fd.Services()
-	require.Equal(t, 1, services.Len(), "expected exactly the UserService in user.proto")
-	methods := services.Get(0).Methods()
 	covered := 0
-	for i := 0; i < methods.Len(); i++ {
-		method := methods.Get(i)
-		consumesSecret := false
-		fields := method.Input().Fields()
-		for j := 0; j < fields.Len(); j++ {
-			if credentialBearingFields[string(fields.Get(j).Name())] {
-				consumesSecret = true
-				break
+	for _, path := range credentialWalkFiles {
+		fd, err := protoregistry.GlobalFiles.FindFileByPath(path)
+		require.NoErrorf(t, err, "%s descriptor must be registered; import the generated pb package", path)
+		services := fd.Services()
+		require.Equalf(t, 1, services.Len(), "expected exactly one service in %s", path)
+		service := services.Get(0)
+		methods := service.Methods()
+		for i := 0; i < methods.Len(); i++ {
+			method := methods.Get(i)
+			consumesSecret := false
+			fields := method.Input().Fields()
+			for j := 0; j < fields.Len(); j++ {
+				if credentialBearingFields[string(fields.Get(j).Name())] {
+					consumesSecret = true
+					break
+				}
 			}
+			if !consumesSecret {
+				continue
+			}
+			covered++
+			procedure := "/" + string(service.FullName()) + "/" + string(method.Name())
+			_, routed := procedureOperations[procedure]
+			// A BUDGET, a CAPTCHA, or a written ceremony-Finish exemption.
+			// The first two stop a caller repeating the work; the third
+			// records why repeating it costs nothing. Demanding a budget
+			// alone would report every captcha'd procedure.
+			_, exempt := ceremonyFinishExemptions[procedure]
+			assert.Truef(t, routed || captcha.IsProtected(procedure) || exempt,
+				"%s.%s carries a credential but has no procedureOperations entry, no captcha, and no written exemption; it ships with unlimited retries (procedure %q)",
+				service.Name(), method.Name(), procedure)
 		}
-		if !consumesSecret {
-			continue
-		}
-		covered++
-		procedure := "/" + string(services.Get(0).FullName()) + "/" + string(method.Name())
-		_, routed := procedureOperations[procedure]
-		assert.Truef(t, routed,
-			"UserService.%s carries a credential but has no procedureOperations entry; it ships with unlimited retries (procedure %q)",
-			method.Name(), procedure)
 	}
 	// Non-vacuity: a walk that matched nothing would pass while covering
 	// nothing, which is what a renamed field would silently produce.
-	assert.GreaterOrEqual(t, covered, 3,
-		"the walk found fewer credential-bearing procedures than exist; check credentialBearingFields against user.proto")
+	assert.GreaterOrEqual(t, covered, 8,
+		"the walk found fewer credential-bearing procedures than exist; check credentialBearingFields and credentialWalkFiles against the protos")
 }
 
 func TestValidateLimits(t *testing.T) {
@@ -910,8 +977,8 @@ func TestSpentFailureWindowStillAdmitsTheProceduresThatVerifyNothing(t *testing.
 			"%s verifies no secret, so a wrong-password burst must not deny it", procedure)
 		m.complete(a, nil)
 	}
-	require.Equal(t, 8, nonProving,
-		"the routing map must still carry the seven mutations an elevation admits, plus email change")
+	require.Equal(t, 9, nonProving,
+		"the routing map must still carry the seven mutations an elevation admits, plus email change and the solo first-password setup")
 
 	// And the window is untouched by those admissions: a procedure that
 	// proves nothing must neither spend the budget nor clear it.

--- a/backend/internal/hub/ratelimit/ratelimit_test.go
+++ b/backend/internal/hub/ratelimit/ratelimit_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -985,8 +984,7 @@ func TestBudgetKeyFor(t *testing.T) {
 	loginSpec := procedureOperations[leapmuxv1connect.AuthServiceLoginProcedure]
 	elevationSpec := procedureOperations[leapmuxv1connect.UserServiceElevateSessionProcedure]
 
-	remote := peer.WithRemoteAddr(context.Background(),
-		&net.TCPAddr{IP: net.ParseIP("192.168.1.24"), Port: 51234})
+	remote := peer.WithClientIP(context.Background(), "192.168.1.24")
 
 	t.Run("an address-keyed operation counts an unauthenticated caller", func(t *testing.T) {
 		key, ok := budgetKeyFor(remote, newTestManager(t), loginSpec)
@@ -1000,9 +998,8 @@ func TestBudgetKeyFor(t *testing.T) {
 		assert.Equal(t, "anonymous:192.168.1.24", key)
 	})
 
-	t.Run("two ports of one caller share a budget", func(t *testing.T) {
-		second := peer.WithRemoteAddr(context.Background(),
-			&net.TCPAddr{IP: net.ParseIP("192.168.1.24"), Port: 51235})
+	t.Run("one verified client IP uses one budget", func(t *testing.T) {
+		second := peer.WithClientIP(context.Background(), "192.168.1.24")
 		first, _ := budgetKeyFor(remote, newTestManager(t), loginSpec)
 		other, _ := budgetKeyFor(second, newTestManager(t), loginSpec)
 		assert.Equal(t, first, other, "a fresh connection per guess must not mint a fresh budget")

--- a/backend/internal/hub/requestsource/middleware.go
+++ b/backend/internal/hub/requestsource/middleware.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"slices"
 	"strings"
 
 	"github.com/realclientip/realclientip-go"
@@ -129,7 +130,10 @@ func parseForwarded(values []string) ([]forwardedElement, error) {
 			return nil, fmt.Errorf("invalid Forwarded element")
 		}
 		element := forwardedElement{}
-		seen := make(map[string]struct{}, len(parts))
+		// A SLICE, not a map. RFC 7239 gives an element four parameter names,
+		// so this scan is over a handful of entries, and a map would allocate
+		// once per element of every header the hub parses.
+		seen := make([]string, 0, len(parts))
 		for _, part := range parts {
 			name, rawValue, ok := strings.Cut(strings.TrimSpace(part), "=")
 			name = strings.ToLower(strings.TrimSpace(name))
@@ -137,10 +141,14 @@ func parseForwarded(values []string) ([]forwardedElement, error) {
 			if !ok || !isToken(name) || rawValue == "" {
 				return nil, fmt.Errorf("invalid Forwarded parameter")
 			}
-			if _, duplicate := seen[name]; duplicate {
+			// A REPEATED parameter is refused rather than resolved. RFC 7239
+			// forbids it, and two `for` values in one element are a request to
+			// pick -- so any choice here would be a parser deciding which
+			// client address an attacker meant.
+			if slices.Contains(seen, name) {
 				return nil, fmt.Errorf("duplicate Forwarded parameter %q", name)
 			}
-			seen[name] = struct{}{}
+			seen = append(seen, name)
 			value, quoted, err := parseParameterValue(rawValue)
 			if err != nil {
 				return nil, err

--- a/backend/internal/hub/requestsource/middleware.go
+++ b/backend/internal/hub/requestsource/middleware.go
@@ -41,47 +41,60 @@ func resolve(r *http.Request, trusted TrustedRanges) (string, string) {
 		directScheme = "https"
 	}
 
+	// The UNCHANGED transport peer decides everything below. A peer no
+	// strategy can parse -- the local IPC socket, a test transport -- reports
+	// an unknown client, and no header may supply one in its place.
 	peerIP := realclientip.RemoteAddrStrategy{}.ClientIP(nil, r.RemoteAddr)
 	peerAddr, err := netip.ParseAddr(peerIP)
 	if err != nil {
 		return "", directScheme
 	}
-	peerTrusted := trusted.Contains(peerAddr)
-	headerName := xForwardedForHeader
+	if !trusted.Contains(peerAddr) {
+		// Every forwarding header is caller-controlled here, so the peer
+		// itself is the rightmost untrusted address and the connection states
+		// its own protocol.
+		return peerIP, directScheme
+	}
+	// Forwarded WINS whenever it exists, and there is no fallback: a proxy
+	// that sends it owns the whole answer, so reading the X-Forwarded headers
+	// after a malformed one would let a second writer supply the client.
 	if _, exists := r.Header[forwardedHeader]; exists {
-		headerName = forwardedHeader
+		return resolveForwarded(r, trusted)
 	}
-	if !peerTrusted {
-		clientIP := trusted.xForwardedFor.ClientIP(r.Header, r.RemoteAddr)
-		if headerName == forwardedHeader {
-			clientIP = trusted.forwarded.ClientIP(r.Header, r.RemoteAddr)
-		}
-		return clientIP, directScheme
-	}
-	if headerName == forwardedHeader {
-		elements, err := parseForwarded(r.Header[forwardedHeader])
-		if err != nil {
-			return "", "http"
-		}
-		clientIP := trusted.forwarded.ClientIP(forwardedIPHeader(elements), r.RemoteAddr)
-		if clientIP == "" {
-			return "", "http"
-		}
-		index := rightmostAddressIndex(elements, clientIP)
-		if index < 0 {
-			return "", "http"
-		}
-		return clientIP, validProtocol(elements[index].protocol)
-	}
+	return resolveXForwarded(r, trusted)
+}
 
+// resolveForwarded answers from RFC 7239 Forwarded. A malformed header, or a
+// chain whose addresses are all trusted, reports an unknown client.
+func resolveForwarded(r *http.Request, trusted TrustedRanges) (string, string) {
+	elements, err := parseForwarded(r.Header[forwardedHeader])
+	if err != nil {
+		return "", "http"
+	}
+	// A REBUILT header carrying the `for` values alone. The library splits the
+	// raw header on every comma, quoted or not, so a quoted comma inside any
+	// other parameter (`host="edge,one"`) would split one element into two
+	// there. The local parser above respects the quoting, and this hands the
+	// library a form that cannot be split wrongly.
+	clientIP := trusted.forwarded.ClientIP(forwardedIPHeader(elements), r.RemoteAddr)
+	// An empty clientIP parses to no address, so this ALSO covers the "no
+	// client address in the chain" case.
+	index := rightmostAddressIndex(elements, clientIP)
+	if index < 0 {
+		return "", "http"
+	}
+	return clientIP, validProtocol(elements[index].protocol)
+}
+
+// resolveXForwarded answers from X-Forwarded-For and X-Forwarded-Proto, which
+// carry no element metadata: the protocol list stands beside the address list
+// rather than inside it.
+func resolveXForwarded(r *http.Request, trusted TrustedRanges) (string, string) {
 	addresses, err := parseXForwardedFor(r.Header[xForwardedForHeader])
 	if err != nil {
 		return "", "http"
 	}
 	clientIP := trusted.xForwardedFor.ClientIP(r.Header, r.RemoteAddr)
-	if clientIP == "" {
-		return "", "http"
-	}
 	index := rightmostAddressIndex(addresses, clientIP)
 	if index < 0 {
 		return "", "http"
@@ -96,14 +109,14 @@ type forwardedElement struct {
 }
 
 func parseForwarded(values []string) ([]forwardedElement, error) {
-	items, err := splitOutsideQuotes(values, ',')
-	if err != nil || len(items) == 0 {
+	items, err := splitElements(values)
+	if err != nil {
 		return nil, fmt.Errorf("invalid Forwarded header")
 	}
 	elements := make([]forwardedElement, 0, len(items))
 	for _, item := range items {
-		parts, err := splitOutsideQuotes([]string{item}, ';')
-		if err != nil || len(parts) == 0 {
+		parts, err := splitOutsideQuotes(item, ';')
+		if err != nil {
 			return nil, fmt.Errorf("invalid Forwarded element")
 		}
 		element := forwardedElement{}
@@ -155,8 +168,8 @@ func forwardedIPHeader(elements []forwardedElement) http.Header {
 }
 
 func parseXForwardedFor(values []string) ([]forwardedElement, error) {
-	items, err := splitOutsideQuotes(values, ',')
-	if err != nil || len(items) == 0 {
+	items, err := splitElements(values)
+	if err != nil {
 		return nil, fmt.Errorf("invalid X-Forwarded-For header")
 	}
 	elements := make([]forwardedElement, 0, len(items))
@@ -170,49 +183,70 @@ func parseXForwardedFor(values []string) ([]forwardedElement, error) {
 	return elements, nil
 }
 
-func splitOutsideQuotes(values []string, separator byte) ([]string, error) {
+// splitElements splits every LINE of one header into its list elements.
+//
+// net/http keeps one entry per header line, and RFC 9110 says that repeated
+// lines carry the same meaning as one comma-joined line. So each line supplies
+// its own elements, and a quoted string never crosses a line: joining the
+// lines into one string first would make the joining comma part of an element
+// instead of a separator, and a two-line chain would parse as one malformed
+// address. Splitting per line also matches how the IP library walks the same
+// header, so the index this package selects addresses the same element.
+func splitElements(values []string) ([]string, error) {
+	var items []string
+	for _, value := range values {
+		lineItems, err := splitOutsideQuotes(value, ',')
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, lineItems...)
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("the header carries no element")
+	}
+	return items, nil
+}
+
+// splitOutsideQuotes splits one header line on separator and keeps a separator
+// inside a quoted string as ordinary text.
+func splitOutsideQuotes(value string, separator byte) ([]string, error) {
 	var items []string
 	var current strings.Builder
 	inQuote := false
 	escaped := false
-	for valueIndex, value := range values {
-		if valueIndex > 0 {
-			current.WriteByte(',')
-		}
-		for index := 0; index < len(value); index++ {
-			char := value[index]
-			if escaped {
-				if char < 0x20 || char == 0x7f {
-					return nil, fmt.Errorf("invalid quoted escape")
-				}
-				current.WriteByte(char)
-				escaped = false
-				continue
-			}
-			if inQuote && char == '\\' {
-				current.WriteByte(char)
-				escaped = true
-				continue
-			}
-			if char == '"' {
-				inQuote = !inQuote
-				current.WriteByte(char)
-				continue
-			}
-			if !inQuote && char == separator {
-				item := strings.TrimSpace(current.String())
-				if item == "" {
-					return nil, fmt.Errorf("empty header element")
-				}
-				items = append(items, item)
-				current.Reset()
-				continue
-			}
-			if char == '\r' || char == '\n' {
-				return nil, fmt.Errorf("invalid control character")
+	for index := 0; index < len(value); index++ {
+		char := value[index]
+		if escaped {
+			if char < 0x20 || char == 0x7f {
+				return nil, fmt.Errorf("invalid quoted escape")
 			}
 			current.WriteByte(char)
+			escaped = false
+			continue
 		}
+		if inQuote && char == '\\' {
+			current.WriteByte(char)
+			escaped = true
+			continue
+		}
+		if char == '"' {
+			inQuote = !inQuote
+			current.WriteByte(char)
+			continue
+		}
+		if !inQuote && char == separator {
+			item := strings.TrimSpace(current.String())
+			if item == "" {
+				return nil, fmt.Errorf("empty header element")
+			}
+			items = append(items, item)
+			current.Reset()
+			continue
+		}
+		if char == '\r' || char == '\n' {
+			return nil, fmt.Errorf("invalid control character")
+		}
+		current.WriteByte(char)
 	}
 	if inQuote || escaped {
 		return nil, fmt.Errorf("unterminated quoted value")
@@ -339,7 +373,7 @@ func rightmostAddressIndex(elements []forwardedElement, clientIP string) int {
 }
 
 func xForwardedProtocol(values []string, selected, addressCount int) string {
-	items, err := splitOutsideQuotes(values, ',')
+	items, err := splitElements(values)
 	if err != nil {
 		return "http"
 	}

--- a/backend/internal/hub/requestsource/middleware.go
+++ b/backend/internal/hub/requestsource/middleware.go
@@ -1,6 +1,7 @@
 package requestsource
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -20,28 +21,47 @@ const (
 	xForwardedProtocolHeader = "X-Forwarded-Proto"
 )
 
-// Middleware records the verified client IP and effective URL scheme. It
-// leaves Request.RemoteAddr and Request.TLS unchanged.
-func Middleware(manager *settings.Manager, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		trusted := TrustedRanges{}
-		if manager != nil {
-			trusted = KeyTrustedProxyRanges.Of(manager.Snapshot(r.Context()))
-		}
-		clientIP, scheme := resolve(r, trusted)
-		ctx := peer.WithClientIP(r.Context(), clientIP)
+// TrustedRangesFunc supplies the configured trusted proxies for one request.
+//
+// It is a function rather than the settings manager itself so the middleware
+// depends on the ONE value it reads instead of the whole settings surface, and
+// so a test can state a trust set without opening a store. RangesFromSettings
+// is the production spelling.
+type TrustedRangesFunc func(context.Context) TrustedRanges
 
-		// A SHALLOW copy plus a copy of the URL, not r.Clone. This runs on
-		// every request the hub serves, and Clone deep-copies the header map,
-		// the trailer, the transfer encoding and the parsed forms -- a slice
-		// allocation per header to change one string. The only field this
-		// middleware writes is URL.Scheme, so the URL is the one value that
-		// must not stay shared with the caller's request.
-		request := r.WithContext(ctx)
-		url := *r.URL
-		url.Scheme = scheme
-		request.URL = &url
-		next.ServeHTTP(w, request)
+// RangesFromSettings reads the configured trusted proxies from a settings
+// manager. A nil manager trusts nothing, which is the shipped default.
+func RangesFromSettings(manager *settings.Manager) TrustedRangesFunc {
+	if manager == nil {
+		return func(context.Context) TrustedRanges { return TrustedRanges{} }
+	}
+	return func(ctx context.Context) TrustedRanges {
+		return KeyTrustedProxyRanges.Of(manager.Snapshot(ctx))
+	}
+}
+
+// Middleware records the verified client IP and protocol on the request
+// context. It leaves Request.RemoteAddr, Request.TLS and Request.URL
+// unchanged.
+//
+// Both answers go in the CONTEXT rather than onto the request, and the
+// protocol used to be written to `URL.Scheme` instead. Nothing read it there:
+// `URL.RequestURI()` ignores the scheme for a server request, and no handler
+// in this hub consults it. The context is where every consumer that needs the
+// answer already looks -- a Connect interceptor holds one, and a WebSocket
+// handler holds a request whose context descends from the same connection --
+// so one home for the fact is also the only home a caller can reach.
+//
+// A SHALLOW copy, not r.Clone. This runs on every request the hub serves, and
+// Clone deep-copies the header map, the trailer, the transfer encoding and the
+// parsed forms. Nothing here writes a field of the request itself, so
+// `r.WithContext` is the whole copy that is needed.
+func Middleware(trustedRanges TrustedRangesFunc, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		trusted := trustedRanges(r.Context())
+		clientIP, scheme := resolve(r, trusted)
+		ctx := peer.WithHTTPS(peer.WithClientIP(r.Context(), clientIP), scheme == "https")
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
@@ -59,7 +79,19 @@ func resolve(r *http.Request, trusted TrustedRanges) (string, string) {
 	if err != nil {
 		return "", directScheme
 	}
-	if !trusted.Contains(peerAddr) {
+	// The ZONE is dropped for the TRUST TEST alone. An accepted link-local
+	// IPv6 connection carries one (`fe80::1%en0`), and netipx refuses a zoned
+	// address outright -- `IPSet.Contains` returns false before it compares
+	// anything. So a trusted range would never match a link-local proxy, and
+	// the operator would see their configured proxy's headers ignored with no
+	// error and no log line. A zone identifies the INTERFACE the address is
+	// reachable on; the range is a set of addresses, and the two are separate
+	// questions.
+	//
+	// The zone stays on peerIP, which is what the caller reports as the
+	// client, because there it IS part of the identity: two peers on different
+	// interfaces can carry the same link-local address.
+	if !trusted.Contains(peerAddr.WithZone("")) {
 		// Every forwarding header is caller-controlled here, so the peer
 		// itself is the rightmost untrusted address and the connection states
 		// its own protocol.
@@ -81,19 +113,11 @@ func resolveForwarded(r *http.Request, trusted TrustedRanges) (string, string) {
 	if err != nil {
 		return "", "http"
 	}
-	// A REBUILT header carrying the `for` values alone. The library splits the
-	// raw header on every comma, quoted or not, so a quoted comma inside any
-	// other parameter (`host="edge,one"`) would split one element into two
-	// there. The local parser above respects the quoting, and this hands the
-	// library a form that cannot be split wrongly.
-	clientIP := trusted.forwarded.ClientIP(forwardedIPHeader(elements), r.RemoteAddr)
-	// An empty clientIP parses to no address, so this ALSO covers the "no
-	// client address in the chain" case.
-	index := rightmostAddressIndex(elements, clientIP)
-	if index < 0 {
+	index, ok := rightmostUntrusted(elements, trusted)
+	if !ok {
 		return "", "http"
 	}
-	return clientIP, validProtocol(elements[index].protocol)
+	return elements[index].address.Unmap().String(), validProtocol(elements[index].protocol)
 }
 
 // resolveXForwarded answers from X-Forwarded-For and X-Forwarded-Proto, which
@@ -104,18 +128,50 @@ func resolveXForwarded(r *http.Request, trusted TrustedRanges) (string, string) 
 	if err != nil {
 		return "", "http"
 	}
-	clientIP := trusted.xForwardedFor.ClientIP(r.Header, r.RemoteAddr)
-	index := rightmostAddressIndex(addresses, clientIP)
-	if index < 0 {
+	index, ok := rightmostUntrusted(addresses, trusted)
+	if !ok {
 		return "", "http"
 	}
-	return clientIP, xForwardedProtocol(r.Header[xForwardedProtocolHeader], index, len(addresses))
+	return addresses[index].address.Unmap().String(),
+		xForwardedProtocol(r.Header[xForwardedProtocolHeader], index, len(addresses))
+}
+
+// rightmostUntrusted walks the chain from the right and reports the first
+// element that is not a trusted proxy: the client, as far as the trusted
+// infrastructure can vouch for it.
+//
+// It walks the elements THIS package parsed, rather than handing a rebuilt
+// header back to the IP library and then finding the chosen element again by
+// matching its address as a string. That round trip needed two parsers to keep
+// agreeing about where one element ends and the next begins, re-parsed every
+// address, and re-tested every hop against a linear scan of the same range set
+// this package already holds as a sorted set.
+//
+// The rule is the library's, unchanged. Skip an element whose address is valid
+// AND trusted. Stop at the first element that is not skipped. An element with
+// NO usable address stops the walk with no answer, because an obfuscated or
+// `unknown` node hides exactly the address the caller would report -- so the
+// chain names no client, and inventing one from further left would let a proxy
+// nominate any address it liked. A chain that is empty, or trusted end to end,
+// also names no client.
+//
+// The caller reaching here already proved the transport peer is trusted, so
+// the library's own "untrusted peer, answer with the peer" branch is
+// unreachable from this package and has no counterpart here.
+func rightmostUntrusted(elements []forwardedElement, trusted TrustedRanges) (int, bool) {
+	for index := len(elements) - 1; index >= 0; index-- {
+		address := elements[index].address
+		if address.IsValid() && trusted.Contains(address) {
+			continue
+		}
+		return index, address.IsValid()
+	}
+	return 0, false
 }
 
 type forwardedElement struct {
 	address  netip.Addr
 	protocol string
-	forValue string
 }
 
 func parseForwarded(values []string) ([]forwardedElement, error) {
@@ -155,7 +211,6 @@ func parseForwarded(values []string) ([]forwardedElement, error) {
 			}
 			switch name {
 			case "for":
-				element.forValue = rawValue
 				addr, present, err := parseForwardedNode(value, quoted)
 				if err != nil {
 					return nil, err
@@ -170,18 +225,6 @@ func parseForwarded(values []string) ([]forwardedElement, error) {
 		elements = append(elements, element)
 	}
 	return elements, nil
-}
-
-func forwardedIPHeader(elements []forwardedElement) http.Header {
-	values := make([]string, len(elements))
-	for index, element := range elements {
-		value := element.forValue
-		if value == "" {
-			value = "unknown"
-		}
-		values[index] = "for=" + value
-	}
-	return http.Header{forwardedHeader: []string{strings.Join(values, ", ")}}
 }
 
 func parseXForwardedFor(values []string) ([]forwardedElement, error) {
@@ -204,11 +247,12 @@ func parseXForwardedFor(values []string) ([]forwardedElement, error) {
 //
 // net/http keeps one entry per header line, and RFC 9110 says that repeated
 // lines carry the same meaning as one comma-joined line. So each line supplies
-// its own elements, and a quoted string never crosses a line: joining the
-// lines into one string first would make the joining comma part of an element
-// instead of a separator, and a two-line chain would parse as one malformed
-// address. Splitting per line also matches how the IP library walks the same
-// header, so the index this package selects addresses the same element.
+// its own elements. A quoted string never crosses a line. If the code joined
+// the lines into one string first, the joining comma would become part of an
+// element instead of a separator, and a two-line chain would parse as one
+// malformed address. Splitting per line also matches how the IP library walks
+// the same header, so the index this package selects addresses the same
+// element.
 func splitElements(values []string) ([]string, error) {
 	var items []string
 	for _, value := range values {
@@ -375,20 +419,19 @@ func parseHeaderAddress(value string) (netip.Addr, error) {
 	return addr.Unmap(), nil
 }
 
-func rightmostAddressIndex(elements []forwardedElement, clientIP string) int {
-	wanted, err := netip.ParseAddr(clientIP)
-	if err != nil {
-		return -1
-	}
-	wanted = wanted.Unmap()
-	for index := len(elements) - 1; index >= 0; index-- {
-		if elements[index].address.IsValid() && elements[index].address.Unmap() == wanted {
-			return index
-		}
-	}
-	return -1
-}
-
+// xForwardedProtocol reads the protocol that belongs to the selected address.
+//
+// X-Forwarded-Proto carries no element metadata, so the two lists are matched
+// by POSITION. One value states the protocol for the whole chain. A list as
+// long as the address list is per-hop, and the selected index picks from it.
+// Any other length is a chain the hub cannot align, and an unaligned protocol
+// is not a protocol -- reading one at the wrong index would report a hop's
+// answer as the client's.
+//
+// `selected` is an index into the address list, which the caller obtained from
+// the chain walk, so it is always in range for a list of equal length. No guard
+// restates that here, because a guard on a state the caller excluded reads as
+// though the state can occur.
 func xForwardedProtocol(values []string, selected, addressCount int) string {
 	items, err := splitElements(values)
 	if err != nil {
@@ -397,7 +440,7 @@ func xForwardedProtocol(values []string, selected, addressCount int) string {
 	if len(items) == 1 {
 		return validProtocol(items[0])
 	}
-	if len(items) == addressCount && selected >= 0 && selected < len(items) {
+	if len(items) == addressCount {
 		return validProtocol(items[selected])
 	}
 	return "http"

--- a/backend/internal/hub/requestsource/middleware.go
+++ b/backend/internal/hub/requestsource/middleware.go
@@ -29,8 +29,17 @@ func Middleware(manager *settings.Manager, next http.Handler) http.Handler {
 		}
 		clientIP, scheme := resolve(r, trusted)
 		ctx := peer.WithClientIP(r.Context(), clientIP)
-		request := r.Clone(ctx)
-		request.URL.Scheme = scheme
+
+		// A SHALLOW copy plus a copy of the URL, not r.Clone. This runs on
+		// every request the hub serves, and Clone deep-copies the header map,
+		// the trailer, the transfer encoding and the parsed forms -- a slice
+		// allocation per header to change one string. The only field this
+		// middleware writes is URL.Scheme, so the URL is the one value that
+		// must not stay shared with the caller's request.
+		request := r.WithContext(ctx)
+		url := *r.URL
+		url.Scheme = scheme
+		request.URL = &url
 		next.ServeHTTP(w, request)
 	})
 }

--- a/backend/internal/hub/requestsource/middleware.go
+++ b/backend/internal/hub/requestsource/middleware.go
@@ -1,0 +1,390 @@
+package requestsource
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+
+	"github.com/realclientip/realclientip-go"
+
+	"github.com/leapmux/leapmux/internal/hub/peer"
+	"github.com/leapmux/leapmux/internal/hub/settings"
+)
+
+const (
+	forwardedHeader          = "Forwarded"
+	xForwardedForHeader      = "X-Forwarded-For"
+	xForwardedProtocolHeader = "X-Forwarded-Proto"
+)
+
+// Middleware records the verified client IP and effective URL scheme. It
+// leaves Request.RemoteAddr and Request.TLS unchanged.
+func Middleware(manager *settings.Manager, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		trusted := TrustedRanges{}
+		if manager != nil {
+			trusted = KeyTrustedProxyRanges.Of(manager.Snapshot(r.Context()))
+		}
+		clientIP, scheme := resolve(r, trusted)
+		ctx := peer.WithClientIP(r.Context(), clientIP)
+		request := r.Clone(ctx)
+		request.URL.Scheme = scheme
+		next.ServeHTTP(w, request)
+	})
+}
+
+func resolve(r *http.Request, trusted TrustedRanges) (string, string) {
+	directScheme := "http"
+	if r.TLS != nil {
+		directScheme = "https"
+	}
+
+	peerIP := realclientip.RemoteAddrStrategy{}.ClientIP(nil, r.RemoteAddr)
+	peerAddr, err := netip.ParseAddr(peerIP)
+	if err != nil {
+		return "", directScheme
+	}
+	peerTrusted := trusted.Contains(peerAddr)
+	headerName := xForwardedForHeader
+	if _, exists := r.Header[forwardedHeader]; exists {
+		headerName = forwardedHeader
+	}
+	if !peerTrusted {
+		clientIP := trusted.xForwardedFor.ClientIP(r.Header, r.RemoteAddr)
+		if headerName == forwardedHeader {
+			clientIP = trusted.forwarded.ClientIP(r.Header, r.RemoteAddr)
+		}
+		return clientIP, directScheme
+	}
+	if headerName == forwardedHeader {
+		elements, err := parseForwarded(r.Header[forwardedHeader])
+		if err != nil {
+			return "", "http"
+		}
+		clientIP := trusted.forwarded.ClientIP(forwardedIPHeader(elements), r.RemoteAddr)
+		if clientIP == "" {
+			return "", "http"
+		}
+		index := rightmostAddressIndex(elements, clientIP)
+		if index < 0 {
+			return "", "http"
+		}
+		return clientIP, validProtocol(elements[index].protocol)
+	}
+
+	addresses, err := parseXForwardedFor(r.Header[xForwardedForHeader])
+	if err != nil {
+		return "", "http"
+	}
+	clientIP := trusted.xForwardedFor.ClientIP(r.Header, r.RemoteAddr)
+	if clientIP == "" {
+		return "", "http"
+	}
+	index := rightmostAddressIndex(addresses, clientIP)
+	if index < 0 {
+		return "", "http"
+	}
+	return clientIP, xForwardedProtocol(r.Header[xForwardedProtocolHeader], index, len(addresses))
+}
+
+type forwardedElement struct {
+	address  netip.Addr
+	protocol string
+	forValue string
+}
+
+func parseForwarded(values []string) ([]forwardedElement, error) {
+	items, err := splitOutsideQuotes(values, ',')
+	if err != nil || len(items) == 0 {
+		return nil, fmt.Errorf("invalid Forwarded header")
+	}
+	elements := make([]forwardedElement, 0, len(items))
+	for _, item := range items {
+		parts, err := splitOutsideQuotes([]string{item}, ';')
+		if err != nil || len(parts) == 0 {
+			return nil, fmt.Errorf("invalid Forwarded element")
+		}
+		element := forwardedElement{}
+		seen := make(map[string]struct{}, len(parts))
+		for _, part := range parts {
+			name, rawValue, ok := strings.Cut(strings.TrimSpace(part), "=")
+			name = strings.ToLower(strings.TrimSpace(name))
+			rawValue = strings.TrimSpace(rawValue)
+			if !ok || !isToken(name) || rawValue == "" {
+				return nil, fmt.Errorf("invalid Forwarded parameter")
+			}
+			if _, duplicate := seen[name]; duplicate {
+				return nil, fmt.Errorf("duplicate Forwarded parameter %q", name)
+			}
+			seen[name] = struct{}{}
+			value, quoted, err := parseParameterValue(rawValue)
+			if err != nil {
+				return nil, err
+			}
+			switch name {
+			case "for":
+				element.forValue = rawValue
+				addr, present, err := parseForwardedNode(value, quoted)
+				if err != nil {
+					return nil, err
+				}
+				if present {
+					element.address = addr
+				}
+			case "proto":
+				element.protocol = value
+			}
+		}
+		elements = append(elements, element)
+	}
+	return elements, nil
+}
+
+func forwardedIPHeader(elements []forwardedElement) http.Header {
+	values := make([]string, len(elements))
+	for index, element := range elements {
+		value := element.forValue
+		if value == "" {
+			value = "unknown"
+		}
+		values[index] = "for=" + value
+	}
+	return http.Header{forwardedHeader: []string{strings.Join(values, ", ")}}
+}
+
+func parseXForwardedFor(values []string) ([]forwardedElement, error) {
+	items, err := splitOutsideQuotes(values, ',')
+	if err != nil || len(items) == 0 {
+		return nil, fmt.Errorf("invalid X-Forwarded-For header")
+	}
+	elements := make([]forwardedElement, 0, len(items))
+	for _, item := range items {
+		addr, err := parseHeaderAddress(strings.TrimSpace(item))
+		if err != nil {
+			return nil, fmt.Errorf("invalid X-Forwarded-For address: %w", err)
+		}
+		elements = append(elements, forwardedElement{address: addr})
+	}
+	return elements, nil
+}
+
+func splitOutsideQuotes(values []string, separator byte) ([]string, error) {
+	var items []string
+	var current strings.Builder
+	inQuote := false
+	escaped := false
+	for valueIndex, value := range values {
+		if valueIndex > 0 {
+			current.WriteByte(',')
+		}
+		for index := 0; index < len(value); index++ {
+			char := value[index]
+			if escaped {
+				if char < 0x20 || char == 0x7f {
+					return nil, fmt.Errorf("invalid quoted escape")
+				}
+				current.WriteByte(char)
+				escaped = false
+				continue
+			}
+			if inQuote && char == '\\' {
+				current.WriteByte(char)
+				escaped = true
+				continue
+			}
+			if char == '"' {
+				inQuote = !inQuote
+				current.WriteByte(char)
+				continue
+			}
+			if !inQuote && char == separator {
+				item := strings.TrimSpace(current.String())
+				if item == "" {
+					return nil, fmt.Errorf("empty header element")
+				}
+				items = append(items, item)
+				current.Reset()
+				continue
+			}
+			if char == '\r' || char == '\n' {
+				return nil, fmt.Errorf("invalid control character")
+			}
+			current.WriteByte(char)
+		}
+	}
+	if inQuote || escaped {
+		return nil, fmt.Errorf("unterminated quoted value")
+	}
+	last := strings.TrimSpace(current.String())
+	if last == "" {
+		return nil, fmt.Errorf("empty header element")
+	}
+	items = append(items, last)
+	return items, nil
+}
+
+func parseParameterValue(raw string) (string, bool, error) {
+	if raw[0] != '"' {
+		if !isToken(raw) {
+			return "", false, fmt.Errorf("invalid Forwarded token")
+		}
+		return raw, false, nil
+	}
+	if len(raw) < 2 || raw[len(raw)-1] != '"' {
+		return "", false, fmt.Errorf("unterminated Forwarded quoted value")
+	}
+	var value strings.Builder
+	escaped := false
+	for index := 1; index < len(raw)-1; index++ {
+		char := raw[index]
+		if escaped {
+			if char < 0x20 || char == 0x7f {
+				return "", false, fmt.Errorf("invalid Forwarded quoted escape")
+			}
+			value.WriteByte(char)
+			escaped = false
+			continue
+		}
+		if char == '\\' {
+			escaped = true
+			continue
+		}
+		if char == '"' || char < 0x20 || char == 0x7f {
+			return "", false, fmt.Errorf("invalid Forwarded quoted value")
+		}
+		value.WriteByte(char)
+	}
+	if escaped {
+		return "", false, fmt.Errorf("invalid Forwarded quoted value")
+	}
+	return value.String(), true, nil
+}
+
+func parseForwardedNode(value string, quoted bool) (netip.Addr, bool, error) {
+	if strings.EqualFold(value, "unknown") || strings.HasPrefix(value, "_") {
+		if !isToken(value) {
+			return netip.Addr{}, false, fmt.Errorf("invalid obfuscated Forwarded node")
+		}
+		return netip.Addr{}, false, nil
+	}
+	if strings.HasPrefix(value, "[") {
+		if !quoted {
+			return netip.Addr{}, false, fmt.Errorf("an IPv6 Forwarded node must be quoted")
+		}
+		end := strings.IndexByte(value, ']')
+		if end < 0 {
+			return netip.Addr{}, false, fmt.Errorf("invalid bracketed Forwarded node")
+		}
+		rest := value[end+1:]
+		if rest != "" && (!strings.HasPrefix(rest, ":") || !validNodePort(rest[1:])) {
+			return netip.Addr{}, false, fmt.Errorf("invalid Forwarded node port")
+		}
+		addr, err := netip.ParseAddr(value[1:end])
+		if err != nil || addr.Zone() != "" || !addr.Is6() || addr.IsUnspecified() {
+			return netip.Addr{}, false, fmt.Errorf("invalid Forwarded IPv6 address")
+		}
+		return addr, true, nil
+	}
+	if strings.Count(value, ":") > 1 {
+		return netip.Addr{}, false, fmt.Errorf("an IPv6 Forwarded node must use brackets")
+	}
+	addr, err := parseHeaderAddress(value)
+	if err != nil || !addr.Is4() {
+		return netip.Addr{}, false, fmt.Errorf("invalid Forwarded IPv4 address")
+	}
+	return addr, true, nil
+}
+
+func parseHeaderAddress(value string) (netip.Addr, error) {
+	if strings.Contains(value, "%") || value == "" {
+		return netip.Addr{}, fmt.Errorf("zones and empty addresses are not allowed")
+	}
+	if addr, err := netip.ParseAddr(value); err == nil {
+		addr = addr.Unmap()
+		if !addr.IsUnspecified() {
+			return addr, nil
+		}
+	}
+	if addrPort, err := netip.ParseAddrPort(value); err == nil {
+		addr := addrPort.Addr().Unmap()
+		if !addr.IsUnspecified() {
+			return addr, nil
+		}
+	}
+	host, port, err := net.SplitHostPort(value)
+	if err != nil || port == "" {
+		return netip.Addr{}, fmt.Errorf("not an IP address")
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil || addr.Zone() != "" || addr.IsUnspecified() {
+		return netip.Addr{}, fmt.Errorf("not an IP address")
+	}
+	return addr.Unmap(), nil
+}
+
+func rightmostAddressIndex(elements []forwardedElement, clientIP string) int {
+	wanted, err := netip.ParseAddr(clientIP)
+	if err != nil {
+		return -1
+	}
+	wanted = wanted.Unmap()
+	for index := len(elements) - 1; index >= 0; index-- {
+		if elements[index].address.IsValid() && elements[index].address.Unmap() == wanted {
+			return index
+		}
+	}
+	return -1
+}
+
+func xForwardedProtocol(values []string, selected, addressCount int) string {
+	items, err := splitOutsideQuotes(values, ',')
+	if err != nil {
+		return "http"
+	}
+	if len(items) == 1 {
+		return validProtocol(items[0])
+	}
+	if len(items) == addressCount && selected >= 0 && selected < len(items) {
+		return validProtocol(items[selected])
+	}
+	return "http"
+}
+
+func validProtocol(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "https" {
+		return "https"
+	}
+	return "http"
+}
+
+func validNodePort(value string) bool {
+	if strings.HasPrefix(value, "_") {
+		return isToken(value)
+	}
+	if value == "" {
+		return false
+	}
+	for _, char := range []byte(value) {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, char := range []byte(value) {
+		if (char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+			(char >= '0' && char <= '9') || strings.ContainsRune("!#$%&'*+-.^_`|~", rune(char)) {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/backend/internal/hub/requestsource/middleware_test.go
+++ b/backend/internal/hub/requestsource/middleware_test.go
@@ -19,8 +19,11 @@ import (
 )
 
 type observedRequest struct {
-	clientIP  string
-	remote    string
+	clientIP string
+	remote   string
+	// scheme is the VERIFIED protocol, read from the context where the
+	// middleware records it. It is not `r.URL.Scheme`: the middleware leaves
+	// the URL alone, because nothing in the hub read the scheme there.
 	scheme    string
 	tlsActive bool
 }
@@ -28,29 +31,31 @@ type observedRequest struct {
 func observeRequest(t *testing.T, trusted requestsource.TrustedRanges, configure func(*http.Request)) observedRequest {
 	t.Helper()
 	var observed observedRequest
-	// A NIL manager trusts nothing, which is the default the hub ships and
-	// the state the direct-peer tests need. A manager appears only when a
-	// test configures selectors, because each one costs a store.
-	var manager *settings.Manager
-	if len(trusted.Selectors()) > 0 {
-		manager = settings.NewManager(hubtestutil.OpenTestStore(t), nil, requestsource.SettingsDescriptors())
-		require.NoError(t, manager.Load(context.Background()))
-		encoded, err := json.Marshal(trusted)
-		require.NoError(t, err)
-		require.NoError(t, manager.Update(context.Background(), requestsource.KeyTrustedProxyRanges, encoded))
-	}
+	// The trust set is stated DIRECTLY. The middleware takes the one value it
+	// reads rather than a settings manager, so a test that only needs a trust
+	// set does not open a store to say so. TestMiddleware_AppliesHotSettingChanges
+	// covers the settings-backed path.
+	ranges := func(context.Context) requestsource.TrustedRanges { return trusted }
 
 	request := httptest.NewRequest(http.MethodGet, "http://hub.example.test/", nil)
 	configure(request)
-	requestsource.Middleware(manager, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+	requestsource.Middleware(ranges, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		observed = observedRequest{
 			clientIP:  peer.ClientIP(r.Context()),
 			remote:    r.RemoteAddr,
-			scheme:    r.URL.Scheme,
+			scheme:    observedScheme(r),
 			tlsActive: r.TLS != nil,
 		}
 	})).ServeHTTP(httptest.NewRecorder(), request)
 	return observed
+}
+
+// observedScheme renders the recorded protocol the way these tests spell it.
+func observedScheme(r *http.Request) string {
+	if peer.IsHTTPS(r.Context()) {
+		return "https"
+	}
+	return "http"
 }
 
 func mustTrusted(t *testing.T, selectors ...string) requestsource.TrustedRanges {
@@ -239,6 +244,13 @@ func TestMiddleware_AllTrustedChainProducesUnknownClient(t *testing.T) {
 	assert.Empty(t, observed.clientIP)
 }
 
+// absentProtocol marks the subtest that sends NO X-Forwarded-Proto. An empty
+// string cannot mark it, because an empty string is itself an input this table
+// exercises.
+const absentProtocol = "\x00absent"
+
+const xForwardedProtocolHeaderName = "X-Forwarded-Proto"
+
 func TestMiddleware_XForwardedProtocolAlignment(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {
@@ -250,15 +262,21 @@ func TestMiddleware_XForwardedProtocolAlignment(t *testing.T) {
 		{"aligned", "https, http", "https"},
 		{"misaligned", "https, http, https", "http"},
 		{"invalid", "ssh", "http"},
-		{"empty", "", "http"},
+		// PRESENT and empty, which is not the same input as absent: the
+		// present one reaches splitElements, whose "empty header element"
+		// refusal is what produces the fallback. Setting the header through
+		// the map is the only way to send it, because Header.Set with an
+		// empty value would be indistinguishable from the absent case.
+		{"present but empty", "", "http"},
+		{"absent", absentProtocol, "http"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
 				r.RemoteAddr = "10.0.0.3:4327"
 				r.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.2")
-				if test.protocol != "" {
-					r.Header.Set("X-Forwarded-Proto", test.protocol)
+				if test.protocol != absentProtocol {
+					r.Header[xForwardedProtocolHeaderName] = []string{test.protocol}
 				}
 			})
 			assert.Equal(t, "198.51.100.7", observed.clientIP)
@@ -280,17 +298,22 @@ func TestMiddleware_LeavesTheCallersRequestAlone(t *testing.T) {
 	originalScheme := request.URL.Scheme
 
 	var seen *http.Request
-	requestsource.Middleware(nil, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+	requestsource.Middleware(requestsource.RangesFromSettings(nil), http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		seen = r
 	})).ServeHTTP(httptest.NewRecorder(), request)
 
 	require.NotNil(t, seen)
-	assert.Equal(t, "https", seen.URL.Scheme, "the handler reads the effective scheme")
-	assert.Equal(t, "/path", seen.URL.Path, "the copied URL keeps every other field")
+	// The URL is UNCHANGED and unshared-by-nobody: the middleware no longer
+	// rewrites it. The verified protocol lives on the context, which is where
+	// the cookie policy and the base-URL builder read it, so there is no
+	// per-request URL copy to make and no field of the request to write.
+	assert.Same(t, originalURL, seen.URL, "the middleware leaves the URL alone")
+	assert.Equal(t, originalScheme, seen.URL.Scheme, "the URL scheme is not the hub's answer")
+	assert.Equal(t, "/path", seen.URL.Path)
 	assert.Equal(t, "q=1", seen.URL.RawQuery)
-	assert.NotSame(t, originalURL, seen.URL, "the handler must not share the caller's URL")
-	assert.Equal(t, originalScheme, request.URL.Scheme, "the caller's scheme is untouched")
+	assert.True(t, peer.IsHTTPS(seen.Context()), "the handler reads the effective protocol from the context")
 	assert.Equal(t, "203.0.113.9:4327", seen.RemoteAddr, "RemoteAddr stays the physical peer")
+	assert.NotNil(t, seen.TLS, "Request.TLS is untouched")
 }
 
 func TestMiddleware_PreservesActualTLS(t *testing.T) {
@@ -325,7 +348,7 @@ func TestMiddleware_AppliesHotSettingChanges(t *testing.T) {
 	require.NoError(t, manager.Load(context.Background()))
 
 	var clientIP string
-	handler := requestsource.Middleware(manager, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+	handler := requestsource.Middleware(requestsource.RangesFromSettings(manager), http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		clientIP = peer.ClientIP(r.Context())
 	}))
 	request := func() *http.Request {
@@ -342,4 +365,131 @@ func TestMiddleware_AppliesHotSettingChanges(t *testing.T) {
 		json.RawMessage(`["10.0.0.0/8"]`)))
 	handler.ServeHTTP(httptest.NewRecorder(), request())
 	assert.Equal(t, "198.51.100.7", clientIP)
+}
+
+// The chain walk is this package's own, so these pin the rule it implements
+// rather than the library's behaviour it used to delegate to.
+func TestMiddleware_RightmostUntrustedSelection(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name     string
+		header   string
+		clientIP string
+	}{
+		// The rightmost address that is NOT a trusted proxy. Everything to its
+		// right is infrastructure the operator vouched for.
+		{"stops at the first untrusted hop", "203.0.113.1, 198.51.100.9, 10.0.0.2", "198.51.100.9"},
+		{"a single untrusted hop", "198.51.100.9, 10.0.0.2", "198.51.100.9"},
+		// A REPEATED address cannot move the answer: every element to the
+		// right of the pick is trusted, so a trusted element can never hold
+		// the untrusted address.
+		{"a repeated address", "198.51.100.9, 10.0.0.5, 198.51.100.9, 10.0.0.2", "198.51.100.9"},
+		// Trusted end to end names no client. Reporting the leftmost proxy
+		// would report infrastructure as a person.
+		{"an all-trusted chain", "10.0.0.9, 10.0.0.2", ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+				r.RemoteAddr = "10.0.0.3:4327"
+				r.Header.Set("X-Forwarded-For", test.header)
+			})
+			assert.Equal(t, test.clientIP, observed.clientIP)
+		})
+	}
+}
+
+// An OBFUSCATED node stops the walk with no client, rather than letting the
+// search continue leftward.
+//
+// The node hides the address the hub would report, so the chain names no
+// client. Continuing left would let whichever proxy wrote the obfuscated entry
+// nominate any address to its left as the client, which is the substitution
+// the trust test exists to prevent.
+func TestMiddleware_ObfuscatedNodeStopsTheWalk(t *testing.T) {
+	t.Parallel()
+	for _, node := range []string{"unknown", "_hidden"} {
+		t.Run(node, func(t *testing.T) {
+			t.Parallel()
+			observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+				r.RemoteAddr = "10.0.0.3:4327"
+				r.Header.Set("Forwarded", "for=198.51.100.7, for="+node+", for=10.0.0.2")
+			})
+			assert.Empty(t, observed.clientIP,
+				"an obfuscated node hides the client; the chain names none")
+		})
+	}
+}
+
+// A quoted-pair escape inside a `for` node is legal RFC 7230 syntax, and the
+// parser has always unescaped it. The selection now reads that parsed address
+// directly, so the escaped form and the plain form name the same client.
+func TestMiddleware_AcceptsAQuotedPairEscapeInAForNode(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+		r.RemoteAddr = "10.0.0.3:4327"
+		r.Header.Set("Forwarded", `for="\1\9\8.51.100.7", for=10.0.0.2`)
+	})
+	assert.Equal(t, "198.51.100.7", observed.clientIP)
+}
+
+// The verified protocol reaches the CONTEXT, which is where the cookie policy
+// and the base-URL builder read it. It used to be written to `URL.Scheme`,
+// where nothing read it at all.
+func TestMiddleware_RecordsTheVerifiedProtocolOnTheContext(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name      string
+		trusted   []string
+		configure func(*http.Request)
+		wantHTTPS bool
+	}{
+		{
+			name:    "a trusted proxy that verified TLS",
+			trusted: []string{"10.0.0.0/8"},
+			configure: func(r *http.Request) {
+				r.RemoteAddr = "10.0.0.3:4327"
+				r.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.2")
+				r.Header.Set("X-Forwarded-Proto", "https")
+			},
+			wantHTTPS: true,
+		},
+		{
+			name:    "a trusted proxy that reports plain HTTP",
+			trusted: []string{"10.0.0.0/8"},
+			configure: func(r *http.Request) {
+				r.RemoteAddr = "10.0.0.3:4327"
+				r.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.2")
+				r.Header.Set("X-Forwarded-Proto", "http")
+			},
+		},
+		{
+			// The header is caller-controlled here, so it must not be read.
+			// This is the case that would hand any caller a Secure cookie.
+			name:    "an UNTRUSTED peer claiming https",
+			trusted: nil,
+			configure: func(r *http.Request) {
+				r.RemoteAddr = "198.51.100.7:4327"
+				r.Header.Set("X-Forwarded-Proto", "https")
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			var https bool
+			trusted := requestsource.TrustedRanges{}
+			if len(test.trusted) > 0 {
+				trusted = mustTrusted(t, test.trusted...)
+			}
+			request := httptest.NewRequest(http.MethodGet, "http://hub.example.test/", nil)
+			test.configure(request)
+			requestsource.Middleware(
+				func(context.Context) requestsource.TrustedRanges { return trusted },
+				http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+					https = peer.IsHTTPS(r.Context())
+				}),
+			).ServeHTTP(httptest.NewRecorder(), request)
+			assert.Equal(t, test.wantHTTPS, https)
+		})
+	}
 }

--- a/backend/internal/hub/requestsource/middleware_test.go
+++ b/backend/internal/hub/requestsource/middleware_test.go
@@ -242,6 +242,32 @@ func TestMiddleware_XForwardedProtocolAlignment(t *testing.T) {
 	}
 }
 
+// The middleware hands the next handler its own Request and its own URL. It
+// must not write the effective scheme back onto the caller's request: net/http
+// owns that value, and the URL is the one field this middleware changes, so a
+// shared URL would leak the rewrite out of the handler chain.
+func TestMiddleware_LeavesTheCallersRequestAlone(t *testing.T) {
+	t.Parallel()
+	request := httptest.NewRequest(http.MethodGet, "http://hub.example.test/path?q=1", nil)
+	request.RemoteAddr = "203.0.113.9:4327"
+	request.TLS = &tls.ConnectionState{}
+	originalURL := request.URL
+	originalScheme := request.URL.Scheme
+
+	var seen *http.Request
+	requestsource.Middleware(nil, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen = r
+	})).ServeHTTP(httptest.NewRecorder(), request)
+
+	require.NotNil(t, seen)
+	assert.Equal(t, "https", seen.URL.Scheme, "the handler reads the effective scheme")
+	assert.Equal(t, "/path", seen.URL.Path, "the copied URL keeps every other field")
+	assert.Equal(t, "q=1", seen.URL.RawQuery)
+	assert.NotSame(t, originalURL, seen.URL, "the handler must not share the caller's URL")
+	assert.Equal(t, originalScheme, request.URL.Scheme, "the caller's scheme is untouched")
+	assert.Equal(t, "203.0.113.9:4327", seen.RemoteAddr, "RemoteAddr stays the physical peer")
+}
+
 func TestMiddleware_PreservesActualTLS(t *testing.T) {
 	t.Parallel()
 	observed := observeRequest(t, requestsource.TrustedRanges{}, func(r *http.Request) {

--- a/backend/internal/hub/requestsource/middleware_test.go
+++ b/backend/internal/hub/requestsource/middleware_test.go
@@ -28,30 +28,20 @@ type observedRequest struct {
 func observeRequest(t *testing.T, trusted requestsource.TrustedRanges, configure func(*http.Request)) observedRequest {
 	t.Helper()
 	var observed observedRequest
-	handler := requestsource.Middleware(nil, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		observed = observedRequest{
-			clientIP:  peer.ClientIP(r.Context()),
-			remote:    r.RemoteAddr,
-			scheme:    r.URL.Scheme,
-			tlsActive: r.TLS != nil,
-		}
-	}))
+	// A NIL manager trusts nothing, which is the default the hub ships and
+	// the state the direct-peer tests need. A manager appears only when a
+	// test configures selectors, because each one costs a store.
+	var manager *settings.Manager
+	if len(trusted.Selectors()) > 0 {
+		manager = settings.NewManager(hubtestutil.OpenTestStore(t), nil, requestsource.SettingsDescriptors())
+		require.NoError(t, manager.Load(context.Background()))
+		encoded, err := json.Marshal(trusted)
+		require.NoError(t, err)
+		require.NoError(t, manager.Update(context.Background(), requestsource.KeyTrustedProxyRanges, encoded))
+	}
 
 	request := httptest.NewRequest(http.MethodGet, "http://hub.example.test/", nil)
 	configure(request)
-	// A manager-less middleware uses no trusted ranges. To test explicit
-	// ranges, exercise the same request through a manager below.
-	if len(trusted.Selectors()) == 0 {
-		handler.ServeHTTP(httptest.NewRecorder(), request)
-		return observed
-	}
-
-	store := hubtestutil.OpenTestStore(t)
-	manager := settings.NewManager(store, nil, requestsource.SettingsDescriptors())
-	require.NoError(t, manager.Load(context.Background()))
-	encoded, err := json.Marshal(trusted)
-	require.NoError(t, err)
-	require.NoError(t, manager.Update(context.Background(), requestsource.KeyTrustedProxyRanges, encoded))
 	requestsource.Middleware(manager, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		observed = observedRequest{
 			clientIP:  peer.ClientIP(r.Context()),
@@ -146,6 +136,37 @@ func TestMiddleware_ForwardedParserKeepsQuotedDelimitersInsideAnElement(t *testi
 	assert.Equal(t, "https", observed.scheme)
 }
 
+// Each proxy in a chain may append its OWN header line rather than extend the
+// one before it. net/http keeps those lines apart, and RFC 9110 says the two
+// forms mean the same thing, so the chain must read the same either way.
+func TestMiddleware_ReadsRepeatedHeaderLinesAsOneChain(t *testing.T) {
+	t.Parallel()
+	t.Run("X-Forwarded-For and X-Forwarded-Proto", func(t *testing.T) {
+		t.Parallel()
+		observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+			r.RemoteAddr = "10.0.0.3:4327"
+			r.Header.Add("X-Forwarded-For", "198.51.100.7")
+			r.Header.Add("X-Forwarded-For", "10.0.0.1, 10.0.0.2")
+			r.Header.Add("X-Forwarded-Proto", "https")
+			r.Header.Add("X-Forwarded-Proto", "http, http")
+		})
+		assert.Equal(t, "198.51.100.7", observed.clientIP)
+		assert.Equal(t, "https", observed.scheme,
+			"three protocols align with three addresses, and the client sits first")
+	})
+
+	t.Run("Forwarded", func(t *testing.T) {
+		t.Parallel()
+		observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+			r.RemoteAddr = "10.0.0.3:4327"
+			r.Header.Add("Forwarded", "for=198.51.100.7;proto=https")
+			r.Header.Add("Forwarded", "for=10.0.0.2;proto=http")
+		})
+		assert.Equal(t, "198.51.100.7", observed.clientIP)
+		assert.Equal(t, "https", observed.scheme)
+	})
+}
+
 func TestMiddleware_PrefersForwardedWithoutFallback(t *testing.T) {
 	t.Parallel()
 	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
@@ -160,12 +181,28 @@ func TestMiddleware_PrefersForwardedWithoutFallback(t *testing.T) {
 
 func TestMiddleware_MalformedXForwardedForProducesUnknownClient(t *testing.T) {
 	t.Parallel()
-	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
-		r.RemoteAddr = "10.0.0.3:4327"
-		r.Header.Set("X-Forwarded-For", "198.51.100.7, not-an-address")
-	})
-	assert.Empty(t, observed.clientIP)
-	assert.Equal(t, "http", observed.scheme)
+	for _, test := range []struct {
+		name  string
+		lines []string
+	}{
+		{"a value that is not an address", []string{"198.51.100.7, not-an-address"}},
+		{"an empty element", []string{"198.51.100.7, , 10.0.0.1"}},
+		// One EMPTY line among several. Each line is its own list, so an empty
+		// one is an empty list and not a separator that the join swallows.
+		{"an empty repeated line", []string{"198.51.100.7", "", "10.0.0.1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+				r.RemoteAddr = "10.0.0.3:4327"
+				for _, line := range test.lines {
+					r.Header.Add("X-Forwarded-For", line)
+				}
+			})
+			assert.Empty(t, observed.clientIP)
+			assert.Equal(t, "http", observed.scheme)
+		})
+	}
 }
 
 func TestMiddleware_AllTrustedChainProducesUnknownClient(t *testing.T) {

--- a/backend/internal/hub/requestsource/middleware_test.go
+++ b/backend/internal/hub/requestsource/middleware_test.go
@@ -167,6 +167,31 @@ func TestMiddleware_ReadsRepeatedHeaderLinesAsOneChain(t *testing.T) {
 	})
 }
 
+// A repeated parameter inside one Forwarded element is REFUSED, never
+// resolved. RFC 7239 forbids it, and two `for` values in one element ask the
+// parser to pick which client address the sender meant -- so a parser that
+// picked would let whoever writes the second value choose the answer.
+func TestMiddleware_RefusesARepeatedForwardedParameter(t *testing.T) {
+	t.Parallel()
+	for _, header := range []string{
+		`for=198.51.100.7;for=198.51.100.8`,
+		`for=198.51.100.7;proto=https;proto=http`,
+		// Case-folded: the parameter name is case-insensitive, so `For` and
+		// `for` are one name and not two.
+		`For=198.51.100.7;for=198.51.100.8`,
+	} {
+		t.Run(header, func(t *testing.T) {
+			t.Parallel()
+			observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+				r.RemoteAddr = "10.0.0.3:4327"
+				r.Header.Set("Forwarded", header)
+			})
+			assert.Empty(t, observed.clientIP)
+			assert.Equal(t, "http", observed.scheme)
+		})
+	}
+}
+
 func TestMiddleware_PrefersForwardedWithoutFallback(t *testing.T) {
 	t.Parallel()
 	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {

--- a/backend/internal/hub/requestsource/middleware_test.go
+++ b/backend/internal/hub/requestsource/middleware_test.go
@@ -1,0 +1,257 @@
+package requestsource_test
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/peer"
+	"github.com/leapmux/leapmux/internal/hub/requestsource"
+	"github.com/leapmux/leapmux/internal/hub/settings"
+	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
+)
+
+type observedRequest struct {
+	clientIP  string
+	remote    string
+	scheme    string
+	tlsActive bool
+}
+
+func observeRequest(t *testing.T, trusted requestsource.TrustedRanges, configure func(*http.Request)) observedRequest {
+	t.Helper()
+	var observed observedRequest
+	handler := requestsource.Middleware(nil, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = observedRequest{
+			clientIP:  peer.ClientIP(r.Context()),
+			remote:    r.RemoteAddr,
+			scheme:    r.URL.Scheme,
+			tlsActive: r.TLS != nil,
+		}
+	}))
+
+	request := httptest.NewRequest(http.MethodGet, "http://hub.example.test/", nil)
+	configure(request)
+	// A manager-less middleware uses no trusted ranges. To test explicit
+	// ranges, exercise the same request through a manager below.
+	if len(trusted.Selectors()) == 0 {
+		handler.ServeHTTP(httptest.NewRecorder(), request)
+		return observed
+	}
+
+	store := hubtestutil.OpenTestStore(t)
+	manager := settings.NewManager(store, nil, requestsource.SettingsDescriptors())
+	require.NoError(t, manager.Load(context.Background()))
+	encoded, err := json.Marshal(trusted)
+	require.NoError(t, err)
+	require.NoError(t, manager.Update(context.Background(), requestsource.KeyTrustedProxyRanges, encoded))
+	requestsource.Middleware(manager, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		observed = observedRequest{
+			clientIP:  peer.ClientIP(r.Context()),
+			remote:    r.RemoteAddr,
+			scheme:    r.URL.Scheme,
+			tlsActive: r.TLS != nil,
+		}
+	})).ServeHTTP(httptest.NewRecorder(), request)
+	return observed
+}
+
+func mustTrusted(t *testing.T, selectors ...string) requestsource.TrustedRanges {
+	t.Helper()
+	trusted, err := requestsource.NewTrustedRanges(selectors)
+	require.NoError(t, err)
+	return trusted
+}
+
+func TestMiddleware_DirectPeerIgnoresForgedHeaders(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, requestsource.TrustedRanges{}, func(r *http.Request) {
+		r.RemoteAddr = "203.0.113.9:4327"
+		r.Header.Set("Forwarded", "for=198.51.100.1;proto=https")
+		r.Header.Set("X-Forwarded-For", "198.51.100.2")
+		r.Header.Set("X-Forwarded-Proto", "https")
+	})
+	assert.Equal(t, "203.0.113.9", observed.clientIP)
+	assert.Equal(t, "203.0.113.9:4327", observed.remote)
+	assert.Equal(t, "http", observed.scheme)
+}
+
+func TestMiddleware_WalksTrustedProxyChainFromTheRight(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+		r.RemoteAddr = "10.0.0.3:4327"
+		r.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.1, 10.0.0.2")
+		r.Header.Set("X-Forwarded-Proto", "https")
+	})
+	assert.Equal(t, "198.51.100.7", observed.clientIP)
+	assert.Equal(t, "https", observed.scheme)
+}
+
+func TestMiddleware_UsesSelectedForwardedElementProtocol(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+		r.RemoteAddr = "10.0.0.3:4327"
+		r.Header.Set("Forwarded", "for=198.51.100.7;proto=https, for=10.0.0.2;proto=http")
+	})
+	assert.Equal(t, "198.51.100.7", observed.clientIP)
+	assert.Equal(t, "https", observed.scheme)
+}
+
+func TestMiddleware_ForwardedProtocolDefaultsToHTTP(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name     string
+		protocol string
+	}{
+		{name: "absent"},
+		{name: "empty", protocol: `;proto=""`},
+		{name: "invalid", protocol: ";proto=ssh"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+				r.RemoteAddr = "10.0.0.3:4327"
+				r.Header.Set("Forwarded", "for=198.51.100.7"+test.protocol+", for=10.0.0.2")
+			})
+			assert.Equal(t, "198.51.100.7", observed.clientIP)
+			assert.Equal(t, "http", observed.scheme)
+		})
+	}
+}
+
+func TestMiddleware_AcceptsQuotedForwardedIPv6(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, mustTrusted(t, "2001:db8:1::/64"), func(r *http.Request) {
+		r.RemoteAddr = "[2001:db8:1::3]:4327"
+		r.Header.Set("Forwarded", `for="[2001:db8:2::7]:4711";proto="HTTPS", for="[2001:db8:1::2]"`)
+	})
+	assert.Equal(t, "2001:db8:2::7", observed.clientIP)
+	assert.Equal(t, "https", observed.scheme)
+}
+
+func TestMiddleware_ForwardedParserKeepsQuotedDelimitersInsideAnElement(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+		r.RemoteAddr = "10.0.0.3:4327"
+		r.Header.Set("Forwarded", `for=198.51.100.7;host="hub,edge;one";proto=https, for=10.0.0.2`)
+	})
+	assert.Equal(t, "198.51.100.7", observed.clientIP)
+	assert.Equal(t, "https", observed.scheme)
+}
+
+func TestMiddleware_PrefersForwardedWithoutFallback(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+		r.RemoteAddr = "10.0.0.3:4327"
+		r.Header.Set("Forwarded", `for="[2001:db8::1]`)
+		r.Header.Set("X-Forwarded-For", "198.51.100.7")
+		r.Header.Set("X-Forwarded-Proto", "https")
+	})
+	assert.Empty(t, observed.clientIP)
+	assert.Equal(t, "http", observed.scheme)
+}
+
+func TestMiddleware_MalformedXForwardedForProducesUnknownClient(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+		r.RemoteAddr = "10.0.0.3:4327"
+		r.Header.Set("X-Forwarded-For", "198.51.100.7, not-an-address")
+	})
+	assert.Empty(t, observed.clientIP)
+	assert.Equal(t, "http", observed.scheme)
+}
+
+func TestMiddleware_AllTrustedChainProducesUnknownClient(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+		r.RemoteAddr = "10.0.0.3:4327"
+		r.Header.Set("X-Forwarded-For", "10.0.0.1, 10.0.0.2")
+	})
+	assert.Empty(t, observed.clientIP)
+}
+
+func TestMiddleware_XForwardedProtocolAlignment(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name     string
+		protocol string
+		want     string
+	}{
+		{"global", "https", "https"},
+		{"aligned", "https, http", "https"},
+		{"misaligned", "https, http, https", "http"},
+		{"invalid", "ssh", "http"},
+		{"empty", "", "http"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			observed := observeRequest(t, mustTrusted(t, "10.0.0.0/8"), func(r *http.Request) {
+				r.RemoteAddr = "10.0.0.3:4327"
+				r.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.2")
+				if test.protocol != "" {
+					r.Header.Set("X-Forwarded-Proto", test.protocol)
+				}
+			})
+			assert.Equal(t, "198.51.100.7", observed.clientIP)
+			assert.Equal(t, test.want, observed.scheme)
+		})
+	}
+}
+
+func TestMiddleware_PreservesActualTLS(t *testing.T) {
+	t.Parallel()
+	observed := observeRequest(t, requestsource.TrustedRanges{}, func(r *http.Request) {
+		r.RemoteAddr = "203.0.113.9:4327"
+		r.TLS = &tls.ConnectionState{}
+	})
+	assert.Equal(t, "https", observed.scheme)
+	assert.True(t, observed.tlsActive)
+}
+
+func TestMiddleware_ProviderRangesTrustTheirPeers(t *testing.T) {
+	t.Parallel()
+	for _, token := range []string{"cloudflare", "cloudfront"} {
+		t.Run(token, func(t *testing.T) {
+			t.Parallel()
+			trusted := mustTrusted(t, token)
+			peerAddress := trusted.Prefixes()[0].Addr()
+			observed := observeRequest(t, trusted, func(r *http.Request) {
+				r.RemoteAddr = netip.AddrPortFrom(peerAddress, 4327).String()
+				r.Header.Set("X-Forwarded-For", "198.51.100.7")
+			})
+			assert.Equal(t, "198.51.100.7", observed.clientIP)
+		})
+	}
+}
+
+func TestMiddleware_AppliesHotSettingChanges(t *testing.T) {
+	store := hubtestutil.OpenTestStore(t)
+	manager := settings.NewManager(store, nil, requestsource.SettingsDescriptors())
+	require.NoError(t, manager.Load(context.Background()))
+
+	var clientIP string
+	handler := requestsource.Middleware(manager, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		clientIP = peer.ClientIP(r.Context())
+	}))
+	request := func() *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "http://hub.example.test/", nil)
+		r.RemoteAddr = "10.0.0.3:4327"
+		r.Header.Set("X-Forwarded-For", "198.51.100.7")
+		return r
+	}
+
+	handler.ServeHTTP(httptest.NewRecorder(), request())
+	assert.Equal(t, "10.0.0.3", clientIP)
+
+	require.NoError(t, manager.Update(context.Background(), requestsource.KeyTrustedProxyRanges,
+		json.RawMessage(`["10.0.0.0/8"]`)))
+	handler.ServeHTTP(httptest.NewRecorder(), request())
+	assert.Equal(t, "198.51.100.7", clientIP)
+}

--- a/backend/internal/hub/requestsource/ranges.go
+++ b/backend/internal/hub/requestsource/ranges.go
@@ -6,13 +6,12 @@ package requestsource
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/netip"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
-	"github.com/realclientip/realclientip-go"
 	providerranges "github.com/realclientip/realclientip-go/ranges"
 	"go4.org/netipx"
 
@@ -23,11 +22,27 @@ import (
 // TrustedRanges is the stored selector list and its decoded address set. JSON
 // contains only the canonical selectors. Provider ranges stay symbolic there.
 type TrustedRanges struct {
-	selectors     []string
-	prefixes      []netip.Prefix
-	set           *netipx.IPSet
-	forwarded     realclientip.RightmostTrustedRangeStrategy
-	xForwardedFor realclientip.RightmostTrustedRangeStrategy
+	selectors []string
+	prefixes  []netip.Prefix
+	set       *netipx.IPSet
+	// invalid records why a STORED selector list could not expand.
+	//
+	// UnmarshalJSON keeps the list and sets this instead of returning an
+	// error, because the settings framework treats a decode failure and a
+	// validation failure differently. A decode failure is a HARD refusal in
+	// mergeForUpdate, so it would refuse every later write to this key and
+	// leave `Reset` -- which discards the operator's whole list -- as the only
+	// way out. A validation failure degrades the write's base to the default
+	// and logs, which is the recovery every other setting has.
+	//
+	// The trigger is realistic: the bundled provider ranges are a generated
+	// snapshot, so a dependency bump that widens a Cloudflare prefix over an
+	// operator's manual selector makes the stored pair overlap, and the row
+	// stops expanding. Lowering MaxTrustedProxySelectors does the same.
+	//
+	// A degraded value trusts NOBODY -- Contains guards a nil set -- so the
+	// recovery is fail-closed.
+	invalid error
 }
 
 // NewTrustedRanges validates and canonicalizes configured selectors.
@@ -40,10 +55,21 @@ func NewTrustedRanges(selectors []string) (TrustedRanges, error) {
 	canonical := make([]string, 0, len(selectors))
 	seen := make(map[string]struct{}, len(selectors))
 	var combinedBuilder netipx.IPSetBuilder
-	combined, err := combinedBuilder.IPSet()
-	if err != nil {
-		return TrustedRanges{}, fmt.Errorf("create the trusted proxy set: %w", err)
-	}
+	// The ACCEPTED selectors' own sets, and the overlap test runs against
+	// them rather than against a combined set rebuilt on each step.
+	//
+	// `IPSetBuilder.IPSet()` sorts and merges every accumulated range and
+	// copies the whole list into a fresh slice, so calling it inside the loop
+	// made an O(n) selector list cost O(n^2 log n). That is not a startup
+	// cost: the settings snapshot re-decodes this key on every cache refresh,
+	// so a hub with `cloudfront` configured -- 241 bundled prefixes -- redid
+	// the whole rebuild every refresh, for ever, although the stored value
+	// never changed.
+	//
+	// `IPSet.Overlaps` is itself a nested walk over two range lists, so asking
+	// each accepted set separately answers the same question over the same
+	// ranges. The combined set is built ONCE, after the loop.
+	accepted := make([]*netipx.IPSet, 0, len(selectors))
 	for index, raw := range selectors {
 		selector, selectorSet, err := parseSelector(raw)
 		if err != nil {
@@ -52,37 +78,24 @@ func NewTrustedRanges(selectors []string) (TrustedRanges, error) {
 		if _, ok := seen[selector]; ok {
 			return TrustedRanges{}, fmt.Errorf("trusted proxy selector %d (%q) duplicates %q", index+1, raw, selector)
 		}
-		if combined.Overlaps(selectorSet) {
+		// EVERY earlier selector, not the previous one.
+		if slices.ContainsFunc(accepted, func(earlier *netipx.IPSet) bool { return earlier.Overlaps(selectorSet) }) {
 			return TrustedRanges{}, fmt.Errorf("trusted proxy selector %d (%q) overlaps an earlier selector", index+1, raw)
 		}
 		seen[selector] = struct{}{}
 		canonical = append(canonical, selector)
+		accepted = append(accepted, selectorSet)
 		combinedBuilder.AddSet(selectorSet)
-		combined, err = combinedBuilder.IPSet()
-		if err != nil {
-			return TrustedRanges{}, fmt.Errorf("combine trusted proxy selector %d: %w", index+1, err)
-		}
+	}
+	combined, err := combinedBuilder.IPSet()
+	if err != nil {
+		return TrustedRanges{}, fmt.Errorf("combine the trusted proxy selectors: %w", err)
 	}
 
-	prefixes := combined.Prefixes()
-	ipNets := make([]net.IPNet, 0, len(prefixes))
-	for _, prefix := range prefixes {
-		ipNets = append(ipNets, *netipx.PrefixIPNet(prefix))
-	}
-	forwarded, err := realclientip.NewRightmostTrustedRangeStrategy("Forwarded", ipNets)
-	if err != nil {
-		return TrustedRanges{}, fmt.Errorf("create the Forwarded strategy: %w", err)
-	}
-	xForwardedFor, err := realclientip.NewRightmostTrustedRangeStrategy("X-Forwarded-For", ipNets)
-	if err != nil {
-		return TrustedRanges{}, fmt.Errorf("create the X-Forwarded-For strategy: %w", err)
-	}
 	return TrustedRanges{
-		selectors:     slices.Clone(canonical),
-		prefixes:      prefixes,
-		set:           combined,
-		forwarded:     forwarded,
-		xForwardedFor: xForwardedFor,
+		selectors: slices.Clone(canonical),
+		prefixes:  combined.Prefixes(),
+		set:       combined,
 	}, nil
 }
 
@@ -110,8 +123,13 @@ func (r TrustedRanges) MarshalJSON() ([]byte, error) {
 	return json.Marshal(selectors)
 }
 
-// UnmarshalJSON validates and expands the stored selector list during snapshot
-// decode. The snapshot then carries a ready-to-use address set.
+// UnmarshalJSON expands the stored selector list during snapshot decode. The
+// snapshot then carries a ready-to-use address set.
+//
+// The SHAPE is a decode error, because a value that is not a list of strings
+// is not a selector list at all and no later write could merge onto it. A list
+// that will not EXPAND is a validation failure instead: see TrustedRanges.
+// invalid for why the two must not share an answer.
 func (r *TrustedRanges) UnmarshalJSON(data []byte) error {
 	var selectors []string
 	if err := json.Unmarshal(data, &selectors); err != nil {
@@ -122,16 +140,25 @@ func (r *TrustedRanges) UnmarshalJSON(data []byte) error {
 	}
 	decoded, err := NewTrustedRanges(selectors)
 	if err != nil {
-		return err
+		// The raw selectors are kept so the admin surface can still SHOW the
+		// operator what the stored row says while it refuses to use it.
+		*r = TrustedRanges{selectors: slices.Clone(selectors), invalid: err}
+		return nil
 	}
 	*r = decoded
 	return nil
+}
+
+// Validate reports why a stored selector list could not expand.
+func (r TrustedRanges) Validate() error {
+	return r.invalid
 }
 
 // KeyTrustedProxyRanges controls which transport peers can supply forwarding
 // headers. It is hot because the middleware reads a settings snapshot for each
 // request.
 var KeyTrustedProxyRanges = settings.NewKey[TrustedRanges]("trusted_proxy_ranges").
+	WithValidate(TrustedRanges.Validate).
 	WithUI(settings.UIMeta{
 		Category: "network",
 		Title:    "Trusted reverse proxies",
@@ -154,11 +181,7 @@ func parseSelector(raw string) (string, *netipx.IPSet, error) {
 		return "", nil, fmt.Errorf("the selector is empty")
 	}
 	lower := strings.ToLower(value)
-	if providerValues, ok := providerRanges(lower); ok {
-		set, err := prefixSet(providerValues)
-		if err != nil {
-			return "", nil, fmt.Errorf("expand provider %q: %w", lower, err)
-		}
+	if set, ok := providerRanges(lower); ok {
 		return lower, set, nil
 	}
 	if strings.Contains(value, "/") {
@@ -188,15 +211,41 @@ func parseSelector(raw string) (string, *netipx.IPSet, error) {
 	return addr.String(), set, err
 }
 
-func providerRanges(token string) ([]string, bool) {
-	switch token {
-	case contracts.TrustedProxyProviderCloudflare:
-		return providerranges.Cloudflare, true
-	case contracts.TrustedProxyProviderCloudFront:
-		return providerranges.CloudFront, true
-	default:
-		return nil, false
+// providerTables binds every token in the generated catalogue to its bundled
+// prefixes.
+//
+// It is DERIVED from `contracts.TrustedProxyProviders` rather than written
+// beside it, so a token the contract adds and this map does not bind fails
+// TestProviderCatalogueIsBound instead of failing an operator at write time
+// with "unknown provider" for a token the settings editor offered them.
+//
+// Each table is parsed ONCE. The tables are compile-time constants -- 22
+// prefixes for Cloudflare and 241 for CloudFront -- and the settings snapshot
+// re-decodes this key on every cache refresh, so parsing them per decode
+// re-did the same work for ever.
+var providerTables = sync.OnceValue(func() map[string]*netipx.IPSet {
+	sources := map[string][]string{
+		contracts.TrustedProxyProviderCloudflare: providerranges.Cloudflare,
+		contracts.TrustedProxyProviderCloudFront: providerranges.CloudFront,
 	}
+	tables := make(map[string]*netipx.IPSet, len(sources))
+	for token, values := range sources {
+		set, err := prefixSet(values)
+		if err != nil {
+			// A bundled table that will not parse is a build-time fault in a
+			// vendored constant, not an operator's input, and the selector
+			// would silently stop matching. TestProviderCatalogueIsBound
+			// exercises every token, so this cannot reach a release.
+			panic(fmt.Sprintf("bundled provider ranges for %q do not parse: %v", token, err))
+		}
+		tables[token] = set
+	}
+	return tables
+})
+
+func providerRanges(token string) (*netipx.IPSet, bool) {
+	set, ok := providerTables()[token]
+	return set, ok
 }
 
 func parseInclusiveRange(value string) (string, *netipx.IPSet, error) {

--- a/backend/internal/hub/requestsource/ranges.go
+++ b/backend/internal/hub/requestsource/ranges.go
@@ -1,0 +1,275 @@
+// Package requestsource verifies the client address and protocol of an HTTP
+// request. It trusts forwarding headers only when the transport peer matches a
+// configured reverse-proxy range.
+package requestsource
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/netip"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/realclientip/realclientip-go"
+	providerranges "github.com/realclientip/realclientip-go/ranges"
+	"go4.org/netipx"
+
+	"github.com/leapmux/leapmux/generated/contracts"
+	"github.com/leapmux/leapmux/internal/hub/settings"
+)
+
+// TrustedRanges is the stored selector list and its decoded address set. JSON
+// contains only the canonical selectors. Provider ranges stay symbolic there.
+type TrustedRanges struct {
+	selectors     []string
+	prefixes      []netip.Prefix
+	set           *netipx.IPSet
+	forwarded     realclientip.RightmostTrustedRangeStrategy
+	xForwardedFor realclientip.RightmostTrustedRangeStrategy
+}
+
+// NewTrustedRanges validates and canonicalizes configured selectors.
+func NewTrustedRanges(selectors []string) (TrustedRanges, error) {
+	if len(selectors) > contracts.MaxTrustedProxySelectors {
+		return TrustedRanges{}, fmt.Errorf("at most %d trusted proxy selectors are allowed; got %d",
+			contracts.MaxTrustedProxySelectors, len(selectors))
+	}
+
+	canonical := make([]string, 0, len(selectors))
+	seen := make(map[string]struct{}, len(selectors))
+	var combinedBuilder netipx.IPSetBuilder
+	combined, err := combinedBuilder.IPSet()
+	if err != nil {
+		return TrustedRanges{}, fmt.Errorf("create the trusted proxy set: %w", err)
+	}
+	for index, raw := range selectors {
+		selector, selectorSet, err := parseSelector(raw)
+		if err != nil {
+			return TrustedRanges{}, fmt.Errorf("trusted proxy selector %d (%q): %w", index+1, raw, err)
+		}
+		if _, ok := seen[selector]; ok {
+			return TrustedRanges{}, fmt.Errorf("trusted proxy selector %d (%q) duplicates %q", index+1, raw, selector)
+		}
+		if combined.Overlaps(selectorSet) {
+			return TrustedRanges{}, fmt.Errorf("trusted proxy selector %d (%q) overlaps an earlier selector", index+1, raw)
+		}
+		seen[selector] = struct{}{}
+		canonical = append(canonical, selector)
+		combinedBuilder.AddSet(selectorSet)
+		combined, err = combinedBuilder.IPSet()
+		if err != nil {
+			return TrustedRanges{}, fmt.Errorf("combine trusted proxy selector %d: %w", index+1, err)
+		}
+	}
+
+	prefixes := combined.Prefixes()
+	ipNets := make([]net.IPNet, 0, len(prefixes))
+	for _, prefix := range prefixes {
+		ipNets = append(ipNets, *netipx.PrefixIPNet(prefix))
+	}
+	forwarded, err := realclientip.NewRightmostTrustedRangeStrategy("Forwarded", ipNets)
+	if err != nil {
+		return TrustedRanges{}, fmt.Errorf("create the Forwarded strategy: %w", err)
+	}
+	xForwardedFor, err := realclientip.NewRightmostTrustedRangeStrategy("X-Forwarded-For", ipNets)
+	if err != nil {
+		return TrustedRanges{}, fmt.Errorf("create the X-Forwarded-For strategy: %w", err)
+	}
+	return TrustedRanges{
+		selectors:     slices.Clone(canonical),
+		prefixes:      prefixes,
+		set:           combined,
+		forwarded:     forwarded,
+		xForwardedFor: xForwardedFor,
+	}, nil
+}
+
+// Selectors returns the canonical configured selectors.
+func (r TrustedRanges) Selectors() []string {
+	return slices.Clone(r.selectors)
+}
+
+// Prefixes returns the expanded and normalized trusted prefixes.
+func (r TrustedRanges) Prefixes() []netip.Prefix {
+	return slices.Clone(r.prefixes)
+}
+
+// Contains reports whether the expanded trusted set contains an address.
+func (r TrustedRanges) Contains(addr netip.Addr) bool {
+	return r.set != nil && r.set.Contains(addr.Unmap())
+}
+
+// MarshalJSON preserves symbolic provider selectors in storage and listings.
+func (r TrustedRanges) MarshalJSON() ([]byte, error) {
+	selectors := r.selectors
+	if selectors == nil {
+		selectors = []string{}
+	}
+	return json.Marshal(selectors)
+}
+
+// UnmarshalJSON validates and expands the stored selector list during snapshot
+// decode. The snapshot then carries a ready-to-use address set.
+func (r *TrustedRanges) UnmarshalJSON(data []byte) error {
+	var selectors []string
+	if err := json.Unmarshal(data, &selectors); err != nil {
+		return fmt.Errorf("trusted_proxy_ranges must be a JSON list of strings: %w", err)
+	}
+	if selectors == nil {
+		return fmt.Errorf("trusted_proxy_ranges must be a JSON list of strings")
+	}
+	decoded, err := NewTrustedRanges(selectors)
+	if err != nil {
+		return err
+	}
+	*r = decoded
+	return nil
+}
+
+// KeyTrustedProxyRanges controls which transport peers can supply forwarding
+// headers. It is hot because the middleware reads a settings snapshot for each
+// request.
+var KeyTrustedProxyRanges = settings.NewKey[TrustedRanges]("trusted_proxy_ranges").
+	WithUI(settings.UIMeta{
+		Category: "network",
+		Title:    "Trusted reverse proxies",
+		Summary:  "transport peers whose Forwarded or X-Forwarded headers can identify the client",
+		Fields: []settings.Field{{
+			Name: "", Label: "Trusted reverse proxies", Kind: settings.FieldCustom,
+			CustomID: "trustedProxies",
+			Help:     "Trust only reverse proxies that remove client-supplied forwarding headers or append verified values.",
+		}},
+	})
+
+// SettingsDescriptors lists the request-source settings.
+func SettingsDescriptors() []settings.Descriptor {
+	return []settings.Descriptor{KeyTrustedProxyRanges}
+}
+
+func parseSelector(raw string) (string, *netipx.IPSet, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", nil, fmt.Errorf("the selector is empty")
+	}
+	lower := strings.ToLower(value)
+	if providerValues, ok := providerRanges(lower); ok {
+		set, err := prefixSet(providerValues)
+		if err != nil {
+			return "", nil, fmt.Errorf("expand provider %q: %w", lower, err)
+		}
+		return lower, set, nil
+	}
+	if strings.Contains(value, "/") {
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil || prefix.Addr().Zone() != "" {
+			return "", nil, fmt.Errorf("invalid CIDR")
+		}
+		if prefix.Addr().Is4In6() {
+			return "", nil, fmt.Errorf("an IPv4-mapped IPv6 CIDR is ambiguous; use its IPv4 form")
+		}
+		prefix = prefix.Masked()
+		if prefix.Addr().IsUnspecified() && prefix.Bits() == prefix.Addr().BitLen() {
+			return "", nil, fmt.Errorf("an unspecified address is not a proxy")
+		}
+		set, err := prefixSet([]string{prefix.String()})
+		return prefix.String(), set, err
+	}
+	if strings.Contains(value, "-") {
+		return parseInclusiveRange(value)
+	}
+	addr, err := parseAddress(value)
+	if err != nil {
+		return "", nil, fmt.Errorf("unknown provider or invalid IP address")
+	}
+	prefix := netip.PrefixFrom(addr, addr.BitLen())
+	set, err := prefixSet([]string{prefix.String()})
+	return addr.String(), set, err
+}
+
+func providerRanges(token string) ([]string, bool) {
+	switch token {
+	case contracts.TrustedProxyProviderCloudflare:
+		return providerranges.Cloudflare, true
+	case contracts.TrustedProxyProviderCloudFront:
+		return providerranges.CloudFront, true
+	default:
+		return nil, false
+	}
+}
+
+func parseInclusiveRange(value string) (string, *netipx.IPSet, error) {
+	parts := strings.Split(value, "-")
+	if len(parts) != 2 {
+		return "", nil, fmt.Errorf("invalid inclusive range")
+	}
+	first, err := parseAddress(parts[0])
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid range start")
+	}
+	last, err := parseAddress(parts[1])
+	if err != nil {
+		last, err = shortIPv4End(first, parts[1])
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid range end")
+		}
+	}
+	if first.BitLen() != last.BitLen() {
+		return "", nil, fmt.Errorf("range addresses use different address families")
+	}
+	if last.Less(first) {
+		return "", nil, fmt.Errorf("range end precedes range start")
+	}
+	ipRange := netipx.IPRangeFrom(first, last)
+	if !ipRange.IsValid() {
+		return "", nil, fmt.Errorf("invalid inclusive range")
+	}
+	var builder netipx.IPSetBuilder
+	builder.AddRange(ipRange)
+	set, err := builder.IPSet()
+	if err != nil {
+		return "", nil, fmt.Errorf("decompose inclusive range: %w", err)
+	}
+	return ipRange.String(), set, nil
+}
+
+func parseAddress(value string) (netip.Addr, error) {
+	if strings.Contains(value, "%") {
+		return netip.Addr{}, fmt.Errorf("zones are not allowed")
+	}
+	addr, err := netip.ParseAddr(value)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+	addr = addr.Unmap()
+	if addr.IsUnspecified() {
+		return netip.Addr{}, fmt.Errorf("an unspecified address is not a proxy")
+	}
+	return addr, nil
+}
+
+func shortIPv4End(first netip.Addr, value string) (netip.Addr, error) {
+	if !first.Is4() || value == "" || strings.TrimSpace(value) != value {
+		return netip.Addr{}, fmt.Errorf("not a short IPv4 range")
+	}
+	octet, err := strconv.ParseUint(value, 10, 8)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("parse the final IPv4 octet: %w", err)
+	}
+	bytes := first.As4()
+	bytes[3] = byte(octet)
+	return netip.AddrFrom4(bytes), nil
+}
+
+func prefixSet(values []string) (*netipx.IPSet, error) {
+	var builder netipx.IPSetBuilder
+	for _, value := range values {
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			return nil, fmt.Errorf("parse prefix %q: %w", value, err)
+		}
+		builder.AddPrefix(prefix.Masked())
+	}
+	return builder.IPSet()
+}

--- a/backend/internal/hub/requestsource/ranges_test.go
+++ b/backend/internal/hub/requestsource/ranges_test.go
@@ -70,6 +70,38 @@ func TestTrustedRanges_RejectsInvalidSelectors(t *testing.T) {
 	}
 }
 
+// Overlap is checked against EVERY earlier selector, not the previous one.
+//
+// The set accumulates across the loop, and a two-selector test cannot tell
+// that apart from a set rebuilt on each step: with two, "all the earlier ones"
+// and "the previous one" are the same selector. The third below overlaps the
+// FIRST and is disjoint from the second, so it is caught only by the
+// accumulated set.
+func TestTrustedRanges_DetectsAnOverlapWithAnySelectorNotOnlyTheLast(t *testing.T) {
+	t.Parallel()
+	_, err := requestsource.NewTrustedRanges([]string{
+		"192.0.2.0/24",
+		"198.51.100.0/24",
+		"192.0.2.7",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overlaps")
+	assert.Contains(t, err.Error(), "selector 3", "the report must name the selector that collided")
+
+	// The same three, with the collision removed, are accepted together -- so
+	// the refusal above is the overlap and not the count.
+	ranges, err := requestsource.NewTrustedRanges([]string{
+		"192.0.2.0/24",
+		"198.51.100.0/24",
+		"203.0.113.7",
+	})
+	require.NoError(t, err)
+	assert.True(t, ranges.Contains(netip.MustParseAddr("192.0.2.7")))
+	assert.True(t, ranges.Contains(netip.MustParseAddr("198.51.100.9")))
+	assert.True(t, ranges.Contains(netip.MustParseAddr("203.0.113.7")))
+	assert.False(t, ranges.Contains(netip.MustParseAddr("203.0.113.8")))
+}
+
 func TestTrustedRanges_EnforcesConfiguredSelectorCap(t *testing.T) {
 	t.Parallel()
 	selectors := make([]string, contracts.MaxTrustedProxySelectors+1)

--- a/backend/internal/hub/requestsource/ranges_test.go
+++ b/backend/internal/hub/requestsource/ranges_test.go
@@ -1,0 +1,133 @@
+package requestsource_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/generated/contracts"
+	"github.com/leapmux/leapmux/internal/hub/requestsource"
+)
+
+func TestTrustedRanges_CanonicalizesSupportedSelectors(t *testing.T) {
+	t.Parallel()
+	configured := []string{
+		"192.0.2.10",
+		"2001:0DB8::10",
+		"192.168.0.1-100",
+		"198.51.100.1-198.51.100.100",
+		"2001:db8:1::1-2001:db8:1::ffff",
+		"203.0.113.17/24",
+		"2001:db8:2::17/64",
+	}
+	ranges, err := requestsource.NewTrustedRanges(configured)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"192.0.2.10",
+		"2001:db8::10",
+		"192.168.0.1-192.168.0.100",
+		"198.51.100.1-198.51.100.100",
+		"2001:db8:1::1-2001:db8:1::ffff",
+		"203.0.113.0/24",
+		"2001:db8:2::/64",
+	}, ranges.Selectors())
+}
+
+func TestTrustedRanges_RejectsInvalidSelectors(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name      string
+		selectors []string
+		message   string
+	}{
+		{"empty", []string{""}, "empty"},
+		{"IPv4 port", []string{"192.0.2.1:443"}, "invalid IP"},
+		{"IPv6 port", []string{"[2001:db8::1]:443"}, "invalid IP"},
+		{"zone", []string{"fe80::1%en0"}, "invalid IP"},
+		{"mapped CIDR", []string{"::ffff:192.0.2.0/120"}, "ambiguous"},
+		{"unknown provider", []string{"fastly"}, "unknown provider"},
+		{"mixed families", []string{"192.0.2.1-2001:db8::1"}, "different address families"},
+		{"reversed range", []string{"192.0.2.100-1"}, "precedes"},
+		{"bad range", []string{"192.0.2.1-2-3"}, "inclusive range"},
+		{"duplicate address", []string{"192.0.2.1", "192.0.2.1"}, "duplicates"},
+		{"duplicate provider", []string{"cloudflare", "CLOUDFLARE"}, "duplicates"},
+		{"CIDR overlap", []string{"192.0.2.0/24", "192.0.2.20"}, "overlaps"},
+		{"range overlap", []string{"192.0.2.1-100", "192.0.2.50-150"}, "overlaps"},
+		{"provider overlap", []string{"cloudflare", "104.16.0.1"}, "overlaps"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := requestsource.NewTrustedRanges(test.selectors)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.message)
+		})
+	}
+}
+
+func TestTrustedRanges_EnforcesConfiguredSelectorCap(t *testing.T) {
+	t.Parallel()
+	selectors := make([]string, contracts.MaxTrustedProxySelectors+1)
+	for index := range selectors {
+		selectors[index] = fmt.Sprintf("192.0.2.%d", index+1)
+	}
+	_, err := requestsource.NewTrustedRanges(selectors)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("at most %d", contracts.MaxTrustedProxySelectors))
+}
+
+func TestTrustedRanges_ProvidersStaySymbolicAndExpandBothFamilies(t *testing.T) {
+	t.Parallel()
+	for _, token := range []string{"cloudflare", "cloudfront"} {
+		t.Run(token, func(t *testing.T) {
+			t.Parallel()
+			trusted, err := requestsource.NewTrustedRanges([]string{strings.ToUpper(token)})
+			require.NoError(t, err)
+			assert.Equal(t, []string{token}, trusted.Selectors())
+
+			prefixes := trusted.Prefixes()
+			assert.True(t, slices.ContainsFunc(prefixes, func(prefix netip.Prefix) bool { return prefix.Addr().Is4() }))
+			assert.True(t, slices.ContainsFunc(prefixes, func(prefix netip.Prefix) bool { return prefix.Addr().Is6() }))
+			if token == "cloudfront" {
+				assert.Greater(t, len(prefixes), contracts.MaxTrustedProxySelectors,
+					"expanded provider prefixes must not count against the configured selector cap")
+			}
+
+			encoded, err := json.Marshal(trusted)
+			require.NoError(t, err)
+			assert.JSONEq(t, fmt.Sprintf("[%q]", token), string(encoded))
+		})
+	}
+}
+
+func TestTrustedRanges_ManualSelectorCanSupplementProvider(t *testing.T) {
+	t.Parallel()
+	trusted, err := requestsource.NewTrustedRanges([]string{"cloudflare", "192.0.2.10"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cloudflare", "192.0.2.10"}, trusted.Selectors())
+	assert.True(t, trusted.Contains(netip.MustParseAddr("192.0.2.10")))
+}
+
+func TestTrustedRanges_JSONDecodeValidatesAndCanonicalizes(t *testing.T) {
+	t.Parallel()
+	var trusted requestsource.TrustedRanges
+	require.NoError(t, json.Unmarshal([]byte(`["CLOUDFRONT","192.0.2.1-20"]`), &trusted))
+	assert.Equal(t, []string{"cloudfront", "192.0.2.1-192.0.2.20"}, trusted.Selectors())
+
+	err := json.Unmarshal([]byte(`["192.0.2.1","192.0.2.0/24"]`), &trusted)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overlaps")
+}
+
+func TestTrustedRanges_JSONDecodeRejectsNull(t *testing.T) {
+	t.Parallel()
+	var trusted requestsource.TrustedRanges
+	err := json.Unmarshal([]byte(`null`), &trusted)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "JSON list of strings")
+}

--- a/backend/internal/hub/requestsource/ranges_test.go
+++ b/backend/internal/hub/requestsource/ranges_test.go
@@ -1,6 +1,7 @@
 package requestsource_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/netip"
@@ -13,6 +14,9 @@ import (
 
 	"github.com/leapmux/leapmux/generated/contracts"
 	"github.com/leapmux/leapmux/internal/hub/requestsource"
+	"github.com/leapmux/leapmux/internal/hub/settings"
+	"github.com/leapmux/leapmux/internal/hub/store"
+	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
 )
 
 func TestTrustedRanges_CanonicalizesSupportedSelectors(t *testing.T) {
@@ -72,11 +76,11 @@ func TestTrustedRanges_RejectsInvalidSelectors(t *testing.T) {
 
 // Overlap is checked against EVERY earlier selector, not the previous one.
 //
-// The set accumulates across the loop, and a two-selector test cannot tell
-// that apart from a set rebuilt on each step: with two, "all the earlier ones"
-// and "the previous one" are the same selector. The third below overlaps the
-// FIRST and is disjoint from the second, so it is caught only by the
-// accumulated set.
+// The set accumulates across the loop. A two-selector test cannot tell that
+// apart from a set rebuilt on each step. With two selectors, "all the earlier
+// ones" and "the previous one" are the same selector. The third below overlaps
+// the FIRST and is disjoint from the second, so only the accumulated set
+// catches it.
 func TestTrustedRanges_DetectsAnOverlapWithAnySelectorNotOnlyTheLast(t *testing.T) {
 	t.Parallel()
 	_, err := requestsource.NewTrustedRanges([]string{
@@ -150,10 +154,44 @@ func TestTrustedRanges_JSONDecodeValidatesAndCanonicalizes(t *testing.T) {
 	var trusted requestsource.TrustedRanges
 	require.NoError(t, json.Unmarshal([]byte(`["CLOUDFRONT","192.0.2.1-20"]`), &trusted))
 	assert.Equal(t, []string{"cloudfront", "192.0.2.1-192.0.2.20"}, trusted.Selectors())
+}
 
-	err := json.Unmarshal([]byte(`["192.0.2.1","192.0.2.0/24"]`), &trusted)
+// A list that will not EXPAND decodes, and reports itself through Validate.
+//
+// The split matters to the settings framework and nowhere else. A decode error
+// is a hard refusal in mergeForUpdate, so a stored row that stopped expanding
+// -- because a bundled provider range widened over a manual selector, or
+// because the selector cap dropped -- would refuse every later write and leave
+// Reset, which discards the operator's whole list, as the only way out. A
+// validation failure degrades the write's base to the default and logs, which
+// is the recovery every other settings key has.
+func TestTrustedRanges_JSONDecodeDefersAnUnexpandableListToValidate(t *testing.T) {
+	t.Parallel()
+	var trusted requestsource.TrustedRanges
+	require.NoError(t, json.Unmarshal([]byte(`["192.0.2.1","192.0.2.0/24"]`), &trusted),
+		"an unexpandable list must decode, or the key becomes unwritable")
+
+	err := trusted.Validate()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "overlaps")
+
+	// FAIL-CLOSED: a degraded value trusts nobody, so the window between the
+	// bad row and the operator's next write never widens the trust set.
+	assert.False(t, trusted.Contains(netip.MustParseAddr("192.0.2.1")))
+	assert.Empty(t, trusted.Prefixes())
+	// The raw selectors survive, so the admin surface can still show the
+	// operator what the stored row says.
+	assert.Equal(t, []string{"192.0.2.1", "192.0.2.0/24"}, trusted.Selectors())
+}
+
+// A value the constructor accepted reports no validation error, so the
+// framework never degrades a good row.
+func TestTrustedRanges_ValidateAcceptsAnExpandedList(t *testing.T) {
+	t.Parallel()
+	var trusted requestsource.TrustedRanges
+	require.NoError(t, json.Unmarshal([]byte(`["192.0.2.0/24"]`), &trusted))
+	assert.NoError(t, trusted.Validate())
+	assert.True(t, trusted.Contains(netip.MustParseAddr("192.0.2.7")))
 }
 
 func TestTrustedRanges_JSONDecodeRejectsNull(t *testing.T) {
@@ -162,4 +200,73 @@ func TestTrustedRanges_JSONDecodeRejectsNull(t *testing.T) {
 	err := json.Unmarshal([]byte(`null`), &trusted)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "JSON list of strings")
+}
+
+// The whole point of deferring the expansion failure to Validate: an operator
+// whose STORED row stopped expanding can still write a new one.
+//
+// The trigger is realistic. `providerranges` is a generated snapshot, so a
+// dependency bump that widens a bundled Cloudflare or CloudFront prefix over
+// an operator's manual selector makes the stored pair overlap, and the row
+// stops expanding. Before this, `mergeForUpdate` refused to decode the current
+// value, so every later write to the key answered "decode current value of
+// trusted_proxy_ranges" and only `Reset` -- which discards the whole list --
+// escaped.
+func TestKeyTrustedProxyRanges_StaysWritableAfterAnUnexpandableRow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := hubtestutil.OpenTestStore(t)
+	manager := settings.NewManager(st, nil, requestsource.SettingsDescriptors())
+
+	// Written straight to the TABLE, which is how a row the current rules
+	// refuse gets there: direct SQL, or an older hub whose bundled provider
+	// ranges did not yet overlap this operator's manual selector. Every write
+	// verb the admin surface exposes validates, so none of them can produce it.
+	row := `["192.0.2.1","192.0.2.0/24"]`
+	require.NoError(t, st.Settings().Upsert(ctx, store.UpsertSettingParams{
+		Key:   "trusted_proxy_ranges",
+		Value: &row,
+	}))
+	require.NoError(t, manager.Load(ctx))
+
+	// The READ degrades to the default, so nothing is trusted meanwhile.
+	degraded := requestsource.KeyTrustedProxyRanges.Of(manager.Snapshot(ctx))
+	assert.False(t, degraded.Contains(netip.MustParseAddr("192.0.2.1")),
+		"a row the rules refuse must trust nobody")
+
+	// The WRITE succeeds, which is the property this test exists for.
+	require.NoError(t, manager.Update(ctx, requestsource.KeyTrustedProxyRanges,
+		json.RawMessage(`["198.51.100.0/24"]`)))
+	repaired := requestsource.KeyTrustedProxyRanges.Of(manager.Snapshot(ctx))
+	assert.Equal(t, []string{"198.51.100.0/24"}, repaired.Selectors())
+	assert.True(t, repaired.Contains(netip.MustParseAddr("198.51.100.7")))
+
+	// And an invalid NEW write is still refused, so the recovery did not widen
+	// what an operator can store.
+	require.Error(t, manager.Update(ctx, requestsource.KeyTrustedProxyRanges,
+		json.RawMessage(`["203.0.113.1","203.0.113.0/24"]`)),
+		"an overlapping list must still be refused on the way in")
+}
+
+// Every token in the generated catalogue must resolve to bundled ranges.
+//
+// The catalogue is what the settings editor renders its Add menu from, so a
+// token the contract carries and this package does not bind is a menu entry
+// that stages a selector the hub then refuses with "unknown provider or
+// invalid IP address". The failure lands on the operator at write time, and
+// nothing upstream catches it: the JSON schema and the generator's own check
+// both pass for a well-formed entry.
+func TestProviderCatalogueIsBound(t *testing.T) {
+	t.Parallel()
+	require.NotEmpty(t, contracts.TrustedProxyProviders, "an empty catalogue makes this test vacuous")
+	for _, provider := range contracts.TrustedProxyProviders {
+		t.Run(provider.Token, func(t *testing.T) {
+			t.Parallel()
+			trusted, err := requestsource.NewTrustedRanges([]string{provider.Token})
+			require.NoErrorf(t, err, "the catalogue offers %q but the hub cannot expand it", provider.Token)
+			assert.Equal(t, []string{provider.Token}, trusted.Selectors(),
+				"a provider selector must stay symbolic in storage")
+			assert.NotEmpty(t, trusted.Prefixes(), "%q expands to no ranges", provider.Token)
+		})
+	}
 }

--- a/backend/internal/hub/service/admin_network_service_test.go
+++ b/backend/internal/hub/service/admin_network_service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/bootstrap"
 	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/listenset"
+	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/servicetest"
 	"github.com/leapmux/leapmux/internal/hub/settings"
@@ -29,6 +30,15 @@ import (
 type fakeListenReporter struct {
 	bound   []listenset.Bound
 	primary string
+}
+
+func tcpCtx(ip string) context.Context {
+	return peer.WithTransportAddr(context.Background(), &net.TCPAddr{IP: net.ParseIP(ip), Port: 51234})
+}
+
+func ipcCtxForTest() context.Context {
+	return peer.WithTransportAddr(peer.WithLocalIPC(context.Background()),
+		&net.UnixAddr{Name: "/tmp/hub.sock", Net: "unix"})
 }
 
 func (f fakeListenReporter) Bound() []listenset.Bound  { return f.bound }
@@ -191,38 +201,39 @@ func systemInfoForSolo(t *testing.T, listen service.ListenReporter, ctx context.
 	return resp.Msg
 }
 
-// auto_authenticated is the fact the app reads to decide whether to fall back
-// to the login form. It is per CONNECTION, so the whole rule table has to
-// reach it.
-func TestGetSystemInfo_AutoAuthenticatedFollowsTheTransportAndThePassword(t *testing.T) {
+// SoloAccess gives each connection one exclusive access state.
+func TestGetSystemInfo_SoloAccessFollowsTheTransportAndThePassword(t *testing.T) {
 	loopbackOnly := fakeListenReporter{primary: "127.0.0.1:4327"}
 
-	assert.True(t, systemInfoForSolo(t, loopbackOnly, tcpCtx("127.0.0.1"), false).GetAutoAuthenticated(),
-		"the bootstrap state: a browser reaches a solo hub over TCP and nothing else")
-	assert.True(t, systemInfoForSolo(t, loopbackOnly, ipcCtxForTest(), false).GetAutoAuthenticated())
-	assert.True(t, systemInfoForSolo(t, loopbackOnly, ipcCtxForTest(), true).GetAutoAuthenticated(),
-		"the desktop app is never asked for a password, whatever the account holds")
-	assert.False(t, systemInfoForSolo(t, loopbackOnly, tcpCtx("127.0.0.1"), true).GetAutoAuthenticated(),
-		"once a password exists every TCP address asks for it, 127.0.0.1 included")
-	assert.False(t, systemInfoForSolo(t, loopbackOnly, tcpCtx("192.168.1.24"), true).GetAutoAuthenticated())
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_PASSWORD_SETUP,
+		systemInfoForSolo(t, loopbackOnly, tcpCtx("127.0.0.1"), false).GetSoloAccess())
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_CREDENTIAL_FREE,
+		systemInfoForSolo(t, loopbackOnly, ipcCtxForTest(), false).GetSoloAccess())
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_CREDENTIAL_FREE,
+		systemInfoForSolo(t, loopbackOnly, ipcCtxForTest(), true).GetSoloAccess())
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_SIGN_IN_REQUIRED,
+		systemInfoForSolo(t, loopbackOnly, tcpCtx("127.0.0.1"), true).GetSoloAccess())
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_SIGN_IN_REQUIRED,
+		systemInfoForSolo(t, loopbackOnly, tcpCtx("192.168.1.24"), true).GetSoloAccess())
 }
 
-// password_setup_required blocks the whole app, so its condition is EXPOSURE
-// without a credential and nothing weaker.
-func TestGetSystemInfo_PasswordSetupRequiredNeedsExposureAndNoPassword(t *testing.T) {
+// TCP setup is restricted even on loopback. The listener set does not change
+// the authentication rule.
+func TestGetSystemInfo_PasswordSetupDoesNotDependOnListenerExposure(t *testing.T) {
 	loopbackOnly := fakeListenReporter{primary: "127.0.0.1:4327"}
 	exposed := fakeListenReporter{primary: ":4327", bound: []listenset.Bound{
 		{Addr: listenset.MustParse("*:4327"), Source: listenset.SourceListen},
 	}}
 	ctx := tcpCtx("127.0.0.1")
 
-	assert.True(t, systemInfoForSolo(t, exposed, ctx, false).GetPasswordSetupRequired(),
-		"reachable from another machine and nobody can sign in: the one useful thing left is to ask for a password")
-	assert.False(t, systemInfoForSolo(t, exposed, ctx, true).GetPasswordSetupRequired(),
-		"a password answers it")
-	assert.False(t, systemInfoForSolo(t, loopbackOnly, ctx, false).GetPasswordSetupRequired(),
-		"a loopback-only hub exposes nothing, so the demand would be friction with nothing behind it")
-	assert.False(t, systemInfoForSolo(t, loopbackOnly, ctx, true).GetPasswordSetupRequired())
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_PASSWORD_SETUP,
+		systemInfoForSolo(t, exposed, ctx, false).GetSoloAccess())
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_SIGN_IN_REQUIRED,
+		systemInfoForSolo(t, exposed, ctx, true).GetSoloAccess())
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_PASSWORD_SETUP,
+		systemInfoForSolo(t, loopbackOnly, ctx, false).GetSoloAccess())
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_SIGN_IN_REQUIRED,
+		systemInfoForSolo(t, loopbackOnly, ctx, true).GetSoloAccess())
 }
 
 func TestGetSystemInfo_SoloPasswordSet(t *testing.T) {
@@ -254,9 +265,7 @@ func TestGetSystemInfo_TheSoloFieldsAreFalseOnAMultiUserHub(t *testing.T) {
 	resp, err := service.NewAuthService(deps).GetSystemInfo(tcpCtx("192.168.1.24"),
 		connect.NewRequest(&leapmuxv1.GetSystemInfoRequest{}))
 	require.NoError(t, err)
-	assert.False(t, resp.Msg.GetAutoAuthenticated())
-	assert.False(t, resp.Msg.GetPasswordSetupRequired(),
-		"an exposed multi-user hub already asks every caller to sign in")
+	assert.Equal(t, leapmuxv1.SoloAccess_SOLO_ACCESS_UNSPECIFIED, resp.Msg.GetSoloAccess())
 	assert.False(t, resp.Msg.GetSoloPasswordSet())
 }
 

--- a/backend/internal/hub/service/admin_settings_elevation_test.go
+++ b/backend/internal/hub/service/admin_settings_elevation_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/bootstrap"
 	"github.com/leapmux/leapmux/internal/hub/config"
+	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/servicetest"
 	"github.com/leapmux/leapmux/internal/hub/settings"
@@ -328,6 +330,9 @@ func setupAdminSettingsSoloEnv(t *testing.T) *adminSettingsEnv {
 	mux.Handle(path, handler)
 
 	server := httptest.NewUnstartedServer(mux)
+	server.Config.BaseContext = func(net.Listener) context.Context {
+		return peer.WithLocalIPC(context.Background())
+	}
 	server.EnableHTTP2 = true
 	server.StartTLS()
 	t.Cleanup(server.Close)

--- a/backend/internal/hub/service/admin_settings_service_test.go
+++ b/backend/internal/hub/service/admin_settings_service_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/keystore"
 	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/ratelimit"
+	"github.com/leapmux/leapmux/internal/hub/requestsource"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/settings"
 	"github.com/leapmux/leapmux/internal/hub/settingsregistry"
@@ -196,9 +197,8 @@ func TestAdminSettingsService_ListDescriptorsComplete(t *testing.T) {
 		assert.NotEmpty(t, d.GetTitle(), d.GetKey())
 		assert.NotEmpty(t, d.GetFields(), d.GetKey())
 	}
-	// The three declaration domains are all present: hub-core, captcha,
-	// rate-limit.
-	for _, want := range []string{"smtp", "signup_enabled", "captcha.altcha", "rate_limit.elevation", "max_message_size_bytes"} {
+	// Every declaration domain is present.
+	for _, want := range []string{"smtp", "signup_enabled", "captcha.altcha", "rate_limit.elevation", "max_message_size_bytes", "trusted_proxy_ranges"} {
 		assert.Contains(t, keys, want)
 	}
 
@@ -237,6 +237,10 @@ func TestAdminSettingsService_ValuesDefaultAndCustomized(t *testing.T) {
 	assert.False(t, byKey["queue_budget"].GetCustomized())
 	assert.JSONEq(t, `{"relay_bytes":0,"worker_bytes":0,"userevents_bytes":0}`, byKey["queue_budget"].GetEffectiveJson())
 
+	require.Contains(t, byKey, "trusted_proxy_ranges")
+	assert.False(t, byKey["trusted_proxy_ranges"].GetCustomized())
+	assert.JSONEq(t, `[]`, byKey["trusted_proxy_ranges"].GetEffectiveJson())
+
 	// A partial update merges onto the current value.
 	upd, err := env.client.UpdateSetting(ctx, authedReq(&leapmuxv1.UpdateSettingRequest{
 		Key:         "session_duration_seconds",
@@ -270,6 +274,17 @@ func TestAdminSettingsService_ValuesDefaultAndCustomized(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, reset.Msg.GetValue().GetCustomized())
 	assert.JSONEq(t, "604800", reset.Msg.GetValue().GetEffectiveJson())
+}
+
+func TestAdminSettingsService_RejectsOverlappingTrustedProxySelectors(t *testing.T) {
+	env := setupAdminSettingsTest(t, &config.Config{})
+	_, err := env.client.UpdateSetting(context.Background(), authedReq(&leapmuxv1.UpdateSettingRequest{
+		Key:         requestsource.KeyTrustedProxyRanges.Name(),
+		PartialJson: `["192.0.2.0/24","192.0.2.7"]`,
+	}, env.token))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "overlaps")
 }
 
 // TestAdminSettingsService_SecretsNeverLeave covers all THREE documents the
@@ -472,6 +487,8 @@ func TestAdminSettingsService_SoloOmitsHiddenInSolo(t *testing.T) {
 		// reverse proxy are how a multi-user hub is published.
 		"extra_listen_addresses",
 	}, soloOnly)
+	assert.Contains(t, hub, "trusted_proxy_ranges")
+	assert.Contains(t, solo, "trusted_proxy_ranges")
 }
 
 // The section-level outcome the hiding exists to produce. Categories are

--- a/backend/internal/hub/service/admin_settings_service_test.go
+++ b/backend/internal/hub/service/admin_settings_service_test.go
@@ -520,8 +520,9 @@ func TestAdminSettingsService_SoloSectionsGeneralSurvivesWithPublicURL(t *testin
 	assert.Equal(t, []string{
 		ratelimit.SettingKeyPrefix + string(ratelimit.OpLoginAnonymous),
 		ratelimit.SettingKeyPrefix + string(ratelimit.OpOAuthAnonymous),
+		ratelimit.SettingKeyPrefix + string(ratelimit.OpSoloPasswordSetup),
 	}, solo["rate-limits"],
-		"solo keeps the two address-keyed limits and drops the per-user ones")
+		"solo keeps every address-keyed limit and drops the per-user ones; the first-password setup budget is solo-only, so hiding it here would hide it everywhere")
 
 	// The sections that solo keeps whole. Without this, hiding every
 	// remaining key would still satisfy the assertions above.

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -16,7 +16,6 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/captcha"
 	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/keystore"
-	"github.com/leapmux/leapmux/internal/hub/listenset"
 	"github.com/leapmux/leapmux/internal/hub/mail"
 	"github.com/leapmux/leapmux/internal/hub/password"
 	"github.com/leapmux/leapmux/internal/hub/settings"
@@ -156,33 +155,19 @@ func (s *AuthService) baseURL(ctx context.Context) string {
 	return settings.BaseURL(s.snap(ctx), s.listenAddr())
 }
 
-// soloPasswordSetupRequired reports whether the app must block itself with a
-// password-setup screen.
-//
-// The condition is EXPOSURE without a credential: the hub answers on an
-// address another machine can reach, and its one account has no password. In
-// that state everything the app offers is offered to whoever reaches the port,
-// and no sign-in stands between them -- so the one useful thing the app can do
-// is ask for a password.
-//
-// A loopback-only hub does NOT trigger it. `leapmux solo` with no -listen, and
-// `leapmux solo -listen 127.0.0.1:5000`, expose nothing, so demanding a
-// password there would be friction with nothing behind it.
-//
-// It takes the gate's two answers rather than reading them again: its one
-// caller reports three solo facts from the same row, and asking a second time
-// costs a second store read on every hub that has no password yet.
-//
-// credentialFree is what carries the MODE, and it must stay in the condition.
-// A gate that is not solo answers false to it, so a multi-user hub with a
-// non-loopback listener reports false here -- where testing `!passwordSet`
-// alone would report TRUE and replace the whole app with the password-setup
-// screen for every visitor to `leapmux hub`.
-func (s *AuthService) soloPasswordSetupRequired(credentialFree, passwordSet bool) bool {
-	if !credentialFree || passwordSet {
-		return false
+// soloAccess reports how this connection reaches a solo hub. The enum makes
+// local IPC, restricted TCP setup, and TCP sign-in exclusive states.
+func (s *AuthService) soloAccess(ctx context.Context, passwordSet bool) leapmuxv1.SoloAccess {
+	if !s.cfg.SoloMode {
+		return leapmuxv1.SoloAccess_SOLO_ACCESS_UNSPECIFIED
 	}
-	return listenset.AnyNonLoopback(s.listen.Bound())
+	if s.soloGate.CredentialFree(ctx) {
+		return leapmuxv1.SoloAccess_SOLO_ACCESS_CREDENTIAL_FREE
+	}
+	if !passwordSet {
+		return leapmuxv1.SoloAccess_SOLO_ACCESS_PASSWORD_SETUP
+	}
+	return leapmuxv1.SoloAccess_SOLO_ACCESS_SIGN_IN_REQUIRED
 }
 
 // listenAddr is the TCP address a browser reaches this hub at, in the form
@@ -237,6 +222,92 @@ func (s *AuthService) Login(ctx context.Context, req *connect.Request[leapmuxv1.
 	resp.Msg.User = userToProtoWithPasskeys(ctx, s.store, user)
 	resp.Msg.EmailVerification = emailVerificationToProto(s.loginVerificationOutcome(ctx, user))
 	s.setSessionCookie(ctx, resp.Header(), token, expiresAt)
+	return resp, nil
+}
+
+var errInitialSoloPasswordAlreadySet = errors.New("the solo account already has a password")
+
+// SetInitialSoloPassword claims a passwordless solo account and creates an
+// elevated session. The password, session, and elevation commit together.
+func (s *AuthService) SetInitialSoloPassword(ctx context.Context, req *connect.Request[leapmuxv1.SetInitialSoloPasswordRequest]) (*connect.Response[leapmuxv1.SetInitialSoloPasswordResponse], error) {
+	if !s.cfg.SoloMode {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("initial solo password setup requires solo mode"))
+	}
+
+	user, err := s.store.Users().GetByUsername(ctx, usernames.Solo)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("get the solo account: %w", err))
+	}
+	if user.HasUsablePassword() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errInitialSoloPasswordAlreadySet)
+	}
+	if err := validate.ValidatePassword(req.Msg.GetPassword()); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	hashed, err := password.Hash(req.Msg.GetPassword())
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("hash the password: %w", err))
+	}
+	uid, ok := userid.New(user.ID)
+	if !ok {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("the solo account has no user id"))
+	}
+
+	snap := s.snap(ctx)
+	now := s.now().UTC()
+	var sessionID string
+	var expiresAt time.Time
+	var storedUser *store.User
+	err = s.store.RunInUserAuthTransaction(ctx, uid, func(tx store.Store) error {
+		lockedUser, err := tx.Users().GetByID(ctx, uid.String())
+		if err != nil {
+			return fmt.Errorf("read the locked solo account: %w", err)
+		}
+		if lockedUser.HasUsablePassword() {
+			return errInitialSoloPasswordAlreadySet
+		}
+		if err := tx.Users().UpdatePassword(ctx, store.UpdateUserPasswordParams{
+			ID: lockedUser.ID, PasswordHash: hashed,
+		}); err != nil {
+			return fmt.Errorf("store the initial solo password: %w", err)
+		}
+		sessionID, expiresAt, err = auth.CreateSession(ctx, tx, uid, settings.SessionDuration(snap), auth.SessionMeta{
+			UserAgent: req.Header().Get("User-Agent"),
+		})
+		if err != nil {
+			return err
+		}
+		affected, err := tx.Sessions().Elevate(ctx, store.ElevateSessionParams{
+			SessionID:          sessionID,
+			UserID:             uid,
+			ElevationProvenAt:  now,
+			ElevationExpiresAt: now.Add(auth.ElevationWindow),
+		}, now)
+		if err != nil {
+			return fmt.Errorf("elevate the initial solo session: %w", err)
+		}
+		if affected != 1 {
+			return fmt.Errorf("elevate the initial solo session: session is not active")
+		}
+		userCopy := *lockedUser
+		userCopy.PasswordHash = hashed
+		storedUser = &userCopy
+		return nil
+	})
+	if errors.Is(err, errInitialSoloPasswordAlreadySet) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errInitialSoloPasswordAlreadySet)
+	}
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	s.lifecycle.UserInfoInvalidated(uid.String())
+	resp := connect.NewResponse(&leapmuxv1.SetInitialSoloPasswordResponse{
+		User: userToProto(storedUser, 0),
+	})
+	resp.Header().Set("Set-Cookie", auth.BuildSessionCookie(
+		sessionID, expiresAt, settings.KeySecureCookies.Of(snap)).String())
 	return resp, nil
 }
 
@@ -603,41 +674,27 @@ func (s *AuthService) GetSystemInfo(ctx context.Context, req *connect.Request[le
 		}
 	}
 
-	// ONE store read for the three solo facts, and NONE outside solo mode --
-	// the GATE answers both, so neither is a conjunct here.
-	//
-	// Each fact rests on the same row, and the latch that would make a second
-	// read free is set only once a password exists, so asking through
-	// CredentialFree and PasswordSet separately cost three round trips for one
-	// fact on every page load of a hub that has none. And a gate that is not
-	// solo refuses without reading anything, so a `leapmux hub` no longer looks
-	// up a `solo` row that can never exist.
-	credentialFree, soloPasswordSet := s.soloGate.CredentialFreeAndPasswordSet(ctx)
+	soloPasswordSet := s.soloGate.PasswordSet(ctx)
 
 	return connect.NewResponse(&leapmuxv1.GetSystemInfoResponse{
-		SignupEnabled:  s.signupEnabled(ctx),
-		SoloMode:       s.cfg.SoloMode,
-		SetupRequired:  setupRequired,
-		Version:        version.Value,
-		CommitHash:     version.CommitHash,
-		CommitTime:     version.CommitTime,
-		BuildTime:      version.BuildTime,
-		Branch:         version.Branch,
-		OauthEnabled:   len(providers) > 0,
-		WorkerHubUrl:   workerHubURL,
-		EmailEnabled:   settings.KeySMTP.Of(snap).Enabled(),
-		PasskeyEnabled: s.passkeysRunnableForOrigin(ctx, originFromRequest(req)),
-		CaptchaEnabled: captchaEnabled,
-		// The three solo facts. Each is FALSE outside solo mode, where a
-		// multi-user hub authenticates every caller and each account answers
-		// for its own password -- and the gate says so itself, so no mode test
-		// appears here.
-		AutoAuthenticated:     credentialFree,
-		PasswordSetupRequired: s.soloPasswordSetupRequired(credentialFree, soloPasswordSet),
-		SoloPasswordSet:       soloPasswordSet,
-		AltchaAlgorithm:       altchaAlgorithm,
-		CaptchaProvider:       captchaProvider,
-		CaptchaSiteKey:        captchaSiteKey,
+		SignupEnabled:   s.signupEnabled(ctx),
+		SoloMode:        s.cfg.SoloMode,
+		SetupRequired:   setupRequired,
+		Version:         version.Value,
+		CommitHash:      version.CommitHash,
+		CommitTime:      version.CommitTime,
+		BuildTime:       version.BuildTime,
+		Branch:          version.Branch,
+		OauthEnabled:    len(providers) > 0,
+		WorkerHubUrl:    workerHubURL,
+		EmailEnabled:    settings.KeySMTP.Of(snap).Enabled(),
+		PasskeyEnabled:  s.passkeysRunnableForOrigin(ctx, originFromRequest(req)),
+		CaptchaEnabled:  captchaEnabled,
+		SoloAccess:      s.soloAccess(ctx, soloPasswordSet),
+		SoloPasswordSet: soloPasswordSet,
+		AltchaAlgorithm: altchaAlgorithm,
+		CaptchaProvider: captchaProvider,
+		CaptchaSiteKey:  captchaSiteKey,
 	}), nil
 }
 

--- a/backend/internal/hub/service/auth_service.go
+++ b/backend/internal/hub/service/auth_service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/hub/auth"
@@ -126,9 +127,10 @@ func (s *AuthService) snap(ctx context.Context) *settings.Snapshot {
 	return s.set.Snapshot(ctx)
 }
 
-// secureCookies reads the cookie-name policy for the current request.
+// secureCookies reads the cookie-name policy for the current request. A
+// trusted proxy that verified HTTPS turns it on whatever the setting says.
 func (s *AuthService) secureCookies(ctx context.Context) bool {
-	return settings.KeySecureCookies.Of(s.snap(ctx))
+	return settings.SecureCookiesFor(ctx, s.snap(ctx))
 }
 
 // sessionDuration reads the sliding session lifetime.
@@ -150,15 +152,20 @@ func (s *AuthService) emailVerificationRequired(ctx context.Context) bool {
 	return settings.EmailVerificationEffective(s.snap(ctx))
 }
 
-// baseURL derives the hub's public base URL for deep-links.
+// baseURL derives the hub's public base URL for deep-links. public_url wins
+// when set; otherwise the scheme follows the same rule the cookies do, so a
+// hub behind a TLS proxy builds https links without a second setting.
 func (s *AuthService) baseURL(ctx context.Context) string {
-	return settings.BaseURL(s.snap(ctx), s.listenAddr())
+	return settings.BaseURLFor(ctx, s.snap(ctx), s.listenAddr())
 }
 
 // soloAccess reports how this connection reaches a solo hub. The enum makes
 // local IPC, restricted TCP setup, and TCP sign-in exclusive states.
 func (s *AuthService) soloAccess(ctx context.Context, passwordSet bool) leapmuxv1.SoloAccess {
-	if !s.cfg.SoloMode {
+	// The GATE answers the mode, not `s.cfg`. One object owns the whole solo
+	// rule, which is what stops "the solo facts are false on a multi-user hub"
+	// from becoming several call sites that must stay in step.
+	if !s.soloGate.SoloMode() {
 		return leapmuxv1.SoloAccess_SOLO_ACCESS_UNSPECIFIED
 	}
 	if s.soloGate.CredentialFree(ctx) {
@@ -236,6 +243,16 @@ func (s *AuthService) SetInitialSoloPassword(ctx context.Context, req *connect.R
 	}
 
 	user, err := s.store.Users().GetByUsername(ctx, usernames.Solo)
+	// NOT FOUND is a precondition, not an internal fault, and the gate routes
+	// a caller here in exactly that state: SoloGate.accountHasPassword treats
+	// an absent row as "no password", so a hub whose row an administrator
+	// deleted reports SOLO_ACCESS_PASSWORD_SETUP and the browser renders the
+	// setup screen. Answering Internal there gives the operator a 500 from the
+	// one screen the hub offers them, for a condition the hub can state.
+	if errors.Is(err, store.ErrNotFound) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition,
+			fmt.Errorf("the %q account does not exist; restart the hub in solo mode to create it", usernames.Solo))
+	}
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("get the solo account: %w", err))
 	}
@@ -258,6 +275,7 @@ func (s *AuthService) SetInitialSoloPassword(ctx context.Context, req *connect.R
 	now := s.now().UTC()
 	var sessionID string
 	var expiresAt time.Time
+	var elevationExpiresAt time.Time
 	var storedUser *store.User
 	err = s.store.RunInUserAuthTransaction(ctx, uid, func(tx store.Store) error {
 		lockedUser, err := tx.Users().GetByID(ctx, uid.String())
@@ -267,6 +285,23 @@ func (s *AuthService) SetInitialSoloPassword(ctx context.Context, req *connect.R
 		if lockedUser.HasUsablePassword() {
 			return errInitialSoloPasswordAlreadySet
 		}
+		// A BARE password write. UserService.ChangePassword calls
+		// revokeOtherCredentialsPreservingActingCredential here, which bumps
+		// the auth generation and tears down every other session, bearer and
+		// channel. This path deliberately does not, and the difference is not
+		// an oversight.
+		//
+		// Nothing exists yet that a revoke would protect against. This
+		// procedure is reachable only while the account holds NO password, and
+		// in that state a TCP caller can reach no other protected RPC, so
+		// every credential that can exist was minted over the local IPC
+		// socket. That socket stays credential-free after this write -- the
+		// gate reads the transport, not the password -- so revoking would sign
+		// the operator's own agents out of a hub they keep full access to, and
+		// buy nothing.
+		//
+		// An operator who believes somebody else won the race to this
+		// procedure runs ChangePassword over local IPC, which does revoke.
 		if err := tx.Users().UpdatePassword(ctx, store.UpdateUserPasswordParams{
 			ID: lockedUser.ID, PasswordHash: hashed,
 		}); err != nil {
@@ -278,18 +313,23 @@ func (s *AuthService) SetInitialSoloPassword(ctx context.Context, req *connect.R
 		if err != nil {
 			return err
 		}
-		affected, err := tx.Sessions().Elevate(ctx, store.ElevateSessionParams{
-			SessionID:          sessionID,
-			UserID:             uid,
-			ElevationProvenAt:  now,
-			ElevationExpiresAt: now.Add(auth.ElevationWindow),
-		}, now)
+		// The same row write every factor path takes, so the window, the
+		// parameters and the zero-row refusal have one home. The cache
+		// invalidation is NOT taken here: it must fire after the commit, or a
+		// concurrent reader refills the cache from the pre-commit row. See
+		// grantSessionElevation, which is that half.
+		//
+		// The session was created two statements above, inside this
+		// transaction, so a zero row count is an internal inconsistency rather
+		// than the ordinary "your session ended" the factor paths report.
+		elevatedUntil, live, err := elevateSessionRow(ctx, tx, sessionID, uid, now)
 		if err != nil {
 			return fmt.Errorf("elevate the initial solo session: %w", err)
 		}
-		if affected != 1 {
-			return fmt.Errorf("elevate the initial solo session: session is not active")
+		if !live {
+			return fmt.Errorf("elevate the initial solo session: the session this transaction created is not active")
 		}
+		elevationExpiresAt = elevatedUntil
 		userCopy := *lockedUser
 		userCopy.PasswordHash = hashed
 		storedUser = &userCopy
@@ -305,9 +345,13 @@ func (s *AuthService) SetInitialSoloPassword(ctx context.Context, req *connect.R
 	s.lifecycle.UserInfoInvalidated(uid.String())
 	resp := connect.NewResponse(&leapmuxv1.SetInitialSoloPasswordResponse{
 		User: userToProto(storedUser, 0),
+		// The deadline the transaction above stamped, so the client's
+		// elevation state comes from the reply that granted it rather than
+		// from a second round trip that can fail.
+		ElevationExpiresAt: timestamppb.New(elevationExpiresAt),
 	})
 	resp.Header().Set("Set-Cookie", auth.BuildSessionCookie(
-		sessionID, expiresAt, settings.KeySecureCookies.Of(snap)).String())
+		sessionID, expiresAt, settings.SecureCookiesFor(ctx, snap)).String())
 	return resp, nil
 }
 

--- a/backend/internal/hub/service/auth_service_test.go
+++ b/backend/internal/hub/service/auth_service_test.go
@@ -161,6 +161,17 @@ func TestAuthService_SetInitialSoloPasswordCreatesElevatedSession(t *testing.T) 
 	info, err := auth.ValidateToken(context.Background(), st, sessionID)
 	require.NoError(t, err)
 	assert.True(t, info.Elevated(time.Now()))
+
+	// The deadline travels WITH the reply, so a client's elevation state comes
+	// from the answer that granted it rather than from a second round trip. A
+	// client that had to recover it from a following GetCurrentUser would show
+	// the operator an un-elevated session, and prompt for the password they
+	// just chose, whenever that call failed transiently.
+	reported := response.Msg.GetElevationExpiresAt()
+	require.NotNil(t, reported, "the reply must carry the elevation it granted")
+	assert.WithinDuration(t, time.Now().Add(auth.ElevationWindow), reported.AsTime(), time.Minute)
+	assert.True(t, info.Elevated(reported.AsTime().Add(-time.Second)),
+		"the reported deadline must fall inside the window the store recorded")
 	session, err := st.Sessions().GetByID(context.Background(), sessionID, time.Now().UTC())
 	require.NoError(t, err)
 	assert.Equal(t, "setup-test", session.UserAgent)
@@ -1672,9 +1683,9 @@ func TestSignUp_AllowsAdminInSetupMode(t *testing.T) {
 }
 
 // The other half of the setup exemption, and the half that matters for
-// safety: `admin` becomes claimable in setup mode, `solo` never does. A user
-// The hub uses a user by that name as the synthetic local IPC identity if
-// somebody opens the same data directory in solo mode.
+// safety: `admin` becomes claimable in setup mode, `solo` never does. The hub
+// uses a user by that name as the synthetic local IPC identity if somebody
+// opens the same data directory in solo mode.
 func TestSignUp_RejectsSoloInSetupMode(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/hub/service/auth_service_test.go
+++ b/backend/internal/hub/service/auth_service_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/generated/proto/leapmux/v1/leapmuxv1connect"
 	"github.com/leapmux/leapmux/internal/hub/auth"
+	"github.com/leapmux/leapmux/internal/hub/bootstrap"
 	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/keystore"
 	"github.com/leapmux/leapmux/internal/hub/mail"
@@ -139,6 +142,105 @@ func TestAuthService_LoginInvalidPassword(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestAuthService_SetInitialSoloPasswordCreatesElevatedSession(t *testing.T) {
+	client, st, _ := setupAuthTestServerBase(t, &config.Config{SoloMode: true}, nil)
+	require.NoError(t, bootstrap.Run(context.Background(), st, true))
+
+	request := connect.NewRequest(&leapmuxv1.SetInitialSoloPasswordRequest{
+		Password: "correct-horse-battery-staple",
+	})
+	request.Header().Set("User-Agent", "setup-test")
+	response, err := client.SetInitialSoloPassword(context.Background(), request)
+	require.NoError(t, err)
+	assert.Equal(t, usernames.Solo, response.Msg.GetUser().GetUsername())
+	assert.True(t, response.Msg.GetUser().GetPasswordSet())
+
+	sessionID := sessionFromCookie(t, response.Header().Get("Set-Cookie"))
+	info, err := auth.ValidateToken(context.Background(), st, sessionID)
+	require.NoError(t, err)
+	assert.True(t, info.Elevated(time.Now()))
+	session, err := st.Sessions().GetByID(context.Background(), sessionID, time.Now().UTC())
+	require.NoError(t, err)
+	assert.Equal(t, "setup-test", session.UserAgent)
+
+	user, err := st.Users().GetByUsername(context.Background(), usernames.Solo)
+	require.NoError(t, err)
+	matched, err := password.Verify(user.PasswordHash, "correct-horse-battery-staple")
+	require.NoError(t, err)
+	assert.True(t, matched)
+
+	_, err = client.SetInitialSoloPassword(context.Background(), connect.NewRequest(
+		&leapmuxv1.SetInitialSoloPasswordRequest{Password: "another-correct-password"}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+func TestAuthService_SetInitialSoloPasswordRefusesOtherModes(t *testing.T) {
+	t.Parallel()
+	client, _, _ := setupAuthTestServer(t, testConfig(), nil)
+	_, err := client.SetInitialSoloPassword(context.Background(), connect.NewRequest(
+		&leapmuxv1.SetInitialSoloPasswordRequest{Password: "correct-horse-battery-staple"}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+func TestAuthService_SetInitialSoloPasswordRejectsAnEmptyPasswordWithoutClaimingTheAccount(t *testing.T) {
+	client, st, _ := setupAuthTestServerBase(t, &config.Config{SoloMode: true}, nil)
+	require.NoError(t, bootstrap.Run(context.Background(), st, true))
+
+	_, err := client.SetInitialSoloPassword(context.Background(), connect.NewRequest(
+		&leapmuxv1.SetInitialSoloPasswordRequest{}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	response, err := client.SetInitialSoloPassword(context.Background(), connect.NewRequest(
+		&leapmuxv1.SetInitialSoloPasswordRequest{Password: "correct-horse-battery-staple"}))
+	require.NoError(t, err)
+	assert.NotEmpty(t, sessionFromCookie(t, response.Header().Get("Set-Cookie")))
+}
+
+func TestAuthService_ConcurrentInitialSoloPasswordHasOneWinner(t *testing.T) {
+	client, st, _ := setupAuthTestServerBase(t, &config.Config{SoloMode: true}, nil)
+	require.NoError(t, bootstrap.Run(context.Background(), st, true))
+
+	const callers = 6
+	type result struct {
+		response *connect.Response[leapmuxv1.SetInitialSoloPasswordResponse]
+		err      error
+	}
+	results := make(chan result, callers)
+	var start sync.WaitGroup
+	start.Add(1)
+	var workers sync.WaitGroup
+	workers.Add(callers)
+	for index := range callers {
+		go func() {
+			defer workers.Done()
+			start.Wait()
+			response, err := client.SetInitialSoloPassword(context.Background(), connect.NewRequest(
+				&leapmuxv1.SetInitialSoloPasswordRequest{Password: fmt.Sprintf("correct-password-%d", index)}))
+			results <- result{response: response, err: err}
+		}()
+	}
+	start.Done()
+	workers.Wait()
+	close(results)
+
+	winners := 0
+	for result := range results {
+		if result.err != nil {
+			assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(result.err))
+			continue
+		}
+		winners++
+		sessionID := sessionFromCookie(t, result.response.Header().Get("Set-Cookie"))
+		info, err := auth.ValidateToken(context.Background(), st, sessionID)
+		require.NoError(t, err)
+		assert.True(t, info.Elevated(time.Now()))
+	}
+	assert.Equal(t, 1, winners)
 }
 
 func TestAuthService_GetCurrentUser(t *testing.T) {
@@ -1571,8 +1673,8 @@ func TestSignUp_AllowsAdminInSetupMode(t *testing.T) {
 
 // The other half of the setup exemption, and the half that matters for
 // safety: `admin` becomes claimable in setup mode, `solo` never does. A user
-// The hub auto-authenticates a user by that name in a non-solo database for
-// every request, from the day somebody opens the same data-dir in solo mode.
+// The hub uses a user by that name as the synthetic local IPC identity if
+// somebody opens the same data directory in solo mode.
 func TestSignUp_RejectsSoloInSetupMode(t *testing.T) {
 	t.Parallel()
 
@@ -1902,9 +2004,9 @@ func TestFinishPasskeySignUp_SetupModeEndingMidCeremonyHonorsSignupDisabled(t *t
 }
 
 // `solo` carries a hazard that belongs to the DATABASE rather than to the
-// flow that wrote the row: opening a non-solo data-dir in solo mode
-// auto-authenticates every request as that user. Setup mode exempts `admin`
-// and nothing else.
+// flow that wrote the row: opening a non-solo data directory in solo mode
+// gives local IPC the synthetic account. Setup mode exempts `admin` and
+// nothing else.
 func TestBeginPasskeySignUp_SetupModeStillRejectsSoloUsername(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/hub/service/elevation_service.go
+++ b/backend/internal/hub/service/elevation_service.go
@@ -861,28 +861,30 @@ func requireElevatableSession(userInfo *auth.UserInfo) (string, error) {
 // an RPC answers Unauthenticated, the OAuth leg answers 401.
 var errElevationSessionEnded = errors.New("your session ended; sign in again")
 
-// grantSessionElevation stamps a fresh window on one session and reports the
-// new deadline. It is the ONE place that grants an elevation, because three
-// factor paths grant one -- a password, a passkey, and the OAuth
-// re-authentication leg -- and the third lives in an HTTP handler rather
-// than an RPC. A change to the window, to the zero-row refusal, or to the
-// cache invalidation must reach all three by construction.
+// elevateSessionRow stamps a fresh window on one session and reports the new
+// deadline. It is the ONE place that writes an elevation, so the window, the
+// parameter set and the zero-row refusal cannot drift between the callers.
 //
 // The write requires a live session, so a zero row count means the session
 // expired or a revoke ended it between the factor check and here. This
 // function reports that as a refusal rather than a silent success: the
 // caller would otherwise read that it may proceed while nothing was recorded.
+// It returns a BARE error, and each caller supplies the message its own state
+// deserves -- "your session ended" is right after a factor check and wrong
+// inside a transaction that created the session two statements earlier.
+//
+// It takes a store rather than a *Server so a caller inside a transaction can
+// pass its tx, which is what keeps the solo first-password write atomic.
 //
 // now is a parameter so each caller passes its own clock seam, rather than
-// this function inventing a fourth notion of the current instant.
-func grantSessionElevation(
+// this function inventing another notion of the current instant.
+func elevateSessionRow(
 	ctx context.Context,
 	st store.Store,
-	lifecycle *auth.CredentialLifecycleEffects,
 	sessionID string,
 	userID userid.UserID,
 	now time.Time,
-) (time.Time, error) {
+) (time.Time, bool, error) {
 	until := now.Add(auth.ElevationWindow)
 	n, err := st.Sessions().Elevate(ctx, store.ElevateSessionParams{
 		SessionID:          sessionID,
@@ -891,9 +893,36 @@ func grantSessionElevation(
 		ElevationExpiresAt: until,
 	}, now)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("record session elevation: %w", err)
+		return time.Time{}, false, fmt.Errorf("record session elevation: %w", err)
 	}
-	if n == 0 {
+	return until, n > 0, nil
+}
+
+// grantSessionElevation elevates one session and drops the cached UserInfo.
+//
+// It is the path every FACTOR takes -- a password, a passkey, and the OAuth
+// re-authentication leg, the third of which lives in an HTTP handler rather
+// than an RPC -- so a change to the invalidation lane reaches all of them.
+//
+// AuthService.SetInitialSoloPassword does not use it, and cannot: that write
+// runs inside a transaction, and the invalidation below must not fire before
+// the transaction commits, or a concurrent reader refills the cache from the
+// pre-commit row. It calls elevateSessionRow directly and invalidates after
+// the commit. Both spellings share the row write, which is where the rule
+// lives.
+func grantSessionElevation(
+	ctx context.Context,
+	st store.Store,
+	lifecycle *auth.CredentialLifecycleEffects,
+	sessionID string,
+	userID userid.UserID,
+	now time.Time,
+) (time.Time, error) {
+	until, live, err := elevateSessionRow(ctx, st, sessionID, userID, now)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !live {
 		return time.Time{}, errElevationSessionEnded
 	}
 	// The cached UserInfo still carries the OLD deadline, and this process

--- a/backend/internal/hub/service/idp_handler.go
+++ b/backend/internal/hub/service/idp_handler.go
@@ -770,7 +770,7 @@ func (h *IdPHandler) redirectBack(w http.ResponseWriter, r *http.Request, redire
 
 // secureCookies reports whether this hub writes __Host- prefixed cookies.
 func (h *IdPHandler) secureCookies(ctx context.Context) bool {
-	return settings.KeySecureCookies.Of(h.set.Snapshot(ctx))
+	return settings.SecureCookiesFor(ctx, h.set.Snapshot(ctx))
 }
 
 // loginOAuthUser stores tokens, creates a session, and redirects the user.

--- a/backend/internal/hub/service/idp_handler.go
+++ b/backend/internal/hub/service/idp_handler.go
@@ -790,7 +790,6 @@ func (h *IdPHandler) loginOAuthUser(w http.ResponseWriter, r *http.Request, user
 	}
 	sessionID, expiresAt, sessionErr := auth.CreateSession(ctx, h.store, loginUID, settings.SessionDuration(h.set.Snapshot(r.Context())), auth.SessionMeta{
 		UserAgent: r.UserAgent(),
-		IPAddress: r.RemoteAddr,
 	})
 	if sessionErr != nil {
 		slog.Error("oauth: create session", "error", sessionErr)

--- a/backend/internal/hub/service/local_socket_auth_test.go
+++ b/backend/internal/hub/service/local_socket_auth_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/bootstrap"
 	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/oauthapp"
+	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/servicetest"
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -65,7 +66,12 @@ func newUnixSocketAuthClient(t *testing.T, st store.Store, interceptor connect.I
 	ln, err := net.Listen("unix", shortSocketPath(t))
 	require.NoError(t, err)
 
-	srv := &http.Server{Handler: mux}
+	srv := &http.Server{
+		Handler: mux,
+		BaseContext: func(net.Listener) context.Context {
+			return peer.WithLocalIPC(context.Background())
+		},
+	}
 	go func() { _ = srv.Serve(ln) }()
 	t.Cleanup(func() {
 		_ = srv.Shutdown(context.Background())

--- a/backend/internal/hub/service/oauth_server_handler.go
+++ b/backend/internal/hub/service/oauth_server_handler.go
@@ -84,15 +84,17 @@ type OAuthServerDeps struct {
 	Store     store.Store
 	Validator *auth.TokenValidator
 	Lifecycle *auth.CredentialLifecycleEffects
-	// SoloUser is the account a SOLO hub authenticates every caller as. It is
-	// nil on an ordinary hub, and that nil is what keeps the rung off there.
+	// SoloUser is the account a SOLO hub authenticates its LOCAL IPC callers
+	// as. It is nil on an ordinary hub, and that nil is what keeps the rung off
+	// there.
 	//
-	// The consent endpoints need it because solo has no browser session at all: a
-	// solo hub authenticates by having the port, not by a cookie, so without
-	// this rung a solo user could never reach a consent screen and could never
-	// authorize an app. The scope model would then be unreachable on exactly
-	// the deployment that most wants it -- one machine, one account, an agent
-	// that should hold file:read and nothing more.
+	// The consent endpoints need it because the desktop app holds no browser
+	// session: it reaches its own hub over that socket and has no password to
+	// present, so without this rung it could never reach a consent screen and
+	// could never authorize an app. The scope model would then be unreachable
+	// on exactly the deployment that most wants it -- one machine, one account,
+	// an agent that should hold file:read and nothing more. A solo TCP caller
+	// signs in and reaches the same screens through the cookie rung.
 	//
 	// The BEARER rung stays off here whatever this is set to; see
 	// requireSession. An app credential must not be able to consent on its own

--- a/backend/internal/hub/service/oauth_server_handler.go
+++ b/backend/internal/hub/service/oauth_server_handler.go
@@ -89,12 +89,12 @@ type OAuthServerDeps struct {
 	// there.
 	//
 	// The consent endpoints need it because the desktop app holds no browser
-	// session: it reaches its own hub over that socket and has no password to
-	// present, so without this rung it could never reach a consent screen and
-	// could never authorize an app. The scope model would then be unreachable
-	// on exactly the deployment that most wants it -- one machine, one account,
-	// an agent that should hold file:read and nothing more. A solo TCP caller
-	// signs in and reaches the same screens through the cookie rung.
+	// session. The app reaches its own hub over the local IPC socket and has no
+	// password to present. Without this rung it could never reach a consent
+	// screen and could never authorize an app. The scope model would then be
+	// unreachable on the deployment that most wants it: one machine, one
+	// account, an agent that should hold file:read and nothing more. A solo TCP
+	// caller signs in and reaches the same screens through the cookie rung.
 	//
 	// The BEARER rung stays off here whatever this is set to; see
 	// requireSession. An app credential must not be able to consent on its own
@@ -235,8 +235,10 @@ func (h *OAuthServerHandler) requireSession(r *http.Request) *auth.UserInfo {
 	// endpoint exists beside these precisely because that is not allowed.
 	//
 	// SoloUser is nil on an ordinary hub, so the rung is off there. On a solo
-	// hub it is the only rung that can answer, because solo authenticates by
-	// having the port rather than by a cookie.
+	// hub it is the only rung that can answer for the LOCAL IPC socket, which
+	// carries no cookie and has no password to present. A solo TCP caller
+	// holds an ordinary session and reaches these screens through the cookie
+	// rung below.
 	//
 	// The hub's own secure_cookies setting decides which cookie spelling the
 	// handler reads; see AuthenticateHTTP for why the fallback direction is
@@ -275,7 +277,7 @@ func settingsSnapshotOf(m *settings.Manager, ctx context.Context) *settings.Snap
 // secureCookies reports whether this hub writes __Host- prefixed cookies.
 // A handler wired with no settings manager reads false; see OAuthServerDeps.
 func (h *OAuthServerHandler) secureCookies(ctx context.Context) bool {
-	return settings.KeySecureCookies.Of(h.snapshot(ctx))
+	return settings.SecureCookiesFor(ctx, h.snapshot(ctx))
 }
 
 // gateMode says how an endpoint answers a caller that is not signed in or not
@@ -415,8 +417,11 @@ func (h *OAuthServerHandler) requireElevatedSession(w http.ResponseWriter, r *ht
 	// making app authorization impossible on exactly the deployment the scope
 	// model most helps, where one agent should hold file:read and nothing more.
 	//
-	// Authentication is not weakened by this: reaching a solo hub at all is the
-	// authentication, and there is no second factor for a check to demand.
+	// Authentication is not weakened by this. The exemption reads
+	// SoloAuthenticated, which is the LOCAL IPC identity alone: that caller
+	// presented no credential, so it has no ceremony to step up from. A solo
+	// TCP caller signed in with a password, holds a real session, and meets
+	// the elevation check like anybody else.
 	if user.SoloAuthenticated() || user.Elevated(h.now()) {
 		return user
 	}

--- a/backend/internal/hub/service/solo_elevation_internal_test.go
+++ b/backend/internal/hub/service/solo_elevation_internal_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 // soloUserInfo is the shape auth.LoadSoloUser produces: an administrator with
-// NO credential row, because solo mode authenticates every request as one
-// bootstrapped account and holds no session and no bearer.
+// no credential row, because solo mode authenticates local IPC as one
+// bootstrapped account and holds no session or bearer.
 func soloUserInfo() *auth.UserInfo {
 	return &auth.UserInfo{
 		ID:              userid.MustNew("solo-user"),

--- a/backend/internal/hub/service/solo_mode.go
+++ b/backend/internal/hub/service/solo_mode.go
@@ -8,8 +8,8 @@ import (
 
 // rejectSolo refuses a surface that solo mode does not serve.
 //
-// Solo mode authenticates every request as one synthetic user, with no
-// session row and no credential store, so a whole family of procedures has
+// Solo mode authenticates local IPC as one synthetic user, with no session
+// row and no credential store. A whole family of procedures has
 // nothing to act on. Nine handlers wrote this refusal by hand, each with its
 // own subject, and two more wrapped it once apiece -- one of the nine
 // already lost its subject and read only "not available in solo mode". One

--- a/backend/internal/hub/service/test_helpers_test.go
+++ b/backend/internal/hub/service/test_helpers_test.go
@@ -72,7 +72,7 @@ func sessionFromCookie(t *testing.T, setCookie string) string {
 
 // insecureCookies answers the secure-cookie policy these plain-HTTP test
 // servers run under.
-func insecureCookies() bool { return false }
+func insecureCookies(context.Context) bool { return false }
 
 func testConfig() *config.Config {
 	return &config.Config{}

--- a/backend/internal/hub/service/user_service.go
+++ b/backend/internal/hub/service/user_service.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
-	"net/http"
 	"time"
 
 	"connectrpc.com/connect"
@@ -343,11 +341,9 @@ func (s *UserService) VerifyEmail(ctx context.Context, req *connect.Request[leap
 
 // ChangePassword sets or replaces the caller's password.
 //
-// It is REACHABLE IN SOLO MODE, unlike the account verbs around it, and that
-// is the feature: the solo account's password is what lets the hub answer on a
-// network address at all, so a hub that refused this could never be published.
-// The other solo refusals stay -- there is still no sign-up, no passkey, no
-// account recovery and no provider link.
+// It is reachable in solo mode for an authenticated caller. Local IPC receives
+// the synthetic solo identity. A TCP caller without a session uses
+// AuthService.SetInitialSoloPassword instead.
 func (s *UserService) ChangePassword(ctx context.Context, req *connect.Request[leapmuxv1.ChangePasswordRequest]) (*connect.Response[leapmuxv1.ChangePasswordResponse], error) {
 	userInfo, err := auth.MustGetUser(ctx)
 	if err != nil {
@@ -407,65 +403,7 @@ func (s *UserService) ChangePassword(ctx context.Context, req *connect.Request[l
 		return nil, mapPasskeyConnectError(ctx, err)
 	}
 
-	resp := connect.NewResponse(&leapmuxv1.ChangePasswordResponse{})
-	// A failure here is LOGGED, never returned. The password committed in the
-	// transaction above, and on a solo hub that write is what starts demanding
-	// one -- so answering with an error tells the caller to retry a change that
-	// already happened, and the retry meets the rule the change armed. The page
-	// would sit in a loop no attempt could leave. Without the cookie the caller
-	// signs in with the password it just chose, which is the ordinary route and
-	// not a trap.
-	if err := s.handOverSoloSession(ctx, userInfo, resp.Header()); err != nil {
-		slog.Error("the solo caller that set the first password could not be handed a session; it must sign in with that password",
-			"error", err)
-	}
-	return resp, nil
-}
-
-// handOverSoloSession gives a credential-free solo caller a real session,
-// because the write it just made is what ended its credential-free access.
-//
-// A solo hub authenticates a TCP caller with nothing while the account holds
-// no password. Storing the first password re-arms the rule against the very
-// browser that stored it: without this, the response returns 200 and the next
-// request from that page is Unauthenticated -- the user is signed out of the
-// form they are standing in, having done nothing wrong.
-//
-// It runs only for a caller the solo rung admitted (SoloAuthenticated), so an
-// ordinary session that changed its password is untouched, and it is a no-op
-// outside solo mode.
-//
-// The session is ELEVATED, deliberately. This caller held unauthenticated full
-// administrator access one request ago, so the grant cannot widen what it can
-// do; refusing it would only ask the user to present, as a step-up proof, the
-// secret they chose in the request before.
-//
-// Its error is a PLAIN one, not a connect error, because its caller logs it
-// rather than answering with it: this runs after the password committed.
-func (s *UserService) handOverSoloSession(ctx context.Context, userInfo *auth.UserInfo, h http.Header) error {
-	if !userInfo.SoloAuthenticated() {
-		return nil
-	}
-	// NOTHING tells the gate. The password committed above, and the gate reads
-	// the store while its latch is false, so the rule is armed for every caller
-	// from here on -- see SoloGate.passwordSet for why the store is its only
-	// source.
-
-	// ONE snapshot for the duration and the cookie attributes. Two reads can
-	// straddle the manager's TTL and see different generations, which would
-	// stamp a lifetime from one configuration and a Secure flag from another.
-	snap := s.set.Snapshot(ctx)
-
-	sessionID, expiresAt, err := auth.CreateSession(ctx, s.store, userInfo.ID, settings.SessionDuration(snap))
-	if err != nil {
-		return fmt.Errorf("create session: %w", err)
-	}
-	if _, err := grantSessionElevation(ctx, s.store, s.lifecycle, sessionID, userInfo.ID, s.now()); err != nil {
-		return fmt.Errorf("elevate session: %w", err)
-	}
-	h.Set("Set-Cookie", auth.BuildSessionCookie(sessionID, expiresAt,
-		settings.KeySecureCookies.Of(snap)).String())
-	return nil
+	return connect.NewResponse(&leapmuxv1.ChangePasswordResponse{}), nil
 }
 
 func (s *UserService) UnlinkOAuthProvider(ctx context.Context, req *connect.Request[leapmuxv1.UnlinkOAuthProviderRequest]) (*connect.Response[leapmuxv1.UnlinkOAuthProviderResponse], error) {

--- a/backend/internal/hub/service/user_solo_password_test.go
+++ b/backend/internal/hub/service/user_solo_password_test.go
@@ -126,9 +126,10 @@ func TestChangePassword_DoesNotCreateASoloSession(t *testing.T) {
 	assert.Empty(t, resp.Header().Get("Set-Cookie"))
 }
 
-// An ordinary session that changes its password must not be handed a second
-// one: it already holds a credential, and a new session would leave the old
-// cookie pointing at a session the change revoked.
+// The OTHER identity kind, beside the synthetic solo one above: a real
+// session, elevated so the step-up rule cannot be what produces the empty
+// header. It already holds a credential, and a second session would leave the
+// old cookie pointing at one the change revoked.
 func TestChangePassword_DoesNotHandASessionToAnOrdinaryCaller(t *testing.T) {
 	st := hubtestutil.OpenTestStore(t)
 	hubtestutil.CreateTestAdmin(t, st)
@@ -167,7 +168,7 @@ func TestChangePassword_DoesNotHandASessionToAnOrdinaryCaller(t *testing.T) {
 		&leapmuxv1.ChangePasswordRequest{NewPassword: "another-good-password"}))
 	require.NoError(t, err)
 	assert.Empty(t, resp.Header().Get("Set-Cookie"),
-		"a caller that already holds a credential keeps it; only the solo rung's caller loses one")
+		"ChangePassword mints no session for any caller; a caller that already holds one keeps it")
 }
 
 // The PASSKEY factor is refused by mode, unlike the elevation surface around

--- a/backend/internal/hub/service/user_solo_password_test.go
+++ b/backend/internal/hub/service/user_solo_password_test.go
@@ -2,8 +2,6 @@ package service_test
 
 import (
 	"context"
-	"net"
-	"net/http"
 	"testing"
 	"time"
 
@@ -17,7 +15,6 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/mail"
 	"github.com/leapmux/leapmux/internal/hub/password"
-	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/service"
 	"github.com/leapmux/leapmux/internal/hub/servicetest"
 	"github.com/leapmux/leapmux/internal/hub/store"
@@ -25,17 +22,6 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/usernames"
 	"github.com/leapmux/leapmux/internal/util/userid"
 )
-
-// tcpCtx is a request that arrived over TCP, whatever the address.
-func tcpCtx(ip string) context.Context {
-	return peer.WithRemoteAddr(context.Background(), &net.TCPAddr{IP: net.ParseIP(ip), Port: 51234})
-}
-
-// ipcCtxForTest is a request that arrived on the local IPC socket.
-func ipcCtxForTest() context.Context {
-	return peer.WithRemoteAddr(peer.WithLocalIPC(context.Background()),
-		&net.UnixAddr{Name: "/tmp/hub.sock", Net: "unix"})
-}
 
 func mustUserID(t *testing.T, id string) userid.UserID {
 	t.Helper()
@@ -126,32 +112,18 @@ func TestGetCurrentUser_ReportsTheSoloAccountsPasswordFromTheHash(t *testing.T) 
 		"the stored password must reach the row that offers to change it")
 }
 
-// The write that stores the first password is also the write that starts
-// demanding one. Without a session handed back, the browser that made it is
-// signed out of the form it is standing in.
-func TestChangePassword_HandsASoloCallerASession(t *testing.T) {
-	svc, st, gate, soloUser := soloUserService(t)
+// ChangePassword stays an authenticated account procedure. Local IPC already
+// keeps its synthetic identity, so this procedure must not mint another
+// session when it sets the first password.
+func TestChangePassword_DoesNotCreateASoloSession(t *testing.T) {
+	svc, _, _, soloUser := soloUserService(t)
 	ctx := auth.WithUser(context.Background(), soloUser)
 
 	resp, err := svc.ChangePassword(ctx, connect.NewRequest(
 		&leapmuxv1.ChangePasswordRequest{NewPassword: "correct-horse-battery-staple"}))
 	require.NoError(t, err)
 
-	cookie := resp.Header().Get("Set-Cookie")
-	require.NotEmpty(t, cookie, "the response must carry a session for the caller it just locked out")
-
-	sessionID := sessionIDFromSetCookie(t, cookie)
-	info, err := auth.ValidateToken(ctx, st, sessionID)
-	require.NoError(t, err, "the handed-over session must authenticate")
-	assert.Equal(t, soloUser.ID.String(), info.ID.String())
-
-	// Elevated, so the next hub-settings write from the same page is not
-	// refused for a factor the user proved one request ago.
-	assert.True(t, info.Elevated(time.Now()),
-		"the handed-over session must be elevated, or applying the addresses asks for the password just chosen")
-
-	// And the rule is armed: the gate now demands credentials over TCP.
-	assert.False(t, gate.CredentialFree(tcpCtx("127.0.0.1")))
+	assert.Empty(t, resp.Header().Get("Set-Cookie"))
 }
 
 // An ordinary session that changes its password must not be handed a second
@@ -196,16 +168,6 @@ func TestChangePassword_DoesNotHandASessionToAnOrdinaryCaller(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, resp.Header().Get("Set-Cookie"),
 		"a caller that already holds a credential keeps it; only the solo rung's caller loses one")
-}
-
-// sessionIDFromSetCookie reads the session id out of a Set-Cookie line,
-// whichever name the hub's secure_cookies setting picked.
-func sessionIDFromSetCookie(t *testing.T, line string) string {
-	t.Helper()
-	resp := http.Response{Header: http.Header{"Set-Cookie": []string{line}}}
-	cookies := resp.Cookies()
-	require.Len(t, cookies, 1)
-	return cookies[0].Value
 }
 
 // The PASSKEY factor is refused by mode, unlike the elevation surface around

--- a/backend/internal/hub/service/ws_auth_lease.go
+++ b/backend/internal/hub/service/ws_auth_lease.go
@@ -24,7 +24,7 @@ import (
 type wsAuthenticator struct {
 	store          store.Store
 	soloUser       *auth.UserInfo
-	secureCookie   func() bool
+	secureCookie   func(context.Context) bool
 	tokenValidator *auth.TokenValidator
 	authLease      webSocketAuthLease
 	// keepalive is how often this endpoint probes its connections. Carried
@@ -70,7 +70,7 @@ func newWSAuthenticator(
 	st store.Store,
 	authContexts *auth.AuthContextRegistry,
 	soloUser *auth.UserInfo,
-	secureCookie func() bool,
+	secureCookie func(context.Context) bool,
 	requiredScope leapmuxv1.Scope,
 ) wsAuthenticator {
 	if !authscope.IsGrantable(requiredScope) {
@@ -96,9 +96,13 @@ func newWSAuthenticator(
 // control CLI's own grant -- passes unconditionally, because a scope subtracts
 // from the account's authority and never adds to it.
 func (a wsAuthenticator) authenticate(r *http.Request) (*auth.UserInfo, error) {
+	// PER REQUEST, because the answer is: a trusted proxy that verified HTTPS
+	// for this connection turns the secure cookie name on whatever the setting
+	// says, and the handshake must read the same name the Connect procedures
+	// write.
 	secureCookie := false
 	if a.secureCookie != nil {
-		secureCookie = a.secureCookie()
+		secureCookie = a.secureCookie(r.Context())
 	}
 	user, err := auth.AuthenticateHTTP(r.Context(), r, auth.HTTPAuthOpts{
 		Store:         a.store,

--- a/backend/internal/hub/service/ws_channel_relay.go
+++ b/backend/internal/hub/service/ws_channel_relay.go
@@ -57,7 +57,7 @@ func NewChannelRelayHandler(
 	cMgr *channelmgr.Manager,
 	authContexts *auth.AuthContextRegistry,
 	soloUser *auth.UserInfo,
-	secureCookie func() bool,
+	secureCookie func(context.Context) bool,
 	queuePool *sendq.Pool,
 ) *ChannelRelayHandler {
 	if queuePool == nil {

--- a/backend/internal/hub/service/ws_channel_relay_test.go
+++ b/backend/internal/hub/service/ws_channel_relay_test.go
@@ -43,7 +43,7 @@ func newTestAuthContexts(t *testing.T) *auth.AuthContextRegistry {
 // insecureCookies is the secure-cookie answer these relay tests run
 // under: plain HTTP test servers, where the __Host- cookie name would be
 // wrong.
-func insecureCookies() bool { return false }
+func insecureCookies(context.Context) bool { return false }
 
 func TestWebSocketHandlersRequireAuthContextRegistry(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/hub/service/ws_scope_test.go
+++ b/backend/internal/hub/service/ws_scope_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/auth"
 	"github.com/leapmux/leapmux/internal/hub/crdt"
 	"github.com/leapmux/leapmux/internal/hub/oauthapp"
+	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/hub/store"
 	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
 	"github.com/leapmux/leapmux/internal/sendq"
@@ -32,6 +33,11 @@ import (
 // endpoint's business: /ws/channel fails the upgrade, /ws/userevents reaches
 // its registry. Pinning either of those here would make this test fail for a
 // reason that has nothing to do with the grant.
+//
+// A test whose caller carries NO credential names 401 as well, because there
+// "not 403" is what an unauthenticated answer gives: the request would never
+// reach the scope rung, and the test would report a pass for a door it never
+// opened.
 
 // mintScopedAPIToken mints an app credential with an arbitrary grant and
 // returns the bearer.
@@ -65,13 +71,31 @@ func newWSScopeEnv(t *testing.T, soloUser *auth.UserInfo) wsScopeEnv {
 	tv, err := auth.NewTokenValidator(st, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
 	return wsScopeEnv{
-		channel: NewChannelRelayHandler(st, newTestRegistry(), nil, newTestAuthContexts(t), soloUser,
+		channel: NewChannelRelayHandler(st, newTestRegistry(), nil, wsScopeAuthContexts(t, st, soloUser), soloUser,
 			insecureCookies, sendq.NewMaxBytesPoolForTest()).WithTokenValidator(tv),
-		userEvents: NewUserEventsHandler(st, unreachableCRDTRegistry(), newTestAuthContexts(t), soloUser,
+		userEvents: NewUserEventsHandler(st, unreachableCRDTRegistry(), wsScopeAuthContexts(t, st, soloUser), soloUser,
 			insecureCookies, sendq.NewMaxBytesPoolForTest()).WithTokenValidator(tv),
 		store:     st,
 		validator: tv,
 	}
+}
+
+// wsScopeAuthContexts builds the registry whose SoloGate the WebSocket doors
+// read. The gate must be told that this hub IS solo.
+//
+// `newTestAuthContexts` passes no SoloUser, so its gate answers "not a solo
+// hub" and refuses every caller. A solo test built on that gate reached no
+// solo rung at all: an absent credential answered 401, which satisfied an
+// assertion written as "not the 403 refusal", so the test passed without the
+// behavior it names.
+func wsScopeAuthContexts(t *testing.T, st store.Store, soloUser *auth.UserInfo) *auth.AuthContextRegistry {
+	t.Helper()
+	if soloUser == nil {
+		return newTestAuthContexts(t)
+	}
+	_, registry := hubtestutil.NewAuthInterceptor(t, auth.InterceptorOptions{Store: st, SoloUser: soloUser})
+	t.Cleanup(registry.Stop)
+	return registry
 }
 
 // unreachableCRDTRegistry is a registry whose factory always fails.
@@ -87,9 +111,26 @@ func unreachableCRDTRegistry() *crdt.Registry {
 }
 
 // serveWithBearer runs one request against one handler and reports the status.
+//
+// The request arrives on the LOCAL IPC socket, which is the one transport the
+// solo rung admits without a credential. A TCP request takes the bearer and
+// cookie rungs like any other caller's, so a solo test built on one would pass
+// whether or not the rung exists. serveOverTCP is that other transport, for
+// the tests that assert the refusal.
 func serveWithBearer(t *testing.T, handler http.Handler, path, bearer string) int {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, path, nil)
+	return serveWS(t, handler, path, bearer, peer.WithLocalIPC(context.Background()))
+}
+
+// serveOverTCP is the same request on a TCP connection.
+func serveOverTCP(t *testing.T, handler http.Handler, path, bearer string) int {
+	t.Helper()
+	return serveWS(t, handler, path, bearer, context.Background())
+}
+
+func serveWS(t *testing.T, handler http.Handler, path, bearer string, ctx context.Context) int {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil).WithContext(ctx)
 	if bearer != "" {
 		req.Header.Set("Authorization", "Bearer "+bearer)
 	}
@@ -168,15 +209,55 @@ func TestUnscopedCredentialPassesTheWebSocketScopeRung(t *testing.T) {
 	}
 	env := newWSScopeEnv(t, solo)
 
-	assert.NotEqual(t, http.StatusForbidden, serveWithBearer(t, env.channel, "/ws/channel", ""))
-	assert.NotEqual(t, http.StatusForbidden, serveWithBearer(t, env.userEvents, "/ws/userevents", ""))
+	for _, door := range []struct {
+		name    string
+		handler http.Handler
+		path    string
+	}{
+		{"channel", env.channel, "/ws/channel"},
+		{"userevents", env.userEvents, "/ws/userevents"},
+	} {
+		status := serveWithBearer(t, door.handler, door.path, "")
+		assert.NotEqualf(t, http.StatusForbidden, status, "%s must not refuse an unscoped caller", door.name)
+		// 401 too, and this is the assertion that makes the test real. The
+		// admission is asserted as "not the refusal" because what an admitted
+		// request does next is the endpoint's business -- but an
+		// UNAUTHENTICATED answer is also "not 403", so a test that named only
+		// the 403 passed without ever reaching the scope rung.
+		assert.NotEqualf(t, http.StatusUnauthorized, status,
+			"%s must admit the solo caller before the scope rung answers", door.name)
+	}
+}
+
+// The other side of the same rung, and the property the restricted TCP setup
+// flow rests on: the WebSocket doors are the two credential-carrying surfaces
+// that are not Connect procedures, so the interceptor's refusal does not cover
+// them. A solo TCP caller with no credential must be refused here as well, or
+// the synthetic administrator is one handshake away from anyone who reaches
+// the port.
+func TestSoloModeRefusesATCPCallerWithoutACredential(t *testing.T) {
+	t.Parallel()
+
+	solo := &auth.UserInfo{
+		ID:       userid.MustNew("u-solo"),
+		Username: "solo",
+		IsAdmin:  true,
+		Scopes:   authscope.UnscopedGrant(),
+		Solo:     true,
+	}
+	env := newWSScopeEnv(t, solo)
+
+	assert.Equal(t, http.StatusUnauthorized, serveOverTCP(t, env.channel, "/ws/channel", ""))
+	assert.Equal(t, http.StatusUnauthorized, serveOverTCP(t, env.userEvents, "/ws/userevents", ""))
 }
 
 // TestSoloModeYieldsToAPresentedBearer is the WebSocket twin of the
-// interceptor's solo test. Solo authenticates every caller as its one account,
-// so without the yield this request would pass the rung on the synthetic
-// user's unscoped grant -- discarding the narrowing the credential's owner
-// accepted, which is the one thing the scope model exists to prevent.
+// interceptor's solo test. Solo authenticates a LOCAL IPC caller as its one
+// account, so without the yield this request would pass the rung on the
+// synthetic user's unscoped grant -- discarding the narrowing the credential's
+// owner accepted, which is the one thing the scope model exists to prevent.
+// The request below arrives on that socket, because a TCP one never meets the
+// rung and would prove nothing about the yield.
 func TestSoloModeYieldsToAPresentedBearer(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/hub/service/ws_scope_test.go
+++ b/backend/internal/hub/service/ws_scope_test.go
@@ -34,7 +34,7 @@ import (
 // its registry. Pinning either of those here would make this test fail for a
 // reason that has nothing to do with the grant.
 //
-// A test whose caller carries NO credential names 401 as well, because there
+// A test whose caller carries NO credential gives 401 as well, because there
 // "not 403" is what an unauthenticated answer gives: the request would never
 // reach the scope rung, and the test would report a pass for a door it never
 // opened.
@@ -87,7 +87,7 @@ func newWSScopeEnv(t *testing.T, soloUser *auth.UserInfo) wsScopeEnv {
 // hub" and refuses every caller. A solo test built on that gate reached no
 // solo rung at all: an absent credential answered 401, which satisfied an
 // assertion written as "not the 403 refusal", so the test passed without the
-// behavior it names.
+// behavior it specifies.
 func wsScopeAuthContexts(t *testing.T, st store.Store, soloUser *auth.UserInfo) *auth.AuthContextRegistry {
 	t.Helper()
 	if soloUser == nil {
@@ -119,16 +119,16 @@ func unreachableCRDTRegistry() *crdt.Registry {
 // the tests that assert the refusal.
 func serveWithBearer(t *testing.T, handler http.Handler, path, bearer string) int {
 	t.Helper()
-	return serveWS(t, handler, path, bearer, peer.WithLocalIPC(context.Background()))
+	return serveWS(peer.WithLocalIPC(context.Background()), t, handler, path, bearer)
 }
 
 // serveOverTCP is the same request on a TCP connection.
 func serveOverTCP(t *testing.T, handler http.Handler, path, bearer string) int {
 	t.Helper()
-	return serveWS(t, handler, path, bearer, context.Background())
+	return serveWS(context.Background(), t, handler, path, bearer)
 }
 
-func serveWS(t *testing.T, handler http.Handler, path, bearer string, ctx context.Context) int {
+func serveWS(ctx context.Context, t *testing.T, handler http.Handler, path, bearer string) int {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, path, nil).WithContext(ctx)
 	if bearer != "" {
@@ -222,7 +222,7 @@ func TestUnscopedCredentialPassesTheWebSocketScopeRung(t *testing.T) {
 		// 401 too, and this is the assertion that makes the test real. The
 		// admission is asserted as "not the refusal" because what an admitted
 		// request does next is the endpoint's business -- but an
-		// UNAUTHENTICATED answer is also "not 403", so a test that named only
+		// UNAUTHENTICATED answer is also "not 403", so a test that checked only
 		// the 403 passed without ever reaching the scope rung.
 		assert.NotEqualf(t, http.StatusUnauthorized, status,
 			"%s must admit the solo caller before the scope rung answers", door.name)

--- a/backend/internal/hub/service/ws_userevents.go
+++ b/backend/internal/hub/service/ws_userevents.go
@@ -82,7 +82,7 @@ func NewUserEventsHandler(
 	registry *crdt.Registry,
 	authContexts *auth.AuthContextRegistry,
 	soloUser *auth.UserInfo,
-	secureCookie func() bool,
+	secureCookie func(context.Context) bool,
 	queuePool *sendq.Pool,
 ) *UserEventsHandler {
 	if queuePool == nil {

--- a/backend/internal/hub/servicetest/authservice.go
+++ b/backend/internal/hub/servicetest/authservice.go
@@ -50,9 +50,9 @@ func NewSettingsManager(t *testing.T, st store.Store, ks *keystore.Keystore) *se
 // settings key. PolicyFromSettings is the same mapping the hub's own
 // closure uses, so a test cannot enforce a policy the hub computes
 // differently.
-func AuthPolicy(set *settings.Manager) func() auth.Policy {
-	return func() auth.Policy {
-		return auth.PolicyFromSettings(set.Snapshot(context.Background()))
+func AuthPolicy(set *settings.Manager) func(context.Context) auth.Policy {
+	return func(ctx context.Context) auth.Policy {
+		return auth.PolicyFromSettings(ctx, set.Snapshot(ctx))
 	}
 }
 

--- a/backend/internal/hub/settings/keys.go
+++ b/backend/internal/hub/settings/keys.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"context"
 	"fmt"
 	"net/mail"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/config"
 	"github.com/leapmux/leapmux/internal/hub/httpsec"
 	"github.com/leapmux/leapmux/internal/hub/listenset"
+	"github.com/leapmux/leapmux/internal/hub/peer"
 	"github.com/leapmux/leapmux/internal/util/ptrconv"
 )
 
@@ -799,6 +801,42 @@ func BaseURL(s *Snapshot, listen string) string {
 	}
 	scheme := "http"
 	if KeySecureCookies.Of(s) {
+		scheme = "https"
+	}
+	return scheme + "://" + browserHostForListen(listen)
+}
+
+// SecureCookiesFor reports the effective secure-cookie policy for ONE request.
+//
+// It is the configured key, OR the protocol a trusted reverse proxy verified
+// for this request. The setting stays the operator's control; the verified
+// protocol only ever turns the policy ON, and never off.
+//
+// The one-way direction is what makes this safe to derive per request. A
+// `__Host-` cookie is readable whatever the setting says, because
+// SessionIDFromCookieHeader tries the secure name first and unconditionally;
+// only the plain name depends on the key. So a session minted through the
+// proxy stays readable, and a hub reachable both ways cannot strand one.
+//
+// It exists because the hub terminates no TLS itself. Before this, an operator
+// who put a solo hub behind a TLS proxy had to KNOW to set `secure_cookies`
+// by hand, and a hub that answered every request over verified HTTPS still
+// wrote a cookie with no Secure attribute until they did. The proxy already
+// told the hub the answer; this reads it.
+func SecureCookiesFor(ctx context.Context, s *Snapshot) bool {
+	return KeySecureCookies.Of(s) || peer.IsHTTPS(ctx)
+}
+
+// BaseURLFor is BaseURL with the same per-request protocol rule.
+//
+// public_url still wins whenever it is set, so an operator who stated the
+// address the browser really uses keeps that answer.
+func BaseURLFor(ctx context.Context, s *Snapshot, listen string) string {
+	if u := KeyPublicURL.Of(s); u != "" {
+		return u
+	}
+	scheme := "http"
+	if SecureCookiesFor(ctx, s) {
 		scheme = "https"
 	}
 	return scheme + "://" + browserHostForListen(listen)

--- a/backend/internal/hub/settings/keys.go
+++ b/backend/internal/hub/settings/keys.go
@@ -511,9 +511,8 @@ var (
 
 	// Solo READS this too, and hiding it took the answer away from the one
 	// deployment that needs it most. Every session cookie a solo hub writes
-	// -- from Login, and from the ChangePassword that hands the first
-	// password's author a session -- takes its __Host- prefix and its Secure
-	// attribute from here. A solo hub published on a LAN behind a TLS proxy
+	// -- from Login and SetInitialSoloPassword -- takes its __Host- prefix and
+	// its Secure attribute from here. A solo hub published behind a TLS proxy
 	// must be able to ask for one, and no other key can.
 	KeySecureCookies = NewKey[bool]("secure_cookies").
 				WithUI(UIMeta{

--- a/backend/internal/hub/settings/keys_secure_cookies_test.go
+++ b/backend/internal/hub/settings/keys_secure_cookies_test.go
@@ -1,0 +1,62 @@
+package settings_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/internal/hub/peer"
+	"github.com/leapmux/leapmux/internal/hub/settings"
+	hubtestutil "github.com/leapmux/leapmux/internal/hub/testutil"
+)
+
+// The rule: the configured key, OR the protocol a trusted proxy verified. The
+// verified protocol only ever turns the policy ON.
+//
+// It exists because the hub terminates no TLS. An operator who put a hub
+// behind a TLS proxy had to know to set `secure_cookies` by hand, and until
+// they did, a hub answering every request over verified HTTPS still wrote
+// session cookies with no Secure attribute.
+func TestSecureCookiesFor(t *testing.T) {
+	t.Parallel()
+	manager := settings.NewManager(hubtestutil.OpenTestStore(t), nil, settings.CoreDescriptors())
+	require.NoError(t, manager.Load(context.Background()))
+	snap := manager.Snapshot(context.Background())
+
+	plain := context.Background()
+	verified := peer.WithHTTPS(context.Background(), true)
+
+	assert.False(t, settings.SecureCookiesFor(plain, snap),
+		"the shipped default writes a plain cookie over plain HTTP")
+	assert.True(t, settings.SecureCookiesFor(verified, snap),
+		"a trusted proxy that verified TLS turns the policy on with no setting")
+
+	require.NoError(t, manager.Update(context.Background(), settings.KeySecureCookies, []byte(`true`)))
+	on := manager.Snapshot(context.Background())
+	assert.True(t, settings.SecureCookiesFor(plain, on),
+		"the setting still decides on its own")
+	assert.True(t, settings.SecureCookiesFor(verified, on))
+}
+
+// public_url wins whenever it is set, so an operator who stated the address a
+// browser really uses keeps that answer whatever a proxy reports.
+func TestBaseURLFor(t *testing.T) {
+	t.Parallel()
+	manager := settings.NewManager(hubtestutil.OpenTestStore(t), nil, settings.CoreDescriptors())
+	require.NoError(t, manager.Load(context.Background()))
+	snap := manager.Snapshot(context.Background())
+
+	assert.Equal(t, "http://127.0.0.1:4327",
+		settings.BaseURLFor(context.Background(), snap, "127.0.0.1:4327"))
+	assert.Equal(t, "https://127.0.0.1:4327",
+		settings.BaseURLFor(peer.WithHTTPS(context.Background(), true), snap, "127.0.0.1:4327"),
+		"a verified TLS request builds https links without a second setting")
+
+	require.NoError(t, manager.Update(context.Background(), settings.KeyPublicURL, []byte(`"https://hub.example.test"`)))
+	published := manager.Snapshot(context.Background())
+	assert.Equal(t, "https://hub.example.test",
+		settings.BaseURLFor(context.Background(), published, "127.0.0.1:4327"),
+		"public_url outranks the per-request scheme")
+}

--- a/backend/internal/hub/settings/schema_test.go
+++ b/backend/internal/hub/settings/schema_test.go
@@ -19,11 +19,12 @@ import (
 // CUSTOM_EDITORS table); a FieldCustom CustomID outside it would render
 // nothing in the preferences dialog.
 var knownCustomEditors = map[string]bool{
-	"keybindings":   true,
-	"terminalTheme": true,
-	"syntaxTheme":   true,
-	"theme":         true,
-	"networkAccess": true,
+	"keybindings":    true,
+	"terminalTheme":  true,
+	"syntaxTheme":    true,
+	"theme":          true,
+	"networkAccess":  true,
+	"trustedProxies": true,
 }
 
 // allDescriptors gathers BOTH descriptor sets the settings surface

--- a/backend/internal/hub/settingsregistry/settingsregistry.go
+++ b/backend/internal/hub/settingsregistry/settingsregistry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/leapmux/leapmux/internal/hub/captcha"
 	"github.com/leapmux/leapmux/internal/hub/keystore"
 	"github.com/leapmux/leapmux/internal/hub/ratelimit"
+	"github.com/leapmux/leapmux/internal/hub/requestsource"
 	"github.com/leapmux/leapmux/internal/hub/settings"
 	"github.com/leapmux/leapmux/internal/hub/store"
 )
@@ -24,6 +25,7 @@ import (
 func NewManager(st store.Store, ks *keystore.Keystore, opts ...settings.Option) *settings.Manager {
 	descs := append(settings.CoreDescriptors(), captcha.SettingsDescriptors()...)
 	descs = append(descs, ratelimit.SettingsDescriptors()...)
+	descs = append(descs, requestsource.SettingsDescriptors()...)
 	opts = append([]settings.Option{
 		settings.WithCrossValidation(captcha.SelectedConfigured),
 	}, opts...)

--- a/backend/internal/hub/usernames/reserved.go
+++ b/backend/internal/hub/usernames/reserved.go
@@ -33,8 +33,8 @@ func normalize(u string) string {
 // IsReservedSystem reports whether a username is reserved in every creation
 // path (public signup, setup signup, OAuth signup, CLI user-create). Covers
 // Solo: an operator who later opens the same data-dir in solo mode hands that
-// account the administrator, either with no credentials at all or against the
-// password its creator chose (see auth/solo_gate.go).
+// account the administrator -- with no credential over the local IPC socket,
+// or against the password its creator chose (see auth/solo_gate.go).
 func IsReservedSystem(u string) bool {
 	return contracts.UsernamesSystemReserved[normalize(u)]
 }

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -105,7 +105,10 @@ func defaultDeps() deps {
 // request, so it cannot know whether a password exists yet -- which is why it
 // states the condition rather than asserting the danger. The frontend makes
 // the same demand where it can be acted on: it blocks the whole app with a
-// password-setup screen while the hub is exposed and the account has none.
+// password-setup screen for every TCP connection while the account has no
+// password. That screen no longer depends on the listen address -- loopback
+// reaches it too -- because the rule is now the TRANSPORT: only the local IPC
+// socket is credential-free.
 const nonLoopbackListenWarnMsg = "solo mode binds a non-loopback address, so this hub is reachable from other machines. " +
 	"Until the \"solo\" account has a password, the first TCP caller can claim it by setting that password. " +
 	"Other protected actions stay closed until setup completes. Open the app and set the password now. " +

--- a/backend/solo/solo.go
+++ b/backend/solo/solo.go
@@ -96,11 +96,10 @@ func defaultDeps() deps {
 // nonLoopbackListenWarnMsg is the security warning the solo launcher prints
 // when the hub answers on an address another machine can reach.
 //
-// Solo mode authenticates a caller with no credentials WHILE the account holds
-// no password (auth.SoloGate states the whole rule), so a non-loopback bind in
-// that state hands the administrator to anyone who can reach the port. Setting
-// a password closes it: every TCP address then asks for one, 127.0.0.1
-// included.
+// A caller that reaches a passwordless solo hub over TCP can claim the account
+// by setting its first password. Other protected RPCs stay closed. Setting a
+// password closes the setup procedure and makes every TCP address require a
+// sign-in.
 //
 // It is printed at STARTUP, once the hub has bound its sockets but before any
 // request, so it cannot know whether a password exists yet -- which is why it
@@ -108,8 +107,8 @@ func defaultDeps() deps {
 // the same demand where it can be acted on: it blocks the whole app with a
 // password-setup screen while the hub is exposed and the account has none.
 const nonLoopbackListenWarnMsg = "solo mode binds a non-loopback address, so this hub is reachable from other machines. " +
-	"Until the \"solo\" account has a password, every request is authenticated as the administrator without credentials. " +
-	"Open the app and set one: it asks for a password before anything else while this address is served. " +
+	"Until the \"solo\" account has a password, the first TCP caller can claim it by setting that password. " +
+	"Other protected actions stay closed until setup completes. Open the app and set the password now. " +
 	"Restrict access externally as well (firewall, Tailscale/WireGuard, SSH tunnel) if the network is not one you trust."
 
 // Config configures the solo launcher.

--- a/backend/solo/solo_integration_test.go
+++ b/backend/solo/solo_integration_test.go
@@ -154,9 +154,8 @@ func isDefaultListenerInUse(err error) bool {
 
 // TestSoloStart_WarnsOnNonLoopbackListen confirms solo.Start emits a security
 // warning when the TCP listener is bound to a non-loopback address. The
-// warning matters because solo mode auto-authenticates every request as the
-// admin — exposing the port to anyone reachable on the network would otherwise
-// hand them passwordless admin access silently.
+// warning matters because the first TCP caller can claim a passwordless solo
+// account. The warning makes that setup race explicit.
 //
 // We assert by piping `os.Stderr` to a buffer before solo.Start runs, because
 // `logging.Setup` (invoked at the top of solo.Start) captures `os.Stderr` at

--- a/backend/solo/solo_test.go
+++ b/backend/solo/solo_test.go
@@ -1301,12 +1301,9 @@ func TestInstanceShutdown_StopsTheHubOnTheDrainNotTheWorkersFullExit(t *testing.
 // TestSoloStart_TheLocalWorkerDialsTheIPCSocket pins the property that keeps
 // the bundled Worker connected once the account holds a password.
 //
-// The solo hub authenticates a caller with no credentials only over the LOCAL
-// IPC socket, or while the account has no password (auth.SoloGate states the
-// rule). The Worker is a caller like any other, so if it dialled a TCP address
-// it would be signed out the moment an operator set that password -- and the
-// whole product would stop working in solo mode at exactly the step the
-// network-access feature asks the operator to take.
+// The solo hub authenticates a caller with no credentials only over local IPC.
+// The Worker uses that transport so it does not depend on a TCP setup or
+// sign-in state.
 //
 // It dials the IPC URL instead, which never asks. (It also presents an lmx_
 // bearer, which the solo rung yields to; this pins the transport, because that

--- a/backend/tunnel/channel_integration_test.go
+++ b/backend/tunnel/channel_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -46,8 +47,9 @@ func uniqueTestListenURL(t *testing.T) string {
 const soloStopBudget = 8 * time.Second
 
 // startTestSolo starts a solo Hub+Worker instance for integration testing.
-// Returns the hub URL, local-listen URL, admin user ID, and worker ID.
-func startTestSolo(t *testing.T) (hubURL, localListenURL, userID, workerID string) {
+// Returns the hub addresses, account and worker IDs, and the authenticated
+// HTTP client that completed first-password setup.
+func startTestSolo(t *testing.T) (hubURL, localListenURL, userID, workerID string, httpClient *http.Client) {
 	t.Helper()
 
 	// Use a short path under /tmp to stay within the 104-byte macOS Unix
@@ -102,12 +104,14 @@ func startTestSolo(t *testing.T) (hubURL, localListenURL, userID, workerID strin
 	// Wait for Hub to be ready.
 	require.NoError(t, waitForHTTP(hubURL, 30*time.Second))
 
-	// Solo mode auto-authenticates all requests — no login needed.
-	// Token is empty; the auth interceptor auto-attaches the solo user.
-
-	// Get user ID via auto-authenticated request.
-	httpClient := &http.Client{Timeout: 10 * time.Second}
-	authClient := leapmuxv1connect.NewAuthServiceClient(httpClient, hubURL)
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	apiClient := &http.Client{Timeout: 10 * time.Second, Jar: jar}
+	authClient := leapmuxv1connect.NewAuthServiceClient(apiClient, hubURL)
+	setup, err := authClient.SetInitialSoloPassword(ctx, connect.NewRequest(
+		&leapmuxv1.SetInitialSoloPasswordRequest{Password: "correct-horse-battery-staple"}))
+	require.NoError(t, err)
+	require.NotEmpty(t, setup.Header().Get("Set-Cookie"))
 
 	meResp, err := authClient.GetCurrentUser(ctx, connect.NewRequest(&leapmuxv1.GetCurrentUserRequest{}))
 	require.NoError(t, err)
@@ -121,7 +125,7 @@ func startTestSolo(t *testing.T) (hubURL, localListenURL, userID, workerID strin
 	// in tens of milliseconds, so a 500ms tick spent nearly all of its time
 	// asleep after the worker was already up -- twice, once here and once for
 	// the handshake params -- on every test in this file.
-	mgmtClient := leapmuxv1connect.NewWorkerManagementServiceClient(httpClient, hubURL)
+	mgmtClient := leapmuxv1connect.NewWorkerManagementServiceClient(apiClient, hubURL)
 	var wID string
 	require.Eventually(t, func() bool {
 		listResp, listErr := mgmtClient.ListWorkers(ctx, connect.NewRequest(&leapmuxv1.ListWorkersRequest{}))
@@ -140,7 +144,7 @@ func startTestSolo(t *testing.T) (hubURL, localListenURL, userID, workerID strin
 	// Wait for the worker to upload its public key. The key is sent over
 	// the bidi stream shortly after connect, so there is a brief window
 	// where the worker is online but has no public key yet.
-	channelClient := leapmuxv1connect.NewChannelServiceClient(httpClient, hubURL)
+	channelClient := leapmuxv1connect.NewChannelServiceClient(apiClient, hubURL)
 	require.Eventually(t, func() bool {
 		resp, keyErr := channelClient.GetWorkerHandshakeParams(ctx, connect.NewRequest(
 			&leapmuxv1.GetWorkerHandshakeParamsRequest{WorkerId: wID},
@@ -148,7 +152,7 @@ func startTestSolo(t *testing.T) (hubURL, localListenURL, userID, workerID strin
 		return keyErr == nil && len(resp.Msg.GetPublicKey()) > 0
 	}, 30*time.Second, 10*time.Millisecond, "worker handshake params not available in time")
 
-	return hubURL, localListenURL, userID, wID
+	return hubURL, localListenURL, userID, wID, &http.Client{Jar: jar}
 }
 
 func waitForHTTP(url string, timeout time.Duration) error {
@@ -170,11 +174,15 @@ func TestChannelOpenAndCallRPC(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	hubURL, _, _, workerID := startTestSolo(t)
+	hubURL, _, _, workerID, httpClient := startTestSolo(t)
 	ctx := context.Background()
 
 	// Open an E2EE channel.
-	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{LifetimeContext: ctx})
+	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{
+		LifetimeContext:     ctx,
+		HTTPClient:          httpClient,
+		WebSocketHTTPClient: httpClient,
+	})
 	require.NoError(t, err)
 	t.Cleanup(ch.Close)
 
@@ -196,13 +204,15 @@ func TestChannelLifetimeCanOutliveHandshakeContext(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	hubURL, _, _, workerID := startTestSolo(t)
+	hubURL, _, _, workerID, httpClient := startTestSolo(t)
 	operationCtx, cancelOperation := context.WithCancel(context.Background())
 	lifetimeCtx, cancelLifetime := context.WithCancel(context.Background())
 	t.Cleanup(cancelLifetime)
 
 	ch, err := tunnel.OpenChannel(operationCtx, hubURL, workerID, &tunnel.OpenChannelOptions{
-		LifetimeContext: lifetimeCtx,
+		LifetimeContext:     lifetimeCtx,
+		HTTPClient:          httpClient,
+		WebSocketHTTPClient: httpClient,
 	})
 	require.NoError(t, err)
 	t.Cleanup(ch.Close)
@@ -230,10 +240,14 @@ func TestChannelTunnelEchoFlow(t *testing.T) {
 	echoAddr := testutil.StartEchoServer(t)
 	echoHost, echoPort := testutil.ParseAddr(echoAddr)
 
-	hubURL, _, _, workerID := startTestSolo(t)
+	hubURL, _, _, workerID, httpClient := startTestSolo(t)
 	ctx := context.Background()
 
-	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{LifetimeContext: ctx})
+	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{
+		LifetimeContext:     ctx,
+		HTTPClient:          httpClient,
+		WebSocketHTTPClient: httpClient,
+	})
 	require.NoError(t, err)
 	t.Cleanup(ch.Close)
 
@@ -318,10 +332,14 @@ func TestChannelSocks5EchoFlow(t *testing.T) {
 	echoAddr := testutil.StartEchoServer(t)
 	echoHost, echoPort := testutil.ParseAddr(echoAddr)
 
-	hubURL, _, _, workerID := startTestSolo(t)
+	hubURL, _, _, workerID, httpClient := startTestSolo(t)
 	ctx := context.Background()
 
-	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{LifetimeContext: ctx})
+	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{
+		LifetimeContext:     ctx,
+		HTTPClient:          httpClient,
+		WebSocketHTTPClient: httpClient,
+	})
 	require.NoError(t, err)
 	t.Cleanup(ch.Close)
 
@@ -529,10 +547,14 @@ func TestChannelMultipleRPCs(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	hubURL, _, _, workerID := startTestSolo(t)
+	hubURL, _, _, workerID, httpClient := startTestSolo(t)
 	ctx := context.Background()
 
-	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{LifetimeContext: ctx})
+	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{
+		LifetimeContext:     ctx,
+		HTTPClient:          httpClient,
+		WebSocketHTTPClient: httpClient,
+	})
 	require.NoError(t, err)
 	t.Cleanup(ch.Close)
 
@@ -553,9 +575,13 @@ func TestChannelConcurrentRPCs(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	hubURL, _, _, workerID := startTestSolo(t)
+	hubURL, _, _, workerID, httpClient := startTestSolo(t)
 	ctx := context.Background()
-	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{LifetimeContext: ctx})
+	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{
+		LifetimeContext:     ctx,
+		HTTPClient:          httpClient,
+		WebSocketHTTPClient: httpClient,
+	})
 	require.NoError(t, err)
 	t.Cleanup(ch.Close)
 
@@ -597,10 +623,14 @@ func TestChannelLargeRPCDoesNotStallTunnelTraffic(t *testing.T) {
 	echoAddr := testutil.StartEchoServer(t)
 	echoHost, echoPort := testutil.ParseAddr(echoAddr)
 
-	hubURL, _, _, workerID := startTestSolo(t)
+	hubURL, _, _, workerID, httpClient := startTestSolo(t)
 	ctx := context.Background()
 
-	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{LifetimeContext: ctx})
+	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{
+		LifetimeContext:     ctx,
+		HTTPClient:          httpClient,
+		WebSocketHTTPClient: httpClient,
+	})
 	require.NoError(t, err)
 	t.Cleanup(ch.Close)
 

--- a/backend/tunnel/channel_scope_test.go
+++ b/backend/tunnel/channel_scope_test.go
@@ -36,13 +36,13 @@ func TestChannelScopeBindsInsideTheNoiseSession(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	hubURL, _, _, workerID := startTestSolo(t)
+	hubURL, _, _, workerID, httpClient := startTestSolo(t)
 	ctx := context.Background()
 
 	// A credential granted file:read and NOTHING else, through the real
 	// device-code flow -- so what binds below is what a consent screen would
 	// actually produce, not a row a test wrote by hand.
-	bearer, granted := authorizeScopedCredential(t, hubURL, "file:read")
+	bearer, granted := authorizeScopedCredential(t, httpClient, hubURL, "file:read")
 	// The closure widens along its OWN implications and no further: file:read
 	// implies worker:read, because reading a file means reaching the machine
 	// that holds it. It must not reach terminal:write, which is what the
@@ -104,7 +104,7 @@ func TestChannelScopeBindsInsideTheNoiseSession(t *testing.T) {
 	// credential that holds terminal:write reaches the handler and fails on the
 	// id instead. Without this the assertion above would pass for an
 	// unimplemented method.
-	wide, _ := authorizeScopedCredential(t, hubURL, "file:read terminal:write")
+	wide, _ := authorizeScopedCredential(t, httpClient, hubURL, "file:read terminal:write")
 	wideCh, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{
 		LifetimeContext: ctx,
 		BearerToken:     wide,
@@ -124,9 +124,8 @@ func TestChannelScopeBindsInsideTheNoiseSession(t *testing.T) {
 // The DEVICE flow, not a hand-written row: it is the one leg whose consent a
 // test can complete without a browser, and driving the real endpoints is what
 // makes the grant below the same value a consent screen produces.
-func authorizeScopedCredential(t *testing.T, hubURL, scope string) (bearer string, granted []string) {
+func authorizeScopedCredential(t *testing.T, client *http.Client, hubURL, scope string) (bearer string, granted []string) {
 	t.Helper()
-	client := &http.Client{}
 
 	postForm := func(path string, form url.Values) map[string]any {
 		t.Helper()
@@ -153,8 +152,7 @@ func authorizeScopedCredential(t *testing.T, hubURL, scope string) (bearer strin
 	require.NotEmpty(t, userCode)
 	require.NotEmpty(t, deviceCode)
 
-	// The consent POST. Solo authenticates it automatically, which is exactly
-	// the rung this test relies on staying above the bearer rung.
+	// The consent POST uses the elevated session from first-password setup.
 	approve, err := client.PostForm(hubURL+"/oauth/device", url.Values{
 		"user_code": {userCode}, "decision": {"allow"},
 	})
@@ -204,12 +202,16 @@ func TestChannelOpenReadsTheAnnouncedGrant(t *testing.T) {
 		t.Skip("skipping integration test in short mode")
 	}
 
-	hubURL, _, _, workerID := startTestSolo(t)
+	hubURL, _, _, workerID, httpClient := startTestSolo(t)
 	ctx := context.Background()
 
-	// A SESSION is unscoped, and solo authenticates as one when no bearer is
-	// presented. It reaches every method, which is what SCOPE_ALL means.
-	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{LifetimeContext: ctx})
+	// The session from first-password setup is unscoped. It reaches every
+	// method, which is what SCOPE_ALL means.
+	ch, err := tunnel.OpenChannel(ctx, hubURL, workerID, &tunnel.OpenChannelOptions{
+		LifetimeContext:     ctx,
+		HTTPClient:          httpClient,
+		WebSocketHTTPClient: httpClient,
+	})
 	require.NoError(t, err)
 	t.Cleanup(ch.Close)
 

--- a/contracts/trusted-proxies.json
+++ b/contracts/trusted-proxies.json
@@ -1,0 +1,16 @@
+{
+  "_readme": "Trusted reverse-proxy selectors cross the Go and TypeScript boundary. The selector cap controls backend validation and the editor Add control. The provider table keeps each stored token, menu label, and help text identical on both sides.",
+  "maxSelectors": 32,
+  "providers": {
+    "cloudflare": {
+      "token": "cloudflare",
+      "label": "Cloudflare",
+      "help": "Use the bundled Cloudflare IPv4 and IPv6 ranges."
+    },
+    "cloudfront": {
+      "token": "cloudfront",
+      "label": "AWS CloudFront",
+      "help": "Use the bundled AWS CloudFront IPv4 and IPv6 ranges."
+    }
+  }
+}

--- a/contracts/trusted-proxies.schema.json
+++ b/contracts/trusted-proxies.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "trusted-proxies.schema.json",
+  "title": "trusted reverse-proxy selector contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["_readme", "maxSelectors", "providers"],
+  "properties": {
+    "_readme": { "type": "string", "minLength": 1 },
+    "maxSelectors": { "type": "integer", "minimum": 1, "maximum": 256 },
+    "providers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cloudflare", "cloudfront"],
+      "properties": {
+        "cloudflare": { "$ref": "#/$defs/provider" },
+        "cloudfront": { "$ref": "#/$defs/provider" }
+      }
+    }
+  },
+  "$defs": {
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["token", "label", "help"],
+      "properties": {
+        "token": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "label": { "type": "string", "minLength": 1 },
+        "help": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/frontend/src/components/common/AuthGuard.test.tsx
+++ b/frontend/src/components/common/AuthGuard.test.tsx
@@ -31,7 +31,6 @@ const mockSoloAccess = vi.fn<() => SoloAccess>(() => SoloAccess.UNSPECIFIED)
 vi.mock('~/lib/systemInfo', () => ({
   isSoloMode: () => mockIsSoloMode(),
   isAutoAuthenticated: () => mockSoloAccess() === SoloAccess.CREDENTIAL_FREE,
-  passwordSetupRequired: () => mockSoloAccess() === SoloAccess.PASSWORD_SETUP,
   isPasswordSetupGate: () => mockSoloAccess() === SoloAccess.PASSWORD_SETUP,
   isSystemInfoLoaded: () => true,
   isCaptchaEnabled: () => false,

--- a/frontend/src/components/common/AuthGuard.test.tsx
+++ b/frontend/src/components/common/AuthGuard.test.tsx
@@ -2,6 +2,7 @@ import { createMemoryHistory, MemoryRouter, Route } from '@solidjs/router'
 import { render, screen } from '@solidjs/testing-library'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AuthGuard } from '~/components/common/AuthGuard'
+import { SoloAccess } from '~/generated/proto/leapmux/v1/auth_pb'
 
 // Mock the auth context module
 const mockUser = vi.fn()
@@ -25,14 +26,13 @@ vi.mock('~/context/AuthContext', () => ({
 }))
 
 const mockIsSoloMode = vi.fn<() => boolean>(() => false)
-const mockIsAutoAuthenticated = vi.fn<() => boolean>(() => false)
-const mockPasswordSetupRequired = vi.fn<() => boolean>(() => false)
+const mockSoloAccess = vi.fn<() => SoloAccess>(() => SoloAccess.UNSPECIFIED)
 
 vi.mock('~/lib/systemInfo', () => ({
   isSoloMode: () => mockIsSoloMode(),
-  isAutoAuthenticated: () => mockIsAutoAuthenticated(),
-  passwordSetupRequired: () => mockPasswordSetupRequired(),
-  isPasswordSetupGate: () => mockPasswordSetupRequired() && mockIsAutoAuthenticated(),
+  isAutoAuthenticated: () => mockSoloAccess() === SoloAccess.CREDENTIAL_FREE,
+  passwordSetupRequired: () => mockSoloAccess() === SoloAccess.PASSWORD_SETUP,
+  isPasswordSetupGate: () => mockSoloAccess() === SoloAccess.PASSWORD_SETUP,
   isSystemInfoLoaded: () => true,
   isCaptchaEnabled: () => false,
 }))
@@ -76,8 +76,7 @@ function renderGuard(options: { path?: string } = {}) {
 describe('authGuard', () => {
   beforeEach(() => {
     mockIsSoloMode.mockReturnValue(false)
-    mockIsAutoAuthenticated.mockReturnValue(false)
-    mockPasswordSetupRequired.mockReturnValue(false)
+    mockSoloAccess.mockReturnValue(SoloAccess.UNSPECIFIED)
     mockBootstrapError.mockReturnValue(null)
     mockRetryBootstrap.mockClear()
   })
@@ -93,18 +92,11 @@ describe('authGuard', () => {
     expect(navigations).toEqual([])
   })
 
-  // The gate branch sits BEFORE the authenticated one, and that order is the
-  // whole point: the visitor this screen exists for IS authenticated -- the hub
-  // let them in with no credentials, which is the problem. Ordering the branch
-  // after `isAuthenticated()` would render the app to exactly that visitor, and
-  // PasswordSetupGate's own tests would all still pass, because the component
-  // is never the thing that breaks.
-  it('replaces the app with the password-setup gate for a credential-free visitor', () => {
-    mockUser.mockReturnValue({ id: '1', isAdmin: true })
+  it('replaces the app with the password-setup gate for a restricted TCP visitor', () => {
+    mockUser.mockReturnValue(null)
     mockLoading.mockReturnValue(false)
-    mockIsAuthenticated.mockReturnValue(true)
-    mockIsAutoAuthenticated.mockReturnValue(true)
-    mockPasswordSetupRequired.mockReturnValue(true)
+    mockIsAuthenticated.mockReturnValue(false)
+    mockSoloAccess.mockReturnValue(SoloAccess.PASSWORD_SETUP)
 
     const { navigations } = renderGuard()
 
@@ -114,16 +106,11 @@ describe('authGuard', () => {
     expect(navigations).toEqual([])
   })
 
-  // BOTH conditions are required. A visitor who signed in reached this hub over
-  // a credentialed connection, so the exposure the gate exists for is already
-  // closed for them -- and the gate would demand a password that the account
-  // already has.
-  it('leaves a signed-in visitor alone even while the hub reports setup required', () => {
+  it('leaves a signed-in TCP visitor alone after setup', () => {
     mockUser.mockReturnValue({ id: '1', isAdmin: true })
     mockLoading.mockReturnValue(false)
     mockIsAuthenticated.mockReturnValue(true)
-    mockIsAutoAuthenticated.mockReturnValue(false)
-    mockPasswordSetupRequired.mockReturnValue(true)
+    mockSoloAccess.mockReturnValue(SoloAccess.SIGN_IN_REQUIRED)
 
     renderGuard()
 
@@ -139,8 +126,7 @@ describe('authGuard', () => {
     mockUser.mockReturnValue({ id: '1', isAdmin: true })
     mockLoading.mockReturnValue(false)
     mockIsAuthenticated.mockReturnValue(true)
-    mockIsAutoAuthenticated.mockReturnValue(true)
-    mockPasswordSetupRequired.mockReturnValue(false)
+    mockSoloAccess.mockReturnValue(SoloAccess.CREDENTIAL_FREE)
 
     renderGuard()
 
@@ -205,7 +191,7 @@ describe('authGuard', () => {
     mockUser.mockReturnValue(null)
     mockLoading.mockReturnValue(false)
     mockIsAuthenticated.mockReturnValue(false)
-    mockIsAutoAuthenticated.mockReturnValue(true)
+    mockSoloAccess.mockReturnValue(SoloAccess.CREDENTIAL_FREE)
 
     const { navigations } = renderGuard()
 
@@ -220,7 +206,7 @@ describe('authGuard', () => {
     mockUser.mockReturnValue(null)
     mockLoading.mockReturnValue(false)
     mockIsAuthenticated.mockReturnValue(false)
-    mockIsAutoAuthenticated.mockReturnValue(true)
+    mockSoloAccess.mockReturnValue(SoloAccess.CREDENTIAL_FREE)
 
     renderGuard()
 

--- a/frontend/src/components/common/AuthGuard.tsx
+++ b/frontend/src/components/common/AuthGuard.tsx
@@ -77,8 +77,8 @@ export const AuthGuard: ParentComponent = (props) => {
 
     // Before the authenticated branch, and before the redirect below. This
     // caller holds no session, so the redirect would send it to a login form
-    // that no password can satisfy; and a caller that DID sign in never
-    // reaches this state, because a stored password ends it.
+    // that no password can satisfy. A caller that DID sign in never reaches
+    // this state, because a stored password ends it.
     if (isPasswordSetupGate())
       return { kind: 'password-setup' }
 

--- a/frontend/src/components/common/AuthGuard.tsx
+++ b/frontend/src/components/common/AuthGuard.tsx
@@ -28,9 +28,10 @@ type GuardState
     | { kind: 'failed', title: string, detail: string }
     | { kind: 'redirect', to: string }
     /**
-     * The hub is reachable from another machine and its one account has no
-     * password, so nothing stands between a stranger and the whole app. The
-     * gate replaces the app until one exists.
+     * A TCP connection to a solo hub whose account holds no password. The
+     * caller has no session and reaches exactly one protected action: the
+     * public first-password procedure. The gate replaces the app with that
+     * one form, because every other affordance would refuse this caller.
      */
     | { kind: 'password-setup' }
 
@@ -74,8 +75,10 @@ export const AuthGuard: ParentComponent = (props) => {
       }
     }
 
-    // Before the authenticated branch because password setup is the only RPC
-    // that this unauthenticated TCP caller can use.
+    // Before the authenticated branch, and before the redirect below. This
+    // caller holds no session, so the redirect would send it to a login form
+    // that no password can satisfy; and a caller that DID sign in never
+    // reaches this state, because a stored password ends it.
     if (isPasswordSetupGate())
       return { kind: 'password-setup' }
 

--- a/frontend/src/components/common/AuthGuard.tsx
+++ b/frontend/src/components/common/AuthGuard.tsx
@@ -74,9 +74,8 @@ export const AuthGuard: ParentComponent = (props) => {
       }
     }
 
-    // BEFORE the authenticated branch, because this caller IS authenticated --
-    // the hub let it in with no credentials, which is the problem. Ordering it
-    // after would render the app to exactly the visitor the gate exists for.
+    // Before the authenticated branch because password setup is the only RPC
+    // that this unauthenticated TCP caller can use.
     if (isPasswordSetupGate())
       return { kind: 'password-setup' }
 

--- a/frontend/src/components/common/LoginPage.tsx
+++ b/frontend/src/components/common/LoginPage.tsx
@@ -45,9 +45,9 @@ export const LoginPage: Component = () => {
   let usernameRef!: HTMLInputElement
   let passwordRef!: HTMLInputElement
 
-  // Two guards ABOVE this page answer the two hubs with no login to offer. A solo
-  // hub authenticates every request, so `SignedOutOnly` sends that visitor to
-  // the app; a hub whose first-run setup is not complete has no account, so
+  // Two guards above this page answer hubs with no login to offer. A local IPC
+  // solo connection needs no credential, so `SignedOutOnly` sends it to the
+  // app. A hub whose first-run setup is not complete has no account, so
   // `SetupGate` sends them to `/setup`. Both guards cover every credential
   // address rather than this one alone.
   //

--- a/frontend/src/components/common/PasswordSetupGate.test.tsx
+++ b/frontend/src/components/common/PasswordSetupGate.test.tsx
@@ -4,15 +4,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockLoadSystemInfo } from '~/test-support/systemInfoMock'
 import { PasswordSetupGate } from './PasswordSetupGate'
 
-const mockChangePassword = vi.fn()
+const mockSetInitialSoloPassword = vi.fn()
 const mockRefreshUser = vi.fn()
+const mockSetAuth = vi.fn()
 
 vi.mock('~/api/clients', () => ({
-  userClient: { changePassword: (...args: unknown[]) => mockChangePassword(...args) },
+  authClient: { setInitialSoloPassword: (...args: unknown[]) => mockSetInitialSoloPassword(...args) },
 }))
 
 vi.mock('~/context/AuthContext', () => ({
-  useAuth: () => ({ refreshUser: () => mockRefreshUser() }),
+  useAuth: () => ({ refreshUser: () => mockRefreshUser(), setAuth: (...args: unknown[]) => mockSetAuth(...args) }),
 }))
 
 vi.mock('~/lib/systemInfo', async () => {
@@ -29,7 +30,7 @@ function fillPassword(pw = 'correct-horse-battery-staple') {
 describe('passwordSetupGate', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockChangePassword.mockResolvedValue({})
+    mockSetInitialSoloPassword.mockResolvedValue({ user: { id: 'solo-id', username: 'solo' } })
     // Restated, not merely cleared: `clearAllMocks` forgets the CALLS and
     // keeps the implementation, so one test's `mockRejectedValue` would
     // otherwise reject in every test after it.
@@ -66,7 +67,8 @@ describe('passwordSetupGate', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Set Password' }))
 
     await vi.waitFor(() => {
-      expect(mockChangePassword).toHaveBeenCalledWith({ newPassword: 'correct-horse-battery-staple' })
+      expect(mockSetInitialSoloPassword).toHaveBeenCalledWith({ password: 'correct-horse-battery-staple' })
+      expect(mockSetAuth).toHaveBeenCalledWith({ id: 'solo-id', username: 'solo' })
       // FORCED, because the gate reads exactly this snapshot: without it the
       // screen stays up over a hub that no longer needs it.
       expect(mockLoadSystemInfo).toHaveBeenCalledWith(true)
@@ -80,7 +82,7 @@ describe('passwordSetupGate', () => {
   })
 
   it('reports a refusal rather than leaving the form silent', async () => {
-    mockChangePassword.mockRejectedValue(new Error('password is too short'))
+    mockSetInitialSoloPassword.mockRejectedValue(new Error('password is too short'))
     render(() => <PasswordSetupGate />)
     fillPassword()
 
@@ -91,9 +93,6 @@ describe('passwordSetupGate', () => {
     expect(screen.getByRole('button', { name: 'Set Password' })).toBeInTheDocument()
   })
 
-  // The exposed address is deliberately NOT named: the hub can answer on
-  // several, and the one this page was opened at is often not the one that
-  // exposes it.
   // The password committed and only the re-read failed. Reporting that as
   // "Failed to set the password" told the operator to retry a write that
   // succeeded, from a screen that offers no other way out.
@@ -106,13 +105,13 @@ describe('passwordSetupGate', () => {
 
     expect(await screen.findByText(/The password is set/)).toBeInTheDocument()
     expect(screen.queryByText(/Failed to set the password/)).toBeNull()
-    expect(mockChangePassword).toHaveBeenCalledTimes(1)
+    expect(mockSetInitialSoloPassword).toHaveBeenCalledTimes(1)
   })
 
-  it('does not claim which address exposes the hub', () => {
+  it('explains the restricted TCP setup state', () => {
     render(() => <PasswordSetupGate />)
     expect(screen.getByTestId('password-setup-gate')).toHaveTextContent(
-      'This hub answers on an address other machines can reach',
+      'Until then, TCP callers can only complete this setup',
     )
   })
 })

--- a/frontend/src/components/common/PasswordSetupGate.test.tsx
+++ b/frontend/src/components/common/PasswordSetupGate.test.tsx
@@ -7,6 +7,9 @@ import { PasswordSetupGate } from './PasswordSetupGate'
 const mockSetInitialSoloPassword = vi.fn()
 const mockRefreshUser = vi.fn()
 const mockSetAuth = vi.fn()
+// A stand-in for the protobuf Timestamp the hub returns; the gate only passes
+// it through, so its shape does not matter here.
+const soloElevation = { seconds: 1700000000n, nanos: 0 }
 
 vi.mock('~/api/clients', () => ({
   authClient: { setInitialSoloPassword: (...args: unknown[]) => mockSetInitialSoloPassword(...args) },
@@ -30,7 +33,10 @@ function fillPassword(pw = 'correct-horse-battery-staple') {
 describe('passwordSetupGate', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockSetInitialSoloPassword.mockResolvedValue({ user: { id: 'solo-id', username: 'solo' } })
+    mockSetInitialSoloPassword.mockResolvedValue({
+      user: { id: 'solo-id', username: 'solo' },
+      elevationExpiresAt: soloElevation,
+    })
     // Restated, not merely cleared: `clearAllMocks` forgets the CALLS and
     // keeps the implementation, so one test's `mockRejectedValue` would
     // otherwise reject in every test after it.
@@ -68,7 +74,11 @@ describe('passwordSetupGate', () => {
 
     await vi.waitFor(() => {
       expect(mockSetInitialSoloPassword).toHaveBeenCalledWith({ password: 'correct-horse-battery-staple' })
-      expect(mockSetAuth).toHaveBeenCalledWith({ id: 'solo-id', username: 'solo' })
+      // The elevation the SAME reply granted travels with the user, so the
+      // client's elevation state never depends on the follow-up refresh. That
+      // refresh swallows its own failure, so recovering the window from it
+      // would prompt the operator for the password they just chose.
+      expect(mockSetAuth).toHaveBeenCalledWith({ id: 'solo-id', username: 'solo' }, soloElevation)
       // FORCED, because the gate reads exactly this snapshot: without it the
       // screen stays up over a hub that no longer needs it.
       expect(mockLoadSystemInfo).toHaveBeenCalledWith(true)

--- a/frontend/src/components/common/PasswordSetupGate.tsx
+++ b/frontend/src/components/common/PasswordSetupGate.tsx
@@ -50,7 +50,12 @@ export const PasswordSetupGate: Component = () => {
       const response = await authClient.setInitialSoloPassword({ password: password() })
       if (!response.user)
         throw new Error('The hub returned no solo user')
-      auth.setAuth(response.user)
+      // The elevation travels WITH the reply. The transaction that stored the
+      // password created this session and elevated it, so the deadline is
+      // known here and needs no second round trip. `setAuth` clears the
+      // elevation on its own, which is right for every other caller and wrong
+      // for this one.
+      auth.setAuth(response.user, response.elevationExpiresAt)
     }
     catch (e) {
       setMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to set the password') })

--- a/frontend/src/components/common/PasswordSetupGate.tsx
+++ b/frontend/src/components/common/PasswordSetupGate.tsx
@@ -1,6 +1,6 @@
 import type { Component } from 'solid-js'
 import { createSignal } from 'solid-js'
-import { userClient } from '~/api/clients'
+import { authClient } from '~/api/clients'
 import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { passwordCanSubmit, PasswordFields } from '~/components/common/PasswordFields'
 import { StatusLine } from '~/components/common/StatusLine'
@@ -12,24 +12,15 @@ import { centeredFull, pageCard } from '~/styles/shared.css'
 import { fieldLabel } from '../settings/account/accountFields.css'
 
 /**
- * The screen that replaces the whole app while the hub is exposed and its one
- * account has no password.
+ * The screen that replaces the app on a passwordless solo TCP connection.
  *
- * In that state everything the app offers is offered to whoever can reach the
- * port, and no sign-in stands between them, so the one useful thing left is to
- * ask for a password. `AuthGuard` renders it instead of the app rather than
- * beside it, because a dismissible notice would leave the exposure standing.
+ * The only useful action in that state is to set the first password.
+ * `AuthGuard` renders this screen instead of the app because no other protected
+ * RPC accepts the caller.
  *
- * It is reachable only from a CREDENTIAL-FREE connection -- the hub reports
- * `password_setup_required` and `auto_authenticated` together, and a visitor
- * from a network address on such a hub is not signed in and never gets this
- * far. So the caller here is already the administrator, and asking it to prove
- * anything first would ask for the secret it is about to choose.
- *
- * ChangePassword hands this browser a session in its reply, so the app loads
- * straight after without a sign-in. That is not a convenience: storing the
- * password is what starts demanding one, and the page that made the write
- * would otherwise be signed out of the form it is standing in.
+ * It is reachable from the restricted PASSWORD_SETUP state. The public setup
+ * RPC stores the password and an elevated session in one transaction. No
+ * other protected RPC accepts the caller before that transaction commits.
  */
 export const PasswordSetupGate: Component = () => {
   const [password, setPassword] = createSignal('')
@@ -56,7 +47,10 @@ export const PasswordSetupGate: Component = () => {
     setBusy(true)
     setMessage(null)
     try {
-      await userClient.changePassword({ newPassword: password() })
+      const response = await authClient.setInitialSoloPassword({ password: password() })
+      if (!response.user)
+        throw new Error('The hub returned no solo user')
+      auth.setAuth(response.user)
     }
     catch (e) {
       setMessage({ type: 'error', text: formatErrorMessage(e, 'Failed to set the password') })
@@ -106,9 +100,9 @@ export const PasswordSetupGate: Component = () => {
           * Network access lists them exactly.
           */}
         <p>
-          This hub answers on an address other machines can reach, and it asks
-          nobody for a password. Set one now. Every network address then asks
-          for it, 127.0.0.1 included.
+          This connection uses TCP, and the “solo” account has no password.
+          Set one now. Until then, TCP callers can only complete this setup.
+          Every TCP address asks for the password after setup.
         </p>
         <div class="vstack gap-4">
           <label class={fieldLabel}>

--- a/frontend/src/components/common/SignedOutOnly.test.tsx
+++ b/frontend/src/components/common/SignedOutOnly.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SignedOutOnly } from '~/components/common/SignedOutOnly'
+import { SoloAccess } from '~/generated/proto/leapmux/v1/auth_pb'
 import { resetSystemInfoMock, setSystemInfoMock } from '~/test-support/systemInfoMock'
 
 vi.mock('~/lib/systemInfo', async () => {
@@ -252,7 +253,7 @@ describe('signedOutOnly', () => {
   // in". With a user present the ordinary signed-in redirect answers instead,
   // so the assertion would pass with this rule deleted.
   it('sends a credential-free visitor to the app, from every credential page', async () => {
-    setSystemInfoMock({ soloMode: true, autoAuthenticated: true })
+    setSystemInfoMock({ soloMode: true, soloAccess: SoloAccess.CREDENTIAL_FREE })
     mockUser.mockReturnValue(null)
     const { navigations } = renderGate('/recover-account')
     await vi.waitFor(() => {
@@ -274,7 +275,7 @@ describe('signedOutOnly', () => {
     expect(screen.getByTestId('credential-form')).toBeInTheDocument()
     expect(navigations).toEqual([])
 
-    setSystemInfoMock({ soloMode: true, autoAuthenticated: true })
+    setSystemInfoMock({ soloMode: true, soloAccess: SoloAccess.CREDENTIAL_FREE })
     mockLoading.mockReturnValue(false)
 
     await vi.waitFor(() => {
@@ -286,7 +287,7 @@ describe('signedOutOnly', () => {
   // the wrong answer on a connection where signing out is impossible, and
   // there is no password to reset either.
   it('redirects rather than explains on a credential-free connection', async () => {
-    setSystemInfoMock({ soloMode: true, autoAuthenticated: true })
+    setSystemInfoMock({ soloMode: true, soloAccess: SoloAccess.CREDENTIAL_FREE })
     mockUser.mockReturnValue({ id: 'solo', username: 'solo' })
     const { navigations } = renderGate('/recover-account/complete?token=abc', 'explain')
 
@@ -301,7 +302,7 @@ describe('signedOutOnly', () => {
   // callers to sign in, so those callers do have a sign-out and the ordinary
   // explanation applies to them.
   it('explains on a solo hub reached at a network address', async () => {
-    setSystemInfoMock({ soloMode: true, autoAuthenticated: false })
+    setSystemInfoMock({ soloMode: true, soloAccess: SoloAccess.SIGN_IN_REQUIRED })
     mockUser.mockReturnValue({ id: 'solo', username: 'solo' })
     const { navigations } = renderGate('/recover-account/complete?token=abc', 'explain')
 

--- a/frontend/src/components/common/SignedOutOnly.test.tsx
+++ b/frontend/src/components/common/SignedOutOnly.test.tsx
@@ -297,6 +297,30 @@ describe('signedOutOnly', () => {
     expect(screen.queryByTestId('signed-out-only-explain')).not.toBeInTheDocument()
   })
 
+  // The PASSWORD_SETUP state, which is the other connection with no usable
+  // credential. The account holds no password, so this form can only ever
+  // answer "invalid credentials" -- and nothing on the page routes to `/`,
+  // where AuthGuard renders the setup screen. Without this rule `/login` is a
+  // dead end that a bookmark, a stale tab or a `?redirect=` bounce reaches on
+  // every fresh `leapmux solo`, loopback included.
+  it('sends a passwordless TCP visitor to the app, from every credential page', async () => {
+    setSystemInfoMock({ soloMode: true, soloAccess: SoloAccess.PASSWORD_SETUP })
+    mockUser.mockReturnValue(null)
+    const { navigations } = renderGate('/login')
+    await vi.waitFor(() => {
+      expect(navigations).toEqual(['/'])
+    })
+  })
+
+  it('sends a passwordless TCP visitor away from account recovery too', async () => {
+    setSystemInfoMock({ soloMode: true, soloAccess: SoloAccess.PASSWORD_SETUP })
+    mockUser.mockReturnValue(null)
+    const { navigations } = renderGate('/recover-account')
+    await vi.waitFor(() => {
+      expect(navigations).toEqual(['/'])
+    })
+  })
+
   // The other half of that rule, and the reason it reads the CONNECTION rather
   // than the hub: a solo hub whose account holds a password asks its network
   // callers to sign in, so those callers do have a sign-out and the ordinary

--- a/frontend/src/components/common/SignedOutOnly.tsx
+++ b/frontend/src/components/common/SignedOutOnly.tsx
@@ -4,7 +4,7 @@ import { createEffect, createSignal, Show } from 'solid-js'
 import { useAuth } from '~/context/AuthContext'
 import { postAuthNavigate } from '~/lib/postAuthNavigate'
 import { stringParam } from '~/lib/searchParam'
-import { isAutoAuthenticated } from '~/lib/systemInfo'
+import { isAutoAuthenticated, isPasswordSetupGate } from '~/lib/systemInfo'
 import { centeredFull, pageCard } from '~/styles/shared.css'
 
 /**
@@ -15,13 +15,16 @@ import { centeredFull, pageCard } from '~/styles/shared.css'
  *
  * TWO rules, and both belong to every one of the five pages.
  *
- * A SOLO hub serves no credential endpoint at all: it authenticates every
- * request as the synthetic solo user, so there is nothing to sign in to, no
- * account to create, and no account to recover. Each page used to spell that
- * rule out, and it reached two of the five, so `/recover-account`,
- * `/recover-account/complete` and `/setup` each offered a form the hub answers nothing
- * for. It OUTRANKS `whenSignedIn`: an `explain` panel that offers to sign out
- * is the wrong answer on a hub where signing out is impossible.
+ * A SOLO hub offers no credential the visitor can use, in two of its three
+ * connection states. Local IPC needs none, so there is nothing to sign in to.
+ * A passwordless TCP connection has no password that could work. Either way
+ * there is no account to create and no account to recover. Each page used to
+ * spell that rule out, and it reached two of the five, so `/recover-account`,
+ * `/recover-account/complete` and `/setup` each offered a form the hub answers
+ * nothing for. It OUTRANKS `whenSignedIn`: an `explain` panel that offers to
+ * sign out is the wrong answer on a connection where signing out is
+ * impossible. A solo hub whose account HAS a password is the third state, and
+ * its network callers sign in like anybody else.
  *
  * `SetupGate` does not cover this. It asks whether the HUB still needs a first
  * administrator, which is a different question with a different answer.
@@ -103,11 +106,20 @@ export const SignedOutOnly: ParentComponent<{
       return
     const signedIn = auth.user() !== null
     setArrivedSignedIn(signedIn)
-    // The credential-free rule first: it holds whether or not somebody is
-    // signed in, and it outranks `whenSignedIn`, because a connection with no
-    // sign-out has nothing to explain. A solo hub reached at a network address
-    // DOES have one, so it falls through to the ordinary branches.
-    if (isAutoAuthenticated()) {
+    // The no-credential-to-offer rule first: it holds whether or not somebody
+    // is signed in, and it outranks `whenSignedIn`, because a connection with
+    // no sign-out has nothing to explain.
+    //
+    // TWO solo states qualify, and both send the visitor to `/`. Local IPC
+    // needs no credential, so there is nothing to sign in to. A passwordless
+    // TCP connection has a credential form that NO password can satisfy --
+    // the account holds none — so `/login` is a dead end that offers
+    // "invalid credentials" for every attempt and no route to the setup
+    // screen. `AuthGuard` renders that screen at `/`, which is the only
+    // useful destination for either state. A solo hub whose account HAS a
+    // password reports SIGN_IN_REQUIRED and falls through to the ordinary
+    // branches, because there the form works.
+    if (isAutoAuthenticated() || isPasswordSetupGate()) {
       navigate('/', { replace: true })
       return
     }

--- a/frontend/src/components/settings/account/AccountPassword.test.tsx
+++ b/frontend/src/components/settings/account/AccountPassword.test.tsx
@@ -137,7 +137,7 @@ describe('accountPassword', () => {
     mockUser.mockReturnValue(withoutPassword)
     render(() => <AccountPassword />)
 
-    expect(await screen.findByText(/asks every network address for a sign-in as “solo”/))
+    expect(await screen.findByText(/makes every TCP address require a sign-in as “solo”/))
       .toBeInTheDocument()
   })
 

--- a/frontend/src/components/settings/account/AccountPassword.tsx
+++ b/frontend/src/components/settings/account/AccountPassword.tsx
@@ -90,10 +90,9 @@ export const AccountPassword: Component = () => {
       */}
       <Show when={isSoloMode() && !passwordSet()}>
         <Alert variant="warning">
-          This hub authenticates everyone who can reach it while the “solo”
-          account has no password. Setting one asks every network address for a
-          sign-in as “solo”, 127.0.0.1 included. The desktop app’s local socket
-          is the only exception.
+          TCP callers can only set the first “solo” password while none exists.
+          Setting one makes every TCP address require a sign-in as “solo”. The
+          desktop app’s local socket stays credential-free.
         </Alert>
       </Show>
       <PasswordFields

--- a/frontend/src/components/settings/controls/NetworkAccessControl.test.tsx
+++ b/frontend/src/components/settings/controls/NetworkAccessControl.test.tsx
@@ -249,8 +249,7 @@ describe('networkAccessControl', () => {
 
     expect(await screen.findByRole('button', { name: 'Apply' })).toBeEnabled()
     expect(screen.queryByText(/Set the password below first/)).toBeNull()
-    // It still states the standing condition: this hub asks nobody for one yet.
-    expect(screen.getByText(/authenticates everyone who can reach it/)).toBeInTheDocument()
+    expect(screen.getByText(/TCP callers can only set its first password/)).toBeInTheDocument()
   })
 
   // The other half of the same rule: an address another machine can reach is

--- a/frontend/src/components/settings/controls/NetworkAccessControl.tsx
+++ b/frontend/src/components/settings/controls/NetworkAccessControl.tsx
@@ -201,8 +201,8 @@ export const NetworkAccessControl: CustomEditorComponent = (props) => {
         //
         // The caller keeps working across the write, and no session changes
         // hands. Only a credential-free connection reaches this panel while the
-        // account has no password -- a TCP browser in that state meets the
-        // password-setup screen instead of the app -- and local IPC stays
+        // account has no password. A TCP browser in that state meets the
+        // password-setup screen instead of the app. Local IPC stays
         // credential-free whatever the account holds.
         //
         // LATCHED, and the fields are cleared only once the whole apply lands.

--- a/frontend/src/components/settings/controls/NetworkAccessControl.tsx
+++ b/frontend/src/components/settings/controls/NetworkAccessControl.tsx
@@ -26,11 +26,9 @@ import { ANY_HOST, mergeNotes, newRow, portOf, rowFromAddress, rowIsLoopback, to
  * The Network access panel: which addresses this hub answers on, and the
  * password that guards them.
  *
- * The two belong in ONE form because they are one decision. Publishing an
- * address without a password would put the whole app behind nothing, and the
- * hub's rule says as much: once the account holds a password every network
- * address asks for it, so the panel refuses to apply an address until one
- * exists.
+ * The two belong in one form because they are one decision. A passwordless
+ * TCP caller can only set the first password. This panel stores that password
+ * before it publishes an address, so the new address can sign in immediately.
  *
  * It writes the address list through the row's BINDING -- the same admin
  * settings store the rest of the dialog uses -- so the list has one home and
@@ -188,8 +186,8 @@ export const NetworkAccessControl: CustomEditorComponent = (props) => {
       return 'Applying this asks every network address for a sign-in, 127.0.0.1 included. '
         + 'The desktop app’s local socket is the only exception. Set the password below first.'
     }
-    return 'While the “solo” account has no password, this hub authenticates everyone who can reach it. '
-      + 'An address other machines can reach demands one, and Apply asks for it then.'
+    return 'While the “solo” account has no password, TCP callers can only set its first password. '
+      + 'An address other machines can reach needs one, and Apply stores it first.'
   }
 
   const apply = async () => {

--- a/frontend/src/components/settings/controls/NetworkAccessControl.tsx
+++ b/frontend/src/components/settings/controls/NetworkAccessControl.tsx
@@ -198,9 +198,12 @@ export const NetworkAccessControl: CustomEditorComponent = (props) => {
       work: async () => {
         // The password FIRST. A failure here leaves no address published, where
         // the reverse would publish an address nobody can authenticate against.
-        // The reply carries this browser's new session: storing the first
-        // password is what starts demanding one, so without it the page that
-        // made the write is signed out of the form it is standing in.
+        //
+        // The caller keeps working across the write, and no session changes
+        // hands. Only a credential-free connection reaches this panel while the
+        // account has no password -- a TCP browser in that state meets the
+        // password-setup screen instead of the app -- and local IPC stays
+        // credential-free whatever the account holds.
         //
         // LATCHED, and the fields are cleared only once the whole apply lands.
         // Clearing them beside this call left the operator with no way to retry

--- a/frontend/src/components/settings/controls/TrustedProxiesControl.css.ts
+++ b/frontend/src/components/settings/controls/TrustedProxiesControl.css.ts
@@ -37,6 +37,12 @@ export const exampleList = style({
   listStyle: 'none',
 })
 
+export const addRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--space-2)',
+})
+
 export const note = style({
   color: 'var(--muted-foreground)',
   fontSize: 'var(--text-8)',

--- a/frontend/src/components/settings/controls/TrustedProxiesControl.css.ts
+++ b/frontend/src/components/settings/controls/TrustedProxiesControl.css.ts
@@ -1,0 +1,43 @@
+import { style } from '@vanilla-extract/css'
+
+export const warningList = style({
+  margin: 0,
+  paddingInlineStart: 'var(--space-5)',
+})
+
+export const selectorRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--space-2)',
+})
+
+export const selectorInput = style({
+  flex: 1,
+  minWidth: 0,
+  marginBlockStart: 0,
+  fontFamily: 'var(--font-mono)',
+})
+
+export const removeButton = style({
+  paddingInline: 'var(--space-3)',
+})
+
+export const examples = style({
+  color: 'var(--muted-foreground)',
+  fontSize: 'var(--text-8)',
+  lineHeight: 1.6,
+})
+
+export const exampleList = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 'var(--space-1) var(--space-3)',
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+})
+
+export const note = style({
+  color: 'var(--muted-foreground)',
+  fontSize: 'var(--text-8)',
+})

--- a/frontend/src/components/settings/controls/TrustedProxiesControl.test.tsx
+++ b/frontend/src/components/settings/controls/TrustedProxiesControl.test.tsx
@@ -24,7 +24,13 @@ function openAddMenu() {
   fireEvent.click(screen.getByRole('button', { name: /^Add/ }))
 }
 
-function chooseAddOption(label: string) {
+/** The manual entry is a plain action; each provider is a checkable state. */
+function chooseManualAdd() {
+  openAddMenu()
+  fireEvent.click(screen.getByRole('menuitem', { name: /IP address or range/, hidden: true }))
+}
+
+function chooseProvider(label: string) {
   openAddMenu()
   fireEvent.click(screen.getByRole('menuitemcheckbox', { name: new RegExp(label), hidden: true }))
 }
@@ -63,7 +69,7 @@ describe('trustedProxiesControl', () => {
   it('adds and edits a manual selector before apply', () => {
     const current = binding([])
     render(() => <TrustedProxiesControl binding={current.model} />)
-    chooseAddOption('IP address or range')
+    chooseManualAdd()
 
     const input = screen.getByLabelText('Trusted proxy selector')
     fireEvent.input(input, { target: { value: '192.0.2.10' } })
@@ -72,10 +78,28 @@ describe('trustedProxiesControl', () => {
     expect(current.write).toHaveBeenCalledWith(['192.0.2.10'])
   })
 
+  // The manual entry is an ACTION, so choosing it twice stages two rows. A
+  // checkable item could not express that: the second choice would read as
+  // unchecking the first.
+  it('stages one row for each manual add', () => {
+    const current = binding([])
+    render(() => <TrustedProxiesControl binding={current.model} />)
+    chooseManualAdd()
+    chooseManualAdd()
+
+    const inputs = screen.getAllByLabelText('Trusted proxy selector')
+    expect(inputs).toHaveLength(2)
+    fireEvent.input(inputs[0], { target: { value: '192.0.2.10' } })
+    fireEvent.input(inputs[1], { target: { value: '2001:db8::/64' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(current.write).toHaveBeenCalledWith(['192.0.2.10', '2001:db8::/64'])
+  })
+
   it('adds providers symbolically and disables a duplicate provider', () => {
     const current = binding([])
     render(() => <TrustedProxiesControl binding={current.model} />)
-    chooseAddOption('Cloudflare')
+    chooseProvider('Cloudflare')
 
     expect(screen.getByDisplayValue('cloudflare')).toBeInTheDocument()
     openAddMenu()

--- a/frontend/src/components/settings/controls/TrustedProxiesControl.test.tsx
+++ b/frontend/src/components/settings/controls/TrustedProxiesControl.test.tsx
@@ -2,7 +2,7 @@ import type { SettingBinding } from '../types'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { MAX_TRUSTED_PROXY_SELECTORS } from '~/generated/contracts/trusted-proxies'
+import { MAX_TRUSTED_PROXY_SELECTORS, TRUSTED_PROXY_PROVIDERS } from '~/generated/contracts/trusted-proxies'
 import { TrustedProxiesControl } from './TrustedProxiesControl'
 
 function binding(initial: string[], write = vi.fn()) {
@@ -40,8 +40,14 @@ describe('trustedProxiesControl', () => {
     vi.clearAllMocks()
   })
 
+  // The address forms are LITERAL here on purpose: they are what the parser
+  // accepts, and restating them is how this test would catch a form dropped
+  // from the list. The provider tokens are DERIVED, because they and the Add
+  // menu are two renderings of one generated catalogue -- listing them twice
+  // is how a new contract entry reaches the menu and misses the examples.
   it('shows every supported manual example and provider token', () => {
     render(() => <TrustedProxiesControl binding={binding([]).model} />)
+    expect(TRUSTED_PROXY_PROVIDERS.length).toBeGreaterThan(0)
     for (const example of [
       '192.0.2.10',
       '2001:db8::10',
@@ -50,8 +56,7 @@ describe('trustedProxiesControl', () => {
       '2001:db8::1-2001:db8::ffff',
       '192.168.0.0/24',
       '2001:db8::/64',
-      'cloudflare',
-      'cloudfront',
+      ...TRUSTED_PROXY_PROVIDERS.map(provider => provider.token),
     ]) {
       expect(screen.getByText(example)).toBeInTheDocument()
     }

--- a/frontend/src/components/settings/controls/TrustedProxiesControl.test.tsx
+++ b/frontend/src/components/settings/controls/TrustedProxiesControl.test.tsx
@@ -1,0 +1,127 @@
+import type { SettingBinding } from '../types'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MAX_TRUSTED_PROXY_SELECTORS } from '~/generated/contracts/trusted-proxies'
+import { TrustedProxiesControl } from './TrustedProxiesControl'
+
+function binding(initial: string[], write = vi.fn()) {
+  const [value, setValue] = createSignal<unknown>(initial)
+  return {
+    model: {
+      value,
+      set: async (next: unknown) => {
+        await write(next)
+        setValue(next)
+      },
+    } satisfies SettingBinding,
+    setValue,
+    write,
+  }
+}
+
+function openAddMenu() {
+  fireEvent.click(screen.getByRole('button', { name: /^Add/ }))
+}
+
+function chooseAddOption(label: string) {
+  openAddMenu()
+  fireEvent.click(screen.getByRole('menuitemcheckbox', { name: new RegExp(label), hidden: true }))
+}
+
+describe('trustedProxiesControl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows every supported manual example and provider token', () => {
+    render(() => <TrustedProxiesControl binding={binding([]).model} />)
+    for (const example of [
+      '192.0.2.10',
+      '2001:db8::10',
+      '192.168.0.1-100',
+      '192.168.0.1-192.168.0.100',
+      '2001:db8::1-2001:db8::ffff',
+      '192.168.0.0/24',
+      '2001:db8::/64',
+      'cloudflare',
+      'cloudfront',
+    ]) {
+      expect(screen.getByText(example)).toBeInTheDocument()
+    }
+  })
+
+  it('shows the non-dismissible provider security warning', () => {
+    render(() => <TrustedProxiesControl binding={binding([]).model} />)
+    const warning = screen.getByRole('alert')
+    expect(warning).toHaveTextContent('shared provider infrastructure, not your account')
+    expect(warning).toHaveTextContent('authenticated origin requests')
+    expect(warning).toHaveTextContent('remove client-supplied forwarding headers')
+    expect(warning.querySelector('button')).toBeNull()
+  })
+
+  it('adds and edits a manual selector before apply', () => {
+    const current = binding([])
+    render(() => <TrustedProxiesControl binding={current.model} />)
+    chooseAddOption('IP address or range')
+
+    const input = screen.getByLabelText('Trusted proxy selector')
+    fireEvent.input(input, { target: { value: '192.0.2.10' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(current.write).toHaveBeenCalledWith(['192.0.2.10'])
+  })
+
+  it('adds providers symbolically and disables a duplicate provider', () => {
+    const current = binding([])
+    render(() => <TrustedProxiesControl binding={current.model} />)
+    chooseAddOption('Cloudflare')
+
+    expect(screen.getByDisplayValue('cloudflare')).toBeInTheDocument()
+    openAddMenu()
+    expect(screen.getByRole('menuitemcheckbox', { name: /Cloudflare/, hidden: true })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+    expect(current.write).toHaveBeenCalledWith(['cloudflare'])
+  })
+
+  it('preserves provider tokens after read-back', () => {
+    render(() => <TrustedProxiesControl binding={binding(['cloudfront']).model} />)
+    expect(screen.getByDisplayValue('cloudfront')).toBeInTheDocument()
+    expect(screen.queryByDisplayValue(/\/\d+$/)).toBeNull()
+  })
+
+  it('removes staged rows and restores them on cancel', () => {
+    render(() => <TrustedProxiesControl binding={binding(['cloudflare', '192.0.2.1']).model} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Remove cloudflare' }))
+    expect(screen.queryByDisplayValue('cloudflare')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.getByDisplayValue('cloudflare')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('192.0.2.1')).toBeInTheDocument()
+  })
+
+  it('follows an external reset when no edit is staged', () => {
+    const current = binding(['cloudflare'])
+    render(() => <TrustedProxiesControl binding={current.model} />)
+    current.setValue([])
+    expect(screen.queryByDisplayValue('cloudflare')).toBeNull()
+    expect(screen.getByText(/No proxy is trusted/)).toBeInTheDocument()
+  })
+
+  it('keeps staged rows and shows a backend refusal', async () => {
+    const current = binding(['192.0.2.1'], vi.fn().mockRejectedValue(new Error('selector overlaps an earlier selector')))
+    render(() => <TrustedProxiesControl binding={current.model} />)
+    fireEvent.input(screen.getByLabelText('Trusted proxy selector'), { target: { value: '192.0.2.0/24' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+
+    expect(await screen.findByText(/overlaps an earlier selector/)).toBeInTheDocument()
+    expect(screen.getByDisplayValue('192.0.2.0/24')).toBeInTheDocument()
+  })
+
+  it('stops adding selectors at the backend cap', () => {
+    const selectors = Array.from({ length: MAX_TRUSTED_PROXY_SELECTORS }, (_, index) => `192.0.2.${index + 1}`)
+    render(() => <TrustedProxiesControl binding={binding(selectors).model} />)
+    expect(screen.getByRole('button', { name: /^Add/ })).toBeDisabled()
+    expect(screen.getByText(`At most ${MAX_TRUSTED_PROXY_SELECTORS} selectors.`)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/settings/controls/TrustedProxiesControl.tsx
+++ b/frontend/src/components/settings/controls/TrustedProxiesControl.tsx
@@ -1,0 +1,193 @@
+import type { CustomEditorComponent } from '../types'
+import ChevronDown from 'lucide-solid/icons/chevron-down'
+import X from 'lucide-solid/icons/x'
+import { createEffect, For, Show, untrack } from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { actionsFooter } from '~/components/common/actionsFooter.css'
+import { Alert } from '~/components/common/Alert'
+import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
+import { Icon } from '~/components/common/Icon'
+import { StatusLine } from '~/components/common/StatusLine'
+import { MAX_TRUSTED_PROXY_SELECTORS, TRUSTED_PROXY_PROVIDERS } from '~/generated/contracts/trusted-proxies'
+import { createAccountAction } from '../account/createAccountAction'
+import * as styles from './TrustedProxiesControl.css'
+
+interface SelectorRow {
+  id: number
+  value: string
+}
+
+let nextSelectorRowID = 1
+
+const selectorExamples = [
+  '192.0.2.10',
+  '2001:db8::10',
+  '192.168.0.1-100',
+  '192.168.0.1-192.168.0.100',
+  '2001:db8::1-2001:db8::ffff',
+  '192.168.0.0/24',
+  '2001:db8::/64',
+  'cloudflare',
+  'cloudfront',
+] as const
+
+function row(value: string): SelectorRow {
+  return { id: nextSelectorRowID++, value }
+}
+
+/** Edits the trusted reverse-proxy selector list as one staged value. */
+export const TrustedProxiesControl: CustomEditorComponent = (props) => {
+  const [state, setState] = createStore<{ rows: SelectorRow[] }>({ rows: [] })
+  const [dirty, setDirty] = createStore({ value: false })
+  const action = createAccountAction()
+
+  const storedSelectors = (): string[] => {
+    const value = props.binding.value()
+    return Array.isArray(value) ? value.filter(item => typeof item === 'string') : []
+  }
+
+  createEffect(() => {
+    const stored = storedSelectors()
+    if (!untrack(() => dirty.value))
+      setState('rows', stored.map(row))
+  })
+
+  const configuredProvider = (token: string) =>
+    state.rows.some(item => item.value.trim().toLowerCase() === token)
+
+  const canAdd = () => state.rows.length < MAX_TRUSTED_PROXY_SELECTORS
+
+  const add = (value: string) => {
+    if (!canAdd())
+      return
+    setDirty('value', true)
+    setState('rows', state.rows.length, row(value))
+  }
+
+  const update = (id: number, value: string) => {
+    setDirty('value', true)
+    setState('rows', item => item.id === id, 'value', value)
+  }
+
+  const remove = (id: number) => {
+    setDirty('value', true)
+    setState('rows', items => items.filter(item => item.id !== id))
+  }
+
+  const cancel = () => {
+    setDirty('value', false)
+    setState('rows', storedSelectors().map(row))
+    action.clear()
+  }
+
+  const apply = async () => {
+    if (!dirty.value || action.running())
+      return
+    await action.run({
+      fallback: 'Failed to update trusted reverse proxies',
+      work: async () => {
+        await props.binding.set(state.rows.map(item => item.value))
+        setState('rows', storedSelectors().map(row))
+        setDirty('value', false)
+        return 'Trusted reverse proxies updated.'
+      },
+    })
+  }
+
+  return (
+    <div class="vstack gap-4">
+      <Alert variant="warning" label="Provider range warning">
+        <ul class={styles.warningList}>
+          <li>These ranges identify shared provider infrastructure, not your account.</li>
+          <li>Restrict the origin to your distribution or use authenticated origin requests.</li>
+          <li>Each proxy must remove client-supplied forwarding headers or append verified values.</li>
+        </ul>
+      </Alert>
+
+      <Show
+        when={state.rows.length > 0}
+        fallback={<div class={styles.note}>No proxy is trusted. Forwarding headers are ignored.</div>}
+      >
+        <div class="vstack gap-2">
+          <For each={state.rows}>
+            {item => (
+              <div class={styles.selectorRow} data-testid="trusted-proxy-row">
+                <input
+                  type="text"
+                  class={styles.selectorInput}
+                  value={item.value}
+                  aria-label="Trusted proxy selector"
+                  placeholder="192.168.0.0/24"
+                  spellcheck={false}
+                  onInput={event => update(item.id, event.currentTarget.value)}
+                />
+                <button
+                  type="button"
+                  class={`outline ${styles.removeButton}`}
+                  data-variant="danger"
+                  aria-label={`Remove ${item.value || 'empty selector'}`}
+                  onClick={() => remove(item.id)}
+                >
+                  <Icon icon={X} size="xs" aria-hidden="true" />
+                </button>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <div class={styles.examples}>
+        <span>Examples:</span>
+        <ul class={styles.exampleList}>
+          <For each={selectorExamples}>
+            {example => <li><code>{example}</code></li>}
+          </For>
+        </ul>
+      </div>
+
+      <div>
+        <DropdownMenu
+          aria-label="Add trusted proxy"
+          trigger={triggerProps => (
+            <button type="button" class="outline small" disabled={!canAdd()} {...triggerProps}>
+              Add
+              {' '}
+              <Icon icon={ChevronDown} size="xs" aria-hidden="true" />
+            </button>
+          )}
+        >
+          <DropdownMenuCheckableItem
+            kind="checkbox"
+            label="IP address or range"
+            checked={false}
+            disabled={!canAdd()}
+            onSelect={() => add('')}
+          />
+          <For each={TRUSTED_PROXY_PROVIDERS}>
+            {provider => (
+              <DropdownMenuCheckableItem
+                kind="checkbox"
+                label={provider.label}
+                detail={() => provider.help}
+                checked={configuredProvider(provider.token)}
+                disabled={!canAdd() || configuredProvider(provider.token)}
+                onSelect={() => add(provider.token)}
+              />
+            )}
+          </For>
+        </DropdownMenu>
+        <Show when={!canAdd()}>
+          <span class={styles.note}>{` At most ${MAX_TRUSTED_PROXY_SELECTORS} selectors.`}</span>
+        </Show>
+      </div>
+
+      <StatusLine message={action.message()} />
+      <div class={actionsFooter}>
+        <button type="button" class="outline" disabled={action.running()} onClick={cancel}>Cancel</button>
+        <button type="button" disabled={!dirty.value || action.running()} onClick={() => void apply()}>
+          {action.running() ? 'Applying...' : 'Apply'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/settings/controls/TrustedProxiesControl.tsx
+++ b/frontend/src/components/settings/controls/TrustedProxiesControl.tsx
@@ -1,7 +1,7 @@
 import type { CustomEditorComponent } from '../types'
 import ChevronDown from 'lucide-solid/icons/chevron-down'
 import X from 'lucide-solid/icons/x'
-import { createEffect, For, Show, untrack } from 'solid-js'
+import { createEffect, createSignal, For, Show, untrack } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { Alert } from '~/components/common/Alert'
@@ -19,6 +19,10 @@ interface SelectorRow {
 
 let nextSelectorRowID = 1
 
+// The address forms are spelled out; the PROVIDER tokens come from the
+// generated catalogue, which is the same list the Add menu renders. Repeating
+// them here let a new contract entry appear in the menu and be missing from
+// the examples four lines below it.
 const selectorExamples = [
   '192.0.2.10',
   '2001:db8::10',
@@ -27,9 +31,8 @@ const selectorExamples = [
   '2001:db8::1-2001:db8::ffff',
   '192.168.0.0/24',
   '2001:db8::/64',
-  'cloudflare',
-  'cloudfront',
-] as const
+  ...TRUSTED_PROXY_PROVIDERS.map(provider => provider.token),
+]
 
 function row(value: string): SelectorRow {
   return { id: nextSelectorRowID++, value }
@@ -38,7 +41,7 @@ function row(value: string): SelectorRow {
 /** Edits the trusted reverse-proxy selector list as one staged value. */
 export const TrustedProxiesControl: CustomEditorComponent = (props) => {
   const [state, setState] = createStore<{ rows: SelectorRow[] }>({ rows: [] })
-  const [dirty, setDirty] = createStore({ value: false })
+  const [dirty, setDirty] = createSignal(false)
   const action = createAccountAction()
 
   const storedSelectors = (): string[] => {
@@ -48,7 +51,7 @@ export const TrustedProxiesControl: CustomEditorComponent = (props) => {
 
   createEffect(() => {
     const stored = storedSelectors()
-    if (!untrack(() => dirty.value))
+    if (!untrack(dirty))
       setState('rows', stored.map(row))
   })
 
@@ -60,35 +63,35 @@ export const TrustedProxiesControl: CustomEditorComponent = (props) => {
   const add = (value: string) => {
     if (!canAdd())
       return
-    setDirty('value', true)
+    setDirty(true)
     setState('rows', state.rows.length, row(value))
   }
 
   const update = (id: number, value: string) => {
-    setDirty('value', true)
+    setDirty(true)
     setState('rows', item => item.id === id, 'value', value)
   }
 
   const remove = (id: number) => {
-    setDirty('value', true)
+    setDirty(true)
     setState('rows', items => items.filter(item => item.id !== id))
   }
 
   const cancel = () => {
-    setDirty('value', false)
+    setDirty(false)
     setState('rows', storedSelectors().map(row))
     action.clear()
   }
 
   const apply = async () => {
-    if (!dirty.value || action.running())
+    if (!dirty() || action.running())
       return
     await action.run({
       fallback: 'Failed to update trusted reverse proxies',
       work: async () => {
         await props.binding.set(state.rows.map(item => item.value))
         setState('rows', storedSelectors().map(row))
-        setDirty('value', false)
+        setDirty(false)
         return 'Trusted reverse proxies updated.'
       },
     })
@@ -160,7 +163,7 @@ export const TrustedProxiesControl: CustomEditorComponent = (props) => {
             * An ACTION, so a plain menuitem: it stages a blank row every time
             * it is chosen. The provider entries below are checkable because
             * each one is either configured or not, and the menu reports that
-            * state -- a checkbox that never checks would announce a state this
+            * state. A checkbox that never checks would announce a state this
             * item does not have.
             */}
           <button type="button" role="menuitem" onClick={() => add('')}>
@@ -187,7 +190,7 @@ export const TrustedProxiesControl: CustomEditorComponent = (props) => {
       <StatusLine message={action.message()} />
       <div class={actionsFooter}>
         <button type="button" class="outline" disabled={action.running()} onClick={cancel}>Cancel</button>
-        <button type="button" disabled={!dirty.value || action.running()} onClick={() => void apply()}>
+        <button type="button" disabled={!dirty() || action.running()} onClick={() => void apply()}>
           {action.running() ? 'Applying...' : 'Apply'}
         </button>
       </div>

--- a/frontend/src/components/settings/controls/TrustedProxiesControl.tsx
+++ b/frontend/src/components/settings/controls/TrustedProxiesControl.tsx
@@ -5,7 +5,7 @@ import { createEffect, For, Show, untrack } from 'solid-js'
 import { createStore } from 'solid-js/store'
 import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { Alert } from '~/components/common/Alert'
-import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
+import { DropdownMenu, DropdownMenuCheckableItem, DropdownMenuItemContent } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
 import { StatusLine } from '~/components/common/StatusLine'
 import { MAX_TRUSTED_PROXY_SELECTORS, TRUSTED_PROXY_PROVIDERS } from '~/generated/contracts/trusted-proxies'
@@ -145,7 +145,7 @@ export const TrustedProxiesControl: CustomEditorComponent = (props) => {
         </ul>
       </div>
 
-      <div>
+      <div class={styles.addRow}>
         <DropdownMenu
           aria-label="Add trusted proxy"
           trigger={triggerProps => (
@@ -156,13 +156,16 @@ export const TrustedProxiesControl: CustomEditorComponent = (props) => {
             </button>
           )}
         >
-          <DropdownMenuCheckableItem
-            kind="checkbox"
-            label="IP address or range"
-            checked={false}
-            disabled={!canAdd()}
-            onSelect={() => add('')}
-          />
+          {/*
+            * An ACTION, so a plain menuitem: it stages a blank row every time
+            * it is chosen. The provider entries below are checkable because
+            * each one is either configured or not, and the menu reports that
+            * state -- a checkbox that never checks would announce a state this
+            * item does not have.
+            */}
+          <button type="button" role="menuitem" onClick={() => add('')}>
+            <DropdownMenuItemContent label="IP address or range" />
+          </button>
           <For each={TRUSTED_PROXY_PROVIDERS}>
             {provider => (
               <DropdownMenuCheckableItem
@@ -170,14 +173,14 @@ export const TrustedProxiesControl: CustomEditorComponent = (props) => {
                 label={provider.label}
                 detail={() => provider.help}
                 checked={configuredProvider(provider.token)}
-                disabled={!canAdd() || configuredProvider(provider.token)}
+                disabled={configuredProvider(provider.token)}
                 onSelect={() => add(provider.token)}
               />
             )}
           </For>
         </DropdownMenu>
         <Show when={!canAdd()}>
-          <span class={styles.note}>{` At most ${MAX_TRUSTED_PROXY_SELECTORS} selectors.`}</span>
+          <span class={styles.note}>{`At most ${MAX_TRUSTED_PROXY_SELECTORS} selectors.`}</span>
         </Show>
       </div>
 

--- a/frontend/src/components/settings/controls/customEditors.tsx
+++ b/frontend/src/components/settings/controls/customEditors.tsx
@@ -13,6 +13,7 @@ import { NetworkAccessControl } from './NetworkAccessControl'
 import { SyntaxThemeControl } from './SyntaxThemeControl'
 import { TerminalThemeControl } from './TerminalThemeControl'
 import { ThemeControl } from './ThemeControl'
+import { TrustedProxiesControl } from './TrustedProxiesControl'
 
 /**
  * The administration twin of the account registrations panel: the same editor
@@ -86,6 +87,8 @@ export const CUSTOM_EDITORS: Record<CustomEditorId, CustomEditorComponent> = {
    * this entry is unreachable on a multi-user hub.
    */
   networkAccess: NetworkAccessControl,
+  /** Which transport peers can supply verified forwarding headers. */
+  trustedProxies: TrustedProxiesControl,
   /**
    * The palette drop-down and the light/dark tri-switch, as one control.
    * `theme` is one key holding `{name, mode}`, so one row carries one scope

--- a/frontend/src/components/settings/navGroups.ts
+++ b/frontend/src/components/settings/navGroups.ts
@@ -39,11 +39,9 @@ export const NAV_GROUPS: readonly NavGroup[] = [
   { id: 'advanced', title: 'Advanced', category: 'advanced', admin: false },
   { id: 'admin-general', title: 'General', category: 'general', admin: true },
   { id: 'admin-signup', title: 'Sign-up & Access', category: 'signup', admin: true },
-  // Straight after Sign-up & Access, because it answers the same question one
-  // step earlier: that section decides who may hold an account, this one
-  // decides which addresses they can reach the hub at. Solo only -- every key
-  // in the category is hidden_in_hub, so `occupiedNavGroups` drops the group
-  // on a multi-user hub.
+  // Straight after Sign-up & Access because this section controls the hub's
+  // network entry points. The solo listen-address row can be hidden while the
+  // trusted reverse-proxy row keeps this section visible in every hub mode.
   { id: 'admin-network', title: 'Network access', category: 'network', admin: true },
   { id: 'admin-email', title: 'Email (SMTP)', category: 'email', admin: true },
   // The same category on the ADMINISTRATION side, which is where the hub's

--- a/frontend/src/components/settings/navRows.test.ts
+++ b/frontend/src/components/settings/navRows.test.ts
@@ -134,6 +134,17 @@ describe('occupiedNavGroups', () => {
     expect(groups.map(g => g.id)).toContain('admin-captcha')
   })
 
+  it('keeps Network access when the solo-only listen row is hidden', () => {
+    const groups = occupiedNavGroups(NAV_GROUPS, group({
+      isAdmin: true,
+      adminRows: [
+        hubRow({ id: 'extra_listen_addresses', category: 'network', hidden: () => true }),
+        hubRow({ id: 'trusted_proxy_ranges', category: 'network' }),
+      ],
+    }))
+    expect(groups.map(g => g.id)).toContain('admin-network')
+  })
+
   it('lists the occupied groups in navigation order', () => {
     const groups = occupiedNavGroups(NAV_GROUPS, group({
       isAdmin: true,

--- a/frontend/src/components/settings/registry/settings.ts
+++ b/frontend/src/components/settings/registry/settings.ts
@@ -626,7 +626,7 @@ export const browserSettings: BrowserSettingDecl[] = [
   // refuses each without a recently proven factor.
   //
   // FOUR of the five are hidden in solo mode, because the hub refuses the RPCs
-  // behind them: solo authenticates every request as the local user, so it
+  // behind them: solo authenticates local IPC as the local user, so it
   // offers no sign-up, no passkey, no account recovery and no provider link.
   // Password is the exception, and the section exists in solo for it alone.
   {

--- a/frontend/src/components/settings/types.ts
+++ b/frontend/src/components/settings/types.ts
@@ -28,6 +28,7 @@ export const CUSTOM_EDITOR_IDS = [
   'hubWideAppRegistrations',
   'keyPins',
   'networkAccess',
+  'trustedProxies',
   'theme',
   'terminalTheme',
   'syntaxTheme',

--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -16,6 +16,7 @@ import { AuthProvider, useAuth } from './AuthContext'
 
 const mockGetCurrentUser = vi.fn()
 const mockLogin = vi.fn()
+const mockPasswordSetupGate = vi.fn<() => boolean>(() => false)
 vi.mock('~/api/clients', () => ({
   authClient: {
     getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
@@ -66,7 +67,7 @@ vi.mock('~/lib/systemInfo', () => ({
   // A multi-user hub: every caller signs in, and none of the solo facts hold.
   isAutoAuthenticated: () => false,
   passwordSetupRequired: () => false,
-  isPasswordSetupGate: () => false,
+  isPasswordSetupGate: () => mockPasswordSetupGate(),
   soloPasswordSet: () => false,
   loadSystemInfo: () => mockLoadSystemInfo(),
   isSystemInfoLoaded: () => true,
@@ -115,6 +116,7 @@ describe('authContext', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockLoadSystemInfo.mockResolvedValue(undefined)
+    mockPasswordSetupGate.mockReturnValue(false)
   })
 
   // Bootstrap writes the boot splash's phase onto <html>; later tests in this
@@ -167,6 +169,17 @@ describe('authContext', () => {
     await vi.waitFor(() => {
       expect(document.documentElement.getAttribute(BOOT_SPLASH_PHASE_ATTRIBUTE)).toBe('ready')
     })
+  })
+
+  it('lands on ready without revealing the shell during TCP password setup', async () => {
+    mockPasswordSetupGate.mockReturnValue(true)
+    mockGetCurrentUser.mockRejectedValue(new ConnectError('unauthenticated', Code.Unauthenticated))
+    renderWithAuth()
+
+    await vi.waitFor(() => {
+      expect(document.documentElement.getAttribute(BOOT_SPLASH_PHASE_ATTRIBUTE)).toBe('ready')
+    })
+    expect(screen.getByTestId('authenticated')).toHaveTextContent('no')
   })
 
   // A failed system-info load aborts bootstrap; the checklist stays on the

--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -422,6 +422,27 @@ describe('authContext', () => {
     expect(auth().elevationExpiresAt()).toBeUndefined()
   })
 
+  // The one reply that GRANTS an elevation in the same transaction that creates
+  // the session: SetInitialSoloPassword. Passing the deadline keeps the client
+  // state derived from the answer that created it, rather than from a following
+  // refresh whose failure is swallowed -- which would prompt the operator for
+  // the password they chose a moment earlier.
+  it('keeps an elevation the same reply granted', async () => {
+    const inherited = timestampFromDate(new Date(Date.now() + 2 * 60 * 60 * 1000))
+    const granted = timestampFromDate(new Date(Date.now() + 30 * 60 * 1000))
+    mockGetCurrentUser.mockResolvedValue({
+      user: { id: 'u1', username: 'alice', isAdmin: false },
+      elevationExpiresAt: inherited,
+    })
+    const { auth } = renderWithAuthCapture()
+    await vi.waitFor(() => expect(screen.getByTestId('username')).toHaveTextContent('alice'))
+
+    auth().setAuth({ id: 'solo', username: 'solo', isAdmin: true } as unknown as User, granted)
+
+    await vi.waitFor(() => expect(screen.getByTestId('username')).toHaveTextContent('solo'))
+    expect(auth().elevationExpiresAt()).toBe(granted)
+  })
+
   // One adoption site, so a refresh cannot leave one signal stale while
   // another moves. The verification cooldown was the one that drifted:
   // refreshUser dropped it, and /verify-email then counted from zero against

--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -235,10 +235,11 @@ describe('authContext', () => {
 
   // System info is a hard prerequisite, not an optional best-effort step: its
   // module getters are fabricated defaults until it succeeds. Discarding the
-  // failure leaves `isSoloMode()` at `false` while the session restore SUCCEEDS on a
-  // solo hub (which authenticates every procedure), so the app renders as
-  // multi-user and offers a "Log out" that strands the user at a login form
-  // no credentials can satisfy. Bootstrap must stop and report instead.
+  // failure leaves `isSoloMode()` at `false` while the session restore SUCCEEDS
+  // on a solo hub reached over local IPC (which needs no credential), so the app
+  // renders as multi-user and offers a "Log out" that strands the user at a
+  // login form no credentials can satisfy. Bootstrap must stop and report
+  // instead.
   it('records a bootstrap error when the system info load fails', async () => {
     mockLoadSystemInfo.mockRejectedValue(new Error('not connected'))
     mockGetCurrentUser.mockResolvedValue({

--- a/frontend/src/context/AuthContext.test.tsx
+++ b/frontend/src/context/AuthContext.test.tsx
@@ -66,7 +66,6 @@ vi.mock('~/lib/systemInfo', () => ({
   isSoloMode: () => false,
   // A multi-user hub: every caller signs in, and none of the solo facts hold.
   isAutoAuthenticated: () => false,
-  passwordSetupRequired: () => false,
   isPasswordSetupGate: () => mockPasswordSetupGate(),
   soloPasswordSet: () => false,
   loadSystemInfo: () => mockLoadSystemInfo(),

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -438,10 +438,10 @@ export const AuthProvider: ParentComponent = (props) => {
    * decision (solo vs. multi-user, setup-required) reads module getters that
    * are fabricated defaults until it succeeds. Continuing to the session
    * restore on a failed load is how the app treats a solo user as a multi-user
-   * one -- the restore succeeds (a solo hub authenticates every procedure), the
-   * code records nothing, and the app offers a "Log out" that strands them at
-   * /login. So a failed load aborts here with a
-   * `bootstrapError` for the guard's retry panel to render.
+   * one -- the restore succeeds (a solo hub authenticates the desktop app's
+   * local IPC connection with no credential), the code records nothing, and the
+   * app offers a "Log out" that strands them at /login. So a failed load aborts
+   * here with a `bootstrapError` for the guard's retry panel to render.
    *
    * Each stage also advances the boot splash's checklist (data-boot-phase on
    * <html>): system info, then the session restore, then either `ready`

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -466,8 +466,8 @@ export const AuthProvider: ParentComponent = (props) => {
     await restoreSession()
     if (bootstrapError())
       return
-    // Same gate AuthGuard uses: password-setup is authenticated but not the
-    // shell, so it must not reveal the workspaces/tabs rows.
+    // The restricted TCP setup state is not a session and not the shell, so it
+    // must not reveal the workspace rows.
     if (user() && !isPasswordSetupGate()) {
       setBootShell(true)
       setBootPhase('workspaces')

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -90,7 +90,17 @@ export interface AuthState {
   loginWithPasskey: (username: string, captcha?: CaptchaRequestFields) => Promise<AuthLoginResult>
   setVerificationResendAvailableAt: (at?: Timestamp) => void
   logout: () => Promise<void>
-  setAuth: (user: User) => void
+  /**
+   * Adopt a NEW identity. Clears the elevation, because a window proven by the
+   * previous identity must not survive the transition.
+   *
+   * `elevation` is for the one reply that GRANTS an elevation in the same
+   * transaction that creates the session: `SetInitialSoloPassword`. Passing it
+   * keeps the client's elevation state derived from the answer that created
+   * it, instead of from a following refresh whose failure would prompt the
+   * operator for the password they just chose.
+   */
+  setAuth: (user: User, elevation?: Timestamp) => void
   /**
    * Adopt a user the hub returned for the SESSION THAT IS ALREADY SIGNED IN.
    *
@@ -574,11 +584,17 @@ export const AuthProvider: ParentComponent = (props) => {
     }
   }
 
-  const setAuth = (u: User) => {
+  const setAuth = (u: User, elevation?: Timestamp) => {
     // The same identity transition runSignIn makes: /auth/idp/complete-signup
     // and the verify-email page both land a NEW user in a document that may
     // still hold the previous one's elevation.
     adoptSignedInUser(u)
+    // AFTER the adopt, which cleared it. The only caller that passes one is the
+    // reply that granted the elevation inside the same transaction as the
+    // session, so this restores a window this document owns rather than one it
+    // inherited.
+    if (elevation)
+      setElevationExpiresAt(elevation)
     setLoading(false)
   }
 

--- a/frontend/src/lib/systemInfo.test.ts
+++ b/frontend/src/lib/systemInfo.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest/globals" />
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { CaptchaProvider } from '~/generated/proto/leapmux/v1/auth_pb'
+import { CaptchaProvider, SoloAccess } from '~/generated/proto/leapmux/v1/auth_pb'
 import { captchaProviderNeedsSecureContext, getAltchaAlgorithm, getCaptchaProvider, getCaptchaSiteKey, isAutoAuthenticated, isCaptchaEnabled, isCaptchaUnsolvableHere, isPasswordSetupGate, isSignupEnabled, isSoloMode, isSystemInfoLoaded, loadSystemInfo, passkeyBlocker, passkeysUsableHere, passwordSetupRequired, refreshSnapshot, soloPasswordSet } from './systemInfo'
 
 const mockGetSystemInfo = vi.fn()
@@ -21,8 +21,7 @@ vi.mock('~/api/platformBridge', () => ({
 function systemInfoResponse(overrides: Record<string, unknown> = {}) {
   return {
     soloMode: false,
-    autoAuthenticated: false,
-    passwordSetupRequired: false,
+    soloAccess: SoloAccess.UNSPECIFIED,
     soloPasswordSet: false,
     signupEnabled: false,
     setupRequired: false,
@@ -402,13 +401,13 @@ describe('the solo connection facts', () => {
     expect(soloPasswordSet()).toBe(false)
   })
 
-  // auto_authenticated is per CONNECTION and solo_mode is per hub, so the two
+  // solo_access is per connection and solo_mode is per hub, so the two
   // must not be read as synonyms: a solo hub whose account holds a password
   // asks its network callers to sign in.
   it('separates the hub fact from the connection fact', async () => {
     mockGetSystemInfo.mockResolvedValue(systemInfoResponse({
       soloMode: true,
-      autoAuthenticated: false,
+      soloAccess: SoloAccess.SIGN_IN_REQUIRED,
       soloPasswordSet: true,
     }))
     await loadSystemInfo(true)
@@ -421,8 +420,7 @@ describe('the solo connection facts', () => {
   it('carries the password-setup demand through', async () => {
     mockGetSystemInfo.mockResolvedValue(systemInfoResponse({
       soloMode: true,
-      autoAuthenticated: true,
-      passwordSetupRequired: true,
+      soloAccess: SoloAccess.PASSWORD_SETUP,
     }))
     await loadSystemInfo(true)
 
@@ -430,24 +428,23 @@ describe('the solo connection facts', () => {
     expect(soloPasswordSet()).toBe(false)
   })
 
-  it('isPasswordSetupGate is true only when both halves hold', async () => {
+  it('derives each gate from one exclusive solo access state', async () => {
     mockGetSystemInfo.mockResolvedValue(systemInfoResponse({
-      autoAuthenticated: true,
-      passwordSetupRequired: true,
+      soloAccess: SoloAccess.PASSWORD_SETUP,
     }))
     await loadSystemInfo(true)
     expect(isPasswordSetupGate()).toBe(true)
+    expect(isAutoAuthenticated()).toBe(false)
 
     mockGetSystemInfo.mockResolvedValue(systemInfoResponse({
-      autoAuthenticated: true,
-      passwordSetupRequired: false,
+      soloAccess: SoloAccess.CREDENTIAL_FREE,
     }))
     await loadSystemInfo(true)
     expect(isPasswordSetupGate()).toBe(false)
+    expect(isAutoAuthenticated()).toBe(true)
 
     mockGetSystemInfo.mockResolvedValue(systemInfoResponse({
-      autoAuthenticated: false,
-      passwordSetupRequired: true,
+      soloAccess: SoloAccess.SIGN_IN_REQUIRED,
     }))
     await loadSystemInfo(true)
     expect(isPasswordSetupGate()).toBe(false)

--- a/frontend/src/lib/systemInfo.test.ts
+++ b/frontend/src/lib/systemInfo.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CaptchaProvider, SoloAccess } from '~/generated/proto/leapmux/v1/auth_pb'
-import { captchaProviderNeedsSecureContext, getAltchaAlgorithm, getCaptchaProvider, getCaptchaSiteKey, isAutoAuthenticated, isCaptchaEnabled, isCaptchaUnsolvableHere, isPasswordSetupGate, isSignupEnabled, isSoloMode, isSystemInfoLoaded, loadSystemInfo, passkeyBlocker, passkeysUsableHere, passwordSetupRequired, refreshSnapshot, soloPasswordSet } from './systemInfo'
+import { captchaProviderNeedsSecureContext, getAltchaAlgorithm, getCaptchaProvider, getCaptchaSiteKey, isAutoAuthenticated, isCaptchaEnabled, isCaptchaUnsolvableHere, isPasswordSetupGate, isSignupEnabled, isSoloMode, isSystemInfoLoaded, loadSystemInfo, passkeyBlocker, passkeysUsableHere, refreshSnapshot, soloPasswordSet } from './systemInfo'
 
 const mockGetSystemInfo = vi.fn()
 vi.mock('~/api/clients', () => ({
@@ -397,7 +397,7 @@ describe('the solo connection facts', () => {
     await loadSystemInfo(true)
 
     expect(isAutoAuthenticated()).toBe(false)
-    expect(passwordSetupRequired()).toBe(false)
+    expect(isPasswordSetupGate()).toBe(false)
     expect(soloPasswordSet()).toBe(false)
   })
 
@@ -424,7 +424,7 @@ describe('the solo connection facts', () => {
     }))
     await loadSystemInfo(true)
 
-    expect(passwordSetupRequired()).toBe(true)
+    expect(isPasswordSetupGate()).toBe(true)
     expect(soloPasswordSet()).toBe(false)
   })
 

--- a/frontend/src/lib/systemInfo.ts
+++ b/frontend/src/lib/systemInfo.ts
@@ -135,7 +135,7 @@ export function isAutoAuthenticated(): boolean {
  *
  * `AuthGuard` renders the setup screen from it, and `AuthContext` declines to
  * boot the shell for it. ONE predicate serves both, because both ask the same
- * question — the two booleans this enum replaced could disagree, and a second
+ * question. The two booleans this enum replaced could disagree, and a second
  * spelling of one state is how they did.
  */
 export function isPasswordSetupGate(): boolean {

--- a/frontend/src/lib/systemInfo.ts
+++ b/frontend/src/lib/systemInfo.ts
@@ -130,14 +130,13 @@ export function isAutoAuthenticated(): boolean {
 }
 
 /**
- * Whether a TCP caller must set the first solo password before it can sign in.
- */
-export function passwordSetupRequired(): boolean {
-  return current().soloAccess === GenSoloAccess.PASSWORD_SETUP
-}
-
-/**
- * Whether AuthGuard must take the restricted password-setup path.
+ * Whether this connection reaches the restricted first-password setup state:
+ * TCP, on a solo hub whose account holds no password.
+ *
+ * `AuthGuard` renders the setup screen from it, and `AuthContext` declines to
+ * boot the shell for it. ONE predicate serves both, because both ask the same
+ * question — the two booleans this enum replaced could disagree, and a second
+ * spelling of one state is how they did.
  */
 export function isPasswordSetupGate(): boolean {
   return current().soloAccess === GenSoloAccess.PASSWORD_SETUP

--- a/frontend/src/lib/systemInfo.ts
+++ b/frontend/src/lib/systemInfo.ts
@@ -3,7 +3,7 @@ import type { BuildInfo } from '~/lib/buildEnv'
 import { createSignal } from 'solid-js'
 import { authClient } from '~/api/clients'
 import { getCapabilities, isTauriApp } from '~/api/platformBridge'
-import { CaptchaProvider as GenCaptchaProvider } from '~/generated/proto/leapmux/v1/auth_pb'
+import { CaptchaProvider as GenCaptchaProvider, SoloAccess as GenSoloAccess } from '~/generated/proto/leapmux/v1/auth_pb'
 import { frontendBuildInfo } from '~/lib/buildEnv'
 import { formatLocalDateTime } from './dateFormat'
 
@@ -19,8 +19,7 @@ export type CaptchaProvider = GenCaptchaProvider
 // states.
 interface SystemInfoSnapshot {
   soloMode: boolean
-  autoAuthenticated: boolean
-  passwordSetupRequired: boolean
+  soloAccess: GenSoloAccess
   soloPasswordSet: boolean
   signupEnabled: boolean
   setupRequired: boolean
@@ -39,8 +38,7 @@ interface SystemInfoSnapshot {
 // than flashing an affordance the hub may not support.
 const DEFAULTS: SystemInfoSnapshot = {
   soloMode: false,
-  autoAuthenticated: false,
-  passwordSetupRequired: false,
+  soloAccess: GenSoloAccess.UNSPECIFIED,
   soloPasswordSet: false,
   signupEnabled: false,
   setupRequired: false,
@@ -89,8 +87,7 @@ export async function loadSystemInfo(force = false): Promise<void> {
   const resp = await authClient.getSystemInfo({})
   setSnapshot({
     soloMode: resp.soloMode,
-    autoAuthenticated: resp.autoAuthenticated,
-    passwordSetupRequired: resp.passwordSetupRequired,
+    soloAccess: resp.soloAccess,
     soloPasswordSet: resp.soloPasswordSet,
     signupEnabled: resp.signupEnabled,
     setupRequired: resp.setupRequired,
@@ -116,7 +113,7 @@ export function isSoloMode(): boolean {
 }
 
 /**
- * Whether the hub authenticates THIS connection with no credentials.
+ * Whether this connection uses credential-free local IPC.
  *
  * Not a synonym for `isSoloMode`, and the two must not be swapped. `isSoloMode`
  * is a property of the HUB — one account, no sign-up — and decides which
@@ -129,28 +126,21 @@ export function isSoloMode(): boolean {
  * form rather than leaving it waiting for a session that never arrives.
  */
 export function isAutoAuthenticated(): boolean {
-  return current().autoAuthenticated
+  return current().soloAccess === GenSoloAccess.CREDENTIAL_FREE
 }
 
 /**
- * Whether the app must block itself with a password-setup screen.
- *
- * True only when the hub answers on an address another machine can reach AND
- * its one account has no password. In that state every affordance the app
- * offers is offered to whoever reaches the port, so the one useful thing left
- * is to ask for a password.
+ * Whether a TCP caller must set the first solo password before it can sign in.
  */
 export function passwordSetupRequired(): boolean {
-  return current().passwordSetupRequired
+  return current().soloAccess === GenSoloAccess.PASSWORD_SETUP
 }
 
 /**
- * Whether AuthGuard and Auth bootstrap must take the password-setup path
- * instead of the shell. True only when the hub auto-authenticates AND still
- * requires a password to be set.
+ * Whether AuthGuard must take the restricted password-setup path.
  */
 export function isPasswordSetupGate(): boolean {
-  return passwordSetupRequired() && isAutoAuthenticated()
+  return current().soloAccess === GenSoloAccess.PASSWORD_SETUP
 }
 
 /**

--- a/frontend/src/test-support/systemInfoMock.ts
+++ b/frontend/src/test-support/systemInfoMock.ts
@@ -3,7 +3,7 @@ import type { PasskeyBlocker } from '~/lib/systemInfo'
 import { createSignal } from 'solid-js'
 import { vi } from 'vitest'
 
-import { CaptchaProvider } from '~/generated/proto/leapmux/v1/auth_pb'
+import { CaptchaProvider, SoloAccess } from '~/generated/proto/leapmux/v1/auth_pb'
 
 /**
  * The one shared mock of `~/lib/systemInfo`. Every getter reads through a
@@ -29,16 +29,8 @@ export interface SystemInfoMockState {
   /** Answers `isSystemInfoLoaded`; flip to false to test the fail-closed bootstrap window. */
   loaded: boolean
   soloMode: boolean
-  /**
-   * Answers `isAutoAuthenticated`: whether the hub authenticates THIS
-   * connection with no credentials. Driven directly rather than derived from
-   * `soloMode`, because the two genuinely differ -- a solo hub whose account
-   * holds a password asks its network callers to sign in -- and a test that
-   * states one must be able to state the other.
-   */
-  autoAuthenticated: boolean
-  /** Answers `passwordSetupRequired`: exposed, with no password to sign in with. */
-  passwordSetupRequired: boolean
+  /** Answers all connection access helpers from one exclusive wire state. */
+  soloAccess: SoloAccess
   /** Answers `soloPasswordSet`: the solo account holds a usable password. */
   soloPasswordSet: boolean
   signupEnabled: boolean
@@ -69,8 +61,7 @@ export interface SystemInfoMockState {
 const defaultState: SystemInfoMockState = {
   loaded: true,
   soloMode: false,
-  autoAuthenticated: false,
-  passwordSetupRequired: false,
+  soloAccess: SoloAccess.UNSPECIFIED,
   soloPasswordSet: false,
   signupEnabled: false,
   setupRequired: false,
@@ -93,9 +84,9 @@ export const mockLoadOAuthProviders = vi.fn((): Promise<unknown[]> => Promise.re
 
 export const systemInfoMock = {
   isSoloMode: () => state().soloMode,
-  isAutoAuthenticated: () => state().autoAuthenticated,
-  passwordSetupRequired: () => state().passwordSetupRequired,
-  isPasswordSetupGate: () => state().passwordSetupRequired && state().autoAuthenticated,
+  isAutoAuthenticated: () => state().soloAccess === SoloAccess.CREDENTIAL_FREE,
+  passwordSetupRequired: () => state().soloAccess === SoloAccess.PASSWORD_SETUP,
+  isPasswordSetupGate: () => state().soloAccess === SoloAccess.PASSWORD_SETUP,
   soloPasswordSet: () => state().soloPasswordSet,
   isSignupEnabled: () => state().signupEnabled,
   isSetupRequired: () => state().setupRequired,

--- a/frontend/src/test-support/systemInfoMock.ts
+++ b/frontend/src/test-support/systemInfoMock.ts
@@ -85,7 +85,6 @@ export const mockLoadOAuthProviders = vi.fn((): Promise<unknown[]> => Promise.re
 export const systemInfoMock = {
   isSoloMode: () => state().soloMode,
   isAutoAuthenticated: () => state().soloAccess === SoloAccess.CREDENTIAL_FREE,
-  passwordSetupRequired: () => state().soloAccess === SoloAccess.PASSWORD_SETUP,
   isPasswordSetupGate: () => state().soloAccess === SoloAccess.PASSWORD_SETUP,
   soloPasswordSet: () => state().soloPasswordSet,
   isSignupEnabled: () => state().signupEnabled,

--- a/frontend/tests/e2e/086-network-access.spec.ts
+++ b/frontend/tests/e2e/086-network-access.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test'
 import type { SoloServerHandle } from './helpers/devServer'
 import { connect } from 'node:net'
 import { expect, test } from './fixtures'
@@ -7,6 +8,16 @@ import { logoutViaUI, openSettingsAt } from './helpers/ui'
 
 /** A password the hub's own validator accepts. */
 const SOLO_PASSWORD = 'correct-horse-battery-staple'
+const SOLO_ENV = { LEAPMUX_HUB_DEV_FRONTEND: undefined }
+
+async function completeSoloSetup(page: Page) {
+  const gate = page.getByTestId('password-setup-gate')
+  await expect(gate).toBeVisible()
+  await gate.getByLabel('New Password').fill(SOLO_PASSWORD)
+  await gate.getByLabel('Confirm Password').fill(SOLO_PASSWORD)
+  await gate.getByRole('button', { name: 'Set Password' }).click()
+  await expect(gate).toBeHidden()
+}
 
 /**
  * Whether an address ACCEPTS a TCP connection.
@@ -35,15 +46,15 @@ async function accepts(port: number): Promise<boolean> {
 /**
  * The Network access panel, on a real `leapmux solo` hub.
  *
- * A solo instance of its own, not the shared `leapmux dev` fixture: the panel
- * and the rule it configures exist only in solo mode, and dev mode has real
- * password authentication from the start.
+ * A solo instance of its own, not the shared `leapmux dev` fixture. The
+ * additional listen-address row exists only in solo mode. The trusted-proxy
+ * row also appears in hub and dev modes.
  */
 test.describe('Network access', () => {
   let solo: SoloServerHandle | undefined
 
   test.beforeEach(async () => {
-    solo = await startSoloServer()
+    solo = await startSoloServer({ env: SOLO_ENV })
   })
 
   test.afterEach(async () => {
@@ -52,6 +63,7 @@ test.describe('Network access', () => {
 
   test('publishes an address, then asks every address for the password', async ({ page }) => {
     await page.goto(`${solo!.hubUrl}/`)
+    await completeSoloSetup(page)
 
     const dialog = await openSettingsAt(page, 'admin-network')
     const row = dialog.locator('[data-setting-id="extra_listen_addresses"]')
@@ -69,11 +81,6 @@ test.describe('Network access', () => {
     await row.getByRole('button', { name: '+ Add address' }).click()
     await row.getByLabel('Port').fill(String(port))
 
-    // Apply is refused until the account has a password: publishing an address
-    // without one would put the whole app behind nothing.
-    await expect(row.getByRole('button', { name: 'Apply' })).toBeDisabled()
-    await row.getByLabel('New Password').fill(SOLO_PASSWORD)
-    await row.getByLabel('Confirm Password').fill(SOLO_PASSWORD)
     await expect(row.getByRole('button', { name: 'Apply' })).toBeEnabled()
 
     await row.getByRole('button', { name: 'Apply' }).click()
@@ -113,9 +120,8 @@ test.describe('Network access', () => {
     await page.getByRole('button', { name: 'Sign in' }).click()
     await expect(page.getByRole('button', { name: 'Sign in' })).toBeHidden()
 
-    // And the session can be ENDED. A solo hub offered no Log out while it
-    // authenticated everybody with nothing; this one holds a real session, and
-    // whoever signed in must be able to sign out again.
+    // The session can be ended. This browser holds a real TCP session, and the
+    // user must be able to sign out again.
     //
     // The dialog is closed first because it is addressable -- its open state
     // lives in `?prefs=` -- so the reload above brought it back over the app
@@ -127,14 +133,13 @@ test.describe('Network access', () => {
 
   test('removes an address and stops answering there', async ({ page }) => {
     await page.goto(`${solo!.hubUrl}/`)
+    await completeSoloSetup(page)
     const dialog = await openSettingsAt(page, 'admin-network')
     const row = dialog.locator('[data-setting-id="extra_listen_addresses"]')
 
     const port = await findFreePort()
     await row.getByRole('button', { name: '+ Add address' }).click()
     await row.getByLabel('Port').fill(String(port))
-    await row.getByLabel('New Password').fill(SOLO_PASSWORD)
-    await row.getByLabel('Confirm Password').fill(SOLO_PASSWORD)
     await row.getByRole('button', { name: 'Apply' }).click()
     await expect(row.getByText('Network access updated.')).toBeVisible()
     expect(await accepts(port)).toBe(true)
@@ -159,5 +164,26 @@ test.describe('Network access', () => {
     // And the -listen address is never dropped, whatever the list says: Apply
     // merges it back in every time.
     expect(await accepts(Number(solo!.listen.split(':').pop()))).toBe(true)
+  })
+
+  test('stores trusted proxy providers symbolically', async ({ page }) => {
+    await page.goto(`${solo!.hubUrl}/`)
+    await completeSoloSetup(page)
+    const dialog = await openSettingsAt(page, 'admin-network')
+    const row = dialog.locator('[data-setting-id="trusted_proxy_ranges"]')
+
+    await expect(row).toBeVisible()
+    await expect(row.getByRole('alert')).toContainText('shared provider infrastructure')
+    await row.getByRole('button', { name: /^Add/ }).click()
+    await page.getByRole('menuitemcheckbox', { name: /AWS CloudFront/ }).click()
+    await expect(row.getByLabel('Trusted proxy selector')).toHaveValue('cloudfront')
+    await row.getByRole('button', { name: 'Apply' }).click()
+    await expect(row.getByText('Trusted reverse proxies updated.')).toBeVisible()
+
+    await dialog.getByRole('button', { name: 'Close' }).click()
+    await expect(dialog).toBeHidden()
+    const reopened = await openSettingsAt(page, 'admin-network')
+    await expect(reopened.locator('[data-setting-id="trusted_proxy_ranges"]')
+      .getByLabel('Trusted proxy selector')).toHaveValue('cloudfront')
   })
 })

--- a/frontend/tests/e2e/086-network-access.spec.ts
+++ b/frontend/tests/e2e/086-network-access.spec.ts
@@ -4,7 +4,7 @@ import { connect } from 'node:net'
 import { expect, test } from './fixtures'
 import { startSoloServer, stopSoloServer } from './helpers/devServer'
 import { findFreePort } from './helpers/server'
-import { logoutViaUI, openSettingsAt } from './helpers/ui'
+import { loginViaToken, logoutViaUI, openSettingsAt } from './helpers/ui'
 
 /** A password the hub's own validator accepts. */
 const SOLO_PASSWORD = 'correct-horse-battery-staple'
@@ -187,5 +187,36 @@ test.describe('Network access', () => {
     const reopened = await openSettingsAt(page, 'admin-network')
     await expect(reopened.locator('[data-setting-id="trusted_proxy_ranges"]')
       .getByLabel('Trusted proxy selector')).toHaveValue('cloudfront')
+  })
+})
+
+/**
+ * The same section on a hub that is NOT solo, which is the half the solo
+ * instance above cannot show.
+ *
+ * The listen-address row is solo-only, so here the category holds the
+ * trusted-proxy row alone — and the navigation section has to survive on that
+ * one row. `occupiedNavGroups` decides it, and a unit test states the rule
+ * against rows a test wrote; this states it against the rows the hub sends.
+ */
+test.describe('Network access outside solo mode', () => {
+  test('keeps the section for the trusted-proxy row when the listen row is hidden', async ({ page, leapmuxServer }) => {
+    await loginViaToken(page, leapmuxServer.adminToken)
+    await page.goto('/')
+
+    const dialog = await openSettingsAt(page, 'admin-network')
+    await expect(dialog.getByTestId('preferences-nav-admin-network')).toBeVisible()
+
+    const proxies = dialog.locator('[data-setting-id="trusted_proxy_ranges"]')
+    await expect(proxies).toBeVisible()
+    await expect(dialog.locator('[data-setting-id="extra_listen_addresses"]')).toHaveCount(0)
+
+    // The row works here, not merely renders: dev mode reaches the same
+    // setting through the same binding.
+    await proxies.getByRole('button', { name: /^Add/ }).click()
+    await page.getByRole('menuitemcheckbox', { name: /Cloudflare/ }).click()
+    await proxies.getByRole('button', { name: 'Apply' }).click()
+    await expect(proxies.getByText('Trusted reverse proxies updated.')).toBeVisible()
+    await expect(proxies.getByLabel('Trusted proxy selector')).toHaveValue('cloudflare')
   })
 })

--- a/frontend/tests/e2e/086-network-access.spec.ts
+++ b/frontend/tests/e2e/086-network-access.spec.ts
@@ -8,7 +8,6 @@ import { logoutViaUI, openSettingsAt } from './helpers/ui'
 
 /** A password the hub's own validator accepts. */
 const SOLO_PASSWORD = 'correct-horse-battery-staple'
-const SOLO_ENV = { LEAPMUX_HUB_DEV_FRONTEND: undefined }
 
 async function completeSoloSetup(page: Page) {
   const gate = page.getByTestId('password-setup-gate')
@@ -54,7 +53,7 @@ test.describe('Network access', () => {
   let solo: SoloServerHandle | undefined
 
   test.beforeEach(async () => {
-    solo = await startSoloServer({ env: SOLO_ENV })
+    solo = await startSoloServer()
   })
 
   test.afterEach(async () => {
@@ -89,8 +88,9 @@ test.describe('Network access', () => {
     // The hub answers on the new address straight away -- no restart.
     expect(await accepts(port)).toBe(true)
 
-    // The write that stored the password is what started demanding one, and
-    // the page that made it must NOT be signed out of the form it is in.
+    // The panel offers no password field: `completeSoloSetup` stored one, and
+    // the session it returned is what carried this Apply. A panel that still
+    // asked for a first password would mean the setup reply never reached it.
     await expect(row.getByText(/Change it in Account → Password/)).toBeVisible()
 
     // Account → Password is where it changes from here. It is the one Account
@@ -175,6 +175,8 @@ test.describe('Network access', () => {
     await expect(row).toBeVisible()
     await expect(row.getByRole('alert')).toContainText('shared provider infrastructure')
     await row.getByRole('button', { name: /^Add/ }).click()
+    // A checkable item, not a plain one: the menu reports which providers the
+    // list already holds, and refuses a second copy of one.
     await page.getByRole('menuitemcheckbox', { name: /AWS CloudFront/ }).click()
     await expect(row.getByLabel('Trusted proxy selector')).toHaveValue('cloudfront')
     await row.getByRole('button', { name: 'Apply' }).click()

--- a/frontend/tests/e2e/087-password-setup-gate.spec.ts
+++ b/frontend/tests/e2e/087-password-setup-gate.spec.ts
@@ -49,9 +49,10 @@ test.describe('Password setup gate', () => {
     await expect(submit).toBeEnabled()
     await submit.click()
 
-    // The app loads with NO further sign-in. Storing the password is what
-    // started demanding one, so the reply hands this browser a session; without
-    // it the page would be signed out of the form it just used.
+    // The app loads with NO further sign-in. This browser held no session at
+    // all -- the setup procedure is the one thing a passwordless TCP caller
+    // may call -- so the reply's cookie is what carries it into the app.
+    // Without it the operator would set a password and then sign in with it.
     await expect(gate).toBeHidden()
     await expect(page.getByRole('button', { name: 'Sign in' })).toBeHidden()
 

--- a/frontend/tests/e2e/087-password-setup-gate.spec.ts
+++ b/frontend/tests/e2e/087-password-setup-gate.spec.ts
@@ -4,6 +4,7 @@ import { startSoloServer, stopSoloServer } from './helpers/devServer'
 
 /** A password the hub's own validator accepts. */
 const SOLO_PASSWORD = 'correct-horse-battery-staple'
+const SOLO_ENV = { LEAPMUX_HUB_DEV_FRONTEND: undefined }
 
 /**
  * The password-setup screen, on a solo hub that answers beyond loopback.
@@ -16,7 +17,7 @@ test.describe('Password setup gate', () => {
   let solo: SoloServerHandle | undefined
 
   test.beforeEach(async () => {
-    solo = await startSoloServer({ listenHost: '0.0.0.0' })
+    solo = await startSoloServer({ listenHost: '0.0.0.0', env: SOLO_ENV })
   })
 
   test.afterEach(async () => {
@@ -26,11 +27,11 @@ test.describe('Password setup gate', () => {
   test('blocks the app until the account has a password', async ({ page }) => {
     await page.goto(`${solo!.hubUrl}/`)
 
-    // The whole app, not a dismissible notice: everything it offers is offered
-    // to whoever reaches the port, and no sign-in stands between them.
+    // The whole app, not a dismissible notice. This is the only protected
+    // setup action that a passwordless TCP caller can use.
     const gate = page.getByTestId('password-setup-gate')
     await expect(gate).toBeVisible()
-    await expect(gate).toContainText('This hub answers on an address other machines can reach')
+    await expect(gate).toContainText('TCP callers can only complete this setup')
 
     // Fixed to the single account: a free field could only be filled in with a
     // name that cannot sign in.
@@ -64,13 +65,11 @@ test.describe('Password setup gate', () => {
     await expect(page.getByTestId('password-setup-gate')).toBeHidden()
   })
 
-  test('leaves a loopback-only hub alone', async ({ page }) => {
-    // A second hub, bound to loopback: it exposes nothing, so demanding a
-    // password would be friction with nothing behind it.
-    const loopbackOnly = await startSoloServer()
+  test('restricts loopback TCP to password setup too', async ({ page }) => {
+    const loopbackOnly = await startSoloServer({ env: SOLO_ENV })
     try {
       await page.goto(`${loopbackOnly.hubUrl}/`)
-      await expect(page.getByTestId('password-setup-gate')).toBeHidden()
+      await expect(page.getByTestId('password-setup-gate')).toBeVisible()
       await expect(page.getByRole('button', { name: 'Sign in' })).toBeHidden()
     }
     finally {

--- a/frontend/tests/e2e/087-password-setup-gate.spec.ts
+++ b/frontend/tests/e2e/087-password-setup-gate.spec.ts
@@ -4,20 +4,22 @@ import { startSoloServer, stopSoloServer } from './helpers/devServer'
 
 /** A password the hub's own validator accepts. */
 const SOLO_PASSWORD = 'correct-horse-battery-staple'
-const SOLO_ENV = { LEAPMUX_HUB_DEV_FRONTEND: undefined }
 
 /**
- * The password-setup screen, on a solo hub that answers beyond loopback.
+ * The password-setup screen, on a solo hub reached over TCP.
  *
- * `-listen 0.0.0.0` is what exposes it; the spec still reaches it over
- * loopback, because a wildcard bind answers there too. That matters for CI: a
- * runner may hold no address of its own, and this needs none.
+ * The LISTENER no longer decides it: every TCP address restricts a passwordless
+ * caller to the setup procedure, and the last test below pins that for
+ * loopback. `-listen 0.0.0.0` stays here because the exposed case is the one an
+ * operator meets first; the spec still reaches it over loopback, because a
+ * wildcard bind answers there too. That matters for CI: a runner may hold no
+ * address of its own, and this needs none.
  */
 test.describe('Password setup gate', () => {
   let solo: SoloServerHandle | undefined
 
   test.beforeEach(async () => {
-    solo = await startSoloServer({ listenHost: '0.0.0.0', env: SOLO_ENV })
+    solo = await startSoloServer({ listenHost: '0.0.0.0' })
   })
 
   test.afterEach(async () => {
@@ -66,7 +68,7 @@ test.describe('Password setup gate', () => {
   })
 
   test('restricts loopback TCP to password setup too', async ({ page }) => {
-    const loopbackOnly = await startSoloServer({ env: SOLO_ENV })
+    const loopbackOnly = await startSoloServer()
     try {
       await page.goto(`${loopbackOnly.hubUrl}/`)
       await expect(page.getByTestId('password-setup-gate')).toBeVisible()

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -25,7 +25,7 @@ import {
 } from './helpers/api'
 import { closeAllUserEventsSubscriptions } from './helpers/crdt'
 import { stopProcess } from './helpers/process'
-import { findFreePort, getGlobalState, hubDataDir, waitForServer } from './helpers/server'
+import { findFreePort, getGlobalState, hubDataDir, hubSpawnEnv, waitForServer } from './helpers/server'
 import { createServerOutput, reportStartupFailure } from './helpers/serverOutput'
 import { getRecordedToasts, installToastRecorder } from './helpers/toast'
 import { loginViaToken, openWorkspace } from './helpers/ui'
@@ -114,7 +114,7 @@ export const test = base.extend<
       dataDir,
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low', LEAPMUX_CODEX_DEFAULT_MODEL: 'gpt-5.4-mini', LEAPMUX_COPILOT_DEFAULT_MODEL: 'gpt-5.4-mini', LEAPMUX_WORKER_NAME: 'Local' },
+      env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low', LEAPMUX_CODEX_DEFAULT_MODEL: 'gpt-5.4-mini', LEAPMUX_COPILOT_DEFAULT_MODEL: 'gpt-5.4-mini', LEAPMUX_WORKER_NAME: 'Local' }),
     })
 
     // Consume server output (also prevents backpressure), keeping a tail for

--- a/frontend/tests/e2e/helpers/devServer.ts
+++ b/frontend/tests/e2e/helpers/devServer.ts
@@ -10,7 +10,6 @@ import { spawn } from 'node:child_process'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import process from 'node:process'
 import {
   getUserId,
   getWorkerId,
@@ -20,7 +19,7 @@ import {
   TEST_ADMIN_USERNAME,
 } from './api'
 import { stopProcess } from './process'
-import { findFreePort, getGlobalState, waitForServer } from './server'
+import { findFreePort, getGlobalState, hubSpawnEnv, waitForServer } from './server'
 
 export interface DevServerHandle {
   hubUrl: string
@@ -71,7 +70,7 @@ export async function startUnseededDevServer(opts: StartDevServerOptions = {}): 
 
   const proc = spawn(binaryPath, ['dev', '-listen', `:${port}`, '-data-dir', dataDir], {
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env, ...opts.env },
+    env: hubSpawnEnv(opts.env),
   })
 
   if (opts.onStdio) {
@@ -136,13 +135,7 @@ export async function startSoloServer(opts: StartSoloServerOptions = {}): Promis
 
   const proc = spawn(binaryPath, ['solo', '-listen', listen, '-data-dir', dataDir], {
     stdio: ['ignore', 'pipe', 'pipe'],
-    // LEAPMUX_HUB_DEV_FRONTEND is CLEARED, and a caller may set it again
-    // through `opts.env`. The variable points the hub at a Vite dev server
-    // instead of the frontend built into `binaryPath`, and a developer who
-    // exports it for their own `leapmux solo` exports it into this suite too:
-    // the spec then drives a hub that proxies to a server nobody started, and
-    // every page it opens fails for a reason that is not in the spec.
-    env: { ...process.env, LEAPMUX_HUB_DEV_FRONTEND: undefined, ...opts.env },
+    env: hubSpawnEnv(opts.env),
   })
 
   if (opts.onStdio) {

--- a/frontend/tests/e2e/helpers/devServer.ts
+++ b/frontend/tests/e2e/helpers/devServer.ts
@@ -122,8 +122,10 @@ export interface StartSoloServerOptions extends StartDevServerOptions {
  * changes. The shared fixture runs `leapmux dev`, which has real password
  * authentication from the start and therefore cannot exercise any of it.
  *
- * No admin registration: `bootstrap.Run` creates the account, and until it has
- * a password the hub authenticates every caller as it.
+ * No admin registration: `bootstrap.Run` creates the account. A spec that
+ * drives the hub over TCP reaches the password-setup screen first, because
+ * that transport holds no credential-free access — only the desktop app's
+ * local IPC socket does. Set the first password there before the app loads.
  */
 export async function startSoloServer(opts: StartSoloServerOptions = {}): Promise<SoloServerHandle> {
   const { binaryPath } = getGlobalState()
@@ -134,7 +136,13 @@ export async function startSoloServer(opts: StartSoloServerOptions = {}): Promis
 
   const proc = spawn(binaryPath, ['solo', '-listen', listen, '-data-dir', dataDir], {
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env, ...opts.env },
+    // LEAPMUX_HUB_DEV_FRONTEND is CLEARED, and a caller may set it again
+    // through `opts.env`. The variable points the hub at a Vite dev server
+    // instead of the frontend built into `binaryPath`, and a developer who
+    // exports it for their own `leapmux solo` exports it into this suite too:
+    // the spec then drives a hub that proxies to a server nobody started, and
+    // every page it opens fails for a reason that is not in the spec.
+    env: { ...process.env, LEAPMUX_HUB_DEV_FRONTEND: undefined, ...opts.env },
   })
 
   if (opts.onStdio) {

--- a/frontend/tests/e2e/helpers/multiWorker.ts
+++ b/frontend/tests/e2e/helpers/multiWorker.ts
@@ -36,7 +36,7 @@ import { join } from 'node:path'
 import process from 'node:process'
 import { API_POLL_INTERVAL_MS, authedHeaders, getUserId, signUpViaAPI, TEST_ADMIN_DISPLAY_NAME, TEST_ADMIN_PASSWORD, TEST_ADMIN_USERNAME } from './api'
 import { stopProcesses } from './process'
-import { findFreePort, getGlobalState, waitForServer } from './server'
+import { findFreePort, getGlobalState, hubSpawnEnv, waitForServer } from './server'
 
 /** A single worker spawned by the harness. */
 export interface HarnessWorker {
@@ -98,7 +98,7 @@ export async function startMultiWorkerHarness(count = 2): Promise<MultiWorkerHar
     hubDataDir,
   ], {
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: { ...process.env },
+    env: hubSpawnEnv(),
   })
   hubProc.stdout?.resume()
   hubProc.stderr?.resume()

--- a/frontend/tests/e2e/helpers/server.test.ts
+++ b/frontend/tests/e2e/helpers/server.test.ts
@@ -1,0 +1,73 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { hubSpawnEnv } from './server'
+
+describe('hubSpawnEnv', () => {
+  it('clears the dev-frontend URL the ambient environment carries', () => {
+    const before = process.env.LEAPMUX_HUB_DEV_FRONTEND
+    process.env.LEAPMUX_HUB_DEV_FRONTEND = 'http://localhost:5173'
+    try {
+      expect(hubSpawnEnv().LEAPMUX_HUB_DEV_FRONTEND).toBeUndefined()
+    }
+    finally {
+      if (before === undefined)
+        delete process.env.LEAPMUX_HUB_DEV_FRONTEND
+      else
+        process.env.LEAPMUX_HUB_DEV_FRONTEND = before
+    }
+  })
+
+  it('keeps the variables a caller layers on top', () => {
+    const env = hubSpawnEnv({ LEAPMUX_WORKER_NAME: 'Local' })
+    expect(env.LEAPMUX_WORKER_NAME).toBe('Local')
+  })
+
+  // The guard sits after the spread, so a caller cannot reinstate the value.
+  // The parameter type omits the key as well, so this only reaches the runtime
+  // through a cast -- which is exactly the accident worth pinning, because a
+  // silently honoured override is the same defect the helper exists to remove.
+  it('cannot be overridden by its own caller', () => {
+    const env = hubSpawnEnv({ LEAPMUX_HUB_DEV_FRONTEND: 'http://localhost:5173' } as Record<string, string>)
+    expect(env.LEAPMUX_HUB_DEV_FRONTEND).toBeUndefined()
+  })
+})
+
+// A hub that inherits `LEAPMUX_HUB_DEV_FRONTEND` serves whatever checkout a
+// developer's Vite server runs from, so the spec asserts against a frontend
+// nobody built from the code under test -- and it can PASS that way, which is
+// the worse half. `hubSpawnEnv` is the one home for that guard, and this test
+// is what keeps it the only one: three hub spawns bypassed it for a whole
+// commit whose subject said "every spawned hub".
+describe('every hub spawn goes through hubSpawnEnv', () => {
+  const e2eRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+  const walk = (dir: string): string[] =>
+    readdirSync(dir).flatMap((entry) => {
+      const path = join(dir, entry)
+      if (statSync(path).isDirectory())
+        return entry === 'node_modules' ? [] : walk(path)
+      return path.endsWith('.ts') ? [path] : []
+    })
+
+  it('spawns no hub with a hand-rolled environment', () => {
+    const offenders: string[] = []
+    for (const file of walk(e2eRoot)) {
+      if (file.endsWith('server.test.ts'))
+        continue
+      const source = readFileSync(file, 'utf8')
+      // Each `spawn(...)` call, with the arguments that follow it up to the
+      // closing brace of its options object. A hub spawn is one whose argument
+      // list names the `hub`, `solo` or `dev` subcommand.
+      for (const call of source.split('spawn(').slice(1)) {
+        const block = call.slice(0, call.indexOf('})'))
+        const isHub = /['"](?:hub|solo|dev)['"]/.test(block)
+        if (isHub && block.includes('env:') && !block.includes('hubSpawnEnv'))
+          offenders.push(`${file.slice(e2eRoot.length + 1)}: ${block.split('\n').find(l => l.includes('env:'))?.trim()}`)
+      }
+    }
+    expect(offenders, 'route every hub spawn through hubSpawnEnv').toEqual([])
+  })
+})

--- a/frontend/tests/e2e/helpers/server.ts
+++ b/frontend/tests/e2e/helpers/server.ts
@@ -13,6 +13,25 @@ export function hubDataDir(dataDir: string): string {
   return join(dataDir, 'hub')
 }
 
+/**
+ * The environment every hub this suite spawns must start from.
+ *
+ * `LEAPMUX_HUB_DEV_FRONTEND` is CLEARED. It points a hub at a Vite dev server
+ * instead of the frontend built into the binary under test, and a developer
+ * who exports it for their own `leapmux solo` or `task dev-desktop` exports it
+ * into this suite too. The hub then serves whatever checkout that Vite server
+ * runs from -- a different worktree, or nothing at all -- so a spec asserts
+ * against a frontend that is not the one being tested. It fails for a reason
+ * that is nowhere in the diff, and, worse, it can PASS against code that was
+ * never built.
+ *
+ * Every spawn site layers its own variables on top of this, so a new one
+ * inherits the guard rather than restating it.
+ */
+export function hubSpawnEnv(extra: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  return { ...process.env, LEAPMUX_HUB_DEV_FRONTEND: undefined, ...extra }
+}
+
 // ──────────────────────────────────────────────
 // Global state (read from file written by global-setup)
 // ──────────────────────────────────────────────

--- a/frontend/tests/e2e/helpers/server.ts
+++ b/frontend/tests/e2e/helpers/server.ts
@@ -17,19 +17,25 @@ export function hubDataDir(dataDir: string): string {
  * The environment every hub this suite spawns must start from.
  *
  * `LEAPMUX_HUB_DEV_FRONTEND` is CLEARED. It points a hub at a Vite dev server
- * instead of the frontend built into the binary under test, and a developer
- * who exports it for their own `leapmux solo` or `task dev-desktop` exports it
- * into this suite too. The hub then serves whatever checkout that Vite server
- * runs from -- a different worktree, or nothing at all -- so a spec asserts
- * against a frontend that is not the one being tested. It fails for a reason
- * that is nowhere in the diff, and, worse, it can PASS against code that was
- * never built.
+ * instead of the frontend built into the binary under test. A developer who
+ * exports it for their own `leapmux solo`, or who runs `task dev-desktop`,
+ * exports it into this suite too. The hub then serves whatever checkout that
+ * Vite server runs from: a different worktree, or nothing at all. A spec then
+ * asserts against a frontend that nobody built from the code under test. It
+ * fails for a reason that is nowhere in the diff. Worse, it can PASS against
+ * code that was never built.
  *
  * Every spawn site layers its own variables on top of this, so a new one
  * inherits the guard rather than restating it.
+ *
+ * The guard sits AFTER the spread, so a caller cannot override it by accident.
+ * The parameter type omits the key as well, so naming it does not compile --
+ * a silently dropped value would be the same defect one step later.
  */
-export function hubSpawnEnv(extra: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
-  return { ...process.env, LEAPMUX_HUB_DEV_FRONTEND: undefined, ...extra }
+export function hubSpawnEnv(
+  extra: Omit<Record<string, string | undefined>, 'LEAPMUX_HUB_DEV_FRONTEND'> = {},
+): NodeJS.ProcessEnv {
+  return { ...process.env, ...extra, LEAPMUX_HUB_DEV_FRONTEND: undefined }
 }
 
 // ──────────────────────────────────────────────

--- a/frontend/tests/e2e/process-control-fixtures.ts
+++ b/frontend/tests/e2e/process-control-fixtures.ts
@@ -25,7 +25,7 @@ import {
   TEST_ADMIN_USERNAME,
   waitForNewOnlineWorkerViaAPI,
 } from './helpers/api'
-import { findFreePort, getGlobalState, waitForServer } from './helpers/server'
+import { findFreePort, getGlobalState, hubSpawnEnv, waitForServer } from './helpers/server'
 import { createServerOutput, reportStartupFailure } from './helpers/serverOutput'
 import { getRecordedToasts, installToastRecorder } from './helpers/toast'
 import { loginViaToken, openWorkspace } from './helpers/ui'
@@ -251,7 +251,7 @@ export async function restartHub(serverInfo: SeparateServerInfo) {
   ], {
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
-    env: { ...process.env, LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low' },
+    env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low' }),
   })
   hubProc.unref()
   // Track immediately so the fixture teardown / global-teardown sweep still
@@ -335,7 +335,7 @@ export const processTest = base.extend<
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
-      env: { ...process.env, LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low' },
+      env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low' }),
     })
     hubProc.unref()
     trackSpawnedPid(dataDir, hubProc.pid!)

--- a/proto/leapmux/v1/auth.proto
+++ b/proto/leapmux/v1/auth.proto
@@ -8,6 +8,10 @@ import "google/protobuf/timestamp.proto";
 service AuthService {
   // Authenticate with username and password.
   rpc Login(LoginRequest) returns (LoginResponse);
+  // Set the first password for the solo account and create an elevated
+  // session. This is the only protected setup action available to a TCP
+  // caller before the solo account has a usable password.
+  rpc SetInitialSoloPassword(SetInitialSoloPasswordRequest) returns (SetInitialSoloPasswordResponse);
   // Invalidate the current session.
   rpc Logout(LogoutRequest) returns (LogoutResponse);
   // Get the currently authenticated user.
@@ -92,6 +96,14 @@ message EmailVerificationStatus {
 message LoginResponse {
   User user = 1;
   EmailVerificationStatus email_verification = 2;
+}
+
+message SetInitialSoloPasswordRequest {
+  string password = 1;
+}
+
+message SetInitialSoloPasswordResponse {
+  User user = 1;
 }
 
 message LogoutRequest {}
@@ -191,6 +203,21 @@ message LinkedOAuthProvider {
 
 message GetSystemInfoRequest {}
 
+// SoloAccess tells the client how this connection reaches a solo hub.
+enum SoloAccess {
+  // This is not a solo hub.
+  SOLO_ACCESS_UNSPECIFIED = 0;
+  // The request arrived through local IPC. The local socket needs no
+  // credential, even after the solo account gets a password.
+  SOLO_ACCESS_CREDENTIAL_FREE = 1;
+  // The request arrived through TCP, and the solo account has no usable
+  // password. The client can only set the first password.
+  SOLO_ACCESS_PASSWORD_SETUP = 2;
+  // The request arrived through TCP, and the solo account has a usable
+  // password. The client must sign in.
+  SOLO_ACCESS_SIGN_IN_REQUIRED = 3;
+}
+
 // CaptchaProvider identifies the bot-protection provider securing the
 // unauthenticated credential endpoints. The numbers are part of the wire
 // API and must stay stable.
@@ -260,27 +287,12 @@ message GetSystemInfoResponse {
   // reached at another (a LAN IP behind the reverse proxy, a tunnel host)
   // is configured for passkeys and still runs none for that page.
   bool passkey_enabled = 16;
-  // True when the hub authenticates THIS connection with no credentials.
-  //
-  // Two cases produce it, and both are solo mode: the local IPC socket (the
-  // desktop app reaching its own hub), and any transport while the single
-  // account holds no password. It is FALSE once that account has one, on
-  // every TCP address including 127.0.0.1.
-  //
-  // It is per CONNECTION, where solo_mode is per hub, and the two answer
-  // different questions. solo_mode says "this hub has one account and no
-  // sign-up", which decides which account settings exist at all;
-  // auto_authenticated says "this page needs no sign-in", which decides
-  // whether the app falls back to the login form.
-  bool auto_authenticated = 17;
-  // True when the hub answers on an address another machine can reach and
-  // its single account holds no password, so nobody can sign in from those
-  // addresses.
-  //
-  // Frontend restriction: the app replaces itself with a password-setup
-  // screen while this is true, because every other affordance is reachable
-  // by anyone who can reach the port.
-  bool password_setup_required = 18;
+  // The access state for this connection. This value separates local IPC,
+  // restricted TCP setup, and ordinary TCP sign-in without two booleans that
+  // can describe an invalid combination.
+  SoloAccess solo_access = 17;
+  reserved 18;
+  reserved "auto_authenticated", "password_setup_required";
   // True when the single account holds a password that can sign in. Solo
   // mode only; false on a multi-user hub, where each account answers for
   // itself.

--- a/proto/leapmux/v1/auth.proto
+++ b/proto/leapmux/v1/auth.proto
@@ -104,6 +104,17 @@ message SetInitialSoloPasswordRequest {
 
 message SetInitialSoloPasswordResponse {
   User user = 1;
+  // When the elevation this call granted lapses.
+  //
+  // The transaction that stores the password also creates the session AND
+  // elevates it, so this caller is elevated the moment it reads the reply. The
+  // deadline travels WITH that reply because the client's elevation state must
+  // derive from the answer that created it. Recovering it from a following
+  // GetCurrentUser makes the one-transaction design depend on a second round
+  // trip: a client that adopts this user clears its elevation mirror, and a
+  // transient failure on that second call then prompts the operator for the
+  // password they typed a moment earlier.
+  google.protobuf.Timestamp elevation_expires_at = 2;
 }
 
 message LogoutRequest {}

--- a/scripts/generate-contracts.mjs
+++ b/scripts/generate-contracts.mjs
@@ -272,6 +272,25 @@ export function checkListen(l) {
 }
 
 // ---------------------------------------------------------------------------
+// trusted-proxies: selector limit and built-in provider catalogue
+// ---------------------------------------------------------------------------
+
+export function checkTrustedProxies(v) {
+  mustBe(Number.isInteger(v.maxSelectors) && v.maxSelectors >= 1, 'trusted-proxies.json', 'maxSelectors must be an integer >= 1')
+  const expected = ['cloudflare', 'cloudfront']
+  mustBe(Object.keys(v.providers).join(',') === expected.join(','), 'trusted-proxies.json', 'providers must contain cloudflare and cloudfront in that order')
+  const tokens = []
+  for (const [key, provider] of Object.entries(v.providers)) {
+    mustBe(provider.token === key, 'trusted-proxies.json', `providers.${key}.token must equal ${JSON.stringify(key)}`)
+    mustBe(provider.label.length > 0, 'trusted-proxies.json', `providers.${key}.label must not be empty`)
+    mustBe(provider.help.length > 0, 'trusted-proxies.json', `providers.${key}.help must not be empty`)
+    tokens.push(provider.token)
+  }
+  mustBe(new Set(tokens).size === tokens.length, 'trusted-proxies.json', 'provider tokens must be unique')
+  return {}
+}
+
+// ---------------------------------------------------------------------------
 // retry: cross-language retry policies
 // ---------------------------------------------------------------------------
 
@@ -2192,6 +2211,55 @@ ${sources.join('\n\n')}
 `
 }
 
+export function emitGoTrustedProxies(v) {
+  const entries = Object.values(v.providers).map(provider =>
+    `\t{Token: ${jsonString(provider.token)}, Label: ${jsonString(provider.label)}, Help: ${jsonString(provider.help)}},`).join('\n')
+  return `${GO_HEADER('trusted-proxies.json')}package contracts
+
+// TrustedProxyProvider describes one symbolic provider selector.
+type TrustedProxyProvider struct {
+\tToken string
+\tLabel string
+\tHelp  string
+}
+
+// MaxTrustedProxySelectors caps configured selectors. A provider token counts
+// once, independent of the number of bundled ranges it expands to.
+const MaxTrustedProxySelectors = ${v.maxSelectors}
+
+const (
+\tTrustedProxyProviderCloudflare = ${jsonString(v.providers.cloudflare.token)}
+\tTrustedProxyProviderCloudFront = ${jsonString(v.providers.cloudfront.token)}
+)
+
+// TrustedProxyProviders is the built-in provider catalogue.
+var TrustedProxyProviders = []TrustedProxyProvider{
+${entries}
+}
+`
+}
+
+export function emitTsTrustedProxies(v) {
+  const entries = Object.values(v.providers).map(provider =>
+    `  { token: ${jsonString(provider.token)}, label: ${jsonString(provider.label)}, help: ${jsonString(provider.help)} },`).join('\n')
+  return `${TS_HEADER('trusted-proxies.json')}
+/** A built-in trusted reverse-proxy provider. */
+export interface TrustedProxyProvider {
+  token: string
+  label: string
+  help: string
+}
+
+/** The most configured selectors. A provider token counts once. */
+export const MAX_TRUSTED_PROXY_SELECTORS = ${v.maxSelectors} as const
+
+/** The built-in provider catalogue. */
+export const TRUSTED_PROXY_PROVIDERS: readonly TrustedProxyProvider[] = [
+${entries}
+]
+`
+}
+
 export function emitGoRetry(r) {
   const blocks = Object.entries(r.policies).map(([name, p]) => {
     const prefix = RETRY_GO_NAMES[name]
@@ -2285,6 +2353,15 @@ const DOMAINS = [
       checkListen(l)
       out['backend/generated/contracts/listen.go'] = emitGoListen(l)
       out['frontend/src/generated/contracts/listen.ts'] = emitTsListen(l)
+    },
+  },
+  {
+    name: 'trusted-proxies',
+    emit(out, read) {
+      const v = read('trusted-proxies')
+      checkTrustedProxies(v)
+      out['backend/generated/contracts/trusted-proxies.go'] = emitGoTrustedProxies(v)
+      out['frontend/src/generated/contracts/trusted-proxies.ts'] = emitTsTrustedProxies(v)
     },
   },
   {

--- a/scripts/generate-contracts.test.mjs
+++ b/scripts/generate-contracts.test.mjs
@@ -27,6 +27,7 @@ import {
   checkSessionInfo,
   checkTabNames,
   checkTheme,
+  checkTrustedProxies,
   checkValidate,
   checkWire,
   checkWorkerVocab,
@@ -41,6 +42,7 @@ import {
   emitGoListen,
   emitGoRetry,
   emitGoSessionInfo,
+  emitGoTrustedProxies,
   emitGoValidate,
   emitGoWire,
   emitRsDesktop,
@@ -50,6 +52,7 @@ import {
   emitTsProviders,
   emitTsRetry,
   emitTsSessionInfo,
+  emitTsTrustedProxies,
   emitTsValidate,
   emitTsWire,
   enumValues,
@@ -75,6 +78,7 @@ const readContract = name => JSON.parse(readFileSync(join(ROOT, 'contracts', `${
 const WIRE = readContract('wire')
 const HEADERS = readContract('headers')
 const RETRY = readContract('retry')
+const TRUSTED_PROXIES = readContract('trusted-proxies')
 
 function expectContractError(fn, fragment) {
   try {
@@ -550,6 +554,35 @@ describe('emitGoListen and emitTsListen', () => {
   })
 })
 
+describe('trusted proxy contract', () => {
+  it('accepts the shipped provider catalogue', () => {
+    expect(checkTrustedProxies(TRUSTED_PROXIES)).toEqual({})
+  })
+
+  it('rejects a provider token that differs from its key', () => {
+    expectContractError(
+      () => checkTrustedProxies({
+        ...TRUSTED_PROXIES,
+        providers: {
+          ...TRUSTED_PROXIES.providers,
+          cloudflare: { ...TRUSTED_PROXIES.providers.cloudflare, token: 'other' },
+        },
+      }),
+      'token must equal',
+    )
+  })
+
+  it('emits the cap and provider metadata for both languages', () => {
+    const go = emitGoTrustedProxies(TRUSTED_PROXIES)
+    expect(go).toContain('const MaxTrustedProxySelectors = 32')
+    expect(go).toContain('TrustedProxyProviderCloudflare = "cloudflare"')
+    expect(go).toContain('{Token: "cloudfront", Label: "AWS CloudFront"')
+    const ts = emitTsTrustedProxies(TRUSTED_PROXIES)
+    expect(ts).toContain('MAX_TRUSTED_PROXY_SELECTORS = 32')
+    expect(ts).toContain('{ token: "cloudflare", label: "Cloudflare"')
+  })
+})
+
 describe('usernameConstName', () => {
   // The schema admits a hyphen and no language admits one in an identifier.
   it('folds a hyphen the identifier cannot carry', () => {
@@ -578,6 +611,7 @@ describe('generate', () => {
       'backend/generated/contracts/tab-names.go',
       'backend/generated/contracts/tab-types.go',
       'backend/generated/contracts/theme.go',
+      'backend/generated/contracts/trusted-proxies.go',
       'backend/generated/contracts/validate.go',
       'backend/generated/contracts/wire.go',
       'backend/generated/contracts/worker-vocab.go',
@@ -599,6 +633,7 @@ describe('generate', () => {
       'frontend/src/generated/contracts/tab-names.ts',
       'frontend/src/generated/contracts/tab-types.ts',
       'frontend/src/generated/contracts/theme-default.ts',
+      'frontend/src/generated/contracts/trusted-proxies.ts',
       'frontend/src/generated/contracts/validate.ts',
       'frontend/src/generated/contracts/wire.ts',
       'frontend/src/generated/contracts/worker-vocab.ts',

--- a/site/content/docs/admin/admin-cli.md
+++ b/site/content/docs/admin/admin-cli.md
@@ -104,7 +104,7 @@ The `rate-limit` group is sugar over the `rate_limit.<operation>` settings keys.
 | `login_anonymous` | Failed passwords at the sign-in form. | The client address. Enforced in solo mode too, which puts no captcha in front of sign-in. |
 | `oauth_anonymous` | The authorization server's anonymous endpoints — `/oauth/device-authorization`, `/oauth/token`, `/oauth/revoke`, `/oauth/register`, `/oauth/step-up`, and the app icons. | The client address. Enforced in solo mode too, because those endpoints are served there. |
 
-The two address-keyed budgets count the address the Hub itself sees, never a forwarded header, because a header is caller-controlled. A Hub behind a reverse proxy therefore sees the proxy for every client and shares one budget across all of them: ten failed sign-ins from anywhere pause sign-in for everybody behind that proxy. Raise `login_anonymous`, or limit sign-in at the proxy, which knows the real client address.
+The two address-keyed budgets use the verified client IP. By default, this is the direct TCP peer. The `trusted_proxy_ranges` setting lets a verified proxy supply `Forwarded` or X-Forwarded data. The Hub ignores those headers from every other peer. See [Trusted reverse proxies](/docs/admin/configuration/#trusted-reverse-proxies).
 
 ```bash
 leapmux control admin rate-limit list

--- a/site/content/docs/admin/app-authorization.md
+++ b/site/content/docs/admin/app-authorization.md
@@ -129,7 +129,7 @@ Two registrations ship with the Hub — the control CLI and the service account 
 
 ## Solo mode
 
-A solo Hub authorizes apps like any other. Reaching the port is the authentication there, so a request with no credential is the solo account with no limits — but a request that presents a credential speaks for that app, and the Hub applies the credential's permissions instead.
+A solo Hub authorizes apps like any other. Over the local IPC socket a request with no credential is the solo account with no limits — but a request that presents a credential speaks for that app, and the Hub applies the credential's permissions instead. Over TCP the caller signs in as `solo` first, and the same rule then applies to it. See [Solo mode: a reduced threat model](/docs/admin/security/#solo-mode-a-reduced-threat-model).
 
 That is what makes the model useful on one machine: hand a local agent a credential with `file:read` and it reads files, nothing else, and the Worker enforces it inside the encrypted channel where the Hub cannot see.
 

--- a/site/content/docs/admin/configuration.md
+++ b/site/content/docs/admin/configuration.md
@@ -155,12 +155,12 @@ Defaults differ by mode:
 | ------ | -------------------- | ------------------------------------------------------- |
 | `hub`  | `:4327`              | All interfaces; real authentication required.           |
 | `dev`  | `:4327`              | All interfaces.                                         |
-| `solo` | `127.0.0.1:4327`     | Loopback only; no sign-in until the `solo` account has a password. |
+| `solo` | `127.0.0.1:4327`     | Loopback only; TCP starts with first-password setup. |
 
 `listen` is a command-line option and nothing else — no setting changes it. Solo mode adds **more** addresses beside it through [Network access](#network-access) below.
 
 {{< callout type="warning" >}}
-While the `solo` account has no password, every request is authenticated as the administrator without credentials. If you bind solo mode to a non-loopback address in that state, anyone who can reach the port has full admin access, and the Hub logs a warning to that effect. Set a password — the app asks for one before anything else while such an address is served — and restrict access externally as well (firewall, Tailscale/WireGuard, SSH tunnel) if the network is not one you trust. See [Solo mode: a reduced threat model](/docs/admin/security/#solo-mode-a-reduced-threat-model).
+Before the `solo` account has a password, a TCP caller can only set the first password. The first successful caller claims the account and receives an elevated session. If you bind solo mode to a non-loopback address in that state, another machine can win this setup race. The Hub logs a warning. Set the password from a trusted connection and restrict access with a firewall or tunnel. See [Solo mode: a reduced threat model](/docs/admin/security/#solo-mode-a-reduced-threat-model).
 {{< /callout >}}
 
 ### Network access
@@ -174,7 +174,31 @@ Two things follow from adding one:
 
 An address that cannot be bound — a VPN that is down, a port another program holds — does not stop the Hub. It stays configured, the rest are served, and the panel reports the operating system's own reason beside it.
 
-The section is solo-only. `leapmux hub` and `leapmux dev` already bind every interface by default and already authenticate every caller, so they configure their address with `-listen` and a reverse proxy instead.
+The additional listen-address row is solo-only. The **Trusted reverse proxies** row below it appears in solo, hub, and dev modes.
+
+### Trusted reverse proxies
+
+The `trusted_proxy_ranges` setting is a JSON list. It defaults to `[]`, so LeapMux trusts no proxy, including loopback. The setting is hot and accepts these selectors:
+
+- An IPv4 or IPv6 address: `192.0.2.10`, `2001:db8::10`.
+- A CIDR: `192.168.0.0/24`, `2001:db8::/64`.
+- A full inclusive range: `192.168.0.1-192.168.0.100`, `2001:db8::1-2001:db8::ffff`.
+- A short IPv4 range: `192.168.0.1-100`.
+- A provider preset: `cloudflare`, `cloudfront`.
+
+The Hub canonicalizes manual selectors and stores provider presets as symbolic tokens. Provider names ignore letter case. LeapMux expands the provider tokens from its bundled `realclientip-go` snapshot. It does not fetch new ranges or refresh them automatically. Add a manual range when the bundled snapshot does not include a proxy that you use.
+
+LeapMux rejects ports, IPv6 zones, unknown provider names, mixed address families, reversed ranges, duplicates, overlaps, malformed selectors, and lists above the configured cap.
+
+{{< callout type="warning" >}}
+Provider ranges identify shared infrastructure, not your provider account. Restrict the origin to your own distribution or use authenticated origin requests. Each proxy must remove client-supplied forwarding headers or append only verified values. Otherwise, another provider customer can supply a false client address.
+{{< /callout >}}
+
+LeapMux reads forwarding headers only when the unchanged TCP peer matches the expanded trusted set. It prefers `Forwarded` when that header exists. Otherwise, it uses `X-Forwarded-For` and `X-Forwarded-Proto`. It walks the address chain from right to left and selects the first address outside the trusted set. A malformed preferred header or a chain with no client address produces an unknown client. LeapMux does not fall back to another header.
+
+For `Forwarded`, LeapMux uses the `proto` value on the selected element. For X-Forwarded headers, one protocol value applies globally. Equal-length protocol and address lists align by position. LeapMux accepts only `http` and `https`; absent, empty, invalid, or misaligned protocol data becomes `http`.
+
+The verified client IP controls address-keyed rate limits and new session records. LeapMux keeps `RemoteAddr` as the physical peer. It sets the effective request URL scheme but does not change the TLS state. Set `secure_cookies` explicitly; forwarded protocol data never changes the cookie policy.
 
 ### Local IPC listen (`local_listen`)
 
@@ -234,6 +258,7 @@ Changes fall into two classes, shown by `settings list`:
 | `session_duration_seconds` | integer | `604800` (7d) | hot (minimum 300) |
 | `secure_cookies` | boolean | `false` | hot (changes the cookie name, so it signs everyone out) |
 | `public_url` | string | *(empty)* | hot (scheme+host only, no path) |
+| `trusted_proxy_ranges` | JSON list of IP selectors or provider tokens | `[]` | hot |
 | `smtp` | `{host, port, username, from_address, tls_mode}` + secret `{password}` | disabled | hot |
 | `timeouts` | `{api_seconds, agent_startup_seconds, worktree_create_seconds}` | 10 / 300 / 60 | hot |
 | `limits` | `{max_connections_per_user, max_workers_per_user}` | 32 / 64 | hot (`0` = unlimited) |
@@ -278,7 +303,7 @@ leapmux control admin rate-limit list
 
 With no configuration at all: captcha is **enabled** with the built-in ALTCHA provider at `PBKDF2/SHA-256` cost `10000` (challenges expire after 20 minutes), and `elevation` — failed attempts to verify your identity for a sensitive account change, see [Session elevation](/docs/admin/security/#session-elevation) — is limited to 5 failed attempts per 15 minutes per user. Two more caps guard the relay: `email_change` limits the requests to change an account email that reach the mail machinery (6 per 15 minutes per user — each one drove a mint and an SMTP attempt, a loop otherwise pays no captcha and guesses no secret, while the elevation prompt and validation refusals that precede the work cost nothing), and `mail_limits` caps how often the Hub mails one recipient address (10 per hour by default) plus how long a **failed** send blocks the next verification or recovery mail (10 seconds by default, and never more than the 60-second resend cooldown — one failed send must not block longer than a successful one). The per-recipient budget counts delivered mail: a send the relay refuses spends nothing. It folds plus-tagged addresses (`victim+1@`, `victim+2@`) onto the one inbox they share on every provider that honors tags, so a provider that treats `+` as a literal local-part character shares one budget between mailboxes that differ only in the tag.
 
-Two more limits are keyed by client address rather than by user. `login_anonymous` caps failed passwords at the sign-in form (10 per 15 minutes), and a success clears the window, so a person who mistypes twice and then signs in pays nothing. `oauth_anonymous` caps the authorization server's anonymous endpoints (`/oauth/device-authorization`, `/oauth/token`, `/oauth/revoke`, `/oauth/register`, `/oauth/step-up`, and the app icons) at 600 per 10 minutes; see [App Authorization](/docs/admin/app-authorization/). Solo mode enforces no captcha and no per-user limit, but it does enforce both of these. A Hub behind a reverse proxy sees the proxy's address for every client and shares one budget across all of them — see [Rate limits](/docs/admin/admin-cli/#rate-limits). ALTCHA runs only where a browser can solve it and somebody other than you can reach the Hub — see **When ALTCHA runs** below.
+Two more limits use the verified client address instead of the user. `login_anonymous` caps failed passwords at the sign-in form (10 per 15 minutes), and a success clears the window. `oauth_anonymous` caps the authorization server's anonymous endpoints at 600 per 10 minutes; see [App Authorization](/docs/admin/app-authorization/). Solo mode enforces both limits. A Hub with no trusted proxy setting sees the direct TCP peer. A configured trusted proxy can supply the verified client address as described under [Trusted reverse proxies](#trusted-reverse-proxies). ALTCHA runs only where a browser can solve it and somebody other than you can reach the Hub.
 
 Selecting Google reCAPTCHA v3 or Cloudflare Turnstile needs its site key and its secret, because the Hub refuses a selected provider whose key pair is incomplete. Pass both in the same `captcha set` invocation, as the example above does, or store them first and select the provider after. The Preferences dialog's Bot Protection panel shows every provider's key fields at all times for the same reason: an administrator fills a provider in, then switches to it.
 
@@ -648,6 +673,7 @@ leapmux hub --config /etc/leapmux/hub.yaml
 # survive and can change under the running Hub:
 leapmux control admin settings set public_url "https://hub.example.com"
 leapmux control admin settings set secure_cookies true
+leapmux control admin settings set trusted_proxy_ranges '["127.0.0.1"]'
 leapmux control admin settings set signup_enabled true
 leapmux control admin settings set smtp '{"host":"smtp.example.com","port":587,"username":"leapmux@example.com","from_address":"no-reply@example.com","tls_mode":"starttls"}'
 leapmux control admin settings set-secret smtp '{"password":"..."}'   # or read from your secret manager

--- a/site/content/docs/admin/configuration.md
+++ b/site/content/docs/admin/configuration.md
@@ -198,7 +198,9 @@ LeapMux reads forwarding headers only when the unchanged TCP peer matches the ex
 
 For `Forwarded`, LeapMux uses the `proto` value on the selected element. For X-Forwarded headers, one protocol value applies globally. Equal-length protocol and address lists align by position. LeapMux accepts only `http` and `https`; absent, empty, invalid, or misaligned protocol data becomes `http`.
 
-The verified client IP controls address-keyed rate limits and new session records. LeapMux keeps `RemoteAddr` as the physical peer. It sets the effective request URL scheme but does not change the TLS state. Set `secure_cookies` explicitly; forwarded protocol data never changes the cookie policy.
+The verified client IP controls address-keyed rate limits and new session records. LeapMux keeps `RemoteAddr` as the physical peer and does not change the TLS state.
+
+The verified protocol turns `secure_cookies` on for that request. A trusted proxy that reports `https` gets `__Host-` prefixed cookies, and base URLs the Hub builds use `https`, without a second setting. The rule is one-way: the verified protocol only ever turns the policy on, and the `secure_cookies` setting turns it on for every request whatever a proxy reports. An untrusted peer's protocol header is ignored, so no caller can give itself a secure cookie.
 
 ### Local IPC listen (`local_listen`)
 
@@ -280,7 +282,7 @@ Solo mode omits the settings a single-user Hub has no use for, from `settings li
 
 `public_url` stays: it sets the URL in the startup banner, and the `--hub` address you give a remote Worker. `open_app_registration` stays because a solo Hub authorizes apps like any other — see [App Authorization](/docs/admin/app-authorization/).
 
-The rest stay because a solo Hub whose account holds a password serves a real sign-in. `session_duration_seconds` and `secure_cookies` govern the session and the cookie that sign-in issues, so a Hub published behind a TLS proxy sets `secure_cookies` there like any other. `rate_limit.login_anonymous` and `rate_limit.oauth_anonymous` are keyed by client ADDRESS on surfaces a solo Hub also serves, and because solo runs no captcha, `login_anonymous` is the only thing that limits guesses at the sign-in form.
+The rest stay because a solo Hub whose account holds a password serves a real sign-in. `session_duration_seconds` and `secure_cookies` govern the session and the cookie that sign-in issues. A Hub published behind a trusted TLS proxy already gets secure cookies from the verified protocol; the setting is for a Hub that serves HTTPS through infrastructure it does not trust as a proxy. `rate_limit.login_anonymous` and `rate_limit.oauth_anonymous` are keyed by client ADDRESS on surfaces a solo Hub also serves, and because solo runs no captcha, `login_anonymous` is the only thing that limits guesses at the sign-in form.
 
 See [Accounts & Authentication](/docs/using/accounts/) for sign-up, passkeys, verification, and account-recovery flows, and [Sign-in Providers](/docs/admin/sign-in-providers/) for OAuth/OIDC.
 
@@ -673,7 +675,7 @@ leapmux hub --config /etc/leapmux/hub.yaml
 # survive and can change under the running Hub:
 leapmux control admin settings set public_url "https://hub.example.com"
 leapmux control admin settings set secure_cookies true
-leapmux control admin settings set trusted_proxy_ranges '["127.0.0.1"]'
+leapmux control admin settings set trusted_proxy_ranges '["127.0.0.1", "::1"]'
 leapmux control admin settings set signup_enabled true
 leapmux control admin settings set smtp '{"host":"smtp.example.com","port":587,"username":"leapmux@example.com","from_address":"no-reply@example.com","tls_mode":"starttls"}'
 leapmux control admin settings set-secret smtp '{"password":"..."}'   # or read from your secret manager

--- a/site/content/docs/admin/running-leapmux.md
+++ b/site/content/docs/admin/running-leapmux.md
@@ -15,7 +15,7 @@ The modes that accept inbound connections — `solo`, `hub`, and `dev` — all d
 
 | Mode | What it runs | Default listen | Login required | Config / data location |
 |------|--------------|----------------|----------------|------------------------|
-| `solo` | Hub + Worker in one process | `127.0.0.1:4327` (loopback only), plus any address you add | Not until the `solo` account has a password | `~/.config/leapmux/solo/` |
+| `solo` | Hub + Worker in one process | `127.0.0.1:4327` (loopback only), plus any address you add | Local IPC: no. TCP: first-password setup, then yes. | `~/.config/leapmux/solo/` |
 | `hub` | Hub service only | `:4327` (all interfaces) | Yes — full authentication | `~/.config/leapmux/hub/` |
 | `worker` | Worker only (connects out to a Hub) | n/a (no inbound port) | Registers with the Hub via a registration key | `~/.config/leapmux/worker/` |
 | `dev` | Hub + Worker in one process | `:4327` (all interfaces) | Yes — admin bootstrapped via `/setup` | `~/.config/leapmux/dev/` |
@@ -23,11 +23,11 @@ The modes that accept inbound connections — `solo`, `hub`, and `dev` — all d
 Each mode reads a YAML config file named after the mode inside its config directory — for example `~/.config/leapmux/hub/hub.yaml` for the Hub. The file is optional; a missing config file is silently skipped. The default data directory for each mode is the same as its config directory.
 
 {{< callout type="info" >}}
-`solo` and `dev` are the same program internally — both run a Hub and a Worker together in one process. Solo binds loopback only and has one account, `solo`, which starts with no password; until it has one, solo skips the login and treats every request as that admin. Dev binds all interfaces and uses password authentication from the start. Dev bootstraps its first admin through the `/setup` flow.
+`solo` and `dev` are the same program internally. Both run a Hub and a Worker together. Solo creates one account named `solo`. Local IPC uses it without a credential. A TCP caller can only set the first password until setup succeeds. Dev binds all interfaces and uses password authentication from the start. Dev creates its first admin through the `/setup` flow.
 {{< /callout >}}
 
 {{< callout type="warning" >}}
-While the `solo` account has no password, anyone who can reach the port has full admin access with no credentials. That is safe on `127.0.0.1`. If you bind solo to a non-loopback address in that state, LeapMux logs a startup warning, and the app replaces itself with a password-setup screen until you set one (see [Security & Threat Model](/docs/admin/security/#solo-mode-a-reduced-threat-model)).
+While the `solo` account has no password, the first TCP caller can claim it by setting that password. Other protected RPCs stay closed. If you bind solo to a non-loopback address in that state, LeapMux logs a startup warning. The app shows only the password-setup screen. See [Security & Threat Model](/docs/admin/security/#solo-mode-a-reduced-threat-model).
 
 ### Reaching a solo hub from another machine
 
@@ -40,7 +40,7 @@ A solo hub still has no sign-up, no passkeys, no account recovery and no email: 
 
 ## Solo mode
 
-Solo mode is the single-user setup that runs with no required configuration. Hub and Worker run in the same process on loopback, and the UI opens straight into the workspace with no sign-in.
+Solo mode is the single-user setup that runs with no required configuration. Hub and Worker run in the same process on loopback. A browser over TCP sets the first password before it opens the workspace. The desktop app opens through credential-free local IPC.
 
 ```bash
 leapmux solo
@@ -245,9 +245,18 @@ The Hub never terminates TLS on its own. To serve LeapMux over HTTPS, put a reve
 
 1. Set `public_url` to the external HTTPS URL: `leapmux control admin settings set public_url "https://hub.example.com"`.
 2. Enable secure cookies so they are `__Host-` prefixed and the derived base URL uses `https`: `leapmux control admin settings set secure_cookies true`. (This changes the cookie name, which signs every current session out — do it once, at setup.)
-3. Point each Worker's `-hub` URL at the same external `https://` address. Workers always initiate outbound connections, so they need no inbound ports of their own.
+3. Configure the direct proxy peer: `leapmux control admin settings set trusted_proxy_ranges '["127.0.0.1"]'`. Use the actual proxy address or range when it runs on another host.
+4. Point each Worker's `-hub` URL at the same external `https://` address. Workers always initiate outbound connections, so they need no inbound ports of their own.
 
-Both settings are hot: a running Hub applies them within ~30 seconds — no restart.
+All three settings are hot. A running Hub applies them within about 30 seconds, with no restart.
+
+`trusted_proxy_ranges` accepts IP addresses, CIDRs, inclusive ranges, short IPv4 ranges, and the symbolic provider tokens `cloudflare` and `cloudfront`. LeapMux prefers RFC 7239 `Forwarded`. It uses `X-Forwarded-For` and `X-Forwarded-Proto` only when `Forwarded` is absent. The Hub verifies the direct peer and walks the chain from the trusted side before it records a client IP.
+
+{{< callout type="warning" >}}
+The provider tokens identify all bundled provider ranges, not your account. Restrict the origin to your distribution or use authenticated origin requests. Configure every proxy to remove client-supplied forwarding headers or append only verified values. LeapMux does not download updated provider ranges automatically.
+{{< /callout >}}
+
+The effective forwarded protocol changes request URL metadata only. It does not enable secure cookies. Keep `secure_cookies` explicit as step 2 specifies.
 
 {{< callout type="warning" >}}
 `public_url` must be a bare scheme + host — for example `https://hub.example.com`. Sub-path mounting (such as `https://example.com/leapmux`) is **not** supported and is rejected at write time. Give LeapMux its own hostname or subdomain.

--- a/site/content/docs/admin/running-leapmux.md
+++ b/site/content/docs/admin/running-leapmux.md
@@ -245,7 +245,7 @@ The Hub never terminates TLS on its own. To serve LeapMux over HTTPS, put a reve
 
 1. Set `public_url` to the external HTTPS URL: `leapmux control admin settings set public_url "https://hub.example.com"`.
 2. Enable secure cookies so they are `__Host-` prefixed and the derived base URL uses `https`: `leapmux control admin settings set secure_cookies true`. (This changes the cookie name, which signs every current session out — do it once, at setup.)
-3. Configure the direct proxy peer: `leapmux control admin settings set trusted_proxy_ranges '["127.0.0.1"]'`. Use the actual proxy address or range when it runs on another host.
+3. Configure the direct proxy peer: `leapmux control admin settings set trusted_proxy_ranges '["127.0.0.1", "::1"]'`. Both loopback forms are listed because `proxy_pass http://localhost:4327` reaches the Hub over IPv6 on a dual-stack host, and an untrusted peer has its forwarding headers ignored with no error. Use the actual proxy address or range when the proxy runs on another host.
 4. Point each Worker's `-hub` URL at the same external `https://` address. Workers always initiate outbound connections, so they need no inbound ports of their own.
 
 All three settings are hot. A running Hub applies them within about 30 seconds, with no restart.

--- a/site/content/docs/admin/security.md
+++ b/site/content/docs/admin/security.md
@@ -236,17 +236,19 @@ Point solo mode at a non-loopback address with `-listen` and LeapMux warns you a
 The app shows only the password-setup screen on every passwordless TCP connection, including loopback. Set the password from a trusted connection. Firewall or tunnel a non-loopback address.
 {{< /callout >}}
 
-### Trusted reverse proxies
+The bundled Worker that solo and dev modes auto-register is created in-process and flagged as auto-registered; it deliberately bypasses the registration-key flow, since presenting a bearer token to a local in-process RPC would give no real security.
+
+The **desktop app** avoids the exposure differently: it always starts its in-process Hub with the TCP listener disabled, reaching it over a local Unix socket (named pipe on Windows) instead. There is no `--no-tcp` flag or setting — it is how the desktop app is built, and `leapmux solo` on the command line does not do it. So the desktop app opens no loopback port for its Hub, and the non-loopback warning above cannot apply to it. Tunnels you create yourself still bind a loopback TCP port, by design.
+
+## Trusted reverse proxies
+
+Every Hub mode reads this setting, so it is not part of the solo section above.
 
 LeapMux trusts no forwarding header by default. The `trusted_proxy_ranges` setting identifies the transport peers that may supply one. The Hub first verifies the unchanged physical peer. It then walks `Forwarded`, or X-Forwarded headers when `Forwarded` is absent, from the trusted side. A malformed preferred header produces an unknown client and no fallback.
 
 Provider presets such as `cloudflare` and `cloudfront` are broad trust decisions. They identify shared provider infrastructure, not your account. Another customer can target your origin unless you restrict it to your distribution or require authenticated origin requests. Each proxy must remove client-supplied forwarding headers or append only verified values. LeapMux bundles provider snapshots and does not refresh them automatically.
 
 The verified client IP controls address-keyed rate limits and new session records. Forwarded protocol data changes request URL metadata, but it never changes `secure_cookies`. Configure that setting explicitly. See [Trusted reverse proxies](/docs/admin/configuration/#trusted-reverse-proxies).
-
-The bundled Worker that solo and dev modes auto-register is created in-process and flagged as auto-registered; it deliberately bypasses the registration-key flow, since presenting a bearer token to a local in-process RPC would give no real security.
-
-The **desktop app** avoids the exposure differently: it always starts its in-process Hub with the TCP listener disabled, reaching it over a local Unix socket (named pipe on Windows) instead. There is no `--no-tcp` flag or setting — it is how the desktop app is built, and `leapmux solo` on the command line does not do it. So the desktop app opens no loopback port for its Hub, and the non-loopback warning above cannot apply to it. Tunnels you create yourself still bind a loopback TCP port, by design.
 
 ## Session elevation
 

--- a/site/content/docs/admin/security.md
+++ b/site/content/docs/admin/security.md
@@ -210,9 +210,9 @@ Both follow the same rule: first contact auto-pins, any later mismatch aborts th
 
 ## Solo mode: a reduced threat model
 
-Solo mode collapses the trust boundary on purpose. It runs the Hub and the Worker **in the same process**, by default on `127.0.0.1:4327`, and its single account — named `solo` — starts with **no password**. While that account has none, every request is authenticated as the administrator without credentials, so any local process that can reach the port can drive the Worker. (This applies to solo mode only. Dev mode uses real password authentication.)
+Solo mode collapses the local IPC trust boundary on purpose. It runs the Hub and the Worker in one process. Its account, `solo`, starts with no password. Local IPC always receives the synthetic administrator because only the local operating-system user can open that socket.
 
-So a fresh solo hub's threat model reduces to **local-host trust**. The E2EE channel, the composite keypair, and TOFU pinning all still operate end-to-end inside the single process, but that protocol-level separation offers **no protection against a local attacker** who can reach the loopback port.
+A TCP caller does not receive that administrator. Before a password exists, it can call only `SetInitialSoloPassword`. The first successful caller stores the password and an elevated session in one transaction. All concurrent losers and later calls fail. This setup flow prevents passwordless administration, but it does not identify the first caller.
 
 ### What a password changes
 
@@ -221,7 +221,7 @@ Give the `solo` account a password and the rule changes for every TCP address at
 | Transport | `solo` password | Result |
 |---|---|---|
 | Local socket (the desktop app) | either | No sign-in. Only a process running as you can open it. |
-| TCP, any address | not set | No sign-in. This is the bootstrap state, and it is why the first password can be set from a browser at all. |
+| TCP, any address | not set | Only first-password setup. The first successful caller claims the account. |
 | TCP, any address | set | Sign in as `solo`. This covers `127.0.0.1` and every address you added. |
 
 Loopback buys no exemption once a password exists, and that is deliberate: an address like `*:4327` serves the loopback interface and the LAN from **one socket**, so no rule could admit the first and refuse the second. Reading a loopback port also does not make a process the owner of the account.
@@ -231,10 +231,18 @@ Setting the password is what [Network access](/docs/admin/configuration/#network
 A solo hub runs no captcha, so a rate limit guards the sign-in form instead: ten failed passwords from one client address pause sign-in from that address for fifteen minutes. `rate_limit.login_anonymous` sets it — see [Bot protection](/docs/admin/configuration/#bot-protection-captcha--rate-limits).
 
 {{< callout type="warning" >}}
-Point solo mode at a non-loopback address with `-listen` and LeapMux warns you at startup: the hub is reachable from other machines, and until the `solo` account has a password every request is authenticated as the administrator without credentials.
+Point solo mode at a non-loopback address with `-listen` and LeapMux warns you at startup. Until the `solo` account has a password, another machine can win the first-password setup race.
 
-The app makes the same demand where you can act on it — while the hub answers on such an address and the account has no password, it replaces itself with a password-setup screen. Set one. Firewall or tunnel the address as well if the network is not one you trust.
+The app shows only the password-setup screen on every passwordless TCP connection, including loopback. Set the password from a trusted connection. Firewall or tunnel a non-loopback address.
 {{< /callout >}}
+
+### Trusted reverse proxies
+
+LeapMux trusts no forwarding header by default. The `trusted_proxy_ranges` setting identifies the transport peers that may supply one. The Hub first verifies the unchanged physical peer. It then walks `Forwarded`, or X-Forwarded headers when `Forwarded` is absent, from the trusted side. A malformed preferred header produces an unknown client and no fallback.
+
+Provider presets such as `cloudflare` and `cloudfront` are broad trust decisions. They identify shared provider infrastructure, not your account. Another customer can target your origin unless you restrict it to your distribution or require authenticated origin requests. Each proxy must remove client-supplied forwarding headers or append only verified values. LeapMux bundles provider snapshots and does not refresh them automatically.
+
+The verified client IP controls address-keyed rate limits and new session records. Forwarded protocol data changes request URL metadata, but it never changes `secure_cookies`. Configure that setting explicitly. See [Trusted reverse proxies](/docs/admin/configuration/#trusted-reverse-proxies).
 
 The bundled Worker that solo and dev modes auto-register is created in-process and flagged as auto-registered; it deliberately bypasses the registration-key flow, since presenting a bearer token to a local in-process RPC would give no real security.
 
@@ -385,7 +393,7 @@ If you run a Hub for a team, the security of the deployment rests largely on the
 2. **Terminate TLS in front of the Hub.** The Frontend↔Hub and Worker↔Hub legs are not E2EE; they rely on transport TLS. Put the Hub behind a reverse proxy with valid certificates. See [Running LeapMux](/docs/admin/running-leapmux/).
 3. **Guard the `encryption.key` file like a top-grade secret.** It is base64 key material in a plain text file at mode `0600` — there is no master password, KMS, or HSM wrapping, so filesystem permissions are the only thing protecting it. It holds both the encryption key ring and the token pepper, so whoever reads it can decrypt the OAuth columns *and* forge the hash of any API or delegation token. Back it up with the database, store both encrypted, and restrict access.
 4. **Rotate encryption keys deliberately.** Use `rotate` → restart → `reencrypt`, and never `remove` an old version before the re-encryption migrated every row. The exact runbook is in [Encryption & Data](/docs/admin/encryption-and-data/).
-5. **Give the `solo` account a password before you expose solo mode beyond loopback.** Without one, a non-loopback address is unauthenticated admin access. Run `leapmux hub` for authenticated multi-user deployments, and firewall or tunnel any non-loopback access. See [Configuration](/docs/admin/configuration/#network-access) for listen addresses.
+5. **Give the `solo` account a password before you expose solo mode beyond loopback.** Without one, the first TCP caller can claim the account. Run `leapmux hub` for authenticated multi-user deployments, and firewall or tunnel any non-loopback access. See [Configuration](/docs/admin/configuration/#network-access) for listen addresses.
 6. **Mint registration keys carefully.** A valid registration key immediately produces an active Worker — there is no separate approval queue, so possession of a live key *is* the gate. Keys are single-use, expire 5 minutes after issue, and the UI dialog destroys the key when closed. Note the 5 minutes is per issuance, not a hard lifetime: an open registration dialog auto-extends its key as expiry approaches, so a key stays live as long as the dialog is open. Treat them as one-time secrets, deliver them over a trusted channel, and close the dialog when you are done. See [Managing Workers](/docs/admin/managing-workers/).
 7. **Teach users to take the key-change dialog seriously.** The "Worker public key changed" prompt is the user-facing line of defense against a Hub swapping a Worker. Users should reject unexpected changes and verify the 4-word fingerprint out-of-band before ever accepting.
 8. **Revoke credentials when needed, and know it tears down channels.** Revocation force-closes the affected user's open channels; see [Channels don't outlive their credential](#channels-dont-outlive-their-credential) for which operations do it and the two cases that behave unexpectedly. Run these operations with `leapmux control admin`: `session revoke-user`, `api-token revoke`, and `delegation-token revoke`. See [`admin` — hub administration over RPC](/docs/admin/admin-cli/).

--- a/site/content/docs/admin/security.md
+++ b/site/content/docs/admin/security.md
@@ -248,7 +248,7 @@ LeapMux trusts no forwarding header by default. The `trusted_proxy_ranges` setti
 
 Provider presets such as `cloudflare` and `cloudfront` are broad trust decisions. They identify shared provider infrastructure, not your account. Another customer can target your origin unless you restrict it to your distribution or require authenticated origin requests. Each proxy must remove client-supplied forwarding headers or append only verified values. LeapMux bundles provider snapshots and does not refresh them automatically.
 
-The verified client IP controls address-keyed rate limits and new session records. Forwarded protocol data changes request URL metadata, but it never changes `secure_cookies`. Configure that setting explicitly. See [Trusted reverse proxies](/docs/admin/configuration/#trusted-reverse-proxies).
+The verified client IP controls address-keyed rate limits and new session records. The verified protocol turns `secure_cookies` on for that request, so a Hub behind a TLS-terminating proxy writes `__Host-` cookies without a second setting. Only a trusted peer's protocol is read, and the rule is one-way: it never turns the policy off. See [Trusted reverse proxies](/docs/admin/configuration/#trusted-reverse-proxies).
 
 ## Session elevation
 

--- a/site/content/docs/getting-started/concepts.md
+++ b/site/content/docs/getting-started/concepts.md
@@ -54,10 +54,10 @@ LeapMux runs in two shapes. They use the same components and the same end-to-end
    └───────────────┘
 ```
 
-Solo mode is ideal for one person on one machine. While its one account has no password it authenticates every request as the admin, and it binds loopback, so the security model **reduces to local trust**: any local process that can reach the port can drive the Worker. The end-to-end encryption between Frontend and Worker still operates inside the process, but it offers no protection against an attacker who is already on your machine. Give that account a password and every network address asks for it.
+Solo mode is for one person. Local IPC uses its one account without a credential. A passwordless TCP caller can only set the first password, and the first successful caller claims the account. After setup, every TCP address requires sign-in. The end-to-end encryption between Frontend and Worker still operates inside the process, but it does not protect against an attacker who already controls your user account.
 
 {{< callout type="warning" >}}
-If solo mode answers on a non-loopback address, it logs a warning. The warning states that the hub is reachable from other machines, and that until the `solo` account has a password every request is authenticated as the administrator without credentials. Set that password — the app asks for one before anything else while such an address is served — and restrict access with a firewall, Tailscale/WireGuard, or an SSH tunnel if the network is not one you trust. The desktop app avoids the question entirely by listening on a Unix socket / named pipe instead of TCP.
+If solo mode answers on a non-loopback address, it logs a warning. Another machine can win first-password setup until the `solo` account has a password. Set that password from a trusted connection. Restrict access with a firewall, VPN, or SSH tunnel. The desktop app listens on a Unix socket or named pipe instead of TCP.
 {{< /callout >}}
 
 ### Distributed mode

--- a/site/content/docs/getting-started/installation.md
+++ b/site/content/docs/getting-started/installation.md
@@ -134,7 +134,7 @@ Use `dev` (not `solo`) for an all-in-one container. In `solo` mode the binary de
 {{< /callout >}}
 
 {{< callout type="warning" >}}
-The Hub does not terminate TLS itself. To serve LeapMux over HTTPS, put a reverse proxy in front of the container and set `public_url` and `secure_cookies` with `leapmux control admin settings set`. See [Running LeapMux](/docs/admin/running-leapmux/) and [Configuration](/docs/admin/configuration/) for reverse-proxy guidance.
+The Hub does not terminate TLS itself. To serve LeapMux over HTTPS, put a reverse proxy in front of the container. Set `public_url`, `secure_cookies`, and `trusted_proxy_ranges` with `leapmux control admin settings set`. See [Running LeapMux](/docs/admin/running-leapmux/) and [Configuration](/docs/admin/configuration/) for reverse-proxy guidance.
 {{< /callout >}}
 
 ### Running a Worker container

--- a/site/content/docs/getting-started/introduction.md
+++ b/site/content/docs/getting-started/introduction.md
@@ -17,7 +17,7 @@ LeapMux exists to fix exactly that. It gives every agent its own git worktree an
 
 LeapMux is a workspace for running several coding agents and shell terminals at once, each in a git worktree and branch you pick, tiled or floating, on a local or remote machine. Agent sessions stay attached across restarts. Traffic to your agents is end-to-end encrypted. LeapMux runs in your browser or as a native desktop app.
 
-It is a single program (`leapmux`) you can run two ways. The simplest is **solo mode** (`leapmux solo`): one command on your own machine, with no login and nothing to configure — ideal for a laptop or dev box. For a team, a **distributed** setup runs a central **Hub** that several people sign in to, while the agents themselves run on one or more separate machines — including remote boxes behind a NAT or firewall. The native desktop app can do either.
+It is a single program (`leapmux`) you can run two ways. The simplest is **solo mode** (`leapmux solo`): one command for one account. The desktop app uses credential-free local IPC. A TCP browser sets the first password. For a team, a **distributed** setup runs a central **Hub** that several people sign in to, while the agents run on separate machines. The native desktop app can do either.
 
 Whichever way you run it, your work — agent transcripts, terminal output, and file contents — stays on the machine that runs the agents, never on the Hub. The Hub only relays encrypted traffic it cannot read. For exactly how the pieces fit together — the components, the two deployment shapes, and the trust boundaries — see [Concepts & Architecture](/docs/getting-started/concepts/).
 

--- a/site/content/docs/getting-started/quick-start.md
+++ b/site/content/docs/getting-started/quick-start.md
@@ -8,7 +8,7 @@ weight: 4
 This chapter gets you from zero to a working coding agent in a few minutes. Pick one of two launch paths, then follow the walkthrough to open your first agent, send a message, and open a terminal beside it.
 
 {{< callout type="info" >}}
-Both paths run LeapMux in **solo mode** — a Hub and a Worker running together in a single local process, with no login at first and your data kept on your machine. This is the fastest way to try LeapMux. For multi-user or remote setups, see [Running LeapMux](/docs/admin/running-leapmux/) and [Managing Workers](/docs/admin/managing-workers/).
+Both paths run LeapMux in **solo mode** — a Hub and a Worker running together in a single local process. The desktop app uses credential-free local IPC. A browser over TCP sets the first solo password before it opens the app. Your data stays on your machine. For multi-user or remote setups, see [Running LeapMux](/docs/admin/running-leapmux/) and [Managing Workers](/docs/admin/managing-workers/).
 {{< /callout >}}
 
 ## Before you begin
@@ -45,7 +45,7 @@ This runs a Hub and a Worker in one process, listening on loopback only at **`12
 http://127.0.0.1:4327
 ```
 
-No login is required — solo mode's single account starts with no password, so the Hub authenticates every request as the admin. Give that account a password to reach the same Hub from another machine; see [Network access](/docs/admin/configuration/#network-access).
+The browser first asks you to set the password for the single `solo` account. The Hub stores that password and an elevated session together. Until this succeeds, the TCP caller can only complete this setup. The desktop app uses a local socket and needs no credential.
 
 A few useful flags (full reference in [Configuration](/docs/admin/configuration/) and [CLI Reference](/docs/reference/cli-reference/)):
 
@@ -57,7 +57,7 @@ A few useful flags (full reference in [Configuration](/docs/admin/configuration/
 | `-config` | Path to the config file | `~/.config/leapmux/solo/solo.yaml` |
 
 {{< callout type="warning" >}}
-While the `solo` account has no password, solo mode trusts every request as the admin. If you change `-listen` to a non-loopback address in that state, anyone who can reach that port has full admin access without credentials. For how to expose solo mode safely, see [Security & Threat Model](/docs/admin/security/).
+If you change `-listen` to a non-loopback address before setup, the first TCP caller can claim the `solo` account by setting its password. Other protected RPCs stay closed. Set the password from a trusted connection and restrict the address with a firewall or tunnel. See [Security & Threat Model](/docs/admin/security/).
 {{< /callout >}}
 
 {{< callout >}}

--- a/site/content/docs/reference/cli-reference.md
+++ b/site/content/docs/reference/cli-reference.md
@@ -35,7 +35,7 @@ Any command name can be shortened as far as it stays unambiguous.
 
 | Command | What it does | Reference |
 |---------|--------------|-----------|
-| `solo` | Hub + Worker in one process, loopback by default, no login until you set a password | [Running LeapMux](/docs/admin/running-leapmux/) |
+| `solo` | Hub + Worker in one process; local IPC is credential-free and TCP starts with password setup | [Running LeapMux](/docs/admin/running-leapmux/) |
 | `hub` | Hub service only; Workers connect separately | [Running LeapMux](/docs/admin/running-leapmux/) |
 | `worker` | Worker only; connects out to a Hub | [Managing Workers](/docs/admin/managing-workers/) |
 | `dev` | Hub + Worker in one process with real auth (development) | [Running LeapMux](/docs/admin/running-leapmux/) |
@@ -59,7 +59,7 @@ Flags accept both single- and double-hyphen forms (`-listen` and `--listen` are 
 
 ## solo
 
-Run a Hub and a Worker in one process on loopback. There is no login until the `solo` account has a password; setting one makes every network address ask for it. See [Running LeapMux](/docs/admin/running-leapmux/#solo-mode) for details, and [Network access](/docs/admin/configuration/#network-access) for serving more than loopback.
+Run a Hub and a Worker in one process on loopback. Local IPC needs no credential. A TCP browser sets the first `solo` password, then every TCP address asks for it. See [Running LeapMux](/docs/admin/running-leapmux/#solo-mode) and [Network access](/docs/admin/configuration/#network-access).
 
 ```bash
 leapmux solo [flags]
@@ -82,7 +82,7 @@ leapmux solo [flags]
 | `-version` | — | Print version and exit |
 
 {{< callout type="info" >}}
-Binding solo to a non-loopback address logs a warning, because a fresh solo hub has no password on its one account. Set one (see [Network access](/docs/admin/configuration/#network-access)), or use `hub` or `dev` for a multi-user deployment.
+Binding solo to a non-loopback address logs a warning. Before the account has a password, the first TCP caller can claim it through the restricted setup flow. Set the password first, or use `hub` or `dev` for a multi-user deployment.
 {{< /callout >}}
 
 {{< callout type="info" >}}

--- a/site/content/docs/reference/faq.md
+++ b/site/content/docs/reference/faq.md
@@ -9,7 +9,7 @@ Short answers to the questions people ask most often about LeapMux. Each one lin
 
 ## Do I need a server, or can I just run it locally?
 
-You can run everything locally. The `leapmux solo` command starts a Hub and a Worker in a single process, bound to `127.0.0.1:4327`, with no login required — it authenticates every request as the admin while its single account has no password. The desktop app does the same thing, listening only on a local socket so it opens no TCP port at all. Set that account a password and add an address in **Preferences → Administration → Network access** to reach the same Hub from another machine.
+You can run everything locally. The `leapmux solo` command starts a Hub and a Worker on `127.0.0.1:4327`. A TCP browser sets the first `solo` password before it opens the app. The desktop app listens only on a local socket and needs no credential. Add another address under **Preferences → Administration → Network access** to reach the same Hub from another machine.
 
 You only need a separate Hub when you want multiple users, remote Workers, or sign-in. In that case run `leapmux hub` (central relay, real authentication) and connect one or more `leapmux worker` processes to it.
 
@@ -17,10 +17,10 @@ See [Running LeapMux](/docs/admin/running-leapmux/) for the run modes and [Conce
 
 ## Is solo mode multi-user?
 
-No. Solo mode is single-user by design: it has one account, `solo`. Until that account has a password, every request is authenticated as the admin without credentials, so it offers no protection against another process that can reach the port.
+No. Solo mode is single-user by design. It has one account, `solo`. Local IPC uses that account without a credential. A passwordless TCP caller can only set the first password, but the first successful caller claims the account.
 
 {{< callout type="warning" >}}
-If you ever bind solo mode to a non-loopback address, anyone who can reach the port has full admin access with no password. LeapMux logs a warning when this happens. For multi-user or networked use, run `leapmux hub` instead, or place solo behind a firewall, VPN (Tailscale/WireGuard), or SSH tunnel.
+If you bind solo mode to a non-loopback address before setup, another machine can claim the account. LeapMux logs a warning. Set the password first and use a firewall, VPN, or SSH tunnel. Use `leapmux hub` for multi-user service.
 {{< /callout >}}
 
 For real multi-user setups see [Accounts & Authentication](/docs/using/accounts/) and [Managing Workers](/docs/admin/managing-workers/).

--- a/site/content/docs/reference/glossary.md
+++ b/site/content/docs/reference/glossary.md
@@ -139,7 +139,7 @@ The persistent state of a running coding agent — its conversation history and 
 
 ### Solo mode
 
-The single-user, all-in-one mode (`leapmux solo`) that runs a Hub and a Worker in one process on `127.0.0.1:4327`. Its one account, `solo`, starts with **no password**, and until it has one every request is authenticated as the admin without credentials — so a fresh solo hub's security reduces to local-host trust: any local process that can reach the port has full access. Setting a password makes every network address ask for it, which is what lets solo mode serve more than loopback. Binding it to a non-loopback address without one triggers a warning. Contrast with **distributed mode**. See [Running LeapMux](/docs/admin/running-leapmux/) and [Security & Threat Model](/docs/admin/security/).
+The single-user mode (`leapmux solo`) that runs a Hub and a Worker in one process. Its account, `solo`, starts without a password. Local IPC uses the account without a credential. TCP exposes only first-password setup until one caller claims the account. After setup, every TCP address requires sign-in. Binding a passwordless solo hub to a non-loopback address triggers a warning. Contrast with **distributed mode**. See [Running LeapMux](/docs/admin/running-leapmux/) and [Security & Threat Model](/docs/admin/security/).
 
 ### Step-up
 

--- a/site/content/docs/reference/troubleshooting.md
+++ b/site/content/docs/reference/troubleshooting.md
@@ -169,15 +169,31 @@ See [Running LeapMux](/docs/admin/running-leapmux/) and [Configuration](/docs/ad
 The browser can't connect to the Hub at all (connection refused / timeout) from a different host than the one running LeapMux.
 
 **Cause**
-Solo mode binds **`127.0.0.1:4327`** (loopback only) by default — it is unreachable from other machines on purpose, because until the `solo` account has a password every request is authenticated as the admin with no credentials.
+Solo mode binds **`127.0.0.1:4327`** by default, so another machine cannot reach it. A TCP browser on the same machine completes the restricted first-password setup.
 
 **Fix**
 - For local single-user use, browse to `http://127.0.0.1:4327` on the same machine.
 - To serve other machines, do **not** simply rebind solo to all interfaces. Either:
   - Run `leapmux hub` (or `dev`), which use real authentication and bind `:4327` (all interfaces) by default; or
-  - To expose solo mode, set the `solo` account's password first and add the address in **Preferences → Administration → Network access**; every network address then asks for that password. Restrict access externally as well (firewall, Tailscale/WireGuard, SSH tunnel) if the network is not one you trust. Solo mode emits a warning when it binds a non-loopback address, because until that password exists every request is authenticated as the admin without credentials. See [Security & Threat Model](/docs/admin/security/) for the full implications.
+  - To expose solo mode, set the `solo` password first and add the address in **Preferences → Administration → Network access**. Every TCP address then asks for that password. Restrict access with a firewall, VPN, or SSH tunnel. Solo mode warns on a non-loopback address because another machine can win first-password setup before the password exists. See [Security & Threat Model](/docs/admin/security/).
 
 See [Running LeapMux](/docs/admin/running-leapmux/) for binding and listen-address options.
+
+### Sessions or rate limits show the reverse proxy address
+
+**Symptom**
+Session records show the proxy IP, or all users behind the proxy share one address-keyed rate limit.
+
+**Cause**
+The direct proxy peer does not match `trusted_proxy_ranges`, or the preferred forwarding header is malformed. LeapMux ignores forwarding headers from untrusted peers. If `Forwarded` exists, LeapMux does not fall back to X-Forwarded headers.
+
+**Fix**
+- Add the direct proxy address or range under **Preferences → Administration → Network access → Trusted reverse proxies**.
+- Configure the proxy to remove client-supplied forwarding headers or append only verified values.
+- Correct or remove a malformed `Forwarded` header before you rely on `X-Forwarded-For`.
+- Use a manual range when a bundled `cloudflare` or `cloudfront` snapshot does not contain the current proxy address.
+
+See [Trusted reverse proxies](/docs/admin/configuration/#trusted-reverse-proxies) for selector forms and security requirements.
 
 ### Blank page or the UI won't load in development
 

--- a/site/content/docs/using/accounts.md
+++ b/site/content/docs/using/accounts.md
@@ -15,16 +15,16 @@ LeapMux runs in several modes (see [Running LeapMux](/docs/admin/running-leapmux
 
 | Mode | Account needed? | What you see |
 | --- | --- | --- |
-| **Solo** (`leapmux solo`) | Not at first | No signup screen. LeapMux creates a single user called `solo` that starts with no password, and authenticates every request as it until that password exists. |
+| **Solo** (`leapmux solo`) | One fixed account | No signup screen. Local IPC uses `solo` without a credential. TCP asks the first caller to set its password. |
 | **Dev** (`leapmux dev`) | Yes | Real password authentication. The first admin is created through the `/setup` flow. |
 | **Hub** (`leapmux hub`) | Yes | Full authentication: signup, password login, sessions, OAuth, API tokens. |
 
-In **solo mode** there is nothing to sign up for, and nothing to sign out of until the `solo` account has a password. While it has none, `/login` and `/signup` redirect you straight into the app. Solo mode disables most account actions: it refuses a change to your profile or your email, and it refuses to detach an OAuth provider. Each refusal identifies the action that solo mode does not support.
+In **solo mode** there is nothing to sign up for. Local IPC opens the app without a credential. A passwordless TCP connection shows only the first-password setup screen. It cannot call another protected RPC. After setup, TCP shows the normal sign-in page.
 
 **Password is the exception.** **Preferences → Account → Password** is the one account row solo mode keeps, and it both sets the account's first password and changes it afterwards. Setting one is also what lets the Hub answer on a network address, so **Preferences → Administration → Network access** asks for that first password as well, beside the addresses it guards. See [Network access](/docs/admin/configuration/#network-access).
 
 {{< callout type="info" >}}
-While the `solo` account has no password, solo mode authenticates *every* request as the admin. If the Hub answers on a non-loopback address in that state, anyone who can reach the port has full admin access without credentials, and LeapMux warns you about it at startup. Set the password: every network address then asks for it, `127.0.0.1` included. For a multi-user deployment, run `leapmux hub` (or `leapmux dev`). See [Security & Threat Model](/docs/admin/security/).
+If the Hub answers on a non-loopback address before setup, the first TCP caller can claim the `solo` account. LeapMux warns at startup. Set the password from a trusted connection. Every TCP address then asks for it, including `127.0.0.1`. For a multi-user deployment, run `leapmux hub` or `leapmux dev`. See [Security & Threat Model](/docs/admin/security/).
 {{< /callout >}}
 
 The rest of this chapter applies to **hub** and **dev** mode, where accounts are real.

--- a/site/content/docs/using/accounts.md
+++ b/site/content/docs/using/accounts.md
@@ -19,7 +19,7 @@ LeapMux runs in several modes (see [Running LeapMux](/docs/admin/running-leapmux
 | **Dev** (`leapmux dev`) | Yes | Real password authentication. The first admin is created through the `/setup` flow. |
 | **Hub** (`leapmux hub`) | Yes | Full authentication: signup, password login, sessions, OAuth, API tokens. |
 
-In **solo mode** there is nothing to sign up for. Local IPC opens the app without a credential. A passwordless TCP connection shows only the first-password setup screen. It cannot call another protected RPC. After setup, TCP shows the normal sign-in page.
+In **solo mode** there is nothing to sign up for. Local IPC opens the app without a credential. A passwordless TCP connection shows only the first-password setup screen. It cannot call another protected RPC. After setup, TCP shows the normal sign-in page. Solo mode also disables most account actions in every state: it refuses a change to your profile or your email, and it refuses to detach an OAuth provider. Each refusal identifies the action that solo mode does not support.
 
 **Password is the exception.** **Preferences → Account → Password** is the one account row solo mode keeps, and it both sets the account's first password and changes it afterwards. Setting one is also what lets the Hub answer on a network address, so **Preferences → Administration → Network access** asks for that first password as well, beside the addresses it guards. See [Network access](/docs/admin/configuration/#network-access).
 

--- a/site/content/docs/using/control-cli.md
+++ b/site/content/docs/using/control-cli.md
@@ -628,7 +628,7 @@ A `--hub` value may be a hub IPC listener (`unix:$HOME/.config/leapmux/hub/hub.s
 
 Login rules:
 
-- **Solo needs no login over its local socket.** That socket is reachable only from the machine that runs the Hub, so ordinary commands need no credential there — which is the default `--hub` for solo. A TCP address asks for one once the `solo` account holds a password; see [Solo mode: a reduced threat model](/docs/admin/security/#solo-mode-a-reduced-threat-model). Solo still **authorizes apps**: a login there mints a scoped credential, and the Hub binds that credential's permissions rather than the solo account's. Both flows complete, because the consent pages accept the solo account. See [App Authorization](/docs/admin/app-authorization/#solo-mode).
+- **Solo needs no login over its local socket.** That socket is reachable only from the machine that runs the Hub, so ordinary commands need no credential there. TCP never receives this exemption. Before the `solo` password exists, a TCP caller can only set the first password. Afterward, TCP requires a normal login. See [Solo mode: a reduced threat model](/docs/admin/security/#solo-mode-a-reduced-threat-model).
 - A **non-solo hub over a socket** uses `--device-code`: `leapmux control auth login --hub unix:...hub.sock --device-code` dials the socket for the token exchange while you approve in a browser against the hub's **public** origin (which the hub derives itself from its settings — not from `--hub`). The PKCE local-redirect flow is refused for socket URLs with a message pointing at `--device-code`, because a browser cannot reach a socket hub origin.
 
 ```bash

--- a/site/content/docs/using/control-cli.md
+++ b/site/content/docs/using/control-cli.md
@@ -628,7 +628,7 @@ A `--hub` value may be a hub IPC listener (`unix:$HOME/.config/leapmux/hub/hub.s
 
 Login rules:
 
-- **Solo needs no login over its local socket.** That socket is reachable only from the machine that runs the Hub, so ordinary commands need no credential there. TCP never receives this exemption. Before the `solo` password exists, a TCP caller can only set the first password. Afterward, TCP requires a normal login. See [Solo mode: a reduced threat model](/docs/admin/security/#solo-mode-a-reduced-threat-model).
+- **Solo needs no login over its local socket.** That socket is reachable only from the machine that runs the Hub, so ordinary commands need no credential there. TCP never receives this exemption. Before the `solo` password exists, a TCP caller can only set the first password. Afterward, TCP requires a normal login. See [Solo mode: a reduced threat model](/docs/admin/security/#solo-mode-a-reduced-threat-model). Solo still **authorizes apps**: a login mints a scoped credential, and the Hub binds that credential's permissions rather than the solo account's. Both flows complete, because the consent pages accept the solo account. See [App Authorization](/docs/admin/app-authorization/#solo-mode).
 - A **non-solo hub over a socket** uses `--device-code`: `leapmux control auth login --hub unix:...hub.sock --device-code` dials the socket for the token exchange while you approve in a browser against the hub's **public** origin (which the hub derives itself from its settings — not from `--hub`). The PKCE local-redirect flow is refused for socket URLs with a message pointing at `--device-code`, because a browser cannot reach a socket hub origin.
 
 ```bash

--- a/site/content/docs/using/settings.md
+++ b/site/content/docs/using/settings.md
@@ -236,13 +236,19 @@ Every row here stays in solo mode. A solo Hub whose account holds a password sig
 
 ### Network access
 
-Solo mode only. Which addresses this Hub answers on, beside the one `-listen` gives it, and the password that guards them.
+This section appears in solo, hub, and dev modes. It contains two separate rows.
+
+**Network access** appears only in solo mode. It controls which addresses the Hub answers on beside the one `-listen` gives it.
 
 **Serving now** lists what the Hub answers on right now, with the reason for each entry — from `-listen`, an address you added, or one socket serving both. **Additional addresses** is the editable list: pick an interface (or **All interfaces**) and a port for each, then **Apply**. The Hub binds them at once and again on every later start.
 
-Applying an address asks every network address for a sign-in as `solo`, `127.0.0.1` included, so the panel asks you to set that password first and shows the same fields the sign-up page uses. Once the account has one, the panel points at **Account → Password** instead. The desktop app's local socket never asks.
+Applying an address makes every TCP address require a sign-in as `solo`, including `127.0.0.1`. The panel stores the first password before it publishes a non-loopback address. The desktop app's local socket stays credential-free.
 
 Overlapping addresses merge: ask for every interface on the port `-listen` already uses and one socket serves both, which the "Serving now" list says. An address the Hub cannot bind stays configured and is reported with the operating system's own reason. See [Network access](/docs/admin/configuration/#network-access) and [Solo mode: a reduced threat model](/docs/admin/security/#solo-mode-a-reduced-threat-model).
+
+**Trusted reverse proxies** appears in every Hub mode. Add an IP address, CIDR, inclusive range, short IPv4 range, or the `cloudflare` or `cloudfront` provider preset. Rows stay staged until **Apply**. **Cancel** restores the stored list, and backend validation errors leave the staged rows in place.
+
+The provider warning cannot be dismissed. Provider ranges identify shared infrastructure, not your account. Restrict the origin to your distribution or use authenticated origin requests. Configure every proxy to remove client-supplied forwarding headers or append only verified values. See [Trusted reverse proxies](/docs/admin/configuration/#trusted-reverse-proxies) for header precedence and the full selector rules.
 
 ### Sign-up & Access
 


### PR DESCRIPTION
## Motivation

Two reachable security defects drove this branch.

1. A passwordless solo hub authenticated any TCP caller as the synthetic
   `solo` administrator. Any caller that reached the port held every
   protected RPC.
2. The RPC that replaces that bootstrap path, `SetInitialSoloPassword`,
   shipped with no rate limit and no captcha. An unauthenticated caller
   could run unlimited Argon2id hashing (19 MiB per call) against the
   same exposed hub the RPC exists to protect.

Alongside them, the hub could not name its own callers. It terminates no
TLS itself, so behind a reverse proxy it saw the proxy's address for
every client: one shared rate-limit budget covered everybody behind that
proxy, and every session row recorded the proxy. Reading a forwarding
header without checking who sent it would be worse than not reading one,
because any caller could then claim any address and escape its own
budget or spend somebody else's. So this branch adds a `requestsource`
middleware that verifies the client IP and the TLS-termination state,
and trusts `Forwarded` and `X-Forwarded-*` only when the raw transport
peer matches a configured trusted-proxy range.

## Modifications

**Trusted-proxy verification.** A new `requestsource` package parses the
`Forwarded` and `X-Forwarded-*` headers per RFC 7239. The parser handles
quoted strings, escapes, bracketed IPv6 addresses, and repeated header
lines, and it refuses a duplicate parameter. The package walks the
forwarding chain from the right and stops at the first hop that is not a
trusted proxy, and it trusts a hop only when the raw transport peer
matches a selector in `trusted_proxy_ranges` (a literal IP, a CIDR
range, an inclusive range, or a vendored Cloudflare or CloudFront
provider table). The middleware installs as the outermost HTTP layer and
writes two new marks on `peer`: `ClientIP`/`WithClientIP` and
`IsHTTPS`/`WithHTTPS`. The change renames `RemoteAddr` to
`TransportAddr` to mark it as the connection peer that a caller cannot
spoof, and it deletes `RemoteHost`/`HostOf`. A new contract,
`contracts/trusted-proxies.json`, defines the selector cap (32) and the
provider catalogue. A new `TrustedProxiesControl` editor lists and edits
these selectors; the Network access section now stays visible on a
multi-user hub, because this control does not require solo mode.

**Solo bootstrap hardening.** `SoloGate.CredentialFree` no longer
accepts a TCP caller as credential-free. Credential-free access now
works over the local IPC socket only. A new RPC,
`AuthService.SetInitialSoloPassword`, is the one public action a TCP
caller keeps: it hashes the password, creates a session, and elevates
that session, all inside one transaction, and its response carries the
new `User` and an `elevation_expires_at` deadline. The RPC carries its
own rate-limit operation, `OpSoloPasswordSetup`, which counts an
admitted request only, so a refusal that lands before the hash costs the
caller nothing. A tripwire test walks every procedure that consumes a
credential and checks that a rate limit or a captcha covers it; the test
now also walks `auth.proto`, not only `user.proto`, and that wider walk
is how the missing rate limit came to light.
`UserService.ChangePassword` no longer hands back a session; that job
moved to the new RPC. `grantSessionElevation` splits into a bare row
write (`elevateSessionRow`) and the cache invalidation, so the new RPC
can write the row inside its transaction and invalidate only after
commit.

**Client IP in rate limits and sessions.** `anonymousBudgetKey` now
reads the verified client IP first, and falls back to the raw transport
address only when the middleware cannot verify one. This closes a bug:
every request the middleware could not name (a malformed forwarding
header, an all-trusted chain, a `for=unknown` node, or an IPv6
link-local peer) fell into the same "unknown" bucket as the local IPC
socket, so a remote caller could exhaust the desktop app's own
rate-limit window. `auth.CreateSession` now derives the client IP
itself, so `SessionMeta.IPAddress` is removed. `settings.SecureCookiesFor`
and `settings.BaseURLFor` combine the configured setting with a
per-request "a trusted proxy verified HTTPS" signal, one-way only: the
signal can turn `Secure` on but never off. The WebSocket handlers'
`secureCookie` callback changes from `func() bool` to
`func(context.Context) bool` to carry that signal.

**One `SoloAccess` enum.** `GetSystemInfoResponse` used two booleans that
could disagree. The proto now reuses field 17 for one exclusive enum,
`SoloAccess` (`UNSPECIFIED`, `CREDENTIAL_FREE`, `PASSWORD_SETUP`,
`SIGN_IN_REQUIRED`), and reserves field 18 and both old field names. The
hub now requires password setup over TCP whenever no password exists,
regardless of whether the listener binds to loopback only. The frontend
derives `isAutoAuthenticated()` and `isPasswordSetupGate()` from that one
field, and removes the separate `passwordSetupRequired()` export.
`SignedOutOnly` also redirects a `PASSWORD_SETUP` visitor away from
`/login` and `/recover-account`, closing a dead end those pages left for
that state: the form could be satisfied by no password, and nothing
routed to the setup screen.

**Other fixes.** The trust check now preserves an IPv6 zone identifier
for a link-local client address instead of refusing that address
outright; the earlier behaviour merged every link-local caller into one
shared rate-limit budget and wrote an empty address into the session
row. A stored `trusted_proxy_ranges` row can become invalid when a
vendored provider update starts to overlap an operator's manual
selector; the value now decodes and defers the failure to `Validate()`,
which degrades it to the fail-closed default (trust nobody) but keeps
the key writable. The earlier code failed the decode itself, which
blocked every later write to that key except through `Reset`, and
`Reset` discards the operator's whole list. Overlap detection in
`TrustedRanges` now tests each selector against its own set instead of
rebuilding a combined `IPSet` per selector, and the bundled Cloudflare
and CloudFront prefix tables parse once through `sync.OnceValue` instead
of once per settings decode.

**Tests, docs, and dependencies.** `ws_scope_test.go` fixes a vacuous
test: the earlier solo WebSocket scope tests used a registry with no solo
user, so every request failed with 401 before it reached the scope rung,
and the "not 403" assertions passed without exercising it. A new test
pins that a TCP caller gets 401 on both WebSocket doors. E2E hub spawns
now run through a `hubSpawnEnv()` helper that clears
`LEAPMUX_HUB_DEV_FRONTEND`, so a developer's own exported variable cannot
point a test hub at a foreign checkout, and a self-check test greps the
whole E2E tree to keep every hub spawn routed through it.
`configuration.md` and `security.md` gain a "Trusted reverse proxies"
section, and about fifteen other pages drop the old "no password means
every request authenticates as admin" wording for "local IPC is
credential-free; TCP starts with password setup". The same-host proxy
examples now list both `127.0.0.1` and `::1`, because a dual-stack
`localhost` resolves to `::1` first and an untrusted peer's headers are
ignored with no error. `go.mod` adds
`github.com/realclientip/realclientip-go` and `go4.org/netipx`, and the
NOTICE files are regenerated to list them.

## Result

An operator who runs `leapmux solo` over TCP with no password set can no
longer reach any protected RPC. The hub answers Unauthenticated to
everything except `SetInitialSoloPassword`, and that RPC now refuses a
burst instead of hashing without limit. Setting the first password
signs the operator straight in, already elevated, from the one screen
the app offers. The local IPC socket keeps its credential-free access
unchanged, so the desktop app is unaffected.

An operator who runs a hub behind a reverse proxy names that proxy in
Settings under "Trusted reverse proxies" — a literal IP, a CIDR range,
an inclusive range, or a `cloudflare`/`cloudfront` token. The hub then
records each client's real address in its rate limits and its session
rows instead of the proxy's, and it treats a connection as HTTPS when
that proxy says so, which also gives the session cookie its `Secure`
attribute and its `__Host-` name without a second setting. An operator
who configures no trusted proxy keeps today's behaviour: every
forwarding header is ignored, and callers are limited on the raw
connection address.
