### PR TITLE
feat(chat): Compact the input queue controls and explain pauses

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.test.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.test.tsx
@@ -6,7 +6,7 @@ import { fireEvent, render, screen, waitFor, within } from '@solidjs/testing-lib
 import { createSignal } from 'solid-js'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PreferencesProvider } from '~/context/PreferencesContext'
-import { AgentInputKind, AgentInputQueueSnapshotSchema, AgentInputState, AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
+import { AgentInputKind, AgentInputQueuePauseReason, AgentInputQueueSnapshotSchema, AgentInputState, AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { localStorageLoad, localStorageStore, PREFIX_CONTROL_STATE } from '~/lib/browserStorage'
 import { clearDraft, loadDraft, saveDraft } from '~/lib/editor/draftPersistence'
 import { createControlStore } from '~/stores/control.store'
@@ -460,6 +460,84 @@ describe('agent editor panel', () => {
     expect(screen.getByTestId('queue-pause-button')).toHaveTextContent('Pause Queue')
   })
 
+  it('names the composer actions although a phone hides their labels', () => {
+    renderPanel()
+    // Each label is a `display: none` span below `sm`, and that reaches
+    // neither a screen reader nor a by-name lookup. The aria-label does.
+    expect(screen.getByTestId('queue-pause-button')).toHaveAttribute('aria-label', 'Pause Queue')
+    expect(screen.getByTestId('send-button')).toHaveAttribute('aria-label', 'Send')
+  })
+
+  it('shows an icon beside the queue pause label', () => {
+    renderPanel()
+    expect(screen.getByTestId('queue-pause-button').querySelector('svg')).not.toBeNull()
+  })
+
+  it('shows no pause banner while the queue runs', () => {
+    renderPanel()
+    expect(screen.queryByTestId('queue-pause-banner')).not.toBeInTheDocument()
+  })
+
+  it('says Send will queue while the queue is paused', () => {
+    const snapshot = create(AgentInputQueueSnapshotSchema, {
+      agentId: 'a1',
+      paused: true,
+      pauseReason: AgentInputQueuePauseReason.INTERRUPTED,
+    })
+    render(() => (
+      <PreferencesProvider>
+        <AgentEditorPanel
+          agentId="a1"
+          agent={agent({ workerId: 'w1' })}
+          repoGitStore={createRepoGitStore()}
+          gitTab={{ workerId: 'w1', gitToplevel: WORKTREE_DIR }}
+          onSendMessage={() => {}}
+          branchActions={stubBranchMenuActions()}
+          branchWorkerId="w1"
+          inputQueue={snapshot}
+        />
+      </PreferencesProvider>
+    ))
+
+    // The banner explains the pause even though the queue holds no items --
+    // the case where nothing else on screen says anything.
+    expect(screen.getByTestId('queue-pause-banner')).toHaveTextContent(
+      'Queue paused because you interrupted the agent.',
+    )
+    // And the press itself says what it will do. The visible word stays inside
+    // the accessible name, so a by-name lookup and voice control still match.
+    const send = screen.getByTestId('send-button')
+    expect(send).toHaveAttribute('aria-label', 'Add to queue')
+    expect(send).toHaveTextContent('Queue')
+  })
+
+  it('resumes the queue from the banner button', async () => {
+    const onSetQueuePaused = vi.fn().mockResolvedValue(undefined)
+    const snapshot = create(AgentInputQueueSnapshotSchema, {
+      agentId: 'a1',
+      paused: true,
+      pauseReason: AgentInputQueuePauseReason.AGENT_STOPPED,
+    })
+    render(() => (
+      <PreferencesProvider>
+        <AgentEditorPanel
+          agentId="a1"
+          agent={agent({ workerId: 'w1' })}
+          repoGitStore={createRepoGitStore()}
+          gitTab={{ workerId: 'w1', gitToplevel: WORKTREE_DIR }}
+          onSendMessage={() => {}}
+          branchActions={stubBranchMenuActions()}
+          branchWorkerId="w1"
+          inputQueue={snapshot}
+          onSetQueuePaused={onSetQueuePaused}
+        />
+      </PreferencesProvider>
+    ))
+
+    await fireEvent.click(screen.getByTestId('queue-pause-banner-resume'))
+    expect(onSetQueuePaused).toHaveBeenCalledWith(false)
+  })
+
   it('blocks new attachments while an enqueue remains in flight', async () => {
     vi.useRealTimers()
     const attachment = {
@@ -743,7 +821,9 @@ describe('agent editor panel', () => {
       </PreferencesProvider>
     ))
 
+    // Delete arms on the first click and deletes on the second.
     await fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'Confirm delete?' }))
     await Promise.resolve()
 
     expect(onDeleteQueueItem).toHaveBeenCalledWith(expect.objectContaining({ id: 'queued-1' }))

--- a/frontend/src/components/chat/AgentEditorPanel.test.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.test.tsx
@@ -460,7 +460,7 @@ describe('agent editor panel', () => {
     expect(screen.getByTestId('queue-pause-button')).toHaveTextContent('Pause Queue')
   })
 
-  it('names the composer actions although a phone hides their labels', () => {
+  it('gives the composer actions a name although a phone hides their labels', () => {
     renderPanel()
     // Each label is a `display: none` span below `sm`, and that reaches
     // neither a screen reader nor a by-name lookup. The aria-label does.
@@ -476,6 +476,40 @@ describe('agent editor panel', () => {
   it('shows no pause banner while the queue runs', () => {
     renderPanel()
     expect(screen.queryByTestId('queue-pause-banner')).not.toBeInTheDocument()
+  })
+
+  it('turns the pause toggle into Resume Queue, in the label and in the name', () => {
+    const snapshot = create(AgentInputQueueSnapshotSchema, {
+      agentId: 'a1',
+      paused: true,
+      pauseReason: AgentInputQueuePauseReason.MANUAL,
+    })
+    const { unmount } = render(() => (
+      <PreferencesProvider>
+        <AgentEditorPanel
+          agentId="a1"
+          agent={agent({ workerId: 'w1' })}
+          repoGitStore={createRepoGitStore()}
+          gitTab={{ workerId: 'w1', gitToplevel: WORKTREE_DIR }}
+          onSendMessage={() => {}}
+          branchActions={stubBranchMenuActions()}
+          branchWorkerId="w1"
+          inputQueue={snapshot}
+        />
+      </PreferencesProvider>
+    ))
+
+    const toggle = screen.getByTestId('queue-pause-button')
+    // Both halves, because below `sm` the label is `display: none` and the
+    // aria-label is the button's only name. The visible word must also stay
+    // INSIDE that name, or a voice-control user cannot address it.
+    expect(toggle).toHaveTextContent('Resume Queue')
+    expect(toggle).toHaveAttribute('aria-label', 'Resume Queue')
+    // A `Play` icon, not the `Pause` one it shows at rest. `lucide-solid` puts
+    // the icon's own name in the class list, which is the only handle on which
+    // glyph rendered.
+    expect(toggle.querySelector('svg')?.getAttribute('class')).toContain('play')
+    unmount()
   })
 
   it('says Send will queue while the queue is paused', () => {
@@ -536,6 +570,51 @@ describe('agent editor panel', () => {
 
     await fireEvent.click(screen.getByTestId('queue-pause-banner-resume'))
     expect(onSetQueuePaused).toHaveBeenCalledWith(false)
+  })
+
+  it('sends one pause RPC for two fast presses of Resume', async () => {
+    let settle: () => void = () => {}
+    const onSetQueuePaused = vi.fn(() => new Promise<void>((resolve) => {
+      settle = resolve
+    }))
+    const snapshot = create(AgentInputQueueSnapshotSchema, {
+      agentId: 'a1',
+      paused: true,
+      pauseReason: AgentInputQueuePauseReason.AGENT_STOPPED,
+    })
+    render(() => (
+      <PreferencesProvider>
+        <AgentEditorPanel
+          agentId="a1"
+          agent={agent({ workerId: 'w1' })}
+          repoGitStore={createRepoGitStore()}
+          gitTab={{ workerId: 'w1', gitToplevel: WORKTREE_DIR }}
+          onSendMessage={() => {}}
+          branchActions={stubBranchMenuActions()}
+          branchWorkerId="w1"
+          inputQueue={snapshot}
+          onSetQueuePaused={onSetQueuePaused}
+        />
+      </PreferencesProvider>
+    ))
+
+    // Nothing updates optimistically: `paused` moves only when the Worker's
+    // snapshot lands, so the button still reads Resume for the whole round trip
+    // and invites a second press. The state converges either way, because the
+    // RPC carries an absolute boolean -- but a failure raises one warn toast per
+    // call, so two presses of one intent raise two toasts.
+    const resume = screen.getByTestId('queue-pause-banner-resume')
+    await fireEvent.click(resume)
+    await fireEvent.click(resume)
+    expect(onSetQueuePaused).toHaveBeenCalledTimes(1)
+    expect(resume).toBeDisabled()
+    // The composer's own toggle is the SAME intent, so it is refused too.
+    expect(screen.getByTestId('queue-pause-button')).toBeDisabled()
+
+    settle()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(resume).not.toBeDisabled()
   })
 
   it('blocks new attachments while an enqueue remains in flight', async () => {

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -10,6 +10,8 @@ import type { AgentSessionInfo } from '~/stores/agentSession.store'
 import type { ControlRequest } from '~/stores/control.store'
 import type { createRepoGitStore } from '~/stores/repoGit.store'
 import type { Tab } from '~/stores/tab.types'
+import Pause from 'lucide-solid/icons/pause'
+import Play from 'lucide-solid/icons/play'
 import SendHorizontal from 'lucide-solid/icons/send-horizontal'
 import Square from 'lucide-solid/icons/square'
 import { createEffect, createMemo, createSignal, on, onCleanup, onMount, Show, untrack } from 'solid-js'
@@ -20,7 +22,7 @@ import { Icon } from '~/components/common/Icon'
 import { Spinner } from '~/components/common/Spinner'
 import { Tooltip } from '~/components/common/Tooltip'
 import { usePreferences } from '~/context/PreferencesContext'
-import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
+import { AgentInputQueuePauseReason, AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { EDITOR_MIN_HEIGHT } from '~/lib/editor/editorMinHeight'
 import { keepFocusOnPress } from '~/lib/focusRetention'
@@ -36,6 +38,7 @@ import { workerInfoStore } from '~/stores/workerInfo.store'
 import { iconSize } from '~/styles/tokens'
 import { useAgentInfoCard } from './AgentInfoCard'
 import { AgentInputQueue } from './AgentInputQueue'
+import { AgentInputQueuePauseBanner } from './AgentInputQueuePauseBanner'
 import { clearAttachments as clearCachedAttachments } from './attachments'
 import { AttachmentStrip } from './AttachmentStrip'
 import * as styles from './ChatView.css'
@@ -133,20 +136,36 @@ export interface AgentEditorPanelProps {
   triggerSendRef?: (fn: () => void | Promise<void>) => void
 }
 
+/**
+ * The queue's pause toggle, which shares the composer's action cluster with
+ * Interrupt and Send.
+ *
+ * `actionLabel` hides the word below `sm`, so the three buttons shrink to
+ * icons together on a phone and the cluster stops crowding the `[+]` button.
+ * The tooltip carries the name once the word is gone -- and, through
+ * `ariaLabel`, so does the accessibility tree, which reads nothing from a
+ * `display: none` label.
+ */
 const AgentInputQueuePauseButton: Component<{
   paused: boolean
   onSetPaused?: (paused: boolean) => Promise<void>
-}> = props => (
-  <button
-    type="button"
-    class="outline"
-    onMouseDown={keepFocusOnPress}
-    onClick={() => { void props.onSetPaused?.(!props.paused).catch(() => {}) }}
-    data-testid="queue-pause-button"
-  >
-    {props.paused ? 'Resume Queue' : 'Pause Queue'}
-  </button>
-)
+}> = (props) => {
+  const label = () => (props.paused ? 'Resume Queue' : 'Pause Queue')
+  return (
+    <Tooltip text={label()} ariaLabel>
+      <button
+        type="button"
+        class="outline"
+        onMouseDown={keepFocusOnPress}
+        onClick={() => { void props.onSetPaused?.(!props.paused).catch(() => {}) }}
+        data-testid="queue-pause-button"
+      >
+        <Icon icon={props.paused ? Play : Pause} size="sm" />
+        <span class={styles.actionLabel}>{label()}</span>
+      </button>
+    </Tooltip>
+  )
+}
 
 export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   let panelRef: HTMLDivElement | undefined
@@ -163,6 +182,9 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   // rest of the second.
   const [enqueueInFlight, setEnqueueInFlight] = createSignal(false)
   const interruptLoading = createLoadingSignal()
+  // A paused queue changes what Send DOES, so the button that presses it
+  // reads the same flag the banner above does.
+  const queuePaused = () => props.inputQueue?.paused ?? false
 
   const currentProviderLabel = () => agentProviderLabel(props.agent?.agentProvider)
 
@@ -498,6 +520,11 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
         class={styles.inputArea}
         data-no-status-bar={preferences.showComposerStatusBar() ? undefined : ''}
       >
+        <AgentInputQueuePauseBanner
+          paused={props.inputQueue?.paused ?? false}
+          reason={props.inputQueue?.pauseReason ?? AgentInputQueuePauseReason.UNSPECIFIED}
+          onResume={() => { void props.onSetQueuePaused?.(false).catch(() => {}) }}
+        />
         <AgentInputQueue
           snapshot={props.inputQueue}
           clientId={props.queueClientId ?? ''}
@@ -700,42 +727,63 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                     <div class={styles.actionCluster} data-testid="composer-actions">
                       <AgentInputQueuePauseButton paused={props.inputQueue?.paused ?? false} onSetPaused={props.onSetQueuePaused} />
                       <Show when={ctrl.showInterrupt()}>
-                        <button
-                          class="outline"
-                          onMouseDown={keepFocusOnPress}
-                          onClick={() => {
-                            interruptLoading.start()
-                            props.onInterrupt?.()
-                            // The press leaves the composer focused, so the
-                            // keyboard would sit over the output the user just
-                            // stopped the agent to read. `keepFocusOnPress`
-                            // above is what makes the composer still the
-                            // active element here on Chrome and on Firefox,
-                            // which focus a pressed button; the send path
-                            // reads the same state through `decideSendFocus`.
-                            dismissSoftKeyboard()
-                          }}
-                          disabled={interruptLoading.loading()}
-                          data-testid="interrupt-button"
-                        >
-                          <Show when={interruptLoading.loading()} fallback={<Icon icon={Square} size="sm" />}>
-                            <Spinner />
-                          </Show>
-                          <span class={styles.actionLabel}>{interruptLoading.loading() ? 'Interrupting...' : 'Interrupt'}</span>
-                        </button>
+                        {/*
+                          The tooltip is the ONLY name this button has below
+                          `sm`, where `actionLabel` hides the word: a
+                          `display: none` label reaches neither a screen reader
+                          nor a by-name lookup.
+                        */}
+                        <Tooltip text={interruptLoading.loading() ? 'Interrupting...' : 'Interrupt'} ariaLabel>
+                          <button
+                            class="outline"
+                            onMouseDown={keepFocusOnPress}
+                            onClick={() => {
+                              interruptLoading.start()
+                              props.onInterrupt?.()
+                              // The press leaves the composer focused, so the
+                              // keyboard would sit over the output the user just
+                              // stopped the agent to read. `keepFocusOnPress`
+                              // above is what makes the composer still the
+                              // active element here on Chrome and on Firefox,
+                              // which focus a pressed button; the send path
+                              // reads the same state through `decideSendFocus`.
+                              dismissSoftKeyboard()
+                            }}
+                            disabled={interruptLoading.loading()}
+                            data-testid="interrupt-button"
+                          >
+                            <Show when={interruptLoading.loading()} fallback={<Icon icon={Square} size="sm" />}>
+                              <Spinner />
+                            </Show>
+                            <span class={styles.actionLabel}>{interruptLoading.loading() ? 'Interrupting...' : 'Interrupt'}</span>
+                          </button>
+                        </Tooltip>
                       </Show>
-                      <button
-                        type="button"
-                        disabled={(!hasContent() && attachments().length === 0) || disabled() || sending()}
-                        onMouseDown={keepFocusOnPress}
-                        onClick={() => { void triggerSend?.() }}
-                        data-testid="send-button"
-                      >
-                        <Show when={sending()} fallback={<Icon icon={SendHorizontal} size="sm" />}>
-                          <Spinner data-testid="send-spinner" />
-                        </Show>
-                        <span class={styles.actionLabel}>Send</span>
-                      </button>
+                      {/*
+                        A paused queue does not drain, so this press parks the
+                        message rather than delivering it. The button says so at
+                        the moment of the press, which is the only moment that
+                        reaches a user who never looked at the banner.
+
+                        The visible word stays INSIDE the accessible name
+                        ("Queue" within "Add to queue"), because a name that
+                        drops the visible label breaks both a voice-control user
+                        and every by-name lookup.
+                      */}
+                      <Tooltip text={queuePaused() ? 'Add to queue' : 'Send'} ariaLabel>
+                        <button
+                          type="button"
+                          disabled={(!hasContent() && attachments().length === 0) || disabled() || sending()}
+                          onMouseDown={keepFocusOnPress}
+                          onClick={() => { void triggerSend?.() }}
+                          data-testid="send-button"
+                        >
+                          <Show when={sending()} fallback={<Icon icon={SendHorizontal} size="sm" />}>
+                            <Spinner data-testid="send-spinner" />
+                          </Show>
+                          <span class={styles.actionLabel}>{queuePaused() ? 'Queue' : 'Send'}</span>
+                        </button>
+                      </Tooltip>
                     </div>
                   ),
                 }

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -35,6 +35,7 @@ import { registerPanelSend, unregisterPanelSend } from '~/stores/focusedChatSend
 import { repoGitView } from '~/stores/repoGit'
 import { optionValuesFromGroups } from '~/stores/tab.helpers'
 import { workerInfoStore } from '~/stores/workerInfo.store'
+import { hideInNarrowComposer } from '~/styles/shared.css'
 import { iconSize } from '~/styles/tokens'
 import { useAgentInfoCard } from './AgentInfoCard'
 import { AgentInputQueue } from './AgentInputQueue'
@@ -137,10 +138,22 @@ export interface AgentEditorPanelProps {
 }
 
 /**
+ * Swallows the rejection of a queue RPC.
+ *
+ * `runQueueRpc` in `~/lib/agentInputQueueOperations` already shows the failure
+ * to the user and then rethrows, so every caller here owes the promise a
+ * handler and owes the user nothing further. One helper, so the reason is
+ * stated once rather than at each of the eight call sites.
+ */
+function fireQueueRpc(call: Promise<unknown> | undefined): void {
+  void call?.catch(() => {})
+}
+
+/**
  * The queue's pause toggle, which shares the composer's action cluster with
  * Interrupt and Send.
  *
- * `actionLabel` hides the word below `sm`, so the three buttons shrink to
+ * `hideInNarrowComposer` hides the word below `sm`, so the three buttons shrink to
  * icons together on a phone and the cluster stops crowding the `[+]` button.
  * The tooltip carries the name once the word is gone -- and, through
  * `ariaLabel`, so does the accessibility tree, which reads nothing from a
@@ -148,7 +161,8 @@ export interface AgentEditorPanelProps {
  */
 const AgentInputQueuePauseButton: Component<{
   paused: boolean
-  onSetPaused?: (paused: boolean) => Promise<void>
+  busy: boolean
+  onToggle: () => void
 }> = (props) => {
   const label = () => (props.paused ? 'Resume Queue' : 'Pause Queue')
   return (
@@ -156,12 +170,13 @@ const AgentInputQueuePauseButton: Component<{
       <button
         type="button"
         class="outline"
+        disabled={props.busy}
         onMouseDown={keepFocusOnPress}
-        onClick={() => { void props.onSetPaused?.(!props.paused).catch(() => {}) }}
+        onClick={() => props.onToggle()}
         data-testid="queue-pause-button"
       >
         <Icon icon={props.paused ? Play : Pause} size="sm" />
-        <span class={styles.actionLabel}>{label()}</span>
+        <span class={hideInNarrowComposer}>{label()}</span>
       </button>
     </Tooltip>
   )
@@ -182,9 +197,33 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   // rest of the second.
   const [enqueueInFlight, setEnqueueInFlight] = createSignal(false)
   const interruptLoading = createLoadingSignal()
-  // A paused queue changes what Send DOES, so the button that presses it
-  // reads the same flag the banner above does.
+  // A paused queue changes what Send DOES, and it is what the banner and the
+  // two pause toggles state. ONE accessor answers the question for all four, so
+  // a change to the source or to the default cannot reach three of them and
+  // miss the fourth.
   const queuePaused = () => props.inputQueue?.paused ?? false
+  // ONE in-flight mark for the pause RPC, shared by the two controls that fire
+  // it: the banner's Resume and the composer's toggle. Neither updates
+  // optimistically -- `queuePaused()` moves only when the Worker's snapshot
+  // lands -- so both still read "Resume" for the whole round trip, which is
+  // what invites a second press. The state converges either way, because the
+  // RPC carries an absolute boolean; the cost is that `runQueueRpc` raises one
+  // warn toast per failure, so two presses of one intent raise two toasts.
+  //
+  // A plain signal, NOT `createLoadingSignal`. That hook holds `loading` true
+  // for a one-second debounce after `stop()`, which steadies a spinner but
+  // would leave this toggle dead for a second after a flip that normally
+  // settles in milliseconds.
+  const [pauseInFlight, setPauseInFlight] = createSignal(false)
+  const setQueuePaused = (paused: boolean) => {
+    if (pauseInFlight())
+      return
+    const call = props.onSetQueuePaused?.(paused)
+    if (!call)
+      return
+    setPauseInFlight(true)
+    fireQueueRpc(call.finally(() => setPauseInFlight(false)))
+  }
 
   const currentProviderLabel = () => agentProviderLabel(props.agent?.agentProvider)
 
@@ -521,9 +560,10 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
         data-no-status-bar={preferences.showComposerStatusBar() ? undefined : ''}
       >
         <AgentInputQueuePauseBanner
-          paused={props.inputQueue?.paused ?? false}
+          paused={queuePaused()}
+          busy={pauseInFlight()}
           reason={props.inputQueue?.pauseReason ?? AgentInputQueuePauseReason.UNSPECIFIED}
-          onResume={() => { void props.onSetQueuePaused?.(false).catch(() => {}) }}
+          onResume={() => setQueuePaused(false)}
         />
         <AgentInputQueue
           snapshot={props.inputQueue}
@@ -534,19 +574,19 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
             queueEdit.loadQueueEdit(item, takeover, false)
           }}
           onDelete={(item) => {
-            void props.onDeleteQueueItem?.(item).then(() => queueEdit.clearQueueEditArtifacts(item)).catch(() => {})
+            fireQueueRpc(props.onDeleteQueueItem?.(item).then(() => queueEdit.clearQueueEditArtifacts(item)))
           }}
           onCancelEdit={(item) => {
-            void props.onCancelQueueEdit?.(item).then(() => queueEdit.clearQueueEditArtifacts(item)).catch(() => {})
+            fireQueueRpc(props.onCancelQueueEdit?.(item).then(() => queueEdit.clearQueueEditArtifacts(item)))
           }}
-          onMove={(item, beforeInputId) => { void props.onMoveQueueItem?.(item, beforeInputId).catch(() => {}) }}
+          onMove={(item, beforeInputId) => fireQueueRpc(props.onMoveQueueItem?.(item, beforeInputId))}
           onRetry={(item, confirmUncertain) => {
             if (confirmUncertain)
               setUncertainRetry(item)
             else
-              void props.onRetryQueueItem?.(item, false).catch(() => {})
+              fireQueueRpc(props.onRetryQueueItem?.(item, false))
           }}
-          onSteer={(item) => { void props.onSteerQueueItem?.(item).catch(() => {}) }}
+          onSteer={item => fireQueueRpc(props.onSteerQueueItem?.(item))}
         />
         <Show when={!ctrl.activeControlRequest()}>
           <AttachmentStrip attachments={attachments} onRemove={removeAttachment} />
@@ -624,7 +664,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
           // The ONE place that decides whether a control request blocks an
           // attachment. `MarkdownEditor` reads these handlers at event time, so
           // an absent `attachments` refuses the paste and the drop by itself.
-          // `addFiles`'s second argument marks a pasted image, which renames it.
+          // `addFiles`'s second argument marks a pasted image, which changes its filename.
           attachments={!ctrl.activeControlRequest() && !enqueueInFlight()
             ? {
                 onPaste: files => addFiles(files, true),
@@ -701,7 +741,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                   node: () => (
                     <>
                       <div class={styles.actionCluster}>
-                        <AgentInputQueuePauseButton paused={props.inputQueue?.paused ?? false} onSetPaused={props.onSetQueuePaused} />
+                        <AgentInputQueuePauseButton paused={queuePaused()} busy={pauseInFlight()} onToggle={() => setQueuePaused(!queuePaused())} />
                       </div>
                       <ControlRequestActions
                         request={request}
@@ -725,11 +765,11 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                   layout: 'corner' as const,
                   node: () => (
                     <div class={styles.actionCluster} data-testid="composer-actions">
-                      <AgentInputQueuePauseButton paused={props.inputQueue?.paused ?? false} onSetPaused={props.onSetQueuePaused} />
+                      <AgentInputQueuePauseButton paused={queuePaused()} busy={pauseInFlight()} onToggle={() => setQueuePaused(!queuePaused())} />
                       <Show when={ctrl.showInterrupt()}>
                         {/*
                           The tooltip is the ONLY name this button has below
-                          `sm`, where `actionLabel` hides the word: a
+                          `sm`, where `hideInNarrowComposer` hides the word: a
                           `display: none` label reaches neither a screen reader
                           nor a by-name lookup.
                         */}
@@ -755,7 +795,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                             <Show when={interruptLoading.loading()} fallback={<Icon icon={Square} size="sm" />}>
                               <Spinner />
                             </Show>
-                            <span class={styles.actionLabel}>{interruptLoading.loading() ? 'Interrupting...' : 'Interrupt'}</span>
+                            <span class={hideInNarrowComposer}>{interruptLoading.loading() ? 'Interrupting...' : 'Interrupt'}</span>
                           </button>
                         </Tooltip>
                       </Show>
@@ -781,7 +821,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                           <Show when={sending()} fallback={<Icon icon={SendHorizontal} size="sm" />}>
                             <Spinner data-testid="send-spinner" />
                           </Show>
-                          <span class={styles.actionLabel}>{queuePaused() ? 'Queue' : 'Send'}</span>
+                          <span class={hideInNarrowComposer}>{queuePaused() ? 'Queue' : 'Send'}</span>
                         </button>
                       </Tooltip>
                     </div>
@@ -811,7 +851,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
             onConfirm={() => {
               const retryItem = item()
               setUncertainRetry()
-              void props.onRetryQueueItem?.(retryItem, true).catch(() => {})
+              fireQueueRpc(props.onRetryQueueItem?.(retryItem, true))
             }}
             onCancel={() => setUncertainRetry()}
             data-testid="retry-uncertain-input-dialog"

--- a/frontend/src/components/chat/AgentInputQueue.css.ts
+++ b/frontend/src/components/chat/AgentInputQueue.css.ts
@@ -1,4 +1,15 @@
 import { style } from '@vanilla-extract/css'
+import { breakpoints } from '~/styles/tokens'
+
+/**
+ * The edge of a square action button in a queue row. Not on the spacing
+ * scale: it is a control size, and `steerAction` matches it so a row of
+ * buttons keeps one height whether or not Steer shows its label.
+ *
+ * Exported because the pause banner's Resume button sits in the same column
+ * and has to be the same height. One value, so the two cannot drift.
+ */
+export const ACTION_SIZE = '1.75rem'
 
 export const root = style({
   display: 'flex',
@@ -7,7 +18,8 @@ export const root = style({
   maxHeight: 'min(40vh, 20rem)',
   overflowY: 'auto',
   overscrollBehavior: 'contain',
-  padding: 'var(--space-2) var(--space-3) 0',
+  // `inputArea` owns the gap to the neighbours; see its comment.
+  padding: 0,
 })
 
 export const item = style({
@@ -17,7 +29,7 @@ export const item = style({
   gap: 'var(--space-2)',
   padding: 'var(--space-2)',
   border: '1px solid var(--border)',
-  borderRadius: '0.45rem',
+  borderRadius: 'var(--radius-medium)',
   background: 'var(--card)',
 })
 
@@ -34,5 +46,63 @@ export const metadata = style({
 })
 export const error = style({ color: 'var(--danger)', fontSize: '0.72rem' })
 export const actions = style({ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-1)', justifyContent: 'flex-end' })
-export const action = style({ fontSize: '0.72rem', padding: 'var(--space-1) var(--space-2)' })
-export const drag = style({ cursor: 'grab', color: 'var(--muted-foreground)', userSelect: 'none' })
+/**
+ * One action in a queue row: an outline square holding a single icon.
+ *
+ * Icon-only, because a row offers up to six actions and the words pushed the
+ * row wider than a phone. Each button states its name to the tooltip and to
+ * the accessibility tree instead.
+ *
+ * This sets the geometry only. Oat declares its button rules inside
+ * `@layer base`, and an unlayered class outranks every layered rule whatever
+ * the specificity, so the `outline` class still supplies the border and the
+ * colours.
+ */
+export const iconAction = style({
+  width: ACTION_SIZE,
+  height: ACTION_SIZE,
+  padding: 0,
+  flexShrink: 0,
+})
+
+/**
+ * Steer, the one action whose icon alone does not say what it does, so it
+ * keeps its label on a wide viewport. Below `sm` the label hides and the
+ * button becomes the same square as the others.
+ */
+export const steerAction = style({
+  'height': ACTION_SIZE,
+  'padding': '0 var(--space-2)',
+  'gap': 'var(--space-1)',
+  'fontSize': '0.72rem',
+  'flexShrink': 0,
+  '@media': {
+    [`(max-width: ${breakpoints.sm - 1}px)`]: {
+      width: ACTION_SIZE,
+      padding: 0,
+    },
+  },
+})
+
+export const steerLabel = style({
+  '@media': {
+    [`(max-width: ${breakpoints.sm - 1}px)`]: {
+      display: 'none',
+    },
+  },
+})
+
+/** The row that is currently in flight, as the workspace list marks it. */
+export const itemDragging = style({
+  opacity: 0.4,
+})
+
+/**
+ * The grip of a row that cannot move: hidden, but still occupying its grid
+ * cell so the row's three columns do not shift.
+ *
+ * `visibility`, not `display`, for exactly that reason.
+ */
+export const dragHandleInert = style({
+  visibility: 'hidden',
+})

--- a/frontend/src/components/chat/AgentInputQueue.css.ts
+++ b/frontend/src/components/chat/AgentInputQueue.css.ts
@@ -1,15 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { breakpoints } from '~/styles/tokens'
-
-/**
- * The edge of a square action button in a queue row. Not on the spacing
- * scale: it is a control size, and `steerAction` matches it so a row of
- * buttons keeps one height whether or not Steer shows its label.
- *
- * Exported because the pause banner's Resume button sits in the same column
- * and has to be the same height. One value, so the two cannot drift.
- */
-export const ACTION_SIZE = '1.75rem'
+import { compactAction, compactActionLabelled, compactActionSize, compactTextSize } from '~/styles/tokens'
 
 export const root = style({
   display: 'flex',
@@ -18,13 +8,26 @@ export const root = style({
   maxHeight: 'min(40vh, 20rem)',
   overflowY: 'auto',
   overscrollBehavior: 'contain',
-  // `inputArea` owns the gap to the neighbours; see its comment.
+  // `inputArea` owns the gap to the neighbours. See the `inputArea` comment in
+  // `~/components/chat/ChatView.css.ts`.
   padding: 0,
 })
 
+/**
+ * One queued input: the grip, the text, and the action buttons.
+ *
+ * FLEX, and not a grid with a fixed track for each of the three.
+ *
+ * `DragHandle` hides itself under `(any-pointer: fine)`, so the grip renders on
+ * a touch-only device alone. A `display: none` grid item leaves its track
+ * behind: the text moves into the grip's track, the actions move into the
+ * text's `1fr` track, and a preview long enough to reach its max-content width
+ * then starves the actions to zero and pushes the buttons out of the row. A
+ * `display: none` FLEX item consumes neither a slot nor a gap, so the row keeps
+ * its shape whether or not the grip renders.
+ */
 export const item = style({
-  display: 'grid',
-  gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+  display: 'flex',
   alignItems: 'center',
   gap: 'var(--space-2)',
   padding: 'var(--space-2)',
@@ -33,25 +36,60 @@ export const item = style({
   background: 'var(--card)',
 })
 
-export const body = style({ minWidth: 0 })
+/**
+ * The row that a fine pointer can drag by its body.
+ *
+ * The grip is the affordance on touch, and it hides itself on a fine pointer,
+ * so the cursor is the only signal a mouse user gets that the row moves. The
+ * deleted text glyph carried `cursor: grab` for the same reason.
+ */
+export const itemDraggable = style({
+  '@media': {
+    '(any-pointer: fine)': {
+      'cursor': 'grab',
+      ':active': {
+        cursor: 'grabbing',
+      },
+    },
+  },
+})
+
+export const body = style({ flex: 1, minWidth: 0 })
 export const preview = style({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
+  // A literal, unlike `metadata` below, and for the reason `compactTextSize`
+  // records: Oat's scale stops at `--text-8` (0.75rem) and `--text-7`
+  // (0.875rem), and this line wants a size between the two. One reader, so it
+  // needs no name.
   fontSize: '0.82rem',
 })
 export const metadata = style({
   color: 'var(--muted-foreground)',
-  fontSize: '0.72rem',
+  fontSize: compactTextSize,
 })
-export const error = style({ color: 'var(--danger)', fontSize: '0.72rem' })
+export const error = style({ color: 'var(--danger)', fontSize: compactTextSize })
+/**
+ * The row's action cluster.
+ *
+ * It SHRINKS, and that is what makes `flex-wrap` reachable. A flex item's base
+ * size is its max-content width, which for a wrap container is the whole row of
+ * buttons on one line; `flex-shrink: 0` pins it there, so the shortfall that
+ * wrapping needs can never arise and the cluster overflows the row instead --
+ * and `root`'s `overflow-y: auto` computes `overflow-x` to `auto`, so the queue
+ * scrolls sideways. The BUTTONS keep their own `flex-shrink: 0`
+ * (`compactAction` in `~/styles/tokens.ts`), so they wrap at full size rather
+ * than squeezing.
+ */
 export const actions = style({ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-1)', justifyContent: 'flex-end' })
+
 /**
  * One action in a queue row: an outline square holding a single icon.
  *
  * Icon-only, because a row offers up to six actions and the words pushed the
- * row wider than a phone. Each button states its name to the tooltip and to
- * the accessibility tree instead.
+ * row wider than a phone. Each button gives its name to the tooltip and to the
+ * accessibility tree instead.
  *
  * This sets the geometry only. Oat declares its button rules inside
  * `@layer base`, and an unlayered class outranks every layered rule whatever
@@ -59,37 +97,25 @@ export const actions = style({ display: 'flex', flexWrap: 'wrap', gap: 'var(--sp
  * colours.
  */
 export const iconAction = style({
-  width: ACTION_SIZE,
-  height: ACTION_SIZE,
+  ...compactAction,
+  width: compactActionSize,
   padding: 0,
-  flexShrink: 0,
 })
 
 /**
- * Steer, the one action whose icon alone does not say what it does, so it
- * keeps its label on a wide viewport. Below `sm` the label hides and the
- * button becomes the same square as the others.
+ * Steer, the one action whose icon alone does not say what it does, so it keeps
+ * its label at EVERY width.
+ *
+ * The other five actions give their name to a `<Tooltip>` instead. Steer cannot.
+ * A tooltip opens on hover and on focus, and never on touch, so on a phone this
+ * word is the only name a sighted user can reach. Hiding it below `sm` took the
+ * label away from exactly the surface that needs it most. The word costs about
+ * 34px, and a 320px viewport has the room; `actions` wraps if a narrower one
+ * does not.
  */
 export const steerAction = style({
-  'height': ACTION_SIZE,
-  'padding': '0 var(--space-2)',
-  'gap': 'var(--space-1)',
-  'fontSize': '0.72rem',
-  'flexShrink': 0,
-  '@media': {
-    [`(max-width: ${breakpoints.sm - 1}px)`]: {
-      width: ACTION_SIZE,
-      padding: 0,
-    },
-  },
-})
-
-export const steerLabel = style({
-  '@media': {
-    [`(max-width: ${breakpoints.sm - 1}px)`]: {
-      display: 'none',
-    },
-  },
+  ...compactActionLabelled,
+  gap: 'var(--space-1)',
 })
 
 /** The row that is currently in flight, as the workspace list marks it. */
@@ -98,8 +124,8 @@ export const itemDragging = style({
 })
 
 /**
- * The grip of a row that cannot move: hidden, but still occupying its grid
- * cell so the row's three columns do not shift.
+ * The grip of a row that cannot move: hidden, but still occupying its flex
+ * slot so the row's three columns keep their widths.
  *
  * `visibility`, not `display`, for exactly that reason.
  */

--- a/frontend/src/components/chat/AgentInputQueue.test.tsx
+++ b/frontend/src/components/chat/AgentInputQueue.test.tsx
@@ -8,7 +8,7 @@ import {
   AgentInputState,
   QueuedAgentInputSchema,
 } from '~/generated/proto/leapmux/v1/agent_pb'
-import { AgentInputQueue } from './AgentInputQueue'
+import { AgentInputQueue, resolveQueueDrop } from './AgentInputQueue'
 
 function item(id: string, overrides: MessageInitShape<typeof QueuedAgentInputSchema> = {}) {
   return create(QueuedAgentInputSchema, {
@@ -50,6 +50,61 @@ function renderQueue(overrides: {
   return handlers
 }
 
+// A pointer drag cannot be reproduced here: solid-dnd activates on real
+// pointer geometry and collision detection, which jsdom does not supply. The
+// gesture is covered in tests/e2e/108-agent-input-queue.spec.ts; the
+// arithmetic it feeds is covered directly.
+describe('resolveQueueDrop', () => {
+  const three = [item('one'), item('two'), item('three')]
+
+  it('points an upward drop at the drop target itself', () => {
+    expect(resolveQueueDrop(three, 'qi-two', 'qi-one')).toEqual({
+      moved: expect.objectContaining({ id: 'two' }),
+      beforeInputId: 'one',
+    })
+  })
+
+  it('points a downward drop at the item after the drop target', () => {
+    // The removal shifts everything below up by one, so aiming at the target
+    // itself would land the row one slot short.
+    expect(resolveQueueDrop(three, 'qi-one', 'qi-two')).toEqual({
+      moved: expect.objectContaining({ id: 'one' }),
+      beforeInputId: 'three',
+    })
+  })
+
+  it('sends a drop on the last row to the end', () => {
+    expect(resolveQueueDrop(three, 'qi-one', 'qi-three')).toEqual({
+      moved: expect.objectContaining({ id: 'one' }),
+      beforeInputId: '',
+    })
+  })
+
+  it('refuses a drop on the dragged row itself', () => {
+    expect(resolveQueueDrop(three, 'qi-two', 'qi-two')).toBeUndefined()
+  })
+
+  it('refuses an id that is not in the list', () => {
+    expect(resolveQueueDrop(three, 'qi-nope', 'qi-one')).toBeUndefined()
+    expect(resolveQueueDrop(three, 'qi-one', 'qi-nope')).toBeUndefined()
+  })
+
+  it('refuses to move a dispatching row', () => {
+    const list = [item('one', { state: AgentInputState.DISPATCHING }), item('two')]
+    expect(resolveQueueDrop(list, 'qi-one', 'qi-two')).toBeUndefined()
+  })
+
+  it('refuses to displace a dispatching row', () => {
+    // The Worker is already sending it, so its slot is not the user's to take.
+    const list = [item('one', { state: AgentInputState.DISPATCHING }), item('two')]
+    expect(resolveQueueDrop(list, 'qi-two', 'qi-one')).toBeUndefined()
+  })
+
+  it('refuses an empty list', () => {
+    expect(resolveQueueDrop([], 'qi-one', 'qi-two')).toBeUndefined()
+  })
+})
+
 describe('agentInputQueue', () => {
   it('renders operation, state, text, and attachment metadata', () => {
     renderQueue({
@@ -87,52 +142,14 @@ describe('agentInputQueue', () => {
     expect(handlers.onMove).toHaveBeenCalledWith(expect.objectContaining({ id: 'two' }), '')
   })
 
-  it('moves an input dragged upward before its drop target', async () => {
-    const handlers = renderQueue()
-    const first = screen.getByTestId('queued-input-one')
-    const second = screen.getByTestId('queued-input-two')
-
-    await fireEvent.dragStart(second)
-    await fireEvent.drop(first)
-
-    expect(handlers.onMove).toHaveBeenCalledWith(expect.objectContaining({ id: 'two' }), 'one')
-  })
-
-  it('moves an input dragged downward onto the drop target slot', async () => {
-    const handlers = renderQueue({ items: [item('one'), item('two'), item('three')] })
-
-    await fireEvent.dragStart(screen.getByTestId('queued-input-one'))
-    await fireEvent.drop(screen.getByTestId('queued-input-two'))
-
-    expect(handlers.onMove).toHaveBeenCalledWith(expect.objectContaining({ id: 'one' }), 'three')
-  })
-
-  it('moves an input dragged onto the last row to the end', async () => {
-    const handlers = renderQueue({ items: [item('one'), item('two'), item('three')] })
-
-    await fireEvent.dragStart(screen.getByTestId('queued-input-one'))
-    await fireEvent.drop(screen.getByTestId('queued-input-three'))
-
-    expect(handlers.onMove).toHaveBeenCalledWith(expect.objectContaining({ id: 'one' }), '')
-  })
-
-  it('ignores a drop on the dragged row itself', async () => {
-    const handlers = renderQueue()
-    const first = screen.getByTestId('queued-input-one')
-
-    await fireEvent.dragStart(first)
-    await fireEvent.drop(first)
-
-    expect(handlers.onMove).not.toHaveBeenCalled()
-  })
-
-  it('ignores a drop on a dispatching row', async () => {
-    const handlers = renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two')] })
-
-    await fireEvent.dragStart(screen.getByTestId('queued-input-two'))
-    await fireEvent.drop(screen.getByTestId('queued-input-one'))
-
-    expect(handlers.onMove).not.toHaveBeenCalled()
+  it('gives a dispatching row an inert grip, so it offers no drag it cannot do', () => {
+    renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two')] })
+    const dispatching = screen.getByTestId('queue-drag-handle-one')
+    const movable = screen.getByTestId('queue-drag-handle-two')
+    // Hidden rather than removed: the grip keeps its grid cell, so the row's
+    // text does not shift one column left.
+    expect(dispatching.className).toContain('dragHandleInert')
+    expect(movable.className).not.toContain('dragHandleInert')
   })
 
   it('does not move an item across a dispatching head', () => {
@@ -143,7 +160,7 @@ describe('agentInputQueue', () => {
 
   it('shows Take Over for an edit owned by another client', async () => {
     const handlers = renderQueue({ items: [item('one', { editOwnerClientId: 'client-b' })] })
-    await fireEvent.click(screen.getByText('Take Over'))
+    await fireEvent.click(screen.getByRole('button', { name: 'Take Over' }))
     expect(handlers.onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 'one' }), true)
   })
 
@@ -162,7 +179,7 @@ describe('agentInputQueue', () => {
 
   it('resumes an owned edit that this panel has not loaded', async () => {
     const handlers = renderQueue({ items: [item('one', { editOwnerClientId: 'client-a' })] })
-    await fireEvent.click(screen.getByText('Resume Edit'))
+    await fireEvent.click(screen.getByRole('button', { name: 'Resume Edit' }))
     expect(handlers.onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 'one' }), false)
   })
 
@@ -171,7 +188,7 @@ describe('agentInputQueue', () => {
       items: [item('one', { editOwnerClientId: 'client-a' })],
       activeEditInputId: 'one',
     })
-    await fireEvent.click(screen.getByText('Cancel Edit'))
+    await fireEvent.click(screen.getByRole('button', { name: 'Cancel Edit' }))
     expect(handlers.onCancelEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 'one' }))
   })
 
@@ -204,18 +221,74 @@ describe('agentInputQueue', () => {
   it('offers Retry for a failed head', async () => {
     const handlers = renderQueue({ items: [item('one', { state: AgentInputState.FAILED, error: 'offline' })] })
     expect(screen.getByText('offline')).toBeInTheDocument()
-    await fireEvent.click(screen.getByText('Retry'))
+    await fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
     expect(handlers.onRetry).toHaveBeenCalledWith(expect.objectContaining({ id: 'one' }), false)
   })
 
   it('does not offer Retry while the failed head is edited', () => {
     renderQueue({ items: [item('one', { state: AgentInputState.FAILED, editOwnerClientId: 'client-a' })] })
-    expect(screen.queryByText('Retry')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument()
   })
 
   it('marks a delivery-uncertain retry as requiring confirmation', async () => {
     const handlers = renderQueue({ items: [item('one', { state: AgentInputState.DELIVERY_UNCERTAIN })] })
-    await fireEvent.click(screen.getByText('Retry'))
+    await fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
     expect(handlers.onRetry).toHaveBeenCalledWith(expect.objectContaining({ id: 'one' }), true)
+  })
+
+  it('keeps the first Delete click from deleting', async () => {
+    const handlers = renderQueue({ items: [item('one')] })
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(handlers.onDelete).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument()
+  })
+
+  it('deletes on the second Delete click', async () => {
+    const handlers = renderQueue({ items: [item('one')] })
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await fireEvent.click(screen.getByRole('button', { name: 'Confirm delete?' }))
+    expect(handlers.onDelete).toHaveBeenCalledWith(expect.objectContaining({ id: 'one' }))
+  })
+
+  it('arms Delete as an outline, never as a filled danger button', async () => {
+    renderQueue({ items: [item('one')] })
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    const armed = screen.getByRole('button', { name: 'Confirm delete?' })
+    // `data-variant` alone paints a filled danger background. Keeping the
+    // `outline` class is what reduces it to a danger BORDER, so the pair is
+    // the contract, not either half.
+    expect(armed).toHaveAttribute('data-variant', 'danger')
+    expect(armed.classList.contains('outline')).toBe(true)
+  })
+
+  it('disarms Delete when the button loses focus', async () => {
+    const handlers = renderQueue({ items: [item('one')] })
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await fireEvent.blur(screen.getByRole('button', { name: 'Confirm delete?' }))
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+    expect(handlers.onDelete).not.toHaveBeenCalled()
+  })
+
+  it('names every row action although the row renders no button text', () => {
+    renderQueue({ items: [item('one'), item('two')], supportsSteering: true })
+    const first = screen.getByTestId('queued-input-one')
+    for (const name of ['Move Up', 'Move Down', 'Edit', 'Delete']) {
+      const button = within(first).getByRole('button', { name })
+      expect(button).toBeInTheDocument()
+      expect(button.textContent).toBe('')
+    }
+  })
+
+  it('puts Steer last, as the one action that keeps a visible label', () => {
+    renderQueue({
+      items: [item('one', { canSteer: true }), item('two')],
+      supportsSteering: true,
+    })
+    const first = screen.getByTestId('queued-input-one')
+    const buttons = within(first).getAllByRole('button')
+    const steer = within(first).getByRole('button', { name: 'Steer' })
+    expect(buttons[buttons.length - 1]).toBe(steer)
+    expect(steer).toHaveTextContent('Steer')
   })
 })

--- a/frontend/src/components/chat/AgentInputQueue.test.tsx
+++ b/frontend/src/components/chat/AgentInputQueue.test.tsx
@@ -1,6 +1,7 @@
 import type { MessageInitShape } from '@bufbuild/protobuf'
 import { create } from '@bufbuild/protobuf'
 import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import {
   AgentInputKind,
@@ -8,7 +9,9 @@ import {
   AgentInputState,
   QueuedAgentInputSchema,
 } from '~/generated/proto/leapmux/v1/agent_pb'
-import { AgentInputQueue, resolveQueueDrop } from './AgentInputQueue'
+import { flush } from '~/test-support/async'
+import { pointerEvent } from '~/test-support/pointer'
+import { AgentInputQueue } from './AgentInputQueue'
 
 function item(id: string, overrides: MessageInitShape<typeof QueuedAgentInputSchema> = {}) {
   return create(QueuedAgentInputSchema, {
@@ -19,6 +22,10 @@ function item(id: string, overrides: MessageInitShape<typeof QueuedAgentInputSch
     state: AgentInputState.QUEUED,
     ...overrides,
   })
+}
+
+function snapshotOf(items: ReturnType<typeof item>[]) {
+  return create(AgentInputQueueSnapshotSchema, { agentId: 'agent-1', items })
 }
 
 function renderQueue(overrides: {
@@ -34,76 +41,25 @@ function renderQueue(overrides: {
     onRetry: vi.fn(),
     onSteer: vi.fn(),
   }
-  const snapshot = create(AgentInputQueueSnapshotSchema, {
-    agentId: 'agent-1',
-    items: overrides.items ?? [item('one'), item('two')],
-  })
+  // A SIGNAL, not a fixed value, because the Worker pushes a whole new snapshot
+  // for every queue event -- new objects, new array, same ids. `push` replays
+  // that, which is what the keyed-row cases below need.
+  const [snapshot, setSnapshot] = createSignal(snapshotOf(overrides.items ?? [item('one'), item('two')]))
   render(() => (
     <AgentInputQueue
-      snapshot={snapshot}
+      snapshot={snapshot()}
       clientId="client-a"
       activeEditInputId={overrides.activeEditInputId}
       supportsSteering={overrides.supportsSteering ?? false}
       {...handlers}
     />
   ))
-  return handlers
+  return {
+    ...handlers,
+    /** Deliver a fresh snapshot, exactly as an `inputQueueChanged` event does. */
+    push: (items: ReturnType<typeof item>[]) => setSnapshot(snapshotOf(items)),
+  }
 }
-
-// A pointer drag cannot be reproduced here: solid-dnd activates on real
-// pointer geometry and collision detection, which jsdom does not supply. The
-// gesture is covered in tests/e2e/108-agent-input-queue.spec.ts; the
-// arithmetic it feeds is covered directly.
-describe('resolveQueueDrop', () => {
-  const three = [item('one'), item('two'), item('three')]
-
-  it('points an upward drop at the drop target itself', () => {
-    expect(resolveQueueDrop(three, 'qi-two', 'qi-one')).toEqual({
-      moved: expect.objectContaining({ id: 'two' }),
-      beforeInputId: 'one',
-    })
-  })
-
-  it('points a downward drop at the item after the drop target', () => {
-    // The removal shifts everything below up by one, so aiming at the target
-    // itself would land the row one slot short.
-    expect(resolveQueueDrop(three, 'qi-one', 'qi-two')).toEqual({
-      moved: expect.objectContaining({ id: 'one' }),
-      beforeInputId: 'three',
-    })
-  })
-
-  it('sends a drop on the last row to the end', () => {
-    expect(resolveQueueDrop(three, 'qi-one', 'qi-three')).toEqual({
-      moved: expect.objectContaining({ id: 'one' }),
-      beforeInputId: '',
-    })
-  })
-
-  it('refuses a drop on the dragged row itself', () => {
-    expect(resolveQueueDrop(three, 'qi-two', 'qi-two')).toBeUndefined()
-  })
-
-  it('refuses an id that is not in the list', () => {
-    expect(resolveQueueDrop(three, 'qi-nope', 'qi-one')).toBeUndefined()
-    expect(resolveQueueDrop(three, 'qi-one', 'qi-nope')).toBeUndefined()
-  })
-
-  it('refuses to move a dispatching row', () => {
-    const list = [item('one', { state: AgentInputState.DISPATCHING }), item('two')]
-    expect(resolveQueueDrop(list, 'qi-one', 'qi-two')).toBeUndefined()
-  })
-
-  it('refuses to displace a dispatching row', () => {
-    // The Worker is already sending it, so its slot is not the user's to take.
-    const list = [item('one', { state: AgentInputState.DISPATCHING }), item('two')]
-    expect(resolveQueueDrop(list, 'qi-two', 'qi-one')).toBeUndefined()
-  })
-
-  it('refuses an empty list', () => {
-    expect(resolveQueueDrop([], 'qi-one', 'qi-two')).toBeUndefined()
-  })
-})
 
 describe('agentInputQueue', () => {
   it('renders operation, state, text, and attachment metadata', () => {
@@ -146,10 +102,96 @@ describe('agentInputQueue', () => {
     renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two')] })
     const dispatching = screen.getByTestId('queue-drag-handle-one')
     const movable = screen.getByTestId('queue-drag-handle-two')
-    // Hidden rather than removed: the grip keeps its grid cell, so the row's
-    // text does not shift one column left.
+    // Hidden rather than REMOVED, so the grip keeps its flex slot and the row's
+    // text does not shift one column left. The element being in the document is
+    // the half jsdom can check; `visibility: hidden` versus `display: none` is a
+    // declaration in `./AgentInputQueue.css.ts`, and vitest loads no stylesheet.
+    expect(dispatching).toBeInTheDocument()
     expect(dispatching.className).toContain('dragHandleInert')
     expect(movable.className).not.toContain('dragHandleInert')
+  })
+
+  it('withholds the drag activators from a dispatching row grip', async () => {
+    const handlers = renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two')] })
+    await flush()
+    // An affordance that cannot drag must not behave like one. Hiding the grip
+    // is only half of it: without withholding the activators, a press that
+    // reached the hidden box would still lift the row.
+    screen.getByTestId('queue-drag-handle-one').dispatchEvent(pointerEvent('pointerdown', { x: 10, y: 10, pointerType: 'touch' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 10, y: 90, pointerType: 'touch' }))
+    document.dispatchEvent(pointerEvent('pointerup', { x: 10, y: 90, pointerType: 'touch' }))
+    expect(handlers.onMove).not.toHaveBeenCalled()
+    expect(screen.getByTestId('queued-input-one').className).not.toContain('itemDragging')
+  })
+
+  it('turns a drop into onMove, which is the wiring the arithmetic tests cannot reach', async () => {
+    const handlers = renderQueue({ items: [item('one'), item('two')] })
+    await flush()
+    // Drives the REAL sensor and the real solid-dnd context, so this covers
+    // `onDragEnd`, the `SortableProvider` ids, and the `qi-` prefix on both
+    // sides. Every rect is zero in jsdom, so `closestCenter` measures every
+    // droppable at distance 0 and keeps the FIRST it saw -- the head. The drop
+    // target is therefore deterministic, and the geometry stays with the
+    // Playwright specs.
+    screen.getByTestId('queued-input-two').dispatchEvent(pointerEvent('pointerdown', { x: 50, y: 50, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 50, y: 70, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 50, y: 90, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointerup', { x: 50, y: 90, pointerType: 'mouse' }))
+
+    expect(handlers.onMove).toHaveBeenCalledWith(expect.objectContaining({ id: 'two' }), 'one')
+  })
+
+  it('drops onto the first slot the dispatching head leaves free', async () => {
+    const handlers = renderQueue({
+      items: [item('one', { state: AgentInputState.DISPATCHING }), item('two'), item('three')],
+    })
+    await flush()
+    // The head is a droppable like any other, so it used to win this collision:
+    // the list previewed the move and `handleDragEnd` then discarded it, leaving
+    // the row snapped back with no message. The collision detector takes every
+    // DISPATCHING row out of the candidates, so the drop lands on the first
+    // legal slot instead. Every rect is zero in jsdom, so `closestCenter` keeps
+    // the FIRST candidate it saw -- which the filter makes `qi-two`.
+    screen.getByTestId('queued-input-three').dispatchEvent(pointerEvent('pointerdown', { x: 50, y: 50, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 50, y: 70, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 50, y: 90, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointerup', { x: 50, y: 90, pointerType: 'mouse' }))
+
+    expect(handlers.onMove).toHaveBeenCalledWith(expect.objectContaining({ id: 'three' }), 'two')
+  })
+
+  it('keeps an armed Delete armed across a snapshot the Worker pushes', async () => {
+    const handlers = renderQueue({ items: [item('one'), item('two')] })
+    await fireEvent.click(within(screen.getByTestId('queued-input-one')).getByRole('button', { name: 'Delete' }))
+    expect(screen.getByRole('button', { name: 'Confirm delete?' })).toBeInTheDocument()
+
+    // Any queue event at all delivers a whole new snapshot with new objects. A
+    // reference-keyed list rebuilt every row here, so the armed state vanished
+    // between the user's two clicks and the second click merely re-armed.
+    handlers.push([item('one'), item('two', { state: AgentInputState.FAILED, error: 'offline' })])
+    await flush()
+
+    const armed = screen.getByRole('button', { name: 'Confirm delete?' })
+    expect(armed).toBeInTheDocument()
+    await fireEvent.click(armed)
+    expect(handlers.onDelete).toHaveBeenCalledWith(expect.objectContaining({ id: 'one' }))
+  })
+
+  it('follows a row into DISPATCHING without remounting it', async () => {
+    const handlers = renderQueue({ items: [item('one'), item('two')] })
+    await flush()
+    const grip = screen.getByTestId('queue-drag-handle-one')
+    expect(grip.className).not.toContain('dragHandleInert')
+
+    handlers.push([item('one', { state: AgentInputState.DISPATCHING }), item('two')])
+    await flush()
+
+    // The SAME node, because the row's key did not change. Every per-item read
+    // in the row therefore has to go through the live accessor; one that
+    // captured the item at mount would still report the row as draggable.
+    expect(screen.getByTestId('queue-drag-handle-one')).toBe(grip)
+    expect(grip.className).toContain('dragHandleInert')
+    expect(within(screen.getByTestId('queued-input-two')).getByRole('button', { name: 'Move Up' })).toBeDisabled()
   })
 
   it('does not move an item across a dispatching head', () => {
@@ -270,13 +312,17 @@ describe('agentInputQueue', () => {
     expect(handlers.onDelete).not.toHaveBeenCalled()
   })
 
-  it('names every row action although the row renders no button text', () => {
+  it('gives every row action a name although the row renders no button text', () => {
     renderQueue({ items: [item('one'), item('two')], supportsSteering: true })
     const first = screen.getByTestId('queued-input-one')
     for (const name of ['Move Up', 'Move Down', 'Edit', 'Delete']) {
+      // `getByRole` throws when the name matches nothing, so the lookup itself
+      // proves the aria-label. The icon needs its own assertion: an EMPTY
+      // button has no text content either, so the text check alone passes for a
+      // square with nothing drawn in it.
       const button = within(first).getByRole('button', { name })
-      expect(button).toBeInTheDocument()
       expect(button.textContent).toBe('')
+      expect(button.querySelector('svg')).not.toBeNull()
     }
   })
 

--- a/frontend/src/components/chat/AgentInputQueue.tsx
+++ b/frontend/src/components/chat/AgentInputQueue.tsx
@@ -1,7 +1,27 @@
+import type { DragEventHandler } from '@thisbeyond/solid-dnd'
+import type { LucideIcon } from 'lucide-solid'
 import type { Component } from 'solid-js'
 import type { AgentInputQueueSnapshot, QueuedAgentInput } from '~/generated/proto/leapmux/v1/agent_pb'
-import { createMemo, For, Show } from 'solid-js'
+import { closestCenter, DragDropProvider, SortableProvider } from '@thisbeyond/solid-dnd'
+import ArrowDown from 'lucide-solid/icons/arrow-down'
+import ArrowUp from 'lucide-solid/icons/arrow-up'
+import Navigation from 'lucide-solid/icons/navigation'
+import Pencil from 'lucide-solid/icons/pencil'
+import PencilOff from 'lucide-solid/icons/pencil-off'
+import RotateCcw from 'lucide-solid/icons/rotate-ccw'
+import SquarePen from 'lucide-solid/icons/square-pen'
+import Trash2 from 'lucide-solid/icons/trash-2'
+import TriangleAlert from 'lucide-solid/icons/triangle-alert'
+import UserPen from 'lucide-solid/icons/user-pen'
+import { createMemo, createSignal, For, Show } from 'solid-js'
+import { ConfirmButton } from '~/components/common/ConfirmButton'
+import { DragHandle } from '~/components/common/DragHandle'
+import { Icon } from '~/components/common/Icon'
+import { Tooltip } from '~/components/common/Tooltip'
+import { GuardedPointerSensor } from '~/components/shell/guardedPointerSensor'
 import { AgentInputKind, AgentInputState } from '~/generated/proto/leapmux/v1/agent_pb'
+import { attachDragActivators } from '~/lib/dragActivators'
+import { createGuardedSortableRow } from '~/lib/dragRow'
 import * as styles from './AgentInputQueue.css'
 
 export interface AgentInputQueueProps {
@@ -37,14 +57,84 @@ function stateLabel(state: AgentInputState): string {
   }
 }
 
+/**
+ * The sortable id of a row. Prefixed, and NOT the `queued-input-<id>` test id:
+ * solid-dnd registers a droppable under the same string, so the two namespaces
+ * must not be able to collide.
+ */
+function dragIdOf(item: QueuedAgentInput): string {
+  return `qi-${item.id}`
+}
+
+/**
+ * The move a drop stands for, or `undefined` when the drop changes nothing.
+ *
+ * Pure, and exported, because this is the whole of the reorder logic and a
+ * pointer drag cannot be reproduced in a unit test: solid-dnd activates on real
+ * pointer geometry and collision detection. The gesture is covered end to end
+ * in `tests/e2e/108-agent-input-queue.spec.ts`; the arithmetic is covered here.
+ *
+ * `beforeInputId` carries the Worker's BEFORE semantics, which
+ * MoveQueuedAgentInput defines: the item comes out of the list first, then goes
+ * back in front of `beforeInputId`, and an empty string means the end. So a
+ * DOWNWARD drop points at the item AFTER the drop target -- the removal already
+ * shifted everything below up by one -- and an upward drop points at the target
+ * itself. `moveDown` obeys the same rule.
+ */
+export function resolveQueueDrop(
+  items: readonly QueuedAgentInput[],
+  draggableId: string,
+  droppableId: string,
+): { moved: QueuedAgentInput, beforeInputId: string } | undefined {
+  const fromIndex = items.findIndex(candidate => dragIdOf(candidate) === draggableId)
+  const toIndex = items.findIndex(candidate => dragIdOf(candidate) === droppableId)
+  if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex)
+    return undefined
+  const moved = items[fromIndex]!
+  const target = items[toIndex]!
+  // A DISPATCHING row is refused at BOTH ends: it cannot be picked up, and it
+  // cannot be displaced, because the Worker is already sending it.
+  if (moved.state === AgentInputState.DISPATCHING || target.state === AgentInputState.DISPATCHING)
+    return undefined
+  return {
+    moved,
+    beforeInputId: fromIndex < toIndex ? (items[toIndex + 1]?.id ?? '') : target.id,
+  }
+}
+
 function attachmentLabel(item: QueuedAgentInput): string {
   return item.attachments
     .map(attachment => `${attachment.filename} (${attachment.size.toLocaleString()} B)`)
     .join(', ')
 }
 
+/**
+ * One action in a queue row.
+ *
+ * The label never renders: it names the button to the tooltip and to the
+ * accessibility tree, which is where an icon-only control has to state it.
+ * Every by-name lookup in the tests and in the E2E specs still resolves,
+ * because an `aria-label` is what those lookups read.
+ */
+const RowAction: Component<{
+  icon: LucideIcon
+  label: string
+  disabled?: boolean
+  onClick: () => void
+}> = props => (
+  <Tooltip text={props.label} ariaLabel>
+    <button
+      class={`outline ${styles.iconAction}`}
+      type="button"
+      disabled={props.disabled}
+      onClick={() => props.onClick()}
+    >
+      <Icon icon={props.icon} size="xs" />
+    </button>
+  </Tooltip>
+)
+
 export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
-  let draggedId = ''
   const items = () => props.snapshot?.items ?? []
   // ONE scan for the whole list, not one scan per row. Each row asks the same
   // question, so a per-row scan costs the square of the queue length on every
@@ -59,6 +149,14 @@ export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
   // below, because the removal already shifted the item one slot below up into
   // the vacated slot. Every downward site obeys this: `moveDown` and the
   // downward branch of the drop handler.
+  const handleDragEnd: DragEventHandler = ({ draggable, droppable }) => {
+    if (!draggable || !droppable)
+      return
+    const drop = resolveQueueDrop(items(), String(draggable.id), String(droppable.id))
+    if (drop)
+      props.onMove(drop.moved, drop.beforeInputId)
+  }
+
   const moveUp = (index: number) => {
     if (index > 0 && items()[index - 1]?.state !== AgentInputState.DISPATCHING)
       props.onMove(items()[index]!, items()[index - 1]!.id)
@@ -72,83 +170,164 @@ export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
 
   return (
     <Show when={items().length > 0}>
-      <div class={styles.root} data-testid="agent-input-queue">
-        <For each={items()}>
-          {(item, index) => {
-            const isHead = () => index() === 0
-            const editedByMe = () => item.editOwnerClientId === props.clientId
-            const editedByOther = () => !!item.editOwnerClientId && !editedByMe()
-            // This row has no edit owner, so the shared scan needs no exclusion
-            // for this row: it can only add a false term.
-            const requiresTakeover = () => editedByOther() || (!item.editOwnerClientId && anyItemIsEdited())
-            const retryable = () => item.state === AgentInputState.FAILED || item.state === AgentInputState.DELIVERY_UNCERTAIN
-            return (
-              <div
-                class={styles.item}
-                draggable={item.state !== AgentInputState.DISPATCHING}
-                onDragStart={() => { draggedId = item.id }}
-                onDragOver={event => event.preventDefault()}
-                onDrop={() => {
-                  const list = items()
-                  const fromIndex = list.findIndex(candidate => candidate.id === draggedId)
-                  const toIndex = list.findIndex(candidate => candidate.id === item.id)
-                  draggedId = ''
-                  if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex || item.state === AgentInputState.DISPATCHING)
-                    return
-                  // A downward drop points at the item AFTER the drop target,
-                  // under the before-semantics rule that `moveDown` obeys, so
-                  // the dragged row lands on the drop target's own slot. An
-                  // upward drop points at the drop target itself.
-                  props.onMove(list[fromIndex]!, fromIndex < toIndex ? (list[toIndex + 1]?.id ?? '') : item.id)
-                }}
-                data-testid={`queued-input-${item.id}`}
-              >
-                <span class={styles.drag} aria-hidden="true">⋮⋮</span>
-                <div class={styles.body}>
-                  <div class={styles.preview}>{item.text || '(attachments only)'}</div>
-                  <div class={styles.metadata}>
-                    {operationLabel(item.kind)}
-                    {' · '}
-                    {stateLabel(item.state)}
-                    <Show when={item.attachments.length > 0}>
-                      {` · ${attachmentLabel(item)}`}
-                    </Show>
-                  </div>
-                  <Show when={item.error}><div class={styles.error}>{item.error}</div></Show>
-                </div>
-                <div class={styles.actions}>
-                  <button class={styles.action} type="button" onClick={() => moveUp(index())} disabled={index() === 0 || item.state === AgentInputState.DISPATCHING || items()[index() - 1]?.state === AgentInputState.DISPATCHING}>Move Up</button>
-                  <button class={styles.action} type="button" onClick={() => moveDown(index())} disabled={index() === items().length - 1 || item.state === AgentInputState.DISPATCHING}>Move Down</button>
-                  <Show
-                    when={requiresTakeover()}
-                    fallback={editedByMe()
-                      ? props.activeEditInputId === item.id
-                        ? <button class={styles.action} type="button" onClick={() => props.onCancelEdit(item)}>Cancel Edit</button>
-                        : <button class={styles.action} type="button" onClick={() => props.onEdit(item, false)}>Resume Edit</button>
-                      : <button class={styles.action} type="button" onClick={() => props.onEdit(item, false)} disabled={item.state === AgentInputState.DISPATCHING}>Edit</button>}
+      {/*
+        The queue owns its OWN drag context, rather than registering with the
+        shell's `SectionDragProvider` the way tab drags do. Nothing ever leaves
+        this list -- an input reorders inside its own queue and nowhere else --
+        so there is no cross-surface interaction to preserve, and reaching up to
+        a sidebar-level context would couple the composer to the shell and break
+        it in every test that renders the panel on its own. The shadowing this
+        creates is confined to the list's own subtree.
+      */}
+      <DragDropProvider onDragEnd={handleDragEnd} collisionDetector={closestCenter}>
+        {/* The stock pointer sensor plus this app's guards: a touch press only
+            starts a drag from a grip, so a finger that swipes the queue still
+            scrolls it. See ~/components/shell/guardedPointerSensor.ts. */}
+        <GuardedPointerSensor />
+        <SortableProvider ids={items().map(dragIdOf)}>
+          <div class={styles.root} data-testid="agent-input-queue">
+            <For each={items()}>
+              {(item, index) => {
+                const isHead = () => index() === 0
+                const editedByMe = () => item.editOwnerClientId === props.clientId
+                const editedByOther = () => !!item.editOwnerClientId && !editedByMe()
+                // This row has no edit owner, so the shared scan needs no exclusion
+                // for this row: it can only add a false term.
+                const requiresTakeover = () => editedByOther() || (!item.editOwnerClientId && anyItemIsEdited())
+                const retryable = () => item.state === AgentInputState.FAILED || item.state === AgentInputState.DELIVERY_UNCERTAIN
+                // The edit slot holds ONE button, and who owns the edit decides
+                // which. A memo keeps the four cases in one place, so the icon,
+                // the name and the handler of a case cannot drift apart.
+                const editAction = createMemo(() => {
+                  if (requiresTakeover())
+                    return { icon: UserPen, label: 'Take Over', onClick: () => props.onEdit(item, true) }
+                  if (!editedByMe()) {
+                    return {
+                      icon: Pencil,
+                      label: 'Edit',
+                      disabled: item.state === AgentInputState.DISPATCHING,
+                      onClick: () => props.onEdit(item, false),
+                    }
+                  }
+                  return props.activeEditInputId === item.id
+                    ? { icon: PencilOff, label: 'Cancel Edit', onClick: () => props.onCancelEdit(item) }
+                    : { icon: SquarePen, label: 'Resume Edit', onClick: () => props.onEdit(item, false) }
+                })
+                const dragRow = createGuardedSortableRow(dragIdOf(item))
+                const canDrag = () => item.state !== AgentInputState.DISPATCHING
+                const [rowEl, setRowEl] = createSignal<HTMLElement>()
+                // Fine-pointer presses on the row body drag it; touch presses do
+                // not, so a swipe still scrolls the queue. The grip above carries
+                // the raw activators, which is the only way a touch drag starts.
+                attachDragActivators(() => (canDrag() ? rowEl() : undefined), dragRow.bodyActivators, { touch: 'block' })
+
+                return (
+                  <div
+                    ref={(el: HTMLElement) => {
+                      setRowEl(el)
+                      // Node registration only. Activation lives on the guarded
+                      // body and on the grip, never on the whole row.
+                      dragRow.ref(el)
+                    }}
+                    class={styles.item}
+                    classList={{ [styles.itemDragging]: dragRow.isActiveDraggable }}
+                    style={dragRow.style()}
+                    data-testid={`queued-input-${item.id}`}
                   >
-                    <button class={styles.action} type="button" onClick={() => props.onEdit(item, true)}>Take Over</button>
-                  </Show>
-                  <button class={styles.action} type="button" onClick={() => props.onDelete(item)} disabled={item.state === AgentInputState.DISPATCHING}>Delete</button>
-                  <Show when={isHead() && retryable() && !item.editOwnerClientId}>
-                    <button class={styles.action} type="button" onClick={() => props.onRetry(item, item.state === AgentInputState.DELIVERY_UNCERTAIN)}>Retry</button>
-                  </Show>
-                  {/*
+                    {/*
+                  Kept in the grid whether or not this row can move, so a
+                  DISPATCHING row does not shift its text one column left.
+                  `dragHandleInert` hides it without removing its box, and the
+                  activators go away with it -- an affordance that cannot drag
+                  must not look like one.
+                */}
+                    <DragHandle
+                      activators={() => (canDrag() ? dragRow.gripActivators() : undefined)}
+                      class={canDrag() ? undefined : styles.dragHandleInert}
+                      testId={`queue-drag-handle-${item.id}`}
+                    />
+                    <div class={styles.body}>
+                      <div class={styles.preview}>{item.text || '(attachments only)'}</div>
+                      <div class={styles.metadata}>
+                        {operationLabel(item.kind)}
+                        {' · '}
+                        {stateLabel(item.state)}
+                        <Show when={item.attachments.length > 0}>
+                          {` · ${attachmentLabel(item)}`}
+                        </Show>
+                      </div>
+                      <Show when={item.error}><div class={styles.error}>{item.error}</div></Show>
+                    </div>
+                    <div class={styles.actions}>
+                      <RowAction
+                        icon={ArrowUp}
+                        label="Move Up"
+                        disabled={index() === 0 || item.state === AgentInputState.DISPATCHING || items()[index() - 1]?.state === AgentInputState.DISPATCHING}
+                        onClick={() => moveUp(index())}
+                      />
+                      <RowAction
+                        icon={ArrowDown}
+                        label="Move Down"
+                        disabled={index() === items().length - 1 || item.state === AgentInputState.DISPATCHING}
+                        onClick={() => moveDown(index())}
+                      />
+                      <RowAction
+                        icon={editAction().icon}
+                        label={editAction().label}
+                        disabled={editAction().disabled}
+                        onClick={() => editAction().onClick()}
+                      />
+                      {/*
+                    Delete takes a second click, because an icon carries no
+                    word to read before the press and the queued input is gone
+                    for good. The armed state swaps the bin for a warning sign
+                    and turns the outline red, and `confirmTooltip` renames the
+                    button so a screen reader hears the armed state too.
+                  */}
+                      <ConfirmButton
+                        class={`outline ${styles.iconAction}`}
+                        tooltip="Delete"
+                        confirmTooltip="Confirm delete?"
+                        confirmLabel={<Icon icon={TriangleAlert} size="xs" />}
+                        disabled={item.state === AgentInputState.DISPATCHING}
+                        onClick={() => props.onDelete(item)}
+                      >
+                        <Icon icon={Trash2} size="xs" />
+                      </ConfirmButton>
+                      <Show when={isHead() && retryable() && !item.editOwnerClientId}>
+                        <RowAction
+                          icon={RotateCcw}
+                          label="Retry"
+                          onClick={() => props.onRetry(item, item.state === AgentInputState.DELIVERY_UNCERTAIN)}
+                        />
+                      </Show>
+                      {/*
+                    Steer stays last, so the one button that still shows a word
+                    sits at the end of the row and the squares before it keep an
+                    even rhythm.
+
                     `canSteer` comes from the Worker, which computes it with the
                     same expression that the store's steering guard applies. The
                     browser must never re-implement that precondition: a new
                     input kind would then offer a Steer button that the Worker
                     refuses.
                   */}
-                  <Show when={isHead() && props.supportsSteering && item.canSteer}>
-                    <button class={styles.action} type="button" onClick={() => props.onSteer(item)}>Steer</button>
-                  </Show>
-                </div>
-              </div>
-            )
-          }}
-        </For>
-      </div>
+                      <Show when={isHead() && props.supportsSteering && item.canSteer}>
+                        <Tooltip text="Steer" ariaLabel>
+                          <button class={styles.steerAction} type="button" onClick={() => props.onSteer(item)}>
+                            <Icon icon={Navigation} size="xs" />
+                            <span class={styles.steerLabel}>Steer</span>
+                          </button>
+                        </Tooltip>
+                      </Show>
+                    </div>
+                  </div>
+                )
+              }}
+            </For>
+          </div>
+        </SortableProvider>
+      </DragDropProvider>
     </Show>
   )
 }

--- a/frontend/src/components/chat/AgentInputQueue.tsx
+++ b/frontend/src/components/chat/AgentInputQueue.tsx
@@ -1,6 +1,6 @@
-import type { DragEventHandler } from '@thisbeyond/solid-dnd'
+import type { CollisionDetector, DragEventHandler } from '@thisbeyond/solid-dnd'
 import type { LucideIcon } from 'lucide-solid'
-import type { Component } from 'solid-js'
+import type { Accessor, Component } from 'solid-js'
 import type { AgentInputQueueSnapshot, QueuedAgentInput } from '~/generated/proto/leapmux/v1/agent_pb'
 import { closestCenter, DragDropProvider, SortableProvider } from '@thisbeyond/solid-dnd'
 import ArrowDown from 'lucide-solid/icons/arrow-down'
@@ -13,7 +13,7 @@ import SquarePen from 'lucide-solid/icons/square-pen'
 import Trash2 from 'lucide-solid/icons/trash-2'
 import TriangleAlert from 'lucide-solid/icons/triangle-alert'
 import UserPen from 'lucide-solid/icons/user-pen'
-import { createMemo, createSignal, For, Show } from 'solid-js'
+import { createMemo, createSignal, Show } from 'solid-js'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { DragHandle } from '~/components/common/DragHandle'
 import { Icon } from '~/components/common/Icon'
@@ -22,7 +22,9 @@ import { GuardedPointerSensor } from '~/components/shell/guardedPointerSensor'
 import { AgentInputKind, AgentInputState } from '~/generated/proto/leapmux/v1/agent_pb'
 import { attachDragActivators } from '~/lib/dragActivators'
 import { createGuardedSortableRow } from '~/lib/dragRow'
+import { createKeyedRows, KeyedFor } from '~/lib/keyedRows'
 import * as styles from './AgentInputQueue.css'
+import { dragIdOf, resolveQueueDrop, resolveQueueMove } from './agentInputQueueDrop'
 
 export interface AgentInputQueueProps {
   snapshot?: AgentInputQueueSnapshot
@@ -37,69 +39,46 @@ export interface AgentInputQueueProps {
   onSteer: (item: QueuedAgentInput) => void
 }
 
+/**
+ * The operation a queued input performs.
+ *
+ * A table with `satisfies`, not a `switch` with a `default`. A new
+ * `AgentInputKind` then fails the frontend typecheck instead of rendering as
+ * "Message" and telling the user the wrong thing. `UNSPECIFIED` and
+ * `USER_MESSAGE` both read "Message" on purpose.
+ */
+const OPERATION_LABELS = {
+  [AgentInputKind.UNSPECIFIED]: 'Message',
+  [AgentInputKind.USER_MESSAGE]: 'Message',
+  [AgentInputKind.CLEAR_CONTEXT]: 'Clear context',
+  [AgentInputKind.COMPACT_CONTEXT]: 'Compact context',
+  [AgentInputKind.PLAN_EXECUTION]: 'Execute plan',
+  [AgentInputKind.AUTO_CONTINUE]: 'Auto-continue',
+  [AgentInputKind.CONTROL_FEEDBACK]: 'Control feedback',
+} satisfies Record<AgentInputKind, string>
+
+/**
+ * What the queue does with an input right now.
+ *
+ * The same table shape as `OPERATION_LABELS`, for the same reason.
+ */
+const STATE_LABELS = {
+  [AgentInputState.UNSPECIFIED]: 'Queued',
+  [AgentInputState.QUEUED]: 'Queued',
+  [AgentInputState.DISPATCHING]: 'Dispatching',
+  [AgentInputState.FAILED]: 'Failed',
+  [AgentInputState.DELIVERY_UNCERTAIN]: 'Delivery uncertain',
+} satisfies Record<AgentInputState, string>
+
+// A Worker ahead of this client sends an enum number that the generated table
+// has no key for, so both lookups keep a runtime fallback. protobuf-es passes
+// an unknown number through unchanged.
 function operationLabel(kind: AgentInputKind): string {
-  switch (kind) {
-    case AgentInputKind.CLEAR_CONTEXT: return 'Clear context'
-    case AgentInputKind.COMPACT_CONTEXT: return 'Compact context'
-    case AgentInputKind.PLAN_EXECUTION: return 'Execute plan'
-    case AgentInputKind.AUTO_CONTINUE: return 'Auto-continue'
-    case AgentInputKind.CONTROL_FEEDBACK: return 'Control feedback'
-    default: return 'Message'
-  }
+  return OPERATION_LABELS[kind] ?? OPERATION_LABELS[AgentInputKind.UNSPECIFIED]
 }
 
 function stateLabel(state: AgentInputState): string {
-  switch (state) {
-    case AgentInputState.DISPATCHING: return 'Dispatching'
-    case AgentInputState.FAILED: return 'Failed'
-    case AgentInputState.DELIVERY_UNCERTAIN: return 'Delivery uncertain'
-    default: return 'Queued'
-  }
-}
-
-/**
- * The sortable id of a row. Prefixed, and NOT the `queued-input-<id>` test id:
- * solid-dnd registers a droppable under the same string, so the two namespaces
- * must not be able to collide.
- */
-function dragIdOf(item: QueuedAgentInput): string {
-  return `qi-${item.id}`
-}
-
-/**
- * The move a drop stands for, or `undefined` when the drop changes nothing.
- *
- * Pure, and exported, because this is the whole of the reorder logic and a
- * pointer drag cannot be reproduced in a unit test: solid-dnd activates on real
- * pointer geometry and collision detection. The gesture is covered end to end
- * in `tests/e2e/108-agent-input-queue.spec.ts`; the arithmetic is covered here.
- *
- * `beforeInputId` carries the Worker's BEFORE semantics, which
- * MoveQueuedAgentInput defines: the item comes out of the list first, then goes
- * back in front of `beforeInputId`, and an empty string means the end. So a
- * DOWNWARD drop points at the item AFTER the drop target -- the removal already
- * shifted everything below up by one -- and an upward drop points at the target
- * itself. `moveDown` obeys the same rule.
- */
-export function resolveQueueDrop(
-  items: readonly QueuedAgentInput[],
-  draggableId: string,
-  droppableId: string,
-): { moved: QueuedAgentInput, beforeInputId: string } | undefined {
-  const fromIndex = items.findIndex(candidate => dragIdOf(candidate) === draggableId)
-  const toIndex = items.findIndex(candidate => dragIdOf(candidate) === droppableId)
-  if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex)
-    return undefined
-  const moved = items[fromIndex]!
-  const target = items[toIndex]!
-  // A DISPATCHING row is refused at BOTH ends: it cannot be picked up, and it
-  // cannot be displaced, because the Worker is already sending it.
-  if (moved.state === AgentInputState.DISPATCHING || target.state === AgentInputState.DISPATCHING)
-    return undefined
-  return {
-    moved,
-    beforeInputId: fromIndex < toIndex ? (items[toIndex + 1]?.id ?? '') : target.id,
-  }
+  return STATE_LABELS[state] ?? STATE_LABELS[AgentInputState.UNSPECIFIED]
 }
 
 function attachmentLabel(item: QueuedAgentInput): string {
@@ -109,12 +88,21 @@ function attachmentLabel(item: QueuedAgentInput): string {
 }
 
 /**
+ * The class every icon-only row action carries: Oat's `outline` look plus this
+ * row's square geometry.
+ *
+ * One constant, because `RowAction` and the Delete `ConfirmButton` must render
+ * the same square. A second spelling let one of them drift.
+ */
+const ROW_ACTION_CLASS = `outline ${styles.iconAction}`
+
+/**
  * One action in a queue row.
  *
- * The label never renders: it names the button to the tooltip and to the
- * accessibility tree, which is where an icon-only control has to state it.
- * Every by-name lookup in the tests and in the E2E specs still resolves,
- * because an `aria-label` is what those lookups read.
+ * The label never renders: it gives the button its name through the tooltip and
+ * through the accessibility tree, which is where an icon-only control has to
+ * state it. Every by-name lookup in the tests and in the E2E specs still
+ * resolves, because an `aria-label` is what those lookups read.
  */
 const RowAction: Component<{
   icon: LucideIcon
@@ -124,7 +112,7 @@ const RowAction: Component<{
 }> = props => (
   <Tooltip text={props.label} ariaLabel>
     <button
-      class={`outline ${styles.iconAction}`}
+      class={ROW_ACTION_CLASS}
       type="button"
       disabled={props.disabled}
       onClick={() => props.onClick()}
@@ -136,19 +124,30 @@ const RowAction: Component<{
 
 export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
   const items = () => props.snapshot?.items ?? []
+  /**
+   * Stable string keys, and a live lookup from a key to its item.
+   *
+   * `<For>` over the items themselves keys by object REFERENCE, and every
+   * snapshot the Worker pushes replaces the whole array with freshly decoded
+   * objects. Each of those pushes then disposed and rebuilt every row, which
+   * threw away what the row's DOM was holding: an armed Delete button lost its
+   * armed state between the user's two clicks, and a drag in flight lost its
+   * drop preview. It also rebuilt every Tooltip, every sortable registration
+   * and every drag activator of every row, on every queue event.
+   *
+   * Keys are strings, so the `<For>` inside `KeyedFor` reconciles only when a
+   * row is added, removed, or reordered. Every other field is read INSIDE the
+   * row through the `item()` accessor, where Solid updates in place.
+   */
+  const { keys, byKey } = createKeyedRows(items, dragIdOf)
+  // O(1) per row, and one pass per change. A per-row `indexOf` would cost the
+  // square of the queue length on every snapshot.
+  const indexByKey = createMemo(() => new Map(keys().map((key, index) => [key, index])))
   // ONE scan for the whole list, not one scan per row. Each row asks the same
   // question, so a per-row scan costs the square of the queue length on every
   // snapshot that the Worker sends.
   const anyItemIsEdited = createMemo(() => items().some(candidate => !!candidate.editOwnerClientId))
-  // `onMove` carries BEFORE semantics, which MoveQueuedAgentInput defines: the
-  // Worker takes the item out of the list first, then puts it back in front of
-  // `beforeInputId`. An empty `beforeInputId` moves the item to the end.
-  //
-  // An upward move points at the item one slot above, which is the slot the
-  // user wants. A DOWNWARD move points one slot further, at the item TWO slots
-  // below, because the removal already shifted the item one slot below up into
-  // the vacated slot. Every downward site obeys this: `moveDown` and the
-  // downward branch of the drop handler.
+
   const handleDragEnd: DragEventHandler = ({ draggable, droppable }) => {
     if (!draggable || !droppable)
       return
@@ -157,15 +156,196 @@ export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
       props.onMove(drop.moved, drop.beforeInputId)
   }
 
-  const moveUp = (index: number) => {
-    if (index > 0 && items()[index - 1]?.state !== AgentInputState.DISPATCHING)
-      props.onMove(items()[index]!, items()[index - 1]!.id)
+  /**
+   * `closestCenter`, with every DISPATCHING row taken out of the candidates.
+   *
+   * `createSortable` registers a droppable for every row, whether or not the
+   * queue can displace it, so the Worker's own row won the collision like any
+   * other. `SortableProvider` then PREVIEWED that move -- the rows visibly
+   * reflowed -- and `handleDragEnd` discarded it, because `resolveQueueMove`
+   * refuses a DISPATCHING target. The row snapped back and nothing said why.
+   *
+   * Filtering here keeps the preview and the drop on one answer: the pointer
+   * lands on the first LEGAL slot instead. `resolveQueueMove` stays the single
+   * definition of a legal reorder; this only stops the pointer from selecting a
+   * target that function will refuse.
+   */
+  const dropTarget: CollisionDetector = (draggable, droppables, context) =>
+    closestCenter(
+      draggable,
+      droppables.filter(candidate => byKey().get(String(candidate.id))?.state !== AgentInputState.DISPATCHING),
+      context,
+    )
+
+  const move = (fromIndex: number, toIndex: number) => {
+    const resolved = resolveQueueMove(items(), fromIndex, toIndex)
+    if (resolved)
+      props.onMove(resolved.moved, resolved.beforeInputId)
   }
-  const moveDown = (index: number) => {
-    const list = items()
-    if (index >= list.length - 1)
-      return
-    props.onMove(list[index]!, list[index + 2]?.id ?? '')
+
+  /**
+   * Whether this key's row can be dragged, resolved through the LIVE lookup.
+   *
+   * Read through `byKey()` and never from an item the row captured at mount.
+   * The row keeps its identity now, so a captured item would freeze this at the
+   * state the row started with, and a row that becomes DISPATCHING would keep a
+   * live grip and live drag activators.
+   */
+  const canDragKey = (key: string) => {
+    const item = byKey().get(key)
+    return !!item && item.state !== AgentInputState.DISPATCHING
+  }
+
+  /**
+   * The per-row drag wiring, created in the FOR-ROW owner.
+   *
+   * Outside the `<Show>` that resolves the item, so a tick where the lookup
+   * misses cannot dispose the sortable and drop a drag mid-gesture. The key is
+   * the row's identity for the whole of its life, so the sortable id is fixed
+   * at creation.
+   */
+  const setupRowDnd = (key: string) => {
+    const dragRow = createGuardedSortableRow(key)
+    const [rowEl, setRowEl] = createSignal<HTMLElement>()
+    // Fine-pointer presses on the row body drag it; touch presses do not, so a
+    // swipe still scrolls the queue. The grip carries the raw activators, which
+    // is the only route a touch drag takes.
+    // eslint-disable-next-line solid/reactivity -- attachDragActivators reads this inside its own createEffect
+    attachDragActivators(() => (canDragKey(key) ? rowEl() : undefined), dragRow.bodyActivators, { touch: 'block' })
+    return { dragRow, rowEl, setRowEl, canDrag: () => canDragKey(key) }
+  }
+
+  const renderRow = (item: Accessor<QueuedAgentInput>, key: string, dnd: ReturnType<typeof setupRowDnd>) => {
+    const index = () => indexByKey().get(key) ?? -1
+    const isHead = () => index() === 0
+    const isDispatching = () => item().state === AgentInputState.DISPATCHING
+    const editedByMe = () => item().editOwnerClientId === props.clientId
+    const editedByOther = () => !!item().editOwnerClientId && !editedByMe()
+    // This row has no edit owner, so the shared scan needs no exclusion
+    // for this row: it can only add a false term.
+    const requiresTakeover = () => editedByOther() || (!item().editOwnerClientId && anyItemIsEdited())
+    const retryable = () => item().state === AgentInputState.FAILED || item().state === AgentInputState.DELIVERY_UNCERTAIN
+    // The edit slot holds ONE button, and who owns the edit decides
+    // which. A memo keeps the four cases in one place, so the icon,
+    // the name and the handler of a case cannot drift apart.
+    const editAction = createMemo(() => {
+      if (requiresTakeover())
+        return { icon: UserPen, label: 'Take Over', onClick: () => props.onEdit(item(), true) }
+      if (!editedByMe()) {
+        return {
+          icon: Pencil,
+          label: 'Edit',
+          disabled: isDispatching(),
+          onClick: () => props.onEdit(item(), false),
+        }
+      }
+      return props.activeEditInputId === item().id
+        ? { icon: PencilOff, label: 'Cancel Edit', onClick: () => props.onCancelEdit(item()) }
+        : { icon: SquarePen, label: 'Resume Edit', onClick: () => props.onEdit(item(), false) }
+    })
+
+    return (
+      <div
+        ref={(el) => {
+          dnd.setRowEl(el)
+          // Node registration only. Activation lives on the guarded
+          // body and on the grip, never on the whole row.
+          dnd.dragRow.ref(el)
+        }}
+        class={styles.item}
+        classList={{
+          [styles.itemDragging]: dnd.dragRow.isActiveDraggable,
+          [styles.itemDraggable]: dnd.canDrag(),
+        }}
+        style={dnd.dragRow.style()}
+        data-testid={`queued-input-${item().id}`}
+      >
+        {/*
+          Kept in the row whether or not this row can move, so a DISPATCHING row
+          does not shift its text one slot left. `dragHandleInert` hides it
+          without removing its box, and the activators go away with it -- an
+          affordance that cannot drag must not look like one.
+        */}
+        <DragHandle
+          activators={() => (dnd.canDrag() ? dnd.dragRow.gripActivators() : undefined)}
+          class={dnd.canDrag() ? undefined : styles.dragHandleInert}
+          testId={`queue-drag-handle-${item().id}`}
+        />
+        <div class={styles.body}>
+          <div class={styles.preview}>{item().text || '(attachments only)'}</div>
+          <div class={styles.metadata}>
+            {operationLabel(item().kind)}
+            {' · '}
+            {stateLabel(item().state)}
+            <Show when={item().attachments.length > 0}>
+              {` · ${attachmentLabel(item())}`}
+            </Show>
+          </div>
+          <Show when={item().error}><div class={styles.error}>{item().error}</div></Show>
+        </div>
+        <div class={styles.actions}>
+          <RowAction
+            icon={ArrowUp}
+            label="Move Up"
+            disabled={!resolveQueueMove(items(), index(), index() - 1)}
+            onClick={() => move(index(), index() - 1)}
+          />
+          <RowAction
+            icon={ArrowDown}
+            label="Move Down"
+            disabled={!resolveQueueMove(items(), index(), index() + 1)}
+            onClick={() => move(index(), index() + 1)}
+          />
+          <RowAction
+            icon={editAction().icon}
+            label={editAction().label}
+            disabled={editAction().disabled}
+            onClick={() => editAction().onClick()}
+          />
+          {/*
+            Delete takes a second click, because an icon carries no word to read
+            before the press and the queued input is gone for good. The armed
+            state swaps the bin for a warning sign and turns the outline red,
+            and `confirmTooltip` changes the button's name so a screen reader
+            hears the armed state too.
+          */}
+          <ConfirmButton
+            class={ROW_ACTION_CLASS}
+            tooltip="Delete"
+            confirmTooltip="Confirm delete?"
+            confirmLabel={<Icon icon={TriangleAlert} size="xs" />}
+            disabled={isDispatching()}
+            onClick={() => props.onDelete(item())}
+          >
+            <Icon icon={Trash2} size="xs" />
+          </ConfirmButton>
+          <Show when={isHead() && retryable() && !item().editOwnerClientId}>
+            <RowAction
+              icon={RotateCcw}
+              label="Retry"
+              onClick={() => props.onRetry(item(), item().state === AgentInputState.DELIVERY_UNCERTAIN)}
+            />
+          </Show>
+          {/*
+            Steer stays last, so the one button that still shows a word sits at
+            the end of the row and the squares before it keep an even rhythm.
+
+            `canSteer` comes from the Worker, which computes it with the same
+            expression that the store's steering guard applies. The browser must
+            never re-implement that precondition: a new input kind would then
+            offer a Steer button that the Worker refuses.
+          */}
+          <Show when={isHead() && props.supportsSteering && item().canSteer}>
+            <Tooltip text="Steer" ariaLabel>
+              <button class={styles.steerAction} type="button" onClick={() => props.onSteer(item())}>
+                <Icon icon={Navigation} size="xs" />
+                <span>Steer</span>
+              </button>
+            </Tooltip>
+          </Show>
+        </div>
+      </div>
+    )
   }
 
   return (
@@ -179,152 +359,16 @@ export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
         it in every test that renders the panel on its own. The shadowing this
         creates is confined to the list's own subtree.
       */}
-      <DragDropProvider onDragEnd={handleDragEnd} collisionDetector={closestCenter}>
+      <DragDropProvider onDragEnd={handleDragEnd} collisionDetector={dropTarget}>
         {/* The stock pointer sensor plus this app's guards: a touch press only
             starts a drag from a grip, so a finger that swipes the queue still
             scrolls it. See ~/components/shell/guardedPointerSensor.ts. */}
         <GuardedPointerSensor />
-        <SortableProvider ids={items().map(dragIdOf)}>
+        <SortableProvider ids={keys()}>
           <div class={styles.root} data-testid="agent-input-queue">
-            <For each={items()}>
-              {(item, index) => {
-                const isHead = () => index() === 0
-                const editedByMe = () => item.editOwnerClientId === props.clientId
-                const editedByOther = () => !!item.editOwnerClientId && !editedByMe()
-                // This row has no edit owner, so the shared scan needs no exclusion
-                // for this row: it can only add a false term.
-                const requiresTakeover = () => editedByOther() || (!item.editOwnerClientId && anyItemIsEdited())
-                const retryable = () => item.state === AgentInputState.FAILED || item.state === AgentInputState.DELIVERY_UNCERTAIN
-                // The edit slot holds ONE button, and who owns the edit decides
-                // which. A memo keeps the four cases in one place, so the icon,
-                // the name and the handler of a case cannot drift apart.
-                const editAction = createMemo(() => {
-                  if (requiresTakeover())
-                    return { icon: UserPen, label: 'Take Over', onClick: () => props.onEdit(item, true) }
-                  if (!editedByMe()) {
-                    return {
-                      icon: Pencil,
-                      label: 'Edit',
-                      disabled: item.state === AgentInputState.DISPATCHING,
-                      onClick: () => props.onEdit(item, false),
-                    }
-                  }
-                  return props.activeEditInputId === item.id
-                    ? { icon: PencilOff, label: 'Cancel Edit', onClick: () => props.onCancelEdit(item) }
-                    : { icon: SquarePen, label: 'Resume Edit', onClick: () => props.onEdit(item, false) }
-                })
-                const dragRow = createGuardedSortableRow(dragIdOf(item))
-                const canDrag = () => item.state !== AgentInputState.DISPATCHING
-                const [rowEl, setRowEl] = createSignal<HTMLElement>()
-                // Fine-pointer presses on the row body drag it; touch presses do
-                // not, so a swipe still scrolls the queue. The grip above carries
-                // the raw activators, which is the only way a touch drag starts.
-                attachDragActivators(() => (canDrag() ? rowEl() : undefined), dragRow.bodyActivators, { touch: 'block' })
-
-                return (
-                  <div
-                    ref={(el: HTMLElement) => {
-                      setRowEl(el)
-                      // Node registration only. Activation lives on the guarded
-                      // body and on the grip, never on the whole row.
-                      dragRow.ref(el)
-                    }}
-                    class={styles.item}
-                    classList={{ [styles.itemDragging]: dragRow.isActiveDraggable }}
-                    style={dragRow.style()}
-                    data-testid={`queued-input-${item.id}`}
-                  >
-                    {/*
-                  Kept in the grid whether or not this row can move, so a
-                  DISPATCHING row does not shift its text one column left.
-                  `dragHandleInert` hides it without removing its box, and the
-                  activators go away with it -- an affordance that cannot drag
-                  must not look like one.
-                */}
-                    <DragHandle
-                      activators={() => (canDrag() ? dragRow.gripActivators() : undefined)}
-                      class={canDrag() ? undefined : styles.dragHandleInert}
-                      testId={`queue-drag-handle-${item.id}`}
-                    />
-                    <div class={styles.body}>
-                      <div class={styles.preview}>{item.text || '(attachments only)'}</div>
-                      <div class={styles.metadata}>
-                        {operationLabel(item.kind)}
-                        {' · '}
-                        {stateLabel(item.state)}
-                        <Show when={item.attachments.length > 0}>
-                          {` · ${attachmentLabel(item)}`}
-                        </Show>
-                      </div>
-                      <Show when={item.error}><div class={styles.error}>{item.error}</div></Show>
-                    </div>
-                    <div class={styles.actions}>
-                      <RowAction
-                        icon={ArrowUp}
-                        label="Move Up"
-                        disabled={index() === 0 || item.state === AgentInputState.DISPATCHING || items()[index() - 1]?.state === AgentInputState.DISPATCHING}
-                        onClick={() => moveUp(index())}
-                      />
-                      <RowAction
-                        icon={ArrowDown}
-                        label="Move Down"
-                        disabled={index() === items().length - 1 || item.state === AgentInputState.DISPATCHING}
-                        onClick={() => moveDown(index())}
-                      />
-                      <RowAction
-                        icon={editAction().icon}
-                        label={editAction().label}
-                        disabled={editAction().disabled}
-                        onClick={() => editAction().onClick()}
-                      />
-                      {/*
-                    Delete takes a second click, because an icon carries no
-                    word to read before the press and the queued input is gone
-                    for good. The armed state swaps the bin for a warning sign
-                    and turns the outline red, and `confirmTooltip` renames the
-                    button so a screen reader hears the armed state too.
-                  */}
-                      <ConfirmButton
-                        class={`outline ${styles.iconAction}`}
-                        tooltip="Delete"
-                        confirmTooltip="Confirm delete?"
-                        confirmLabel={<Icon icon={TriangleAlert} size="xs" />}
-                        disabled={item.state === AgentInputState.DISPATCHING}
-                        onClick={() => props.onDelete(item)}
-                      >
-                        <Icon icon={Trash2} size="xs" />
-                      </ConfirmButton>
-                      <Show when={isHead() && retryable() && !item.editOwnerClientId}>
-                        <RowAction
-                          icon={RotateCcw}
-                          label="Retry"
-                          onClick={() => props.onRetry(item, item.state === AgentInputState.DELIVERY_UNCERTAIN)}
-                        />
-                      </Show>
-                      {/*
-                    Steer stays last, so the one button that still shows a word
-                    sits at the end of the row and the squares before it keep an
-                    even rhythm.
-
-                    `canSteer` comes from the Worker, which computes it with the
-                    same expression that the store's steering guard applies. The
-                    browser must never re-implement that precondition: a new
-                    input kind would then offer a Steer button that the Worker
-                    refuses.
-                  */}
-                      <Show when={isHead() && props.supportsSteering && item.canSteer}>
-                        <Tooltip text="Steer" ariaLabel>
-                          <button class={styles.steerAction} type="button" onClick={() => props.onSteer(item)}>
-                            <Icon icon={Navigation} size="xs" />
-                            <span class={styles.steerLabel}>Steer</span>
-                          </button>
-                        </Tooltip>
-                      </Show>
-                    </div>
-                  </div>
-                )
-              }}
-            </For>
+            <KeyedFor each={keys()} lookup={key => byKey().get(key)} rowSetup={setupRowDnd}>
+              {renderRow}
+            </KeyedFor>
           </div>
         </SortableProvider>
       </DragDropProvider>

--- a/frontend/src/components/chat/AgentInputQueuePauseBanner.css.ts
+++ b/frontend/src/components/chat/AgentInputQueuePauseBanner.css.ts
@@ -1,0 +1,37 @@
+import { style } from '@vanilla-extract/css'
+import { ACTION_SIZE } from './AgentInputQueue.css'
+
+/**
+ * The paused-queue notice, directly above the queue and the composer.
+ *
+ * No background, no border and no horizontal padding: it is a line of text in
+ * the composer's own column, not a card sitting on top of it. Vertical padding
+ * is zero too, because `inputArea` owns every gap in that column -- see the
+ * `inputArea` comment in `./ChatView.css.ts`.
+ */
+export const banner = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--space-2)',
+  padding: 0,
+  fontSize: '0.72rem',
+  color: 'var(--muted-foreground)',
+})
+
+export const icon = style({
+  flexShrink: 0,
+  color: 'var(--warning)',
+})
+
+/** Takes the free width, so Resume stays at the end of the row. */
+export const text = style({
+  flex: 1,
+  minWidth: 0,
+})
+
+export const resume = style({
+  height: ACTION_SIZE,
+  padding: '0 var(--space-2)',
+  fontSize: '0.72rem',
+  flexShrink: 0,
+})

--- a/frontend/src/components/chat/AgentInputQueuePauseBanner.css.ts
+++ b/frontend/src/components/chat/AgentInputQueuePauseBanner.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { ACTION_SIZE } from './AgentInputQueue.css'
+import { compactActionLabelled, compactTextSize } from '~/styles/tokens'
 
 /**
  * The paused-queue notice, directly above the queue and the composer.
@@ -7,14 +7,14 @@ import { ACTION_SIZE } from './AgentInputQueue.css'
  * No background, no border and no horizontal padding: it is a line of text in
  * the composer's own column, not a card sitting on top of it. Vertical padding
  * is zero too, because `inputArea` owns every gap in that column -- see the
- * `inputArea` comment in `./ChatView.css.ts`.
+ * `inputArea` comment in `~/components/chat/ChatView.css.ts`.
  */
 export const banner = style({
   display: 'flex',
   alignItems: 'center',
   gap: 'var(--space-2)',
   padding: 0,
-  fontSize: '0.72rem',
+  fontSize: compactTextSize,
   color: 'var(--muted-foreground)',
 })
 
@@ -29,9 +29,9 @@ export const text = style({
   minWidth: 0,
 })
 
-export const resume = style({
-  height: ACTION_SIZE,
-  padding: '0 var(--space-2)',
-  fontSize: '0.72rem',
-  flexShrink: 0,
-})
+/**
+ * Resume sits in the same column as the queue's own row actions, so it takes
+ * the shared compact-action geometry from `~/styles/tokens.ts`. One source, so
+ * the two heights cannot drift.
+ */
+export const resume = style({ ...compactActionLabelled })

--- a/frontend/src/components/chat/AgentInputQueuePauseBanner.test.tsx
+++ b/frontend/src/components/chat/AgentInputQueuePauseBanner.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { AgentInputQueuePauseReason } from '~/generated/proto/leapmux/v1/agent_pb'
+import { AgentInputQueuePauseBanner, pauseSentence } from './AgentInputQueuePauseBanner'
+
+describe('agentInputQueuePauseBanner', () => {
+  it('renders nothing while the queue runs', () => {
+    render(() => (
+      <AgentInputQueuePauseBanner paused={false} reason={AgentInputQueuePauseReason.MANUAL} />
+    ))
+    expect(screen.queryByTestId('queue-pause-banner')).not.toBeInTheDocument()
+  })
+
+  it('shows the banner with an empty queue, which is the case with no other signal', () => {
+    render(() => (
+      <AgentInputQueuePauseBanner paused reason={AgentInputQueuePauseReason.INTERRUPTED} />
+    ))
+    expect(screen.getByTestId('queue-pause-banner')).toHaveTextContent(
+      'Queue paused because you interrupted the agent.',
+    )
+  })
+
+  it('states the cause for every automatic pause reason', () => {
+    const cases: [AgentInputQueuePauseReason, string][] = [
+      [AgentInputQueuePauseReason.INTERRUPTED, 'you interrupted the agent'],
+      [AgentInputQueuePauseReason.AGENT_STOPPED, 'the agent stopped'],
+      [AgentInputQueuePauseReason.DELIVERY_FAILED, 'did not reach the agent'],
+      [AgentInputQueuePauseReason.DELIVERY_UNCERTAIN, 'may not have reached the agent'],
+    ]
+    for (const [reason, fragment] of cases)
+      expect(pauseSentence(reason)).toContain(fragment)
+  })
+
+  it('describes the state, never a cause, when the Worker names no reason', () => {
+    // Inventing a cause is worse than describing the state, so UNSPECIFIED
+    // reads exactly as the manual pause does.
+    expect(pauseSentence(AgentInputQueuePauseReason.UNSPECIFIED))
+      .toBe(pauseSentence(AgentInputQueuePauseReason.MANUAL))
+    expect(pauseSentence(AgentInputQueuePauseReason.UNSPECIFIED)).not.toContain('because')
+  })
+
+  it('falls back to the manual sentence for a reason this build does not know', () => {
+    // A Worker ahead of this client sends an enum value the generated table has
+    // no key for. The banner must still say something.
+    expect(pauseSentence(99 as AgentInputQueuePauseReason))
+      .toBe(pauseSentence(AgentInputQueuePauseReason.MANUAL))
+  })
+
+  it('resumes from its own button', async () => {
+    const onResume = vi.fn()
+    render(() => (
+      <AgentInputQueuePauseBanner paused reason={AgentInputQueuePauseReason.MANUAL} onResume={onResume} />
+    ))
+    await fireEvent.click(screen.getByRole('button', { name: 'Resume' }))
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it('survives a Resume press with no handler attached', () => {
+    // `onResume` is optional, and AgentEditorPanel leaves it unset whenever the
+    // panel has no `onSetQueuePaused`. The press must not throw there.
+    render(() => (
+      <AgentInputQueuePauseBanner paused reason={AgentInputQueuePauseReason.MANUAL} />
+    ))
+    expect(() => fireEvent.click(screen.getByRole('button', { name: 'Resume' }))).not.toThrow()
+  })
+
+  it('keeps the live region mounted while the queue runs, so a later pause announces', () => {
+    const { container } = render(() => (
+      <AgentInputQueuePauseBanner paused={false} reason={AgentInputQueuePauseReason.MANUAL} />
+    ))
+    // A live region that appears together with its text announces nothing on
+    // several screen readers, and four of the five reasons arrive unprompted.
+    const live = container.querySelector('[role="status"]')
+    expect(live).not.toBeNull()
+    expect(live).toHaveTextContent('')
+  })
+
+  it('puts the sentence in the live region once paused', () => {
+    const { container } = render(() => (
+      <AgentInputQueuePauseBanner paused reason={AgentInputQueuePauseReason.AGENT_STOPPED} />
+    ))
+    expect(container.querySelector('[role="status"]')).toHaveTextContent(
+      'Queue paused because the agent stopped.',
+    )
+  })
+})

--- a/frontend/src/components/chat/AgentInputQueuePauseBanner.test.tsx
+++ b/frontend/src/components/chat/AgentInputQueuePauseBanner.test.tsx
@@ -31,7 +31,7 @@ describe('agentInputQueuePauseBanner', () => {
       expect(pauseSentence(reason)).toContain(fragment)
   })
 
-  it('describes the state, never a cause, when the Worker names no reason', () => {
+  it('describes the state, never a cause, when the Worker gives no reason', () => {
     // Inventing a cause is worse than describing the state, so UNSPECIFIED
     // reads exactly as the manual pause does.
     expect(pauseSentence(AgentInputQueuePauseReason.UNSPECIFIED))
@@ -39,11 +39,12 @@ describe('agentInputQueuePauseBanner', () => {
     expect(pauseSentence(AgentInputQueuePauseReason.UNSPECIFIED)).not.toContain('because')
   })
 
-  it('falls back to the manual sentence for a reason this build does not know', () => {
+  it('falls back to the UNSPECIFIED sentence for a reason this build does not know', () => {
     // A Worker ahead of this client sends an enum value the generated table has
-    // no key for. The banner must still say something.
+    // no key for. The banner must still say something, and UNSPECIFIED is
+    // already the "the Worker told us nothing" bucket.
     expect(pauseSentence(99 as AgentInputQueuePauseReason))
-      .toBe(pauseSentence(AgentInputQueuePauseReason.MANUAL))
+      .toBe(pauseSentence(AgentInputQueuePauseReason.UNSPECIFIED))
   })
 
   it('resumes from its own button', async () => {
@@ -56,8 +57,9 @@ describe('agentInputQueuePauseBanner', () => {
   })
 
   it('survives a Resume press with no handler attached', () => {
-    // `onResume` is optional, and AgentEditorPanel leaves it unset whenever the
-    // panel has no `onSetQueuePaused`. The press must not throw there.
+    // `onResume` is optional so this component renders standalone here. The one
+    // production caller always supplies it, so the press must not throw for a
+    // test that does not.
     render(() => (
       <AgentInputQueuePauseBanner paused reason={AgentInputQueuePauseReason.MANUAL} />
     ))
@@ -82,5 +84,32 @@ describe('agentInputQueuePauseBanner', () => {
     expect(container.querySelector('[role="status"]')).toHaveTextContent(
       'Queue paused because the agent stopped.',
     )
+  })
+
+  it('holds the sentence in ONE node, so a screen reader hears it once', () => {
+    const sentence = 'Queue paused because the agent stopped.'
+    const { container } = render(() => (
+      <AgentInputQueuePauseBanner paused reason={AgentInputQueuePauseReason.AGENT_STOPPED} />
+    ))
+    // A second copy beside the live region reaches the accessibility tree too,
+    // so the reader hears the sentence twice and a by-text lookup resolves two
+    // elements. The visible banner IS the live region here; only its class
+    // swaps.
+    const carriers = [...container.querySelectorAll('*')].filter(el => el.textContent === sentence)
+    expect(carriers).toHaveLength(1)
+    expect(container.querySelector('[role="status"]')).toContainElement(carriers[0] as HTMLElement)
+  })
+
+  it('keeps the live region out of flow while the queue runs, so it takes no gap', () => {
+    const { container } = render(() => (
+      <AgentInputQueuePauseBanner paused={false} reason={AgentInputQueuePauseReason.MANUAL} />
+    ))
+    // `inputArea` is a flex column with a `gap`, so an in-flow empty child
+    // would open a gap above the queue. `srOnly` is `position: absolute`, which
+    // takes the node out of that flow. It also carries no test id while the
+    // queue runs, so a locator cannot resolve a banner that is not showing.
+    const live = container.querySelector('[role="status"]')!
+    expect(live.className).toContain('srOnly')
+    expect(live).not.toHaveAttribute('data-testid')
   })
 })

--- a/frontend/src/components/chat/AgentInputQueuePauseBanner.tsx
+++ b/frontend/src/components/chat/AgentInputQueuePauseBanner.tsx
@@ -1,0 +1,78 @@
+import type { Component } from 'solid-js'
+import PauseCircle from 'lucide-solid/icons/circle-pause'
+import { Show } from 'solid-js'
+import { Icon } from '~/components/common/Icon'
+import { AgentInputQueuePauseReason } from '~/generated/proto/leapmux/v1/agent_pb'
+import { srOnly } from '~/styles/shared.css'
+import * as styles from './AgentInputQueuePauseBanner.css'
+
+/**
+ * Why the queue stopped, in one sentence for each reason.
+ *
+ * `satisfies Record<...>` is the enforcement: a sixth pause reason fails the
+ * frontend typecheck until somebody writes its sentence here. Four of the five
+ * reasons are automatic, so a missing entry would leave a user who pressed
+ * nothing with no explanation at all.
+ *
+ * `UNSPECIFIED` reads as the manual case on purpose. A Worker that sends it has
+ * told us nothing, and inventing a cause is worse than describing the state.
+ */
+const PAUSE_SENTENCES = {
+  [AgentInputQueuePauseReason.UNSPECIFIED]: 'Queue paused. New messages wait here until you resume.',
+  [AgentInputQueuePauseReason.MANUAL]: 'Queue paused. New messages wait here until you resume.',
+  [AgentInputQueuePauseReason.INTERRUPTED]: 'Queue paused because you interrupted the agent.',
+  [AgentInputQueuePauseReason.AGENT_STOPPED]: 'Queue paused because the agent stopped.',
+  [AgentInputQueuePauseReason.DELIVERY_FAILED]: 'Queue paused because an input did not reach the agent.',
+  [AgentInputQueuePauseReason.DELIVERY_UNCERTAIN]: 'Queue paused because an input may not have reached the agent.',
+} satisfies Record<AgentInputQueuePauseReason, string>
+
+export function pauseSentence(reason: AgentInputQueuePauseReason): string {
+  return PAUSE_SENTENCES[reason] ?? PAUSE_SENTENCES[AgentInputQueuePauseReason.MANUAL]
+}
+
+export interface AgentInputQueuePauseBannerProps {
+  paused: boolean
+  reason: AgentInputQueuePauseReason
+  onResume?: () => void
+}
+
+/**
+ * States that the queue is paused, and why.
+ *
+ * It reads `paused` alone, never the item count, because the case that needs it
+ * most is the empty one: the queue pauses itself, the list renders nothing, and
+ * the next message the user sends parks in a queue that will not drain. The
+ * pause toggle in the composer's action cluster is not an answer there -- it is
+ * icon-only below `sm`, so its whole signal is an icon that swapped.
+ *
+ * Resume is repeated here rather than pointed at, because the toggle sits in a
+ * different row from the sentence a user just read.
+ */
+export const AgentInputQueuePauseBanner: Component<AgentInputQueuePauseBannerProps> = props => (
+  <>
+    {/*
+      The live region is ALWAYS mounted, and only its text changes. A region
+      that appears together with its content announces nothing on several
+      screen readers, and four of the five pause reasons arrive with no user
+      action to explain them. `srOnly` is absolutely positioned, so it is out
+      of flow and adds no flex item and no gap to `inputArea`.
+    */}
+    <div class={srOnly} role="status" aria-live="polite">
+      {props.paused ? pauseSentence(props.reason) : ''}
+    </div>
+    <Show when={props.paused}>
+      <div class={styles.banner} data-testid="queue-pause-banner">
+        <Icon icon={PauseCircle} size="xs" class={styles.icon} />
+        <span class={styles.text}>{pauseSentence(props.reason)}</span>
+        <button
+          class={`outline ${styles.resume}`}
+          type="button"
+          onClick={() => props.onResume?.()}
+          data-testid="queue-pause-banner-resume"
+        >
+          Resume
+        </button>
+      </div>
+    </Show>
+  </>
+)

--- a/frontend/src/components/chat/AgentInputQueuePauseBanner.tsx
+++ b/frontend/src/components/chat/AgentInputQueuePauseBanner.tsx
@@ -26,13 +26,23 @@ const PAUSE_SENTENCES = {
   [AgentInputQueuePauseReason.DELIVERY_UNCERTAIN]: 'Queue paused because an input may not have reached the agent.',
 } satisfies Record<AgentInputQueuePauseReason, string>
 
+/**
+ * The sentence for a reason, including one this build does not know.
+ *
+ * A Worker ahead of this client sends an enum number the table has no key for,
+ * and protobuf-es passes that number through unchanged. `UNSPECIFIED` is
+ * already the "the Worker told us nothing" bucket, so the fallback points
+ * there rather than at a second reason that happens to read the same.
+ */
 export function pauseSentence(reason: AgentInputQueuePauseReason): string {
-  return PAUSE_SENTENCES[reason] ?? PAUSE_SENTENCES[AgentInputQueuePauseReason.MANUAL]
+  return PAUSE_SENTENCES[reason] ?? PAUSE_SENTENCES[AgentInputQueuePauseReason.UNSPECIFIED]
 }
 
 export interface AgentInputQueuePauseBannerProps {
   paused: boolean
   reason: AgentInputQueuePauseReason
+  /** A resume RPC is in flight, so the button refuses a second press. */
+  busy?: boolean
   onResume?: () => void
 }
 
@@ -47,32 +57,37 @@ export interface AgentInputQueuePauseBannerProps {
  *
  * Resume is repeated here rather than pointed at, because the toggle sits in a
  * different row from the sentence a user just read.
+ *
+ * ONE node carries the sentence, and it is ALWAYS mounted. A live region that
+ * appears together with its content announces nothing on several screen
+ * readers, and four of the five pause reasons arrive with no user action to
+ * explain them -- so the region cannot wait for the pause. A SECOND node
+ * holding the same sentence is equally wrong: a screen reader then announces
+ * the sentence twice, and every lookup that matches on that text resolves two
+ * elements. So the class swaps instead. While the queue runs the region is
+ * `srOnly`, which is `position: absolute` and therefore out of `inputArea`'s
+ * flex flow, so it opens no gap; once the queue pauses the same node becomes
+ * the visible banner.
  */
 export const AgentInputQueuePauseBanner: Component<AgentInputQueuePauseBannerProps> = props => (
-  <>
-    {/*
-      The live region is ALWAYS mounted, and only its text changes. A region
-      that appears together with its content announces nothing on several
-      screen readers, and four of the five pause reasons arrive with no user
-      action to explain them. `srOnly` is absolutely positioned, so it is out
-      of flow and adds no flex item and no gap to `inputArea`.
-    */}
-    <div class={srOnly} role="status" aria-live="polite">
-      {props.paused ? pauseSentence(props.reason) : ''}
-    </div>
+  <div
+    class={props.paused ? styles.banner : srOnly}
+    role="status"
+    aria-live="polite"
+    data-testid={props.paused ? 'queue-pause-banner' : undefined}
+  >
     <Show when={props.paused}>
-      <div class={styles.banner} data-testid="queue-pause-banner">
-        <Icon icon={PauseCircle} size="xs" class={styles.icon} />
-        <span class={styles.text}>{pauseSentence(props.reason)}</span>
-        <button
-          class={`outline ${styles.resume}`}
-          type="button"
-          onClick={() => props.onResume?.()}
-          data-testid="queue-pause-banner-resume"
-        >
-          Resume
-        </button>
-      </div>
+      <Icon icon={PauseCircle} size="xs" class={styles.icon} />
+      <span class={styles.text}>{pauseSentence(props.reason)}</span>
+      <button
+        class={`outline ${styles.resume}`}
+        type="button"
+        disabled={props.busy}
+        onClick={() => props.onResume?.()}
+        data-testid="queue-pause-banner-resume"
+      >
+        Resume
+      </button>
     </Show>
-  </>
+  </div>
 )

--- a/frontend/src/components/chat/AttachmentStrip.css.ts
+++ b/frontend/src/components/chat/AttachmentStrip.css.ts
@@ -5,7 +5,11 @@ export const strip = style({
   gap: 'var(--space-2)',
   overflowX: 'auto',
   scrollbarWidth: 'none',
-  padding: 'var(--space-1) var(--space-3) var(--space-1) var(--space-3)',
+  // `inputArea` owns the gap to the neighbours; see its comment. The pills'
+  // focus ring survives the loss: the project draws it INSIDE the element
+  // (`outline-offset: -2px` in `~/styles/global.css.ts`), so this scroll
+  // container never clips it.
+  padding: 0,
   flexShrink: 0,
 })
 
@@ -18,7 +22,7 @@ export const pill = style({
   alignItems: 'center',
   gap: 'var(--space-1)',
   padding: '2px var(--space-2)',
-  borderRadius: 'var(--radius-small)',
+  borderRadius: 'var(--radius-medium)',
   backgroundColor: 'var(--card)',
   border: '1px solid var(--border)',
   fontSize: 'var(--text-8)',

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -1,7 +1,7 @@
 import { globalStyle, keyframes, style } from '@vanilla-extract/css'
 import { resizeHandleSelectors } from '~/styles/resizeHandle'
 import { chipBase } from '~/styles/shared.css'
-import { breakpoints, motion } from '~/styles/tokens'
+import { breakpoints, composerContainer, motion } from '~/styles/tokens'
 import { CHAT_PAD_LEFT_VAR, CHAT_PAD_RIGHT_VAR, CHAT_RAIL_WIDTH_VAR, COARSE_HIT_PX } from './chatChromeVars'
 import { BAND_BORDER_PX } from './chatRowGeometry'
 import { contentColumnBleed } from './messageStyles.css'
@@ -278,14 +278,28 @@ export const inputArea = style({
   // the input queue, the attachment strip and the composer box.
   //
   // Each of those children keeps its own vertical padding at zero. Padding
-  // ADDS where two children meet -- it never collapses the way margin does --
-  // so when each child owned its own spacing the queue's bottom padding and
-  // the strip's top padding stacked into 8px while every other boundary was
-  // 4px, and the size of one gap depended on which optional children rendered.
-  // A container `gap` cannot do either.
+  // ADDS where two children meet. It never collapses the way margin does.
+  // Each child owned its own spacing before. The queue's bottom padding and
+  // the strip's top padding then stacked into 8px, while every other boundary
+  // was 4px. The size of one gap also changed with which optional children
+  // rendered. A container `gap` does neither.
   display: 'flex',
   flexDirection: 'column',
   gap: 'var(--space-1)',
+  // The composer's own width, named, so the controls inside it can query it.
+  //
+  // The composer sits inside a resizable tile and a floating window, and either
+  // can be a small fraction of the viewport. A VIEWPORT media query therefore
+  // answers a question about the wrong box: a 260px composer on a 1200px
+  // display rendered "Pause Queue", "Interrupt" and "Send" in full, which
+  // crowded the `[+]` button and drove the collapsed text width to zero.
+  // `hideInNarrowComposer` in `~/styles/shared.css.ts` queries this name.
+  //
+  // `inline-size`, not `size`: the query asks about the width alone, and `size`
+  // would also apply block containment, which needs a height this column does
+  // not have.
+  containerType: 'inline-size',
+  containerName: composerContainer,
   // Bottom padding is space-1 when the status bar is shown beneath, and
   // space-2 when it's hidden (the status bar's own space-2 bottom padding
   // then provides the gap to the window edge instead).
@@ -298,27 +312,28 @@ globalStyle(`${inputArea}[data-no-status-bar]`, {
 })
 
 /**
- * The composer's action cluster (Interrupt + Send). Rendered in the box's
- * top-right (collapsed) or bottom-right (expanded) overlay slot, so it's a
- * plain inline-flex with a small gap; the positioning lives in
- * the `footerSlot` style in `./markdownEditor/MarkdownEditor.css.ts`.
+ * The composer's action cluster: the queue pause toggle, Interrupt and Send in
+ * the corner layout, and the pause toggle alone in the full-width
+ * control-request layout.
+ *
+ * Rendered in the box's top-right (collapsed) or bottom-right (expanded)
+ * overlay slot, so it is a plain flex row with a small gap; the positioning
+ * lives in the `footerSlot` style in `./markdownEditor/MarkdownEditor.css.ts`.
+ *
+ * It WRAPS, and it may shrink below its content. This cluster is the only
+ * child of `footerSlot`, so `flex-wrap` on the slot itself can never fire --
+ * a slot with one item has nothing to move to a second line. Without these two
+ * declarations the cluster kept its one-line width, overflowed the slot's
+ * capped left edge, and painted over the `[+]` button that the cap exists to
+ * protect.
  */
 export const actionCluster = style({
-  display: 'inline-flex',
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'flex-end',
   alignItems: 'center',
+  minWidth: 0,
   gap: 'var(--space-1)',
-})
-
-/**
- * Text label inside an action button (Interrupt/Send). Hidden below `sm` so
- * the buttons become icon-only on narrow screens, saving horizontal space.
- */
-export const actionLabel = style({
-  '@media': {
-    [`(max-width: ${breakpoints.sm - 1}px)`]: {
-      display: 'none',
-    },
-  },
 })
 
 export const scrollToBottomButton = style({

--- a/frontend/src/components/chat/ChatView.css.ts
+++ b/frontend/src/components/chat/ChatView.css.ts
@@ -274,6 +274,18 @@ export const loadingOlderIndicator = style([loadingIndicatorBase, { top: 'var(--
 export const loadingNewerIndicator = style([loadingIndicatorBase, { bottom: 'var(--space-3)' }])
 
 export const inputArea = style({
+  // ONE declaration owns every vertical gap in this column: the pause banner,
+  // the input queue, the attachment strip and the composer box.
+  //
+  // Each of those children keeps its own vertical padding at zero. Padding
+  // ADDS where two children meet -- it never collapses the way margin does --
+  // so when each child owned its own spacing the queue's bottom padding and
+  // the strip's top padding stacked into 8px while every other boundary was
+  // 4px, and the size of one gap depended on which optional children rendered.
+  // A container `gap` cannot do either.
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-1)',
   // Bottom padding is space-1 when the status bar is shown beneath, and
   // space-2 when it's hidden (the status bar's own space-2 bottom padding
   // then provides the gap to the window edge instead).

--- a/frontend/src/components/chat/agentInputQueueDrop.test.ts
+++ b/frontend/src/components/chat/agentInputQueueDrop.test.ts
@@ -1,0 +1,138 @@
+import type { MessageInitShape } from '@bufbuild/protobuf'
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it } from 'vitest'
+import {
+  AgentInputKind,
+  AgentInputState,
+  QueuedAgentInputSchema,
+} from '~/generated/proto/leapmux/v1/agent_pb'
+import { resolveQueueDrop, resolveQueueMove } from './agentInputQueueDrop'
+
+function item(id: string, overrides: MessageInitShape<typeof QueuedAgentInputSchema> = {}) {
+  return create(QueuedAgentInputSchema, {
+    id,
+    agentId: 'agent-1',
+    text: `text ${id}`,
+    kind: AgentInputKind.USER_MESSAGE,
+    state: AgentInputState.QUEUED,
+    ...overrides,
+  })
+}
+
+// A pointer drag cannot be reproduced here: solid-dnd activates on real
+// pointer geometry and collision detection, which jsdom does not supply. The
+// gesture is covered in tests/e2e/108-agent-input-queue.spec.ts; the
+// arithmetic it feeds is covered directly.
+describe('resolveQueueDrop', () => {
+  const three = [item('one'), item('two'), item('three')]
+
+  it('points an upward drop at the drop target itself', () => {
+    expect(resolveQueueDrop(three, 'qi-two', 'qi-one')).toEqual({
+      moved: expect.objectContaining({ id: 'two' }),
+      beforeInputId: 'one',
+    })
+  })
+
+  it('points a downward drop at the item after the drop target', () => {
+    // The removal shifts everything below up by one, so aiming at the target
+    // itself would land the row one slot short.
+    expect(resolveQueueDrop(three, 'qi-one', 'qi-two')).toEqual({
+      moved: expect.objectContaining({ id: 'one' }),
+      beforeInputId: 'three',
+    })
+  })
+
+  it('sends a drop on the last row to the end', () => {
+    expect(resolveQueueDrop(three, 'qi-one', 'qi-three')).toEqual({
+      moved: expect.objectContaining({ id: 'one' }),
+      beforeInputId: '',
+    })
+  })
+
+  it('refuses a drop on the dragged row itself', () => {
+    expect(resolveQueueDrop(three, 'qi-two', 'qi-two')).toBeUndefined()
+  })
+
+  it('refuses an id that is not in the list', () => {
+    expect(resolveQueueDrop(three, 'qi-nope', 'qi-one')).toBeUndefined()
+    expect(resolveQueueDrop(three, 'qi-one', 'qi-nope')).toBeUndefined()
+  })
+
+  it('refuses to move a dispatching row', () => {
+    const list = [item('one', { state: AgentInputState.DISPATCHING }), item('two')]
+    expect(resolveQueueDrop(list, 'qi-one', 'qi-two')).toBeUndefined()
+  })
+
+  it('refuses to displace a dispatching row', () => {
+    // The Worker is already sending it, so its slot is not the user's to take.
+    const list = [item('one', { state: AgentInputState.DISPATCHING }), item('two')]
+    expect(resolveQueueDrop(list, 'qi-two', 'qi-one')).toBeUndefined()
+  })
+
+  it('refuses an empty list', () => {
+    expect(resolveQueueDrop([], 'qi-one', 'qi-two')).toBeUndefined()
+  })
+})
+
+// The one definition of a legal reorder. `resolveQueueDrop`, both arrow
+// buttons, and the `disabled` prop of each button all read it, so a case that
+// passes here holds for every path.
+describe('resolveQueueMove', () => {
+  const three = [item('one'), item('two'), item('three')]
+
+  it('points an upward move at the item one slot above', () => {
+    expect(resolveQueueMove(three, 1, 0)).toEqual({
+      moved: expect.objectContaining({ id: 'two' }),
+      beforeInputId: 'one',
+    })
+  })
+
+  it('points a downward move two slots below, where the removal leaves the gap', () => {
+    expect(resolveQueueMove(three, 0, 1)).toEqual({
+      moved: expect.objectContaining({ id: 'one' }),
+      beforeInputId: 'three',
+    })
+  })
+
+  it('sends a move onto the last row to the end', () => {
+    expect(resolveQueueMove(three, 0, 2)).toEqual({
+      moved: expect.objectContaining({ id: 'one' }),
+      beforeInputId: '',
+    })
+  })
+
+  it('moves the last row up over its neighbour', () => {
+    expect(resolveQueueMove(three, 2, 1)).toEqual({
+      moved: expect.objectContaining({ id: 'three' }),
+      beforeInputId: 'two',
+    })
+  })
+
+  it('handles a two-item list in both directions', () => {
+    const two = [item('one'), item('two')]
+    expect(resolveQueueMove(two, 0, 1)).toEqual({ moved: expect.objectContaining({ id: 'one' }), beforeInputId: '' })
+    expect(resolveQueueMove(two, 1, 0)).toEqual({ moved: expect.objectContaining({ id: 'two' }), beforeInputId: 'one' })
+  })
+
+  it('refuses a move to the row itself', () => {
+    expect(resolveQueueMove(three, 1, 1)).toBeUndefined()
+  })
+
+  it('refuses an index off either end, which is what disables the arrows', () => {
+    // Move Up on the head asks for -1, and Move Down on the tail asks for 3.
+    // The two buttons read exactly this, so an out-of-range index must be a
+    // refusal and never a throw.
+    expect(resolveQueueMove(three, 0, -1)).toBeUndefined()
+    expect(resolveQueueMove(three, 2, 3)).toBeUndefined()
+  })
+
+  it('refuses to move a dispatching row and refuses to displace one', () => {
+    const list = [item('one', { state: AgentInputState.DISPATCHING }), item('two')]
+    expect(resolveQueueMove(list, 0, 1)).toBeUndefined()
+    expect(resolveQueueMove(list, 1, 0)).toBeUndefined()
+  })
+
+  it('refuses an empty list', () => {
+    expect(resolveQueueMove([], 0, 1)).toBeUndefined()
+  })
+})

--- a/frontend/src/components/chat/agentInputQueueDrop.ts
+++ b/frontend/src/components/chat/agentInputQueueDrop.ts
@@ -1,0 +1,78 @@
+import type { QueuedAgentInput } from '~/generated/proto/leapmux/v1/agent_pb'
+import { AgentInputState } from '~/generated/proto/leapmux/v1/agent_pb'
+
+/**
+ * The whole reorder policy of the agent input queue, as pure functions.
+ *
+ * Its own module, because a pointer drag cannot be reproduced in a unit test:
+ * solid-dnd activates on real pointer geometry and collision detection, which
+ * jsdom does not supply. The gesture is covered end to end in
+ * `tests/e2e/108-agent-input-queue.spec.ts`; the arithmetic is covered beside
+ * this file, with no component, no drag library and no icons to import.
+ */
+
+/**
+ * The sortable id of a row, which is also the row's key.
+ *
+ * Prefixed, and NOT the `queued-input-<id>` test id: solid-dnd registers a
+ * droppable under the same string, so the two namespaces must not be able to
+ * collide.
+ */
+export function dragIdOf(item: QueuedAgentInput): string {
+  return `qi-${item.id}`
+}
+
+/** The move a reorder stands for, in the shape `MoveQueuedAgentInput` takes. */
+export interface QueueMove {
+  moved: QueuedAgentInput
+  beforeInputId: string
+}
+
+/**
+ * The move from one index to another, or `undefined` when the queue refuses it.
+ *
+ * ONE definition of which reorder is legal. Every path reads it: the drag, the
+ * two arrow buttons, and the `disabled` prop of each of those buttons. The rule
+ * lived at five sites before, and two of them already disagreed.
+ *
+ * `beforeInputId` carries the Worker's BEFORE semantics, which
+ * MoveQueuedAgentInput defines. The Worker takes the item out of the list
+ * first. It then puts the item back in front of `beforeInputId`. An empty
+ * string moves the item to the end.
+ *
+ * So a DOWNWARD move points at the item AFTER the target, because the removal
+ * already shifted every item below the source up by one slot. An upward move
+ * points at the target itself.
+ *
+ * A DISPATCHING row is refused at BOTH ends. It cannot move, and it cannot be
+ * displaced, because the Worker already sends it.
+ */
+export function resolveQueueMove(
+  items: readonly QueuedAgentInput[],
+  fromIndex: number,
+  toIndex: number,
+): QueueMove | undefined {
+  const moved = items[fromIndex]
+  const target = items[toIndex]
+  if (!moved || !target || fromIndex === toIndex)
+    return undefined
+  if (moved.state === AgentInputState.DISPATCHING || target.state === AgentInputState.DISPATCHING)
+    return undefined
+  return {
+    moved,
+    beforeInputId: fromIndex < toIndex ? (items[toIndex + 1]?.id ?? '') : target.id,
+  }
+}
+
+/** {@link resolveQueueMove}, addressed by sortable id rather than by index. */
+export function resolveQueueDrop(
+  items: readonly QueuedAgentInput[],
+  draggableId: string,
+  droppableId: string,
+): QueueMove | undefined {
+  return resolveQueueMove(
+    items,
+    items.findIndex(candidate => dragIdOf(candidate) === draggableId),
+    items.findIndex(candidate => dragIdOf(candidate) === droppableId),
+  )
+}

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
@@ -82,27 +82,37 @@ export const footerSlot = style({
   //
   // This slot and `plusSlot` are both absolute on the same bottom line, one
   // anchored right and one anchored left, inside the same containing block.
-  // With an auto width and no cap, a wide action row grows leftward straight
-  // across the `[+]`: it wins the paint because it comes later in the DOM at
-  // an equal `z-index`, and its children re-enable pointer events, so it
-  // swallows the clicks as well. A narrow viewport with Pause, Interrupt and
-  // Send in the row is where this happens.
+  // With an auto width and no cap, a wide action row grows leftward across the
+  // `[+]`. It wins the paint, because it comes later in the DOM at an equal
+  // `z-index`. Its children re-enable pointer events, so it also takes the
+  // clicks. A narrow composer with Pause, Interrupt and Send in the row is
+  // where this happens.
   //
-  // The cap stops the box one `space-1` to the right of the `[+]`, and
-  // `flex-wrap` sends whatever no longer fits onto a second line rather than
-  // past that edge. `composerLayout` measures the slot's height into
-  // `--composer-actions-h`, and the expanded layout reserves it, so a wrapped
-  // row pushes the text up instead of covering it. The cap also keeps
-  // `collapsedAvailableWidth` at or above zero, so any text at all forces the
-  // expanded layout, which is what does that reserving.
-  maxWidth: 'calc(100% - var(--composer-left-pad) - var(--space-1))',
+  // The cap stops the box one `space-1` to the right of the `[+]`. The CONTENT
+  // has to be able to give way as well: `actionCluster` in
+  // `~/components/chat/ChatView.css.ts` is this slot's only child, so the
+  // `flex-wrap` that moves a button onto a second line belongs there, and the
+  // cluster also declares `min-width: 0` so the cap can actually compress it.
+  // `composerLayout` measures the slot's height into `--composer-actions-h`,
+  // and the expanded layout reserves it, so a wrapped row pushes the text up
+  // instead of covering it.
+  //
+  // `:not([data-full-width])`, because the control-request row fixes BOTH its
+  // edges with `left` and `right` below. A cap there over-constrains the box,
+  // and the browser then drops `right` and the row stops reaching the corner.
+  // Scoping the cap is what lets the two layouts stay exclusive, instead of one
+  // declaring a cap that the other has to undo.
   zIndex: 1,
   display: 'flex',
-  flexWrap: 'wrap',
   justifyContent: 'flex-end',
   alignItems: 'center',
   gap: 'var(--space-1)',
   pointerEvents: 'none',
+  selectors: {
+    '&:not([data-full-width])': {
+      maxWidth: 'calc(100% - var(--composer-left-pad) - var(--space-1))',
+    },
+  },
 })
 
 // Children of the overlay slots re-enable pointer events (the slot itself is
@@ -144,7 +154,6 @@ globalStyle(`${container}[data-expanded] ${plusSlot}`, {
 
 globalStyle(`${container}[data-expanded] ${footerSlot}`, {
   zIndex: 0,
-  justifyContent: 'flex-end',
   pointerEvents: 'auto',
 })
 
@@ -154,14 +163,12 @@ globalStyle(`${container}[data-expanded] ${footerSlot}`, {
 // The left edge stops at `--composer-left-pad`, not at `space-1`, because the
 // `[+]` button sits at `space-1` on this same bottom line and stays rendered
 // during a control request. A row that started at `space-1` covered it
-// outright, which a narrow viewport made obvious. `max-width` goes back to
-// `none` here: `left` and `right` already fix both edges, and leaving the cap
-// on over-constrains the box, so the browser drops `right` and the row stops
-// reaching the corner.
+// outright, which a narrow composer made obvious. This rule sets no
+// `max-width`: the base rule above scopes its cap to
+// `:not([data-full-width])`, so there is nothing here to undo.
 globalStyle(`${container}[data-expanded] ${footerSlot}[data-full-width]`, {
   left: 'var(--composer-left-pad)',
   right: 'var(--space-1)',
-  maxWidth: 'none',
 })
 
 /**

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
@@ -78,8 +78,28 @@ export const footerSlot = style({
   position: 'absolute',
   bottom: 'var(--space-1)',
   right: 'var(--space-1)',
+  // Never reach into the `[+]` button's column.
+  //
+  // This slot and `plusSlot` are both absolute on the same bottom line, one
+  // anchored right and one anchored left, inside the same containing block.
+  // With an auto width and no cap, a wide action row grows leftward straight
+  // across the `[+]`: it wins the paint because it comes later in the DOM at
+  // an equal `z-index`, and its children re-enable pointer events, so it
+  // swallows the clicks as well. A narrow viewport with Pause, Interrupt and
+  // Send in the row is where this happens.
+  //
+  // The cap stops the box one `space-1` to the right of the `[+]`, and
+  // `flex-wrap` sends whatever no longer fits onto a second line rather than
+  // past that edge. `composerLayout` measures the slot's height into
+  // `--composer-actions-h`, and the expanded layout reserves it, so a wrapped
+  // row pushes the text up instead of covering it. The cap also keeps
+  // `collapsedAvailableWidth` at or above zero, so any text at all forces the
+  // expanded layout, which is what does that reserving.
+  maxWidth: 'calc(100% - var(--composer-left-pad) - var(--space-1))',
   zIndex: 1,
   display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'flex-end',
   alignItems: 'center',
   gap: 'var(--space-1)',
   pointerEvents: 'none',
@@ -130,9 +150,18 @@ globalStyle(`${container}[data-expanded] ${footerSlot}`, {
 
 // Control-request footers (full-width two-zone action rows) stretch across the
 // box instead of hugging the right corner.
+//
+// The left edge stops at `--composer-left-pad`, not at `space-1`, because the
+// `[+]` button sits at `space-1` on this same bottom line and stays rendered
+// during a control request. A row that started at `space-1` covered it
+// outright, which a narrow viewport made obvious. `max-width` goes back to
+// `none` here: `left` and `right` already fix both edges, and leaving the cap
+// on over-constrains the box, so the browser drops `right` and the row stops
+// reaching the corner.
 globalStyle(`${container}[data-expanded] ${footerSlot}[data-full-width]`, {
-  left: 'var(--space-1)',
+  left: 'var(--composer-left-pad)',
   right: 'var(--space-1)',
+  maxWidth: 'none',
 })
 
 /**

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.tsx
@@ -802,6 +802,10 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
   return (
     <div
       class={styles.container}
+      // The box whose layout mode `data-expanded` states. A test that asserts
+      // the collapsed-versus-expanded decision has to address this element, and
+      // the class name is a build-mode-dependent hash.
+      data-testid="composer-box"
       data-expanded={isExpanded() ? '' : undefined}
       style={{
         '--composer-right-pad': `${layout.rightPad()}px`,

--- a/frontend/src/components/chat/markdownEditor/composerLayout.test.ts
+++ b/frontend/src/components/chat/markdownEditor/composerLayout.test.ts
@@ -40,9 +40,19 @@ function stubbedRow(width: number): HTMLElement {
   return row
 }
 
+/**
+ * An action slot of a given width, built as a `<span>` so it picks up the
+ * `offsetWidth` stub above: ten pixels per character.
+ */
+function stubbedActionSlot(width: number): HTMLElement {
+  const slot = document.createElement('span')
+  slot.textContent = 'x'.repeat(Math.round(width / CHAR_PX))
+  return slot
+}
+
 /** Build a layout over stubbed DOM and run `fn` with it inside a reactive root. */
 function withLayout(
-  opts: { rowWidth?: number, observe?: boolean },
+  opts: { rowWidth?: number, actionSlotWidth?: number, observe?: boolean },
   fn: (layout: ReturnType<typeof createComposerLayout>) => void,
 ) {
   document.body.replaceChildren()
@@ -51,12 +61,15 @@ function withLayout(
   const row = opts.rowWidth == null ? undefined : stubbedRow(opts.rowWidth)
   if (row)
     document.body.appendChild(row)
+  const actionSlot = opts.actionSlotWidth == null ? undefined : stubbedActionSlot(opts.actionSlotWidth)
+  if (actionSlot)
+    document.body.appendChild(actionSlot)
 
   createRoot((dispose) => {
     const layout = createComposerLayout({
       editorRoot: () => root,
       row: () => row,
-      actionSlot: () => undefined,
+      actionSlot: () => actionSlot,
       // No rendered block: the layout falls back to the classifier's plain text,
       // which is the pre-mount path and keeps this test independent of Milkdown.
       firstBlock: () => undefined,
@@ -83,6 +96,29 @@ describe('createComposerLayout', () => {
     withLayout({ rowWidth: undefined }, (layout) => {
       layout.setDocStats({ multiLine: false, text: 'x'.repeat(500) })
       expect(layout.contentExpanded()).toBe(false)
+    })
+  })
+
+  it('keeps an EMPTY composer collapsed however little width the action row leaves', () => {
+    // `footerSlot` caps its own width at the row minus `--composer-left-pad`
+    // and one `space-1`, and an action row AT that cap drives the available
+    // width to zero. The expand test subtracts a 16px margin, so a text width
+    // of 0 satisfied `0 > 0 - 16` and the composer opened in the tall layout
+    // with nothing typed in it. A row of 100 with a rightPad of 100 reproduces
+    // that: available width 0, empty document.
+    withLayout({ rowWidth: 100, actionSlotWidth: 100 }, (layout) => {
+      expect(layout.rightPad()).toBe(100)
+      layout.setDocStats({ multiLine: false, text: '' })
+      expect(layout.contentExpanded()).toBe(false)
+    })
+  })
+
+  it('still expands for real text once the action row leaves no collapsed width', () => {
+    // The guard above is for the EMPTY document alone. Anything typed into a
+    // composer with no room genuinely has to wrap, so it must still expand.
+    withLayout({ rowWidth: 100, actionSlotWidth: 100 }, (layout) => {
+      layout.setDocStats({ multiLine: false, text: 'x' })
+      expect(layout.contentExpanded()).toBe(true)
     })
   })
 

--- a/frontend/src/components/chat/markdownEditor/composerLayout.ts
+++ b/frontend/src/components/chat/markdownEditor/composerLayout.ts
@@ -162,6 +162,22 @@ export function createComposerLayout(refs: ComposerLayoutRefs): ComposerLayout {
       setContentExpanded(true)
       return
     }
+    // An EMPTY document never expands, whatever the action row costs.
+    //
+    // The comparison below subtracts a margin from the available width, so a
+    // width of 0 still expands once the available width falls under that
+    // margin. The action row reaches that point on its own: `footerSlot` caps
+    // its width at the row minus `--composer-left-pad` and one `space-1`, and a
+    // slot at the cap leaves `collapsedAvailableWidth()` at exactly zero. The
+    // composer then opened in the tall layout with nothing typed in it.
+    //
+    // There is nothing to wrap in an empty document, so the collapsed layout is
+    // always the correct one here. The full-width control-request layout is a
+    // separate flag and this does not touch it.
+    if (width === 0) {
+      setContentExpanded(false)
+      return
+    }
     const availWidth = collapsedAvailableWidth()
     setContentExpanded(prev => width > availWidth - (prev ? COLLAPSE_MARGIN_PX : EXPAND_MARGIN_PX))
   })

--- a/frontend/src/components/common/ConfirmButton.test.tsx
+++ b/frontend/src/components/common/ConfirmButton.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
+import { Tooltip } from '~/components/common/Tooltip'
 
 describe('confirmButton', () => {
   beforeEach(() => {
@@ -155,5 +156,92 @@ describe('confirmButton', () => {
 
     fireEvent.click(button)
     expect(button).toHaveAttribute('data-armed')
+  })
+
+  it('adds no aria-label for a button that names itself with text', () => {
+    render(() => (
+      <ConfirmButton onClick={() => {}}>
+        Delete
+      </ConfirmButton>
+    ))
+    expect(screen.getByRole('button')).not.toHaveAttribute('aria-label')
+  })
+
+  it('names an icon-only button from the tooltip props, and renames it when armed', () => {
+    render(() => (
+      <ConfirmButton
+        onClick={() => {}}
+        tooltip="Delete"
+        confirmTooltip="Confirm delete?"
+        confirmLabel={<svg data-testid="armed-icon" />}
+      >
+        <svg data-testid="resting-icon" />
+      </ConfirmButton>
+    ))
+    // The name is the ONLY thing an icon-only button says, so the armed state
+    // has to reach the accessibility tree through it.
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+    expect(screen.getByTestId('resting-icon')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(screen.getByRole('button', { name: 'Confirm delete?' })).toBeInTheDocument()
+    expect(screen.getByTestId('armed-icon')).toBeInTheDocument()
+    expect(screen.queryByTestId('resting-icon')).not.toBeInTheDocument()
+  })
+
+  it('restores the resting name when the reset timer expires', () => {
+    render(() => (
+      <ConfirmButton onClick={() => {}} tooltip="Delete" confirmTooltip="Confirm delete?">
+        <svg />
+      </ConfirmButton>
+    ))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(screen.getByRole('button', { name: 'Confirm delete?' })).toBeInTheDocument()
+
+    vi.advanceTimersByTime(10_000)
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+  })
+
+  it('leaves a caller-supplied Tooltip in sole charge of the button', () => {
+    // LastTabCloseDialog and DeleteBranchDialog wrap this button in their own
+    // `<Tooltip describedBy>` to say why Delete is refused. Both tooltips
+    // resolve the same `<button>` as their target and both write its
+    // `aria-label` and `aria-describedby`, so this component must add NO
+    // tooltip of its own unless the caller asked for one.
+    render(() => (
+      <>
+        <span id="reason-1">held for review</span>
+        <Tooltip text="held for review" describedBy="reason-1">
+          <ConfirmButton disabled onClick={() => {}}>
+            Delete worktree
+          </ConfirmButton>
+        </Tooltip>
+      </>
+    ))
+    expect(screen.getByRole('button')).toHaveAttribute('aria-describedby', 'reason-1')
+  })
+
+  it('keeps the resting name when armed and no confirm tooltip is given', () => {
+    render(() => (
+      <ConfirmButton onClick={() => {}} tooltip="Delete">
+        <svg />
+      </ConfirmButton>
+    ))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    // Not renamed, but still NAMED. Falling through to undefined would strip
+    // the aria-label and leave an icon-only button unlabelled while armed.
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute('data-armed')
+  })
+
+  it('renders an element confirmLabel instead of the default text', () => {
+    render(() => (
+      <ConfirmButton onClick={() => {}} confirmLabel={<span>Gone?</span>}>
+        Delete
+      </ConfirmButton>
+    ))
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByRole('button')).toHaveTextContent('Gone?')
   })
 })

--- a/frontend/src/components/common/ConfirmButton.test.tsx
+++ b/frontend/src/components/common/ConfirmButton.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
-import { Tooltip } from '~/components/common/Tooltip'
 
 describe('confirmButton', () => {
   beforeEach(() => {
@@ -158,7 +157,7 @@ describe('confirmButton', () => {
     expect(button).toHaveAttribute('data-armed')
   })
 
-  it('adds no aria-label for a button that names itself with text', () => {
+  it('adds no aria-label for a button whose text is already its name', () => {
     render(() => (
       <ConfirmButton onClick={() => {}}>
         Delete
@@ -167,7 +166,7 @@ describe('confirmButton', () => {
     expect(screen.getByRole('button')).not.toHaveAttribute('aria-label')
   })
 
-  it('names an icon-only button from the tooltip props, and renames it when armed', () => {
+  it('gives an icon-only button its name from the tooltip props, and changes it when armed', () => {
     render(() => (
       <ConfirmButton
         onClick={() => {}}
@@ -204,23 +203,59 @@ describe('confirmButton', () => {
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
   })
 
-  it('leaves a caller-supplied Tooltip in sole charge of the button', () => {
-    // LastTabCloseDialog and DeleteBranchDialog wrap this button in their own
-    // `<Tooltip describedBy>` to say why Delete is refused. Both tooltips
-    // resolve the same `<button>` as their target and both write its
-    // `aria-label` and `aria-describedby`, so this component must add NO
-    // tooltip of its own unless the caller asked for one.
+  it('describes a blocked button from the element that already shows the reason', () => {
+    // LastTabCloseDialog and DeleteBranchDialog say why Delete is refused. They
+    // pass `blocked` rather than wrapping this button, because this component
+    // owns its own tooltip and a nested one disables the outer one entirely.
+    // `reasonId` points at the sentence the dialog ALREADY renders, so the
+    // reason reaches the accessibility tree once rather than twice.
     render(() => (
       <>
         <span id="reason-1">held for review</span>
-        <Tooltip text="held for review" describedBy="reason-1">
-          <ConfirmButton disabled onClick={() => {}}>
-            Delete worktree
-          </ConfirmButton>
-        </Tooltip>
+        <ConfirmButton disabled blocked={{ reason: 'held for review', reasonId: 'reason-1' }} onClick={() => {}}>
+          Delete worktree
+        </ConfirmButton>
       </>
     ))
-    expect(screen.getByRole('button')).toHaveAttribute('aria-describedby', 'reason-1')
+    const button = screen.getByRole('button')
+    expect(button).toHaveAttribute('aria-describedby', 'reason-1')
+    // The reason is a DESCRIPTION and never the NAME. A sentence long enough to
+    // be useful would replace "Delete worktree" if it went to `aria-label`,
+    // which is exactly what `title` is banned for.
+    expect(button).not.toHaveAttribute('aria-label')
+    expect(button).toHaveAccessibleName('Delete worktree')
+  })
+
+  it('renders one tooltip and no second copy of the reason', () => {
+    // A caller that wrapped this button instead would nest one `<Tooltip>` in
+    // another. That does not merely publish the reason twice: the outer tooltip
+    // resolves the INNER wrapper span as its target, stops detecting the
+    // disabled state, and once the inner one adds an offscreen description the
+    // outer wrapper holds two children and gives up entirely.
+    const { container } = render(() => (
+      <>
+        <span id="reason-2">held for review</span>
+        <ConfirmButton disabled blocked={{ reason: 'held for review', reasonId: 'reason-2' }} onClick={() => {}}>
+          Delete worktree
+        </ConfirmButton>
+      </>
+    ))
+    const copies = [...container.querySelectorAll('*')].filter(el => el.textContent === 'held for review')
+    expect(copies).toHaveLength(1)
+    expect(copies[0]).toHaveAttribute('id', 'reason-2')
+  })
+
+  it('adds no accessible name for a text button that passes no tooltip', () => {
+    // The unconditional `<Tooltip>` must stay invisible to a button that never
+    // asked for one: with no `tooltip` and no `blocked` it has nothing to show,
+    // so it writes no `aria-label` and the children keep naming the button.
+    render(() => (
+      <ConfirmButton onClick={() => {}}>Close anyway</ConfirmButton>
+    ))
+    const button = screen.getByRole('button')
+    expect(button).not.toHaveAttribute('aria-label')
+    expect(button).not.toHaveAttribute('aria-describedby')
+    expect(button).toHaveAccessibleName('Close anyway')
   })
 
   it('keeps the resting name when armed and no confirm tooltip is given', () => {
@@ -230,18 +265,23 @@ describe('confirmButton', () => {
       </ConfirmButton>
     ))
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
-    // Not renamed, but still NAMED. Falling through to undefined would strip
+    // The name does not change, but the button still HAS one. Falling through to undefined would strip
     // the aria-label and leave an icon-only button unlabelled while armed.
     expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute('data-armed')
   })
 
-  it('renders an element confirmLabel instead of the default text', () => {
+  it('renders an element confirmLabel as an ELEMENT, not as its text', () => {
     render(() => (
-      <ConfirmButton onClick={() => {}} confirmLabel={<span>Gone?</span>}>
+      <ConfirmButton onClick={() => {}} confirmLabel={<span data-testid="armed-label">Gone?</span>}>
         Delete
       </ConfirmButton>
     ))
     fireEvent.click(screen.getByRole('button'))
-    expect(screen.getByRole('button')).toHaveTextContent('Gone?')
+    // The element itself, not `toHaveTextContent`. `confirmLabel` used to take a
+    // string alone, and a text assertion passes either way -- Solid's `insert`
+    // renders a `<span>` the same before and after the type widened, so it can
+    // never observe the change it exists for. An icon-only caller needs the
+    // NODE to survive, which this asserts.
+    expect(screen.getByTestId('armed-label').tagName).toBe('SPAN')
   })
 })

--- a/frontend/src/components/common/ConfirmButton.tsx
+++ b/frontend/src/components/common/ConfirmButton.tsx
@@ -5,16 +5,29 @@ import { Tooltip } from './Tooltip'
 const RESET_TIMEOUT_MS = 10_000
 
 /**
- * This interface omits `title`, and the omission is the enforcement.
+ * This interface omits four attributes, and each omission is the enforcement.
  *
- * Every prop here spreads onto a real `<button>`, so a `title` long enough to
- * state a reason BECOMES the button's accessible name -- and this button's
- * name is STATE ("Confirm?" once armed), which the reason would replace. Wrap
- * the button in a `<Tooltip>` instead; it works on a disabled control and
- * leaves the name alone. `IconButton` omits `title` for the same reason and
- * routes its own `title` prop through `<Tooltip>`.
+ * Every prop here spreads onto a real `<button>`, and the JSX below then sets
+ * these four itself. Solid's `mergeProps` gives the later source priority, so a
+ * caller's value goes missing in silence.
+ *
+ * `title`: a title long enough to state a reason BECOMES the button's
+ * accessible name -- and this button's name is STATE ("Confirm?" once armed),
+ * which the reason would replace. Wrap the button in a `<Tooltip>` instead, or
+ * pass `tooltip`. A tooltip works on a disabled control and leaves the name
+ * alone. `IconButton` omits `title` for the same reason and routes its own
+ * `title` prop through `<Tooltip>`.
+ *
+ * `onClick`: this component owns the two-click protocol, so it takes the
+ * caller's handler under its own name and calls it on the second click alone.
+ *
+ * `onBlur`: this component owns the blur that disarms it. A caller that must
+ * observe blur as well belongs INSIDE the handler below, not layered over it.
+ *
+ * `type`: always `"button"`, so Enter inside a form cannot submit past the
+ * confirmation.
  */
-interface ConfirmButtonProps extends Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'title'> {
+interface ConfirmButtonProps extends Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'onBlur' | 'title' | 'type'> {
   /**
    * Content shown after the first click (armed state). Defaults to "Confirm?".
    *
@@ -23,31 +36,57 @@ interface ConfirmButtonProps extends Omit<JSX.ButtonHTMLAttributes<HTMLButtonEle
    */
   confirmLabel?: JSX.Element
   /**
-   * The tooltip text, and the accessible name, while the button rests.
+   * Why this button is refused, and the id of the element that already states
+   * that reason ON SCREEN.
    *
-   * A button with text needs neither this prop nor `confirmTooltip`, because
-   * its children already state its name and `confirmLabel` renames it. An
-   * icon-only button carries no text: without these two it reaches a screen
-   * reader unnamed, and the armed state stays invisible there.
+   * ONE object, so the pair cannot appear half-set: a reason with no on-screen
+   * element would reach the accessibility tree twice, and an id with no reason
+   * describes nothing.
    *
-   * This component routes both through `<Tooltip>` itself, exactly as
-   * `IconButton` routes its own `title`. A caller cannot do it from outside,
-   * because the armed state lives in here.
+   * A caller passes this instead of wrapping the button in its own `<Tooltip>`.
+   * This component always owns its tooltip (see the return below for why an
+   * outer one cannot work), so a blocked reason has to come in rather than be
+   * layered on. It replaces the tooltip's text while it is set, and points
+   * `aria-describedby` at the caller's element, which keeps the button's own
+   * name as its name.
    */
-  tooltip?: string
-  /** The tooltip text, and the accessible name, while the button is armed. */
-  confirmTooltip?: string
+  blocked?: { reason: string, reasonId: string }
   /** Called only on the second (confirming) click. */
   onClick: () => void
 }
+
+/**
+ * The tooltip text for each of the button's two states.
+ *
+ * `tooltip` is the tooltip text, and the accessible name, while the button
+ * rests. `confirmTooltip` is both while the button is armed; without it the
+ * resting name stands in both states.
+ *
+ * A button with TEXT needs neither. Its children already give it a name, and
+ * `confirmLabel` changes that name when it arms. An icon-only button carries no
+ * text: without these it reaches a screen reader unnamed, and the armed state
+ * stays invisible there.
+ *
+ * The UNION is what stops `confirmTooltip` appearing on its own. That
+ * combination leaves an icon-only button unnamed while it rests, and it gains a
+ * name only on the first click. A resting fallback to `confirmTooltip` is no
+ * answer either, because "Confirm delete?" is the WRONG name for a button that
+ * has not armed yet -- so the type refuses the pair rather than picking between
+ * two bad values at runtime.
+ *
+ * This component routes both through `<Tooltip>` itself, exactly as
+ * `IconButton` routes its own `title`. A caller cannot do it from outside,
+ * because the armed state lives in here.
+ */
+type ConfirmButtonTooltips = { tooltip: string, confirmTooltip?: string } | { tooltip?: undefined, confirmTooltip?: undefined }
 
 /**
  * A two-step confirmation button. The first click arms it (changes label),
  * and only the second click triggers the actual action. Automatically resets
  * on blur or after 10 seconds of inactivity.
  */
-export const ConfirmButton: Component<ConfirmButtonProps> = (props) => {
-  const [local, buttonProps] = splitProps(props, ['confirmLabel', 'tooltip', 'confirmTooltip', 'onClick', 'children'])
+export const ConfirmButton: Component<ConfirmButtonProps & ConfirmButtonTooltips> = (props) => {
+  const [local, buttonProps] = splitProps(props, ['confirmLabel', 'tooltip', 'confirmTooltip', 'blocked', 'onClick', 'children'])
   const [armed, setArmed] = createSignal(false)
   let resetTimer: ReturnType<typeof setTimeout> | undefined
   let blurResetTimer: ReturnType<typeof setTimeout> | undefined
@@ -98,8 +137,8 @@ export const ConfirmButton: Component<ConfirmButtonProps> = (props) => {
     }
   }
 
-  // Falls back to the RESTING name rather than to nothing. A caller that names
-  // the button once still has a named button while it is armed, and an
+  // Falls back to the RESTING name rather than to nothing. A caller that gives
+  // the button one name still has a named button while it is armed, and an
   // icon-only control has no other source of a name: without the fallback the
   // armed state reached a screen reader as an unlabelled button.
   const tooltipText = () => (armed() ? (local.confirmTooltip ?? local.tooltip) : local.tooltip)
@@ -120,23 +159,36 @@ export const ConfirmButton: Component<ConfirmButtonProps> = (props) => {
     </button>
   )
 
-  // Wrap ONLY for a caller that asked for a tooltip.
+  // This component is the ONLY route to its own tooltip, so it wraps
+  // unconditionally rather than when a caller asks.
   //
-  // An unconditional wrapper breaks the callers that supply their OWN
-  // `<Tooltip>` around this button -- LastTabCloseDialog and
-  // DeleteBranchDialog both do, to state why Delete is disabled. Two tooltips
-  // resolve the same `<button>` as their target and both write its
-  // `aria-label` and `aria-describedby`, so the inner one erases the reason
-  // the outer one published and the button loses its description.
+  // A caller cannot supply the tooltip from outside. One `<Tooltip>` inside
+  // another does not merely publish a description twice -- it kills the outer
+  // one. `<Tooltip>` renders its child inside a wrapper `<span>`, so an outer
+  // tooltip resolves the INNER wrapper as its target: `closest('button')` from
+  // that span finds no button, so the outer tooltip stops detecting the
+  // disabled state, and once the inner tooltip adds its own offscreen
+  // description the outer wrapper holds two element children and
+  // `resolveTargetEl` gives up entirely. A caller with a blocked reason passes
+  // `blocked`, which routes through this one tooltip.
+  //
+  // `ariaLabel` carries the button's own NAME, and never the blocked reason. A
+  // reason long enough to be useful BECOMES the accessible name if it goes
+  // there, which is the exact failure `title` is banned for. So the reason
+  // travels as a DESCRIPTION, pointed at the element the caller already renders
+  // on screen. A button with text passes no `tooltip`, so `ariaLabel` is
+  // undefined and its own children keep naming it.
+  //
+  // With neither `tooltip` nor `blocked`, `text` is undefined: `<Tooltip>` then
+  // has nothing to show, keeps its wrapper at `display: contents`, and installs
+  // no observer. `IconButton` wraps unconditionally on the same terms.
   return (
-    <>
-      {local.tooltip === undefined && local.confirmTooltip === undefined
-        ? button
-        : (
-            <Tooltip text={tooltipText()} ariaLabel>
-              {button}
-            </Tooltip>
-          )}
-    </>
+    <Tooltip
+      text={local.blocked?.reason ?? tooltipText()}
+      describedBy={local.blocked?.reasonId}
+      ariaLabel={tooltipText()}
+    >
+      {button}
+    </Tooltip>
   )
 }

--- a/frontend/src/components/common/ConfirmButton.tsx
+++ b/frontend/src/components/common/ConfirmButton.tsx
@@ -1,5 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import { createEffect, createSignal, onCleanup, splitProps } from 'solid-js'
+import { Tooltip } from './Tooltip'
 
 const RESET_TIMEOUT_MS = 10_000
 
@@ -14,8 +15,28 @@ const RESET_TIMEOUT_MS = 10_000
  * routes its own `title` prop through `<Tooltip>`.
  */
 interface ConfirmButtonProps extends Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'title'> {
-  /** Label shown after the first click (armed state). Defaults to "Confirm?". */
-  confirmLabel?: string
+  /**
+   * Content shown after the first click (armed state). Defaults to "Confirm?".
+   *
+   * Takes an element, not only a string, so an icon-only button can swap its
+   * icon for one that shows the next click confirms.
+   */
+  confirmLabel?: JSX.Element
+  /**
+   * The tooltip text, and the accessible name, while the button rests.
+   *
+   * A button with text needs neither this prop nor `confirmTooltip`, because
+   * its children already state its name and `confirmLabel` renames it. An
+   * icon-only button carries no text: without these two it reaches a screen
+   * reader unnamed, and the armed state stays invisible there.
+   *
+   * This component routes both through `<Tooltip>` itself, exactly as
+   * `IconButton` routes its own `title`. A caller cannot do it from outside,
+   * because the armed state lives in here.
+   */
+  tooltip?: string
+  /** The tooltip text, and the accessible name, while the button is armed. */
+  confirmTooltip?: string
   /** Called only on the second (confirming) click. */
   onClick: () => void
 }
@@ -26,7 +47,7 @@ interface ConfirmButtonProps extends Omit<JSX.ButtonHTMLAttributes<HTMLButtonEle
  * on blur or after 10 seconds of inactivity.
  */
 export const ConfirmButton: Component<ConfirmButtonProps> = (props) => {
-  const [local, buttonProps] = splitProps(props, ['confirmLabel', 'onClick', 'children'])
+  const [local, buttonProps] = splitProps(props, ['confirmLabel', 'tooltip', 'confirmTooltip', 'onClick', 'children'])
   const [armed, setArmed] = createSignal(false)
   let resetTimer: ReturnType<typeof setTimeout> | undefined
   let blurResetTimer: ReturnType<typeof setTimeout> | undefined
@@ -77,7 +98,13 @@ export const ConfirmButton: Component<ConfirmButtonProps> = (props) => {
     }
   }
 
-  return (
+  // Falls back to the RESTING name rather than to nothing. A caller that names
+  // the button once still has a named button while it is armed, and an
+  // icon-only control has no other source of a name: without the fallback the
+  // armed state reached a screen reader as an unlabelled button.
+  const tooltipText = () => (armed() ? (local.confirmTooltip ?? local.tooltip) : local.tooltip)
+
+  const button = (
     <button
       {...buttonProps}
       type="button"
@@ -91,5 +118,25 @@ export const ConfirmButton: Component<ConfirmButtonProps> = (props) => {
     >
       {armed() ? (local.confirmLabel ?? 'Confirm?') : local.children}
     </button>
+  )
+
+  // Wrap ONLY for a caller that asked for a tooltip.
+  //
+  // An unconditional wrapper breaks the callers that supply their OWN
+  // `<Tooltip>` around this button -- LastTabCloseDialog and
+  // DeleteBranchDialog both do, to state why Delete is disabled. Two tooltips
+  // resolve the same `<button>` as their target and both write its
+  // `aria-label` and `aria-describedby`, so the inner one erases the reason
+  // the outer one published and the button loses its description.
+  return (
+    <>
+      {local.tooltip === undefined && local.confirmTooltip === undefined
+        ? button
+        : (
+            <Tooltip text={tooltipText()} ariaLabel>
+              {button}
+            </Tooltip>
+          )}
+    </>
   )
 }

--- a/frontend/src/components/common/NewTabMenuItems.test.tsx
+++ b/frontend/src/components/common/NewTabMenuItems.test.tsx
@@ -174,6 +174,18 @@ describe('newTabMenuItems', () => {
       }
     })
 
+    it('keeps each icon button named after what it does, not after the reason', () => {
+      renderItems({ disabledReason: reason })
+      // The provider buttons hold a glyph and no text, so they need an
+      // `aria-label`. It must be their own NAME: an `ariaLabel` that reused the
+      // tooltip's `text` made the blocked reason the name once the worker went
+      // offline, which is the exact failure `title` is banned for. The reason
+      // travels as the DESCRIPTION asserted above.
+      const button = screen.getByTestId(`menu-new-agent-${AgentProvider.CLAUDE_CODE}`)
+      expect(button).toHaveAccessibleName('New Claude Code agent')
+      expect(button.getAttribute('aria-label')).not.toBe(reason)
+    })
+
     it('fires nothing while disabled', async () => {
       const handlers = renderItems({ disabledReason: reason })
       await fireEvent.click(screen.getByTestId(`menu-new-agent-${AgentProvider.CODEX}`))

--- a/frontend/src/components/common/NewTabMenuItems.tsx
+++ b/frontend/src/components/common/NewTabMenuItems.tsx
@@ -71,10 +71,17 @@ export const NewTabMenuItems: Component<NewTabMenuItemsProps> = (props) => {
             {/* `ariaLabel`, because the button holds a glyph and no text.
                 Without it a screen reader announces an unnamed button, and a
                 `getByRole('button', { name })` lookup cannot address it -- which
-                is why the tests here reach these four by test id alone. */}
+                is why the tests here reach these four by test id alone.
+
+                The label is its own STRING and never `true`. `text` becomes the
+                blocked REASON once the worker goes offline, and `ariaLabel`
+                that reuses `text` would make that sentence the button's name --
+                the exact failure `title` is banned for. Two separate strings
+                keep the name a name and leave the reason to the description
+                that `<Tooltip>` publishes for a disabled control. */}
             {provider => (
               <Tooltip
-                ariaLabel
+                ariaLabel={`New ${agentProviderLabel(provider)} agent`}
                 text={props.disabledReason ?? (
                   props.shortcuts
                     ? shortcutHint(`New ${agentProviderLabel(provider)} agent`, 'app.newAgent')

--- a/frontend/src/components/common/Tooltip.test.tsx
+++ b/frontend/src/components/common/Tooltip.test.tsx
@@ -491,6 +491,67 @@ describe('tooltip on a disabled control', () => {
     expect(button.getAttribute('aria-describedby')).toBeTruthy()
   })
 
+  // A pointer guard decides "this press belongs to an embedded control" by
+  // walking UP from `event.target`. When the wrapper takes the box it IS that
+  // target, and no control sits above it -- so the guard needs a mark on the
+  // wrapper itself. See EMBEDDED_UI_SELECTOR in `~/lib/dragActivators.ts`,
+  // where a press on a disabled row button used to drag the whole row.
+  it('marks the wrapper exactly while it takes a box', async () => {
+    const [disabled, setDisabled] = createSignal(true)
+    render(() => (
+      <Tooltip text="Busy">
+        <button type="button" disabled={disabled()}>Save</button>
+      </Tooltip>
+    ))
+
+    const button = screen.getByRole('button', { name: 'Save' })
+    expect(wrapperOf(button)).toHaveAttribute('data-tooltip-box')
+
+    setDisabled(false)
+    await flushAttributeChange()
+    // Boxless again, so the wrapper is out of the hit test and the mark would
+    // guard a press that can no longer land on it.
+    expect(wrapperOf(button)).not.toHaveAttribute('data-tooltip-box')
+  })
+
+  it('leaves an unmarked wrapper on a control that refuses no pointer event', () => {
+    render(() => (
+      <Tooltip text="Save">
+        <button type="button">Save</button>
+      </Tooltip>
+    ))
+    expect(wrapperOf(screen.getByRole('button'))).not.toHaveAttribute('data-tooltip-box')
+  })
+
+  // An icon-only control passes its own NAME as `text` and asks for
+  // `ariaLabel`. Publishing a description as well announced "Move Up, button,
+  // unavailable, Move Up", and every lookup on that text resolved two
+  // elements. A description exists to state a REASON the name does not carry.
+  it('publishes no description that only repeats the name', () => {
+    render(() => (
+      <Tooltip text="Move Up" ariaLabel>
+        <button type="button" disabled><svg /></button>
+      </Tooltip>
+    ))
+
+    const button = screen.getByRole('button', { name: 'Move Up' })
+    expect(button).toHaveAttribute('aria-label', 'Move Up')
+    expect(button).not.toHaveAttribute('aria-describedby')
+  })
+
+  it('still describes a disabled control whose reason differs from its name', () => {
+    render(() => (
+      <Tooltip text="The worker is offline." ariaLabel="New agent">
+        <button type="button" disabled><svg /></button>
+      </Tooltip>
+    ))
+
+    const button = screen.getByRole('button', { name: 'New agent' })
+    const describedBy = button.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    expect(document.getElementById(describedBy!)?.textContent).toBe('The worker is offline.')
+  })
+
   it('opens from the wrapper, which is what the pointer can reach', () => {
     render(() => (
       <Tooltip text="Open the hub over HTTPS to add a passkey.">

--- a/frontend/src/components/common/Tooltip.tsx
+++ b/frontend/src/components/common/Tooltip.tsx
@@ -270,6 +270,19 @@ export function Tooltip(props: TooltipProps) {
   const descriptionId = () => props.describedBy ?? ownDescriptionId
   /** Whether this component renders the offscreen copy itself. */
   const ownsDescription = () => !props.describedBy
+  /** The accessible name this tooltip writes onto the target, if any. */
+  const effectiveAriaLabel = () => (props.ariaLabel === true ? props.text : props.ariaLabel)
+  /**
+   * Whether the offscreen description says anything the NAME does not.
+   *
+   * An icon-only control passes its own name as `text` and asks for
+   * `ariaLabel`, so the description below would repeat it: a screen reader then
+   * announces "Move Up, button, unavailable, Move Up", and every lookup that
+   * matches on that text resolves two elements. A description exists to state a
+   * REASON the name does not carry, so it is only worth publishing when the two
+   * strings differ.
+   */
+  const descriptionAddsMeaning = () => !!props.text && effectiveAriaLabel() !== props.text
   const [visible, setVisible] = createSignal(false)
   /**
    * The target presents itself as unavailable, by EITHER mechanism.
@@ -566,7 +579,7 @@ export function Tooltip(props: TooltipProps) {
       // The offscreen description, for as long as the control is disabled. It
       // is the only route to a screen-reader user there, so it does NOT wait
       // for the tooltip to open -- nothing can open it without a pointer.
-      if (describedAsDisabled() && props.text)
+      if (describedAsDisabled() && descriptionAddsMeaning())
         nextIds.push(descriptionId())
       if (visible() && hasTooltipContent())
         nextIds.push(`tooltip-${tooltipId}`)
@@ -593,9 +606,7 @@ export function Tooltip(props: TooltipProps) {
     const originalAriaLabel = target.getAttribute('aria-label')
 
     createEffect(() => {
-      const nextAriaLabel = props.ariaLabel === true
-        ? props.text
-        : props.ariaLabel
+      const nextAriaLabel = effectiveAriaLabel()
       if (nextAriaLabel)
         target.setAttribute('aria-label', nextAriaLabel)
       else if (originalAriaLabel != null)
@@ -628,10 +639,17 @@ export function Tooltip(props: TooltipProps) {
         // `inline-flex` hugs the child and stays one item of whatever row it
         // sits in.
         style={{ display: wrapperTakesBox() ? 'inline-flex' : 'contents' }}
+        // The wrapper is the HIT-TEST TARGET whenever it takes a box, because
+        // the child that forced the box dispatches no pointer event of its own.
+        // A pointer guard that decides "this press belongs to an embedded
+        // control" by walking up from `event.target` therefore lands on this
+        // span and finds no control above it. The attribute is what those
+        // guards match; see EMBEDDED_UI_SELECTOR in `~/lib/dragActivators.ts`.
+        data-tooltip-box={wrapperTakesBox() ? '' : undefined}
       >
         {props.children}
       </span>
-      <Show when={describedAsDisabled() && props.text && ownsDescription()}>
+      <Show when={describedAsDisabled() && descriptionAddsMeaning() && ownsDescription()}>
         <span id={ownDescriptionId} class={srOnly}>{props.text}</span>
       </Show>
       <Show when={visible() && hasTooltipContent()}>

--- a/frontend/src/components/settings/controls/KeyPinsControl.test.tsx
+++ b/frontend/src/components/settings/controls/KeyPinsControl.test.tsx
@@ -42,6 +42,22 @@ describe('keyPinsControl', () => {
     expect(listKeyPins().map(p => p.workerId)).toEqual(['worker-b'])
   })
 
+  it('lets the armed Remove reach a screen reader', () => {
+    seedPins()
+    render(() => <KeyPinsControl />)
+    const remove = screen.getByTestId('key-pin-remove-worker-a')
+    // No `aria-label`, so the NAME is the button's own text -- and the text is
+    // what `ConfirmButton` swaps when it arms. A `<Tooltip ariaLabel>` around
+    // this button pinned the name to "Remove" in both states, so a screen
+    // reader heard "Remove" for the confirming click too and never learnt that
+    // the first click had armed anything.
+    expect(remove).not.toHaveAttribute('aria-label')
+    expect(remove).toHaveAccessibleName('Remove')
+
+    fireEvent.click(remove)
+    expect(remove).toHaveAccessibleName('Confirm?')
+  })
+
   it('puts the worker id above the date and Remove actions', () => {
     seedPins()
     render(() => <KeyPinsControl />)

--- a/frontend/src/components/settings/controls/KeyPinsControl.tsx
+++ b/frontend/src/components/settings/controls/KeyPinsControl.tsx
@@ -3,7 +3,6 @@ import { createMemo, createSignal, For, Show } from 'solid-js'
 import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ClippedText } from '~/components/common/ClippedText'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
-import { Tooltip } from '~/components/common/Tooltip'
 import { formatLocalDateTime } from '~/lib/dateFormat'
 import { clearAllKeyPins, clearKeyPin, listKeyPins } from '~/lib/keyPinStore'
 import * as styles from './KeyPinsControl.css'
@@ -53,15 +52,21 @@ export const KeyPinsControl: Component = () => {
               <ClippedText text={pin.workerId} class={styles.pinWorker} testId={`key-pin-id-${pin.workerId}`} />
               <div class={styles.pinMeta}>
                 <span class={styles.pinDate}>{formatLocalDateTime(new Date(pin.firstSeen))}</span>
-                <Tooltip text="Remove" ariaLabel>
-                  <ConfirmButton
-                    class="small outline"
-                    data-testid={`key-pin-remove-${pin.workerId}`}
-                    onClick={() => remove(pin.workerId)}
-                  >
-                    Remove
-                  </ConfirmButton>
-                </Tooltip>
+                {/*
+                  No `<Tooltip>` here. This button shows a word, so its children
+                  already give it a name, and `ConfirmButton` swaps that word
+                  for "Confirm?" when it arms. A wrapper with `ariaLabel` pinned
+                  the accessible name to "Remove" in BOTH states, so a screen
+                  reader heard "Remove" for the confirming click as well and
+                  never learnt that the first click had armed anything.
+                */}
+                <ConfirmButton
+                  class="small outline"
+                  data-testid={`key-pin-remove-${pin.workerId}`}
+                  onClick={() => remove(pin.workerId)}
+                >
+                  Remove
+                </ConfirmButton>
               </div>
             </div>
           )}

--- a/frontend/src/components/shell/LastTabCloseDialog.tsx
+++ b/frontend/src/components/shell/LastTabCloseDialog.tsx
@@ -8,7 +8,6 @@ import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { Dialog } from '~/components/common/Dialog'
 import { showWarnToast } from '~/components/common/Toast'
-import { Tooltip } from '~/components/common/Tooltip'
 import { BranchStatusInfo, hasPushableWork } from '~/components/workspace/BranchStatusInfo'
 import { PushBranchButton } from '~/components/workspace/PushBranchButton'
 import { LastTabCloseTarget } from '~/generated/proto/leapmux/v1/git_pb'
@@ -217,20 +216,24 @@ export const LastTabCloseDialog: Component<LastTabCloseDialogProps> = (props) =>
               available, so the user still closes the tab -- only the
               removal is refused.
 
-              The blocked reason goes through <Tooltip>; see that component's
-              header for why no control here takes a `title`. The same text
-              also renders in the body above, for anybody who never hovers --
-              and `describedBy` points the description at THAT element, so the
-              reason reaches the accessibility tree once rather than twice. */}
-          <Tooltip text={removalBlockedReason() || undefined} describedBy={blockedReasonId}>
-            <ConfirmButton
-              data-variant="danger"
-              disabled={Boolean(removalBlockedReason())}
-              onClick={handleScheduleDelete}
-            >
-              Delete worktree
-            </ConfirmButton>
-          </Tooltip>
+              The blocked reason goes to `blocked`, and never to a `title` or
+              to an outer <Tooltip>: ConfirmButton owns its own tooltip, because
+              its name is STATE that changes when the button arms, and one
+              tooltip nested in another disables the outer one entirely. See
+              that component's return for the mechanism.
+
+              The same text also renders in the body above, for anybody who
+              never hovers, and `reasonId` points the description at THAT
+              element -- so the reason reaches the accessibility tree once
+              rather than twice. */}
+          <ConfirmButton
+            data-variant="danger"
+            disabled={Boolean(removalBlockedReason())}
+            blocked={removalBlockedReason() ? { reason: removalBlockedReason()!, reasonId: blockedReasonId } : undefined}
+            onClick={handleScheduleDelete}
+          >
+            Delete worktree
+          </ConfirmButton>
         </Show>
         <ConfirmButton data-variant="danger" onClick={handleCloseAnyway}>
           Close anyway

--- a/frontend/src/components/shell/TabBar.test.tsx
+++ b/frontend/src/components/shell/TabBar.test.tsx
@@ -1032,6 +1032,47 @@ describe('tabBar mobile variant', () => {
     expect(within(row).queryByTestId('tab-rename-input')).toBeNull()
   })
 
+  // The gesture that OPENS a rename moves the focus itself: the Rename item
+  // sits in a popover, and closing that popover hands the focus back to the tab
+  // it belongs to. Committing on that focus closed the rename before the input
+  // could take the caret, so the tab bar's context-menu Rename did nothing at
+  // all.
+  it('survives the focus that the opening gesture hands back', () => {
+    const onRename = vi.fn()
+    renderMobileTabBar(twoTabs(), `${TabType.AGENT}:a1`, { onRename })
+
+    fireEvent.click(screen.getByTestId('tab-chip'))
+    const row = screen.getAllByTestId('tab-sheet-row')[1]
+    fireEvent.click(within(row).getByTestId('tab-menu-rename'))
+    expect(within(row).getByTestId('tab-rename-input')).toBeInTheDocument()
+
+    // The input has not been focused yet -- the programmatic focus waits a
+    // frame -- so this focus belongs to the click that opened the rename.
+    fireEvent.focusIn(document.body)
+
+    expect(onRename).not.toHaveBeenCalled()
+    expect(within(row).getByTestId('tab-rename-input')).toBeInTheDocument()
+  })
+
+  it('commits on a focus change once the input has held the caret', () => {
+    const onRename = vi.fn()
+    renderMobileTabBar(twoTabs(), `${TabType.AGENT}:a1`, { onRename })
+
+    fireEvent.click(screen.getByTestId('tab-chip'))
+    const row = screen.getAllByTestId('tab-sheet-row')[1]
+    fireEvent.click(within(row).getByTestId('tab-menu-rename'))
+    const input = within(row).getByTestId('tab-rename-input') as HTMLInputElement
+    fireEvent.input(input, { target: { value: 'Terminal Liam IV' } })
+
+    // The caret arrives, so from here a focus change IS the user leaving.
+    fireEvent.focus(input)
+    fireEvent.focusIn(document.body)
+
+    expect(onRename).toHaveBeenCalledOnce()
+    expect(onRename.mock.calls[0][1]).toBe('Terminal Liam IV')
+    expect(within(row).queryByTestId('tab-rename-input')).toBeNull()
+  })
+
   // A pointerdown INSIDE the input is the user placing the caret, not leaving.
   it('does not commit when the gesture lands inside the input', () => {
     const onRename = vi.fn()

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -166,6 +166,22 @@ export const TabBar: Component<TabBarProps> = (props) => {
 
   const [editingTabKey, setEditingTabKey] = createSignal<string | null>(null)
   const [editingValue, setEditingValue] = createSignal('')
+  /**
+   * Whether the rename input has held the caret since this rename opened.
+   *
+   * A FOCUS change counts as the user leaving only after this. The gesture that
+   * OPENS a rename moves the focus itself: the Rename item sits in a popover,
+   * and closing that popover hands the focus back to the tab. So a guard that
+   * armed the moment the rename opened read its own opening gesture as a
+   * departure, committed at once, and the input never appeared -- the tab bar's
+   * context-menu Rename did nothing at all.
+   *
+   * A POINTERDOWN carries no such ambiguity, so that half needs no wait.
+   * Nothing but the user presses a pointer, and the app never synthesizes one;
+   * a focus change is the opposite, which is the whole reason this guard exists
+   * instead of a bare `blur` handler.
+   */
+  const [renameHeldCaret, setRenameHeldCaret] = createSignal(false)
 
   // Cross-tile drag context (may not be available on mobile single-tile layout)
   let crossTileDrag: ReturnType<typeof useTabDrag> | undefined
@@ -200,6 +216,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
   const startEditing = (tab: Tab) => {
     setEditingTabKey(tabKey(tab))
     setEditingValue(tabDisplayLabel(tab))
+    setRenameHeldCaret(false)
   }
 
   const commitEdit = (tab: Tab) => {
@@ -261,6 +278,11 @@ export const TabBar: Component<TabBarProps> = (props) => {
     const leaveIfOutside = (event: Event): void => {
       const target = event.target
       if (renameInputEl && target instanceof Node && renameInputEl.contains(target))
+        return
+      // The rename has not had the caret yet, so this focus change belongs to
+      // the gesture that OPENED it -- see `renameHeldCaret`. There is nothing
+      // to leave until the input holds the caret.
+      if (event.type === 'focusin' && !renameHeldCaret())
         return
       // Resolved at GESTURE time, not at setup: the strip can re-key its rows
       // while the rename is open, and the tab to rename is whichever one the
@@ -329,6 +351,10 @@ export const TabBar: Component<TabBarProps> = (props) => {
         }
       }}
       onClick={e => e.stopPropagation()}
+      // Arms the focus half of the guard above. On the input's OWN focus, so it
+      // covers the programmatic focus below and a user who clicks straight into
+      // the field.
+      onFocus={() => setRenameHeldCaret(true)}
       ref={(el) => {
         renameInputEl = el
         onCleanup(() => {

--- a/frontend/src/components/shell/guardedPointerSensor.test.tsx
+++ b/frontend/src/components/shell/guardedPointerSensor.test.tsx
@@ -252,6 +252,125 @@ describe('guardedPointerSensor', () => {
     expect(activeDraggableId()).toBe('row-1')
   })
 
+  /**
+   * The same provider, with the row inside a SCROLLING box whose content
+   * overflows it.
+   *
+   * jsdom lays nothing out, so every rect and every scroll metric is stubbed.
+   * That is enough for the wiring under test: which element the sensor picks as
+   * the scroller, and whether it drives it while the pointer sits at an edge.
+   * The arithmetic itself is covered in `~/lib/dragAutoScroll.test.ts`, and the
+   * real geometry in the Playwright specs.
+   */
+  function renderScrollerProbe() {
+    let scroller!: HTMLDivElement
+    let rowEl!: HTMLDivElement
+    let scrollTop = 0
+
+    function Row() {
+      const draggable = createDraggable('row-1')
+      return (
+        <div
+          ref={(el) => {
+            rowEl = el
+            draggable(el)
+          }}
+        >
+          row
+        </div>
+      )
+    }
+
+    render(() => (
+      <DragDropProvider>
+        <GuardedPointerSensor />
+        <div ref={(el: HTMLDivElement) => { scroller = el }} style={{ 'overflow-y': 'auto' }}>
+          <Row />
+        </div>
+      </DragDropProvider>
+    ))
+
+    Object.defineProperty(scroller, 'scrollHeight', { get: () => 1000, configurable: true })
+    Object.defineProperty(scroller, 'clientHeight', { get: () => 400, configurable: true })
+    Object.defineProperty(scroller, 'scrollTop', {
+      get: () => scrollTop,
+      set: (next: number) => { scrollTop = Math.max(0, Math.min(next, 600)) },
+      configurable: true,
+    })
+    scroller.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 400, left: 0, right: 100, width: 100, height: 400, x: 0, y: 0, toJSON: () => ({}) })
+
+    return { rowEl, scroller, scrollTopOf: () => scrollTop }
+  }
+
+  it('scrolls the row\'s own scroller while a drag rests at its edge', () => {
+    // solid-dnd moves the row with a transform INSIDE the scroller, so without
+    // this every slot past the fold is unreachable: the row is clipped at the
+    // edge and the drop lands on the last VISIBLE row. A native HTML5 drag got
+    // this from the browser for free.
+    const frames: Array<() => void> = []
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => frames.push(cb))
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    try {
+      const { rowEl, scrollTopOf } = renderScrollerProbe()
+
+      rowEl.dispatchEvent(pointerEvent('pointerdown', { x: 50, y: 200, pointerType: 'mouse' }))
+      vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+      document.dispatchEvent(pointerEvent('pointermove', { x: 50, y: 399, pointerType: 'mouse' }))
+      frames.splice(0, frames.length).forEach(frame => frame())
+
+      expect(scrollTopOf()).toBeGreaterThan(0)
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('stands still while the drag stays away from either edge', () => {
+    const frames: Array<() => void> = []
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => frames.push(cb))
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    try {
+      const { rowEl, scrollTopOf } = renderScrollerProbe()
+
+      rowEl.dispatchEvent(pointerEvent('pointerdown', { x: 50, y: 200, pointerType: 'mouse' }))
+      vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+      document.dispatchEvent(pointerEvent('pointermove', { x: 50, y: 210, pointerType: 'mouse' }))
+      frames.splice(0, frames.length).forEach(frame => frame())
+
+      expect(scrollTopOf()).toBe(0)
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('stops scrolling once the press ends', () => {
+    const frames: Array<() => void> = []
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => frames.push(cb))
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    try {
+      const { rowEl, scrollTopOf } = renderScrollerProbe()
+
+      rowEl.dispatchEvent(pointerEvent('pointerdown', { x: 50, y: 200, pointerType: 'mouse' }))
+      vi.advanceTimersByTime(ACTIVATION_DELAY_MS)
+      document.dispatchEvent(pointerEvent('pointermove', { x: 50, y: 399, pointerType: 'mouse' }))
+      frames.splice(0, frames.length).forEach(frame => frame())
+      const scrolledDuringDrag = scrollTopOf()
+      expect(scrolledDuringDrag).toBeGreaterThan(0)
+
+      // A loop that outlived the lift would keep scrolling a list nobody is
+      // dragging.
+      document.dispatchEvent(pointerEvent('pointerup', { x: 50, y: 399, pointerType: 'mouse' }))
+      frames.splice(0, frames.length).forEach(frame => frame())
+
+      expect(scrollTopOf()).toBe(scrolledDuringDrag)
+    }
+    finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('a secondary finger\'s release does not end the primary press', () => {
     const { rowEl, activeDraggableId } = renderProbe()
 

--- a/frontend/src/components/shell/guardedPointerSensor.ts
+++ b/frontend/src/components/shell/guardedPointerSensor.ts
@@ -1,6 +1,8 @@
 import type { Id } from '@thisbeyond/solid-dnd'
+import type { EdgeScroller } from '~/lib/dragAutoScroll'
 import { useDragDropContext } from '@thisbeyond/solid-dnd'
 import { onCleanup, onMount } from 'solid-js'
+import { scrollableAncestor, startEdgeScroll } from '~/lib/dragAutoScroll'
 import { INPUT_OR_EDITABLE_SELECTOR } from '~/lib/textInputBehavior'
 import { motion } from '~/styles/tokens'
 
@@ -22,6 +24,8 @@ export const ACTIVATION_DISTANCE_PX = 10
 export const ACTIVATION_DELAY_MS = 250
 
 const SENSOR_ID = 'pointer-sensor'
+/** The transformer that adds the auto-scroll back to the dragged row's offset. */
+const AUTO_SCROLL_TRANSFORMER_ID = 'pointer-sensor-auto-scroll'
 
 /**
  * Presses that start inside embedded UI belong to that UI, not to a drag:
@@ -80,17 +84,30 @@ const EMBEDDED_UI_SELECTOR = `${INPUT_OR_EDITABLE_SELECTOR}, [popover]`
  * Mouse and pen behavior stays identical to upstream: 250ms of hold or 10px
  * of travel, either one starts the drag.
  *
- * Rendered once, in ./SectionDragContext.tsx, in place of
- * `<DragDropSensors />`.
+ * Rendered once inside EVERY `DragDropProvider`, in place of
+ * `<DragDropSensors />`. There are two providers: the shell's, in
+ * ./SectionDragContext.tsx, and the composer's own, in
+ * ~/components/chat/AgentInputQueue.tsx.
  */
 export function GuardedPointerSensor() {
   const context = useDragDropContext()
-  // `DragDropProvider` is always an ancestor at the one mount site, but the hook is
+  // `DragDropProvider` is always an ancestor at every mount site, but the hook is
   // typed as nullable and a test tree could render this bare.
   if (!context)
     return null
 
-  const [state, { addSensor, removeSensor, sensorStart, sensorMove, sensorEnd, dragStart, dragEnd }] = context
+  const [state, {
+    addSensor,
+    removeSensor,
+    sensorStart,
+    sensorMove,
+    sensorEnd,
+    dragStart,
+    dragEnd,
+    addTransformer,
+    removeTransformer,
+    recomputeLayouts,
+  }] = context
 
   const isActiveSensor = () => state.active.sensorId === SENSOR_ID
 
@@ -98,6 +115,8 @@ export function GuardedPointerSensor() {
   let activationDelayTimeoutId: ReturnType<typeof setTimeout> | null = null
   let holdReleaseTimeoutId: ReturnType<typeof setTimeout> | null = null
   let activationDraggableId: Id | null = null
+  /** The element the press started on. The scroller to auto-scroll is above it. */
+  let pressTarget: Element | null = null
   /** The pointer this sensor tracks. `null` when no press is live. */
   let trackedPointerId: number | null = null
   /** This press is a touch, so it activates on movement only — never on a hold timer. */
@@ -107,6 +126,12 @@ export function GuardedPointerSensor() {
    * moving. The menu owns it now; no later move may start a drag from it.
    */
   let touchHoldExpired = false
+  /** The live edge-scroll loop, while a drag runs inside a scroller. */
+  let edgeScroller: EdgeScroller | undefined
+  /** The draggable this sensor registered the auto-scroll transformer on. */
+  let autoScrollDraggableId: Id | null = null
+  /** How far the auto-scroll moved the container since this drag started. */
+  let autoScrolled = 0
 
   // Declarations, not arrow constants: these handlers reference one another in
   // a cycle (attach -> onPointerMove -> onActivate -> detach -> onPointerMove),
@@ -128,6 +153,7 @@ export function GuardedPointerSensor() {
     document.addEventListener('pointercancel', onPointerCancel)
 
     activationDraggableId = draggableId
+    pressTarget = target
     trackedPointerId = event.pointerId
     isTouchPress = event.pointerType === 'touch'
     touchHoldExpired = false
@@ -154,17 +180,77 @@ export function GuardedPointerSensor() {
       clearTimeout(holdReleaseTimeoutId)
       holdReleaseTimeoutId = null
     }
+    stopEdgeScroll()
     trackedPointerId = null
+    pressTarget = null
     document.removeEventListener('pointermove', onPointerMove)
     document.removeEventListener('pointerup', onPointerUp)
     document.removeEventListener('pointercancel', onPointerCancel)
     document.removeEventListener('selectionchange', clearSelection)
   }
 
+  /**
+   * Follow the pointer to the edges of the nearest scrolling ancestor, and
+   * scroll it while the pointer rests there.
+   *
+   * Every draggable surface in this app lives in a scroller — the input queue's
+   * own box, the mobile tab sheet's list, the sidebar — and the drag moves the
+   * row with a CSS transform INSIDE it. Without this the row is clipped at the
+   * edge and every slot past the fold is unreachable: the drop lands on the last
+   * VISIBLE row rather than the one the user aimed at. A native HTML5 drag got
+   * this from the browser, and a pointer drag has to do it.
+   *
+   * TWO corrections keep the drag consistent with the scroll, and both are
+   * necessary:
+   *
+   *   - A TRANSFORMER on the dragged item. The drag transform is the pointer's
+   *     own delta, so a container that scrolls by S moves the row's box up by S
+   *     and the row leaves the cursor. Adding the accumulated scroll back keeps
+   *     the row under the finger.
+   *   - `recomputeLayouts()`. solid-dnd caches every droppable's rect at
+   *     `dragStart` and never refreshes it during the drag, so after a scroll
+   *     every cached rect names a position the row no longer occupies and the
+   *     collision detector picks the wrong target.
+   */
+  function startEdgeScrollForDrag() {
+    const scroller = scrollableAncestor(pressTarget)
+    const draggableId = activationDraggableId
+    if (!scroller || draggableId === null)
+      return
+    autoScrolled = 0
+    autoScrollDraggableId = draggableId
+    addTransformer('draggables', draggableId, {
+      id: AUTO_SCROLL_TRANSFORMER_ID,
+      // After the sensor's own transformer, so it corrects the pointer delta
+      // rather than being corrected by it.
+      order: 1,
+      callback: transform => ({ x: transform.x, y: transform.y + autoScrolled }),
+    })
+    edgeScroller = startEdgeScroll(scroller, (applied) => {
+      autoScrolled += applied
+      recomputeLayouts()
+    })
+  }
+
+  // Removes ONLY what `startEdgeScrollForDrag` added. `detach` runs for every
+  // press, including the ones that never activate a drag, so removing by
+  // `activationDraggableId` would ask the context to drop a transformer that no
+  // press ever registered.
+  function stopEdgeScroll() {
+    edgeScroller?.stop()
+    edgeScroller = undefined
+    autoScrolled = 0
+    if (autoScrollDraggableId === null)
+      return
+    removeTransformer('draggables', autoScrollDraggableId, AUTO_SCROLL_TRANSFORMER_ID)
+    autoScrollDraggableId = null
+  }
+
   function onActivate() {
     if (!state.active.sensor) {
       sensorStart(SENSOR_ID, initialCoordinates)
       dragStart(activationDraggableId!)
+      startEdgeScrollForDrag()
       clearSelection()
       document.addEventListener('selectionchange', clearSelection)
     }
@@ -194,6 +280,7 @@ export function GuardedPointerSensor() {
     if (isActiveSensor()) {
       event.preventDefault()
       sensorMove(coordinates)
+      edgeScroller?.track(coordinates.y)
     }
   }
 

--- a/frontend/src/components/workspace/DeleteBranchDialog.tsx
+++ b/frontend/src/components/workspace/DeleteBranchDialog.tsx
@@ -8,7 +8,6 @@ import { ConfirmButton } from '~/components/common/ConfirmButton'
 import { labelRow } from '~/components/common/Dialog.css'
 import { Spinner } from '~/components/common/Spinner'
 import { showInfoToast, showWarnToast } from '~/components/common/Toast'
-import { Tooltip } from '~/components/common/Tooltip'
 import { workingTreeDeleteLabel } from '~/components/common/WorkingTree'
 import { TabBusyDetails } from '~/components/shell/TabBusyDetails'
 import { busyGroupList } from '~/components/shell/TabBusyDetails.css'
@@ -428,21 +427,24 @@ export const DeleteBranchDialog: Component<DeleteBranchDialogProps> = (props) =>
               worktree path checks whether git removes the worktree, the
               branch path runs the delete itself.
 
-              The blocked reason goes through <Tooltip>; see that component's
-              header for why no control here takes a `title`. The same text
-              also renders in the body above, for anybody who never hovers. */}
-          <Tooltip text={removalBlockedReason() || undefined} describedBy={blockedReasonId}>
-            <ConfirmButton
-              data-variant="danger"
-              disabled={!canSubmit()}
-              onClick={handleDelete}
-            >
-              <Show when={submitting.loading()} fallback={deleteLabel()}>
-                <Spinner />
-                {isWorktree() ? 'Checking...' : 'Deleting...'}
-              </Show>
-            </ConfirmButton>
-          </Tooltip>
+              The blocked reason goes to `blocked`, and never to a `title` or to
+              an outer <Tooltip>: ConfirmButton owns its own tooltip, because its
+              name is STATE that changes when the button arms, and one tooltip
+              nested in another disables the outer one entirely. See that
+              component's return for the mechanism. The same text also renders
+              in the body above, for anybody who never hovers, and `reasonId`
+              points the description at THAT element. */}
+          <ConfirmButton
+            data-variant="danger"
+            disabled={!canSubmit()}
+            blocked={removalBlockedReason() ? { reason: removalBlockedReason()!, reasonId: blockedReasonId } : undefined}
+            onClick={handleDelete}
+          >
+            <Show when={submitting.loading()} fallback={deleteLabel()}>
+              <Spinner />
+              {isWorktree() ? 'Checking...' : 'Deleting...'}
+            </Show>
+          </ConfirmButton>
         </>
       )}
     >

--- a/frontend/src/lib/dragActivators.test.ts
+++ b/frontend/src/lib/dragActivators.test.ts
@@ -100,6 +100,28 @@ describe('rowBodyActivators', () => {
     }
   })
 
+  it('swallows a mouse press that lands on the box a Tooltip gives a disabled control', () => {
+    // A DISABLED button dispatches no pointer event of its own, so `<Tooltip>`
+    // stops being `display: contents` and takes a real box -- which makes the
+    // wrapper span the hit-test target. `closest` then walks UP from the span,
+    // finds no button above it, and the press reached the row: pressing Move Up
+    // at the top of a queue, a control the row draws as unavailable, started a
+    // drag of the whole row. The attribute is what closes that.
+    const handler = vi.fn()
+    const activators = rowBodyActivators({ onPointerdown: handler })
+    const row = document.createElement('div')
+    const wrapper = document.createElement('span')
+    wrapper.setAttribute('data-tooltip-box', '')
+    const button = document.createElement('button')
+    button.disabled = true
+    wrapper.appendChild(button)
+    row.appendChild(wrapper)
+
+    activators.onPointerdown(pressOn('mouse', wrapper))
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+
   it('swallows a mouse press that starts on a drag grip, so one press activates once', () => {
     const handler = vi.fn()
     const activators = rowBodyActivators({ onPointerdown: handler })
@@ -125,10 +147,13 @@ describe('rowBodyActivators', () => {
     })
     const grip = document.createElement('span')
     grip.setAttribute('data-drag-handle', '')
+    const tooltipBox = document.createElement('span')
+    tooltipBox.setAttribute('data-tooltip-box', '')
     const cases = [
       ...inputOrEditableHosts(),
       popoverHost(),
       ...ownTail,
+      { label: '[data-tooltip-box]', host: tooltipBox, target: tooltipBox },
       { label: '[data-drag-handle]', host: grip, target: grip },
     ]
 

--- a/frontend/src/lib/dragActivators.ts
+++ b/frontend/src/lib/dragActivators.ts
@@ -16,12 +16,20 @@ export type DragActivatorProps = Record<string, (event: PointerEvent) => void>
  *
  * `INPUT_OR_EDITABLE_SELECTOR` carries the text-entry group that all three
  * pointer guards share, and `[popover]` stands in the list itself, as it does
- * in the other two. The last three entries are this guard's own and make it
+ * in the other two. The last four entries are this guard's own and make it
  * the widest: `select` and `button` keep a slow or drifting press on a row
  * control a click, and `[data-drag-handle]` keeps one grip press to one
  * activation.
  *
- * Do NOT push those three into the shared fragment or into the other two
+ * `[data-tooltip-box]` covers the control that `button` alone misses. A
+ * DISABLED button dispatches no pointer event of its own, so `<Tooltip>` gives
+ * it a real box and that wrapper span becomes the hit-test target. `closest`
+ * then walks UP from the span, finds no button, and lets the press through --
+ * so a press on Move Up at the top of a queue, a control the row draws as
+ * unavailable, started a drag of the whole row. `<Tooltip>` marks the wrapper
+ * with this attribute exactly when it takes the box.
+ *
+ * Do NOT push those four into the shared fragment or into the other two
  * lists. ~/components/shell/guardedPointerSensor.ts would then decline the
  * grip's own press and break touch reorder, and
  * ~/components/common/contextMenuGesture.ts would stop opening a row's menu
@@ -29,7 +37,7 @@ export type DragActivatorProps = Record<string, (event: PointerEvent) => void>
  * on a row body, so the two lists already compose where the wider one is
  * wanted.
  */
-const EMBEDDED_UI_SELECTOR = `${INPUT_OR_EDITABLE_SELECTOR}, [popover], select, button, [data-drag-handle]`
+const EMBEDDED_UI_SELECTOR = `${INPUT_OR_EDITABLE_SELECTOR}, [popover], select, button, [data-tooltip-box], [data-drag-handle]`
 
 /**
  * Wrap a draggable's `dragActivators` for a ROW BODY: the press must start on

--- a/frontend/src/lib/dragAutoScroll.test.ts
+++ b/frontend/src/lib/dragAutoScroll.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EDGE_BAND_PX, edgeScrollStep, MAX_SCROLL_STEP_PX, scrollableAncestor, startEdgeScroll } from '~/lib/dragAutoScroll'
+
+const VIEWPORT = { top: 100, bottom: 500 }
+
+describe('edgeScrollStep', () => {
+  it('stands still while the pointer is away from both edges', () => {
+    expect(edgeScrollStep(VIEWPORT, 300)).toBe(0)
+  })
+
+  it('stands still exactly on each band boundary', () => {
+    // The band is EXCLUSIVE at its inner edge, so a pointer resting there does
+    // not creep. Without this the list drifts under a stationary finger.
+    expect(edgeScrollStep(VIEWPORT, VIEWPORT.top + EDGE_BAND_PX)).toBe(0)
+    expect(edgeScrollStep(VIEWPORT, VIEWPORT.bottom - EDGE_BAND_PX)).toBe(0)
+  })
+
+  it('scrolls up inside the top band and down inside the bottom band', () => {
+    expect(edgeScrollStep(VIEWPORT, VIEWPORT.top + 1)).toBeLessThan(0)
+    expect(edgeScrollStep(VIEWPORT, VIEWPORT.bottom - 1)).toBeGreaterThan(0)
+  })
+
+  it('ramps with the depth into the band, so a short list stays controllable', () => {
+    const shallow = edgeScrollStep(VIEWPORT, VIEWPORT.bottom - EDGE_BAND_PX + 1)
+    const deep = edgeScrollStep(VIEWPORT, VIEWPORT.bottom - 1)
+    expect(deep).toBeGreaterThan(shallow)
+    expect(shallow).toBeGreaterThan(0)
+  })
+
+  it('caps at the maximum step past the edge, however far the pointer goes', () => {
+    expect(edgeScrollStep(VIEWPORT, VIEWPORT.bottom + 1000)).toBe(MAX_SCROLL_STEP_PX)
+    expect(edgeScrollStep(VIEWPORT, VIEWPORT.top - 1000)).toBe(-MAX_SCROLL_STEP_PX)
+  })
+
+  it('stands still for a viewport shorter than two bands', () => {
+    // The two bands would overlap, so a pointer in the middle would belong to
+    // both. A box that small already shows every row.
+    const tiny = { top: 0, bottom: EDGE_BAND_PX }
+    expect(edgeScrollStep(tiny, 1)).toBe(0)
+    expect(edgeScrollStep(tiny, EDGE_BAND_PX - 1)).toBe(0)
+  })
+})
+
+describe('scrollableAncestor', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  function box(overflowY: string, scrollHeight: number, clientHeight: number): HTMLElement {
+    const el = document.createElement('div')
+    el.style.overflowY = overflowY
+    Object.defineProperty(el, 'scrollHeight', { get: () => scrollHeight, configurable: true })
+    Object.defineProperty(el, 'clientHeight', { get: () => clientHeight, configurable: true })
+    return el
+  }
+
+  it('finds the nearest ancestor that actually overflows', () => {
+    const outer = box('auto', 900, 300)
+    const inner = box('visible', 100, 100)
+    const leaf = document.createElement('span')
+    inner.appendChild(leaf)
+    outer.appendChild(inner)
+    document.body.appendChild(outer)
+    expect(scrollableAncestor(leaf)).toBe(outer)
+  })
+
+  it('skips a scroll container whose content already fits', () => {
+    // `overflow-y: auto` alone is not enough. Half the app's panels declare it
+    // and never overflow, and treating one as the scroller would auto-scroll a
+    // box that cannot move.
+    const outer = box('auto', 900, 300)
+    const inner = box('auto', 100, 100)
+    const leaf = document.createElement('span')
+    inner.appendChild(leaf)
+    outer.appendChild(inner)
+    document.body.appendChild(outer)
+    expect(scrollableAncestor(leaf)).toBe(outer)
+  })
+
+  it('returns undefined when nothing above the element scrolls', () => {
+    const leaf = document.createElement('span')
+    document.body.appendChild(leaf)
+    expect(scrollableAncestor(leaf)).toBeUndefined()
+  })
+
+  it('returns undefined for a detached node', () => {
+    expect(scrollableAncestor(null)).toBeUndefined()
+  })
+})
+
+describe('startEdgeScroll', () => {
+  let frames: Array<() => void>
+
+  beforeEach(() => {
+    frames = []
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+      frames.push(cb)
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      frames[id - 1] = () => {}
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  /** Run every frame queued so far, once. */
+  function tick() {
+    const pending = frames.splice(0, frames.length)
+    for (const frame of pending)
+      frame()
+  }
+
+  function scroller(opts: { scrollHeight: number, clientHeight: number }): HTMLElement {
+    const el = document.createElement('div')
+    let top = 0
+    Object.defineProperty(el, 'scrollTop', {
+      get: () => top,
+      set: (next: number) => { top = Math.max(0, Math.min(next, opts.scrollHeight - opts.clientHeight)) },
+      configurable: true,
+    })
+    el.getBoundingClientRect = () => ({ top: 0, bottom: opts.clientHeight, left: 0, right: 100, width: 100, height: opts.clientHeight, x: 0, y: 0, toJSON: () => ({}) })
+    return el
+  }
+
+  it('scrolls and reports the pixels it applied while the pointer sits at an edge', () => {
+    const el = scroller({ scrollHeight: 1000, clientHeight: 400 })
+    const applied: number[] = []
+    const loop = startEdgeScroll(el, px => applied.push(px))
+
+    loop.track(399)
+    tick()
+
+    expect(el.scrollTop).toBeGreaterThan(0)
+    expect(applied).toEqual([el.scrollTop])
+    loop.stop()
+  })
+
+  it('keeps running frame after frame until the pointer leaves the band', () => {
+    const el = scroller({ scrollHeight: 1000, clientHeight: 400 })
+    const loop = startEdgeScroll(el, () => {})
+
+    loop.track(399)
+    tick()
+    const afterFirst = el.scrollTop
+    tick()
+    expect(el.scrollTop).toBeGreaterThan(afterFirst)
+
+    loop.track(200)
+    tick()
+    const settled = el.scrollTop
+    tick()
+    expect(el.scrollTop).toBe(settled)
+    loop.stop()
+  })
+
+  it('reports nothing and stops once the scroller reaches its end', () => {
+    // The APPLIED delta, not the wanted one. A box already at the bottom moves
+    // zero, and reporting the wanted amount would push the drag's compensation
+    // past what the container actually did.
+    const el = scroller({ scrollHeight: 410, clientHeight: 400 })
+    const applied: number[] = []
+    const loop = startEdgeScroll(el, px => applied.push(px))
+
+    loop.track(399)
+    tick()
+    expect(el.scrollTop).toBe(10)
+    expect(applied).toEqual([10])
+
+    tick()
+    expect(applied).toEqual([10])
+    loop.stop()
+  })
+
+  it('stops scrolling after stop(), even with a frame already queued', () => {
+    const el = scroller({ scrollHeight: 1000, clientHeight: 400 })
+    const loop = startEdgeScroll(el, () => {})
+    loop.track(399)
+    loop.stop()
+    tick()
+    expect(el.scrollTop).toBe(0)
+  })
+})

--- a/frontend/src/lib/dragAutoScroll.ts
+++ b/frontend/src/lib/dragAutoScroll.ts
@@ -1,0 +1,120 @@
+/**
+ * Edge auto-scroll for a drag inside a scrolling container.
+ *
+ * Every draggable surface in this app sits in one: the input queue caps at
+ * `min(40vh, 20rem)` and holds up to 100 rows, the mobile tab sheet's list
+ * scrolls, and the sidebar scrolls. A pointer drag moves the row with a CSS
+ * transform inside that box, so without this the row is CLIPPED at the edge and
+ * every slot past the fold is unreachable -- the drop lands on the last VISIBLE
+ * row instead of the one the user aimed at. A native HTML5 drag got this from
+ * the browser; a pointer drag has to do it.
+ *
+ * The geometry is a pure function so a unit test can own it. `startEdgeScroll`
+ * below is the loop around it.
+ */
+
+/** How close to an edge the pointer must come, in CSS pixels, before scrolling. */
+export const EDGE_BAND_PX = 48
+/** The fastest the container scrolls, in CSS pixels per frame. */
+export const MAX_SCROLL_STEP_PX = 12
+
+/**
+ * How far to scroll this frame: negative to scroll up, positive to scroll down,
+ * zero to stand still.
+ *
+ * The speed ramps with how far the pointer reaches into the edge band, so a
+ * pointer that rests just inside the band creeps and one held at the very edge
+ * runs at `maxStep`. A jump straight to full speed makes a short list
+ * uncontrollable.
+ *
+ * A viewport shorter than two bands would have overlapping bands, and a pointer
+ * in the middle would then belong to both. Such a box returns 0: it is small
+ * enough that every row is already on screen.
+ */
+export function edgeScrollStep(
+  viewport: { top: number, bottom: number },
+  pointerY: number,
+  opts: { band?: number, maxStep?: number } = {},
+): number {
+  const band = opts.band ?? EDGE_BAND_PX
+  const maxStep = opts.maxStep ?? MAX_SCROLL_STEP_PX
+  if (viewport.bottom - viewport.top < band * 2)
+    return 0
+  const topEdge = viewport.top + band
+  if (pointerY < topEdge)
+    return -maxStep * Math.min(1, (topEdge - pointerY) / band)
+  const bottomEdge = viewport.bottom - band
+  if (pointerY > bottomEdge)
+    return maxStep * Math.min(1, (pointerY - bottomEdge) / band)
+  return 0
+}
+
+/** The nearest ancestor that scrolls vertically, or undefined when none does. */
+export function scrollableAncestor(el: Element | null): HTMLElement | undefined {
+  for (let node = el; node instanceof HTMLElement; node = node.parentElement) {
+    const overflowY = getComputedStyle(node).overflowY
+    if ((overflowY === 'auto' || overflowY === 'scroll') && node.scrollHeight > node.clientHeight)
+      return node
+  }
+  return undefined
+}
+
+/** A live edge-scroll loop. Feed it the pointer, and stop it when the drag ends. */
+export interface EdgeScroller {
+  /** Report where the pointer is now, in client coordinates. */
+  track: (clientY: number) => void
+  /** Stop the loop and release the frame callback. */
+  stop: () => void
+}
+
+/**
+ * Scroll `scroller` while the pointer rests near one of its edges.
+ *
+ * `onScrolled` runs after each step with the pixels actually applied, which is
+ * how the caller keeps the drag consistent: solid-dnd caches every droppable's
+ * rect at `dragStart` and never recomputes it mid-drag, so a scroll invalidates
+ * all of them.
+ *
+ * The loop only runs while a step is non-zero, so a pointer in the middle of the
+ * box costs one comparison per move and no frames at all.
+ */
+export function startEdgeScroll(
+  scroller: HTMLElement,
+  onScrolled: (appliedPx: number) => void,
+): EdgeScroller {
+  let pointerY = Number.NaN
+  let frame = 0
+
+  const step = () => {
+    frame = 0
+    if (Number.isNaN(pointerY))
+      return
+    const rect = scroller.getBoundingClientRect()
+    const wanted = edgeScrollStep({ top: rect.top, bottom: rect.bottom }, pointerY)
+    if (wanted === 0)
+      return
+    // The APPLIED delta, not the wanted one. A scroller already at either end
+    // moves less than asked, or not at all, and reporting the wanted amount
+    // would shift the drag's compensation past what the box actually did.
+    const before = scroller.scrollTop
+    scroller.scrollTop = before + wanted
+    const applied = scroller.scrollTop - before
+    if (applied === 0)
+      return
+    onScrolled(applied)
+    frame = requestAnimationFrame(step)
+  }
+
+  return {
+    track: (clientY) => {
+      pointerY = clientY
+      if (frame === 0)
+        frame = requestAnimationFrame(step)
+    },
+    stop: () => {
+      cancelAnimationFrame(frame)
+      frame = 0
+      pointerY = Number.NaN
+    },
+  }
+}

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css'
 import { declareAppLayers } from '~/styles/layers'
+import { breakpoints, composerContainer } from '~/styles/tokens'
 
 const layers = declareAppLayers()
 
@@ -256,4 +257,32 @@ export const srOnly = style({
   clipPath: 'inset(50%)',
   whiteSpace: 'nowrap',
   border: 0,
+})
+
+/**
+ * Hides the word beside an icon once the COMPOSER is narrow, so a control
+ * shrinks to its icon there.
+ *
+ * A CONTAINER query, not a viewport one. The composer lives inside a resizable
+ * tile and a floating window, and either can be a small fraction of the
+ * viewport, so a viewport query answers a question about the wrong box: a 260px
+ * composer on a 1200px display kept rendering three full words, which crowded
+ * the `[+]` button and drove the collapsed text width to zero.
+ *
+ * ONE declaration for every such label, because the composer's action cluster
+ * and the input queue's row actions sit in the same column. Two copies of the
+ * threshold let them collapse to icons at two different widths.
+ *
+ * A control that composes this MUST give its name to a `<Tooltip ariaLabel>`.
+ * `display: none` reaches neither a screen reader nor a by-name lookup, so the
+ * hidden word is not a name. The one action whose icon cannot speak for
+ * itself -- Steer -- therefore does NOT compose this; see `steerAction` in
+ * `~/components/chat/AgentInputQueue.css.ts`.
+ */
+export const hideInNarrowComposer = style({
+  '@container': {
+    [`${composerContainer} (max-width: ${breakpoints.sm - 1}px)`]: {
+      display: 'none',
+    },
+  },
 })

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -54,3 +54,46 @@ export const breakpoints = {
   sm: 640,
   md: 768,
 }
+
+// The compact action button: a queue row's icon actions, the queue row's Steer
+// button, and the pause banner's Resume button beside them.
+//
+// `compactActionSize` is a CONTROL size, not a step on the spacing scale, so no
+// `--space-N` token fits it. It is in `rem`, so it follows the root font size
+// the way the text in the same row does.
+//
+// `compactTextSize` is the queue's metadata type size. It sits between
+// `--text-8` (0.75rem) and nothing smaller, so no `--text-N` token matches it
+// either. Named here because two components repeat it five times.
+export const compactActionSize = '1.75rem'
+export const compactTextSize = '0.72rem'
+
+// The geometry that every compact action button shares.
+//
+// A stylesheet SPREADS this into its own `style()` call. It does not compose a
+// shared CLASS, because two unlayered classes from two stylesheets tie on
+// specificity, and the emission order of the bundler then decides which
+// `padding` wins. The `controlReset` comment in `~/styles/shared.css.ts`
+// records the rule that this obeys.
+export const compactAction = {
+  height: compactActionSize,
+  flexShrink: 0,
+} as const
+
+// The compact action button that also shows a word.
+export const compactActionLabelled = {
+  ...compactAction,
+  padding: `0 var(--space-2)`,
+  fontSize: compactTextSize,
+} as const
+
+// The composer column's container-query name.
+//
+// `inputArea` in `~/components/chat/ChatView.css.ts` declares the container;
+// `hideInNarrowComposer` in `~/styles/shared.css.ts` and the input queue's own
+// rules query it. The composer sits inside a resizable tile and a floating
+// window, either of which can be a fraction of the viewport, so a viewport
+// media query answers a question about the wrong box: a 260px composer on a
+// 1200px display kept rendering "Pause Queue / Interrupt / Send" in full and
+// crowded the `[+]` button.
+export const composerContainer = 'composer'

--- a/frontend/tests/e2e/108-agent-input-queue.spec.ts
+++ b/frontend/tests/e2e/108-agent-input-queue.spec.ts
@@ -1,8 +1,37 @@
+import type { Page } from '@playwright/test'
 import { Buffer } from 'node:buffer'
 import { getUserId } from './helpers/api'
 import { COARSE_POINTER_METRICS, touchDragGripOnto } from './helpers/touch'
 import { loginViaToken, openWorkspace, sendMessage, waitForEditorDraft } from './helpers/ui'
 import { ensureWorkerOnline, expect, restartWorker, processTest as test } from './process-control-fixtures'
+
+/**
+ * Pause the queue, park two inputs in it, and hand back the locators that both
+ * drag tests need.
+ *
+ * Kept in this spec rather than under `helpers/`, where the repo's
+ * co-located-test rule would ask for a `.test.ts` beside a function that only
+ * drives a browser.
+ *
+ * The row pattern is ANCHORED (`/^queued-input-/`). The two copies of this
+ * setup had already drifted onto two different patterns, and the unanchored one
+ * matches more than the row.
+ */
+async function seedTwoQueuedRows(page: Page) {
+  await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+  await page.getByTestId('queue-pause-button').click()
+  await sendMessage(page, 'first queued')
+  await sendMessage(page, 'second queued')
+
+  const rows = page.getByTestId(/^queued-input-/)
+  await expect(rows).toHaveCount(2)
+  await expect(rows.first()).toContainText('first queued')
+  return {
+    rows,
+    source: rows.filter({ hasText: 'first queued' }),
+    target: rows.filter({ hasText: 'second queued' }),
+  }
+}
 
 test.describe('agent input queue', () => {
   test('persists paused input across clients, a reload, and a Worker restart, then supports queue changes', async ({ page, browser, authenticatedWorkspace, separateHubWorker }) => {
@@ -94,12 +123,24 @@ test.describe('agent input queue', () => {
       await expect(previews.first()).toHaveText('queued second')
 
       // Delete arms on the first click and removes the input on the second, so
-      // each of the two rows takes a pair. The row locator is rebuilt per pass
-      // because deleting one re-resolves `.first()` onto the next.
-      for (let pass = 0; pass < 2; pass++) {
-        const row = page.getByTestId(/queued-input-/).first()
+      // each of the two rows takes a pair.
+      //
+      // Each pass is pinned to ONE row's own test id, and the pass waits for
+      // that row to go before starting the next. `.first()` would not do:
+      // Playwright re-resolves a locator on every action, the removal is not
+      // optimistic (the row survives until the Worker's snapshot returns), and
+      // `ConfirmButton` returns to "Delete" the instant the confirming click
+      // fires -- so a second pass through `.first()` can arm the row the first
+      // pass already deleted, and then find no armed button once it goes.
+      const rowIds = await page.getByTestId(/queued-input-/).evaluateAll(rows =>
+        rows.map(row => row.getAttribute('data-testid')!),
+      )
+      expect(rowIds).toHaveLength(2)
+      for (const rowId of rowIds) {
+        const row = page.getByTestId(rowId)
         await row.getByRole('button', { name: 'Delete' }).click()
         await row.getByRole('button', { name: 'Confirm delete?' }).click()
+        await expect(row).toHaveCount(0)
       }
       for (const clientPage of [page, secondPage])
         await expect(clientPage.getByTestId('agent-input-queue')).toHaveCount(0)
@@ -120,17 +161,7 @@ test.describe('agent input queue', () => {
 
     test('reorders a queued input by dragging its grip with a finger', async ({ page, authenticatedWorkspace }) => {
       void authenticatedWorkspace
-      await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
-      await page.getByTestId('queue-pause-button').click()
-      await sendMessage(page, 'first queued')
-      await sendMessage(page, 'second queued')
-
-      const rows = page.getByTestId(/^queued-input-/)
-      await expect(rows).toHaveCount(2)
-      await expect(rows.first()).toContainText('first queued')
-
-      const source = rows.filter({ hasText: 'first queued' })
-      const target = rows.filter({ hasText: 'second queued' })
+      const { rows, source, target } = await seedTwoQueuedRows(page)
       const grip = source.locator('[data-drag-handle]')
       // The grip is visible ONLY here. On a fine pointer it is display:none,
       // which is the workspace list's own rule.
@@ -154,20 +185,10 @@ test.describe('agent input queue', () => {
 
   test('reorders a queued input by dragging its row', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
-    await page.getByTestId('queue-pause-button').click()
-    await sendMessage(page, 'first queued')
-    await sendMessage(page, 'second queued')
-
-    const rows = page.getByTestId(/^queued-input-/)
-    await expect(rows).toHaveCount(2)
-    await expect(rows.first()).toContainText('first queued')
-
     // A mouse is a FINE pointer, so the grip is hidden and the row body is what
     // drags -- exactly as it is in the workspace list. The grip carries the
     // touch path, which a mouse-driven browser cannot exercise.
-    const source = page.getByTestId(/queued-input-/).filter({ hasText: 'first queued' })
-    const target = page.getByTestId(/queued-input-/).filter({ hasText: 'second queued' })
+    const { rows, source, target } = await seedTwoQueuedRows(page)
     const from = (await source.boundingBox())!
     const to = (await target.boundingBox())!
     await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2)
@@ -179,7 +200,7 @@ test.describe('agent input queue', () => {
     await page.mouse.up()
 
     // The Worker owns the order, so the reorder is real only once it comes back.
-    await expect(page.getByTestId(/^queued-input-/).first()).toContainText('second queued')
+    await expect(rows.first()).toContainText('second queued')
   })
 
   test('spaces the pause banner, the queue, the attachments and the composer alike', async ({ page, authenticatedWorkspace }) => {
@@ -205,29 +226,41 @@ test.describe('agent input queue', () => {
     // paddings ADDED -- padding never collapses the way margin does -- so one
     // boundary was double the rest, and its size changed with which optional
     // children happened to render.
-    const gaps = await page.getByTestId('agent-input-queue').evaluate((queue) => {
+    const measured = await page.getByTestId('agent-input-queue').evaluate((queue) => {
       const column = queue.parentElement!
-      const boxes = Array.from(column.children)
-        .filter((child) => {
+      const children = Array.from(column.children).filter((child) => {
+        const style = getComputedStyle(child)
+        // The live region is absolutely positioned and the file input is
+        // `display: none`. Neither is a flex item, so neither takes a gap.
+        return style.display !== 'none' && style.position !== 'absolute'
+      })
+      const boxes = children.map(child => child.getBoundingClientRect())
+      return {
+        gaps: boxes.slice(1).map((rect, index) => rect.top - (boxes[index]!.top + boxes[index]!.height)),
+        // The OTHER half of the contract, and the half a gap cannot see. A
+        // child's own vertical padding lives INSIDE its border box, so
+        // restoring it changes no measured gap at all while the visible
+        // spacing goes uneven again -- which is the very regression this test
+        // exists to catch.
+        paddings: children.map((child) => {
           const style = getComputedStyle(child)
-          // The live region is absolutely positioned and the file input is
-          // `display: none`. Neither is a flex item, so neither takes a gap.
-          return style.display !== 'none' && style.position !== 'absolute'
-        })
-        .map(child => child.getBoundingClientRect())
-      return boxes.slice(1).map((rect, index) => rect.top - (boxes[index]!.top + boxes[index]!.height))
+          return [style.paddingTop, style.paddingBottom]
+        }),
+      }
     })
 
     // Four children: the banner, the queue, the attachment strip, the composer.
-    expect(gaps).toHaveLength(3)
+    expect(measured.gaps).toHaveLength(3)
     // Rounded: sub-pixel layout puts a fraction on each measurement, and the
     // claim is that the gaps MATCH, not that they are integers.
-    const rounded = gaps.map(gap => Math.round(gap))
+    const rounded = measured.gaps.map(gap => Math.round(gap))
     // Equal AND non-zero: three collapsed gaps are equal too, and that is a
     // different bug rather than a pass.
     expect(rounded[0]).toBeGreaterThan(0)
-    expect(rounded, `gaps between the composer column's children (raw: ${gaps.join(', ')})`)
+    expect(rounded, `gaps between the composer column's children (raw: ${measured.gaps.join(', ')})`)
       .toEqual([rounded[0], rounded[0], rounded[0]])
+    expect(measured.paddings, 'vertical padding of each composer column child')
+      .toEqual(measured.paddings.map(() => ['0px', '0px']))
   })
 
   test('keeps the composer action row clear of the [+] button on a phone', async ({ page, authenticatedWorkspace }) => {
@@ -249,6 +282,54 @@ test.describe('agent input queue', () => {
     const plusBox = (await plus.boundingBox())!
     const footerBox = (await footer.boundingBox())!
     expect(footerBox.x).toBeGreaterThanOrEqual(plusBox.x + plusBox.width)
+
+    // And the `[+]` still answers a click, which the overlap denied.
+    await plus.click()
+    await expect(page.getByTestId('composer-plus-popover')).toBeVisible()
+  })
+
+  test('goes icon-only and stays clear of the [+] when the composer is narrow on a wide viewport', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace // fixture trigger
+    // A WIDE viewport with a NARROW composer, which the phone test above cannot
+    // reach: a 320px viewport is already below `sm` on every measure. A split
+    // pane or a floating window puts a ~260px composer on a 1200px display, and
+    // a VIEWPORT media query calls that composer wide.
+    await page.setViewportSize({ width: 1200, height: 800 })
+    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await page.addStyleTag({ content: '[data-testid="agent-editor-panel"] { max-width: 260px; }' })
+
+    const plus = page.getByTestId('composer-plus-trigger')
+    const footer = page.getByTestId('composer-footer-slot')
+    const cluster = page.getByTestId('composer-actions')
+    await expect(plus).toBeVisible()
+    await expect(cluster).toBeVisible()
+    // `hideInNarrowComposer` is a CONTAINER query on `inputArea`, so the labels
+    // follow the COMPOSER's width and go away here, although the viewport is
+    // 1200px wide. They stay reachable as the buttons' accessible names, which
+    // is the whole contract of an icon-only control.
+    //
+    // The LABEL's visibility, not the button's text: `toHaveText` reads
+    // `textContent`, which includes a `display: none` span, so it reports
+    // "Send" for a button that renders nothing but an icon.
+    await expect(page.getByTestId('send-button').locator('span')).toBeHidden()
+    await expect(page.getByRole('button', { name: 'Send' })).toBeVisible()
+
+    // The CLUSTER's own box, not the slot's. The slot obeys its `max-width`
+    // whatever its content does, so measuring the slot alone proves nothing --
+    // a cluster that refuses to shrink simply overflows the slot's left edge
+    // and paints across the `[+]` from there.
+    const plusBox = (await plus.boundingBox())!
+    const footerBox = (await footer.boundingBox())!
+    const clusterBox = (await cluster.boundingBox())!
+    const plusRight = plusBox.x + plusBox.width
+    expect(footerBox.x, 'the footer slot must stop right of the [+]').toBeGreaterThanOrEqual(plusRight)
+    expect(clusterBox.x, 'the action cluster must stop right of the [+]').toBeGreaterThanOrEqual(plusRight)
+
+    // An EMPTY composer stays collapsed. The cap drives the available collapsed
+    // width to zero here, and the expand test subtracts a margin from it, so a
+    // text width of zero used to satisfy the comparison and open the tall
+    // layout with nothing typed.
+    await expect(page.getByTestId('composer-box')).not.toHaveAttribute('data-expanded')
 
     // And the `[+]` still answers a click, which the overlap denied.
     await plus.click()

--- a/frontend/tests/e2e/108-agent-input-queue.spec.ts
+++ b/frontend/tests/e2e/108-agent-input-queue.spec.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer'
 import { getUserId } from './helpers/api'
+import { COARSE_POINTER_METRICS, touchDragGripOnto } from './helpers/touch'
 import { loginViaToken, openWorkspace, sendMessage, waitForEditorDraft } from './helpers/ui'
 import { ensureWorkerOnline, expect, restartWorker, processTest as test } from './process-control-fixtures'
 
@@ -92,8 +93,14 @@ test.describe('agent input queue', () => {
       const previews = page.getByTestId('agent-input-queue').locator('div').filter({ hasText: /^(edited first|queued second)$/ })
       await expect(previews.first()).toHaveText('queued second')
 
-      await page.getByTestId(/queued-input-/).first().getByRole('button', { name: 'Delete' }).click()
-      await page.getByTestId(/queued-input-/).first().getByRole('button', { name: 'Delete' }).click()
+      // Delete arms on the first click and removes the input on the second, so
+      // each of the two rows takes a pair. The row locator is rebuilt per pass
+      // because deleting one re-resolves `.first()` onto the next.
+      for (let pass = 0; pass < 2; pass++) {
+        const row = page.getByTestId(/queued-input-/).first()
+        await row.getByRole('button', { name: 'Delete' }).click()
+        await row.getByRole('button', { name: 'Confirm delete?' }).click()
+      }
       for (const clientPage of [page, secondPage])
         await expect(clientPage.getByTestId('agent-input-queue')).toHaveCount(0)
       await page.getByTestId('queue-pause-button').click()
@@ -103,5 +110,148 @@ test.describe('agent input queue', () => {
     finally {
       await secondContext.close()
     }
+  })
+
+  test.describe('touch reorder (phone)', () => {
+    // A coarse primary pointer is what shows the grip at all: below `sm` it is
+    // the ONLY way to reorder, because a finger cannot drag a row body -- the
+    // body's activators refuse touch so a swipe still scrolls the queue.
+    test.use(COARSE_POINTER_METRICS)
+
+    test('reorders a queued input by dragging its grip with a finger', async ({ page, authenticatedWorkspace }) => {
+      void authenticatedWorkspace
+      await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+      await page.getByTestId('queue-pause-button').click()
+      await sendMessage(page, 'first queued')
+      await sendMessage(page, 'second queued')
+
+      const rows = page.getByTestId(/^queued-input-/)
+      await expect(rows).toHaveCount(2)
+      await expect(rows.first()).toContainText('first queued')
+
+      const source = rows.filter({ hasText: 'first queued' })
+      const target = rows.filter({ hasText: 'second queued' })
+      const grip = source.locator('[data-drag-handle]')
+      // The grip is visible ONLY here. On a fine pointer it is display:none,
+      // which is the workspace list's own rule.
+      await expect(grip).toBeVisible()
+      const gripBox = (await grip.boundingBox())!
+      const targetBox = (await target.boundingBox())!
+
+      await touchDragGripOnto({
+        page,
+        grip: { x: gripBox.x + gripBox.width / 2, y: gripBox.y + gripBox.height / 2 },
+        target: { x: targetBox.x + targetBox.width / 2, y: targetBox.y + targetBox.height / 2 },
+        draggedRow: source,
+        draggingClass: /itemDragging/,
+      })
+
+      // Polled: the Worker owns the order, so the reorder lands when the
+      // snapshot confirms it, which can be after the lift.
+      await expect.poll(async () => (await rows.first().textContent())?.includes('second queued')).toBe(true)
+    })
+  })
+
+  test('reorders a queued input by dragging its row', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace
+    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await page.getByTestId('queue-pause-button').click()
+    await sendMessage(page, 'first queued')
+    await sendMessage(page, 'second queued')
+
+    const rows = page.getByTestId(/^queued-input-/)
+    await expect(rows).toHaveCount(2)
+    await expect(rows.first()).toContainText('first queued')
+
+    // A mouse is a FINE pointer, so the grip is hidden and the row body is what
+    // drags -- exactly as it is in the workspace list. The grip carries the
+    // touch path, which a mouse-driven browser cannot exercise.
+    const source = page.getByTestId(/queued-input-/).filter({ hasText: 'first queued' })
+    const target = page.getByTestId(/queued-input-/).filter({ hasText: 'second queued' })
+    const from = (await source.boundingBox())!
+    const to = (await target.boundingBox())!
+    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2)
+    await page.mouse.down()
+    // Past the sensor's 10px activation distance, then onto the target's centre
+    // in a second step so the collision detector sees the move.
+    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2 + 20)
+    await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2)
+    await page.mouse.up()
+
+    // The Worker owns the order, so the reorder is real only once it comes back.
+    await expect(page.getByTestId(/^queued-input-/).first()).toContainText('second queued')
+  })
+
+  test('spaces the pause banner, the queue, the attachments and the composer alike', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace
+    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await page.getByTestId('queue-pause-button').click()
+    await sendMessage(page, 'a queued input')
+    await expect(page.getByTestId('agent-input-queue')).toContainText('a queued input')
+    await page.getByTestId('file-input').setInputFiles({
+      name: 'notes.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('an attachment'),
+    })
+    await expect(page.getByTestId('attachment-pill')).toContainText('notes.txt')
+
+    // Measure the composer column's own flex children, not their contents: the
+    // editor's ProseMirror host sits inside a bordered, padded container, so a
+    // box taken from it reports that chrome as part of the gap.
+    //
+    // The gap between each neighbouring pair must be the SAME. `inputArea` owns
+    // it with one `gap` and every child keeps its vertical padding at zero.
+    // When each child owned its own spacing instead, two of them met and their
+    // paddings ADDED -- padding never collapses the way margin does -- so one
+    // boundary was double the rest, and its size changed with which optional
+    // children happened to render.
+    const gaps = await page.getByTestId('agent-input-queue').evaluate((queue) => {
+      const column = queue.parentElement!
+      const boxes = Array.from(column.children)
+        .filter((child) => {
+          const style = getComputedStyle(child)
+          // The live region is absolutely positioned and the file input is
+          // `display: none`. Neither is a flex item, so neither takes a gap.
+          return style.display !== 'none' && style.position !== 'absolute'
+        })
+        .map(child => child.getBoundingClientRect())
+      return boxes.slice(1).map((rect, index) => rect.top - (boxes[index]!.top + boxes[index]!.height))
+    })
+
+    // Four children: the banner, the queue, the attachment strip, the composer.
+    expect(gaps).toHaveLength(3)
+    // Rounded: sub-pixel layout puts a fraction on each measurement, and the
+    // claim is that the gaps MATCH, not that they are integers.
+    const rounded = gaps.map(gap => Math.round(gap))
+    // Equal AND non-zero: three collapsed gaps are equal too, and that is a
+    // different bug rather than a pass.
+    expect(rounded[0]).toBeGreaterThan(0)
+    expect(rounded, `gaps between the composer column's children (raw: ${gaps.join(', ')})`)
+      .toEqual([rounded[0], rounded[0], rounded[0]])
+  })
+
+  test('keeps the composer action row clear of the [+] button on a phone', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace // fixture trigger
+    // Narrower than any phone this app targets, so the action row has the
+    // least space it will ever have.
+    await page.setViewportSize({ width: 320, height: 720 })
+    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+
+    const plus = page.getByTestId('composer-plus-trigger')
+    const footer = page.getByTestId('composer-footer-slot')
+    await expect(plus).toBeVisible()
+    await expect(footer).toBeVisible()
+
+    // The two slots are absolutely positioned on the same bottom line, one
+    // anchored left and one anchored right, so nothing but the footer's
+    // `max-width` stops them from meeting. The footer paints over the `[+]`
+    // and its buttons take the clicks, which is what this guards.
+    const plusBox = (await plus.boundingBox())!
+    const footerBox = (await footer.boundingBox())!
+    expect(footerBox.x).toBeGreaterThanOrEqual(plusBox.x + plusBox.width)
+
+    // And the `[+]` still answers a click, which the overlap denied.
+    await plus.click()
+    await expect(page.getByTestId('composer-plus-popover')).toBeVisible()
   })
 })

--- a/frontend/tests/e2e/179-mobile-tabs-touch.spec.ts
+++ b/frontend/tests/e2e/179-mobile-tabs-touch.spec.ts
@@ -33,19 +33,6 @@ function serverOf(leapmuxServer: { hubUrl: string, adminToken: string, workerId:
   }
 }
 
-/**
- * Wait until the input events already dispatched have been RENDERED.
- *
- * CDP acknowledges the dispatch of a pointer event, not its processing on the
- * main thread, so a lift issued straight after the last move can race the
- * dragOver that decides where the drop lands. Two frames is the guarantee: the
- * first callback runs after the pending work is consumed, the second after
- * that work has painted.
- *
- * This is what a drag settles on instead of a sleep. A wall-clock wait elapses
- * on schedule no matter how far behind the main thread is, which makes it
- * exactly wrong under load — the condition it is supposed to cover.
- */
 /** Position of the row/tab whose text contains `needle`, throwing if absent. */
 async function textIndex(rows: Locator, needle: string): Promise<number> {
   const texts = await rows.allTextContents()
@@ -353,7 +340,7 @@ test.describe('soft-keyboard viewport contract (phone)', () => {
      * which under load spend that entire budget before the release arrives. The
      * tap then reads as a long press and the keyboard stays up: a failure of the
      * driving, not of the app. One evaluate puts the two events microseconds
-     * apart, whatever the machine is doing.
+     * apart, however much load the machine carries.
      *
      * `pointerId` and `isPrimary` are explicit for the same reason -- the
      * recognizer keys its press on both, and neither has a useful default on

--- a/frontend/tests/e2e/179-mobile-tabs-touch.spec.ts
+++ b/frontend/tests/e2e/179-mobile-tabs-touch.spec.ts
@@ -1,7 +1,7 @@
 import type { Locator, Page } from '@playwright/test'
 import { expect, test } from './fixtures'
 import { openAgentViaAPI } from './helpers/api'
-import { COARSE_POINTER_METRICS, touchDown } from './helpers/touch'
+import { COARSE_POINTER_METRICS, settleFrames, touchDown, touchDragGripOnto } from './helpers/touch'
 
 /**
  * The mobile tab UI and the touch drag model.
@@ -46,12 +46,6 @@ function serverOf(leapmuxServer: { hubUrl: string, adminToken: string, workerId:
  * on schedule no matter how far behind the main thread is, which makes it
  * exactly wrong under load — the condition it is supposed to cover.
  */
-async function settleFrames(page: Page) {
-  await page.evaluate(() => new Promise<void>(resolve =>
-    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-  ))
-}
-
 /** Position of the row/tab whose text contains `needle`, throwing if absent. */
 async function textIndex(rows: Locator, needle: string): Promise<number> {
   const texts = await rows.allTextContents()
@@ -81,62 +75,6 @@ async function openSheet(page: Page): Promise<Locator> {
     return first !== null && second !== null && first.y === second.y
   }).toBe(true)
   return rows
-}
-
-/**
- * Touch-press `grip`, travel past the 10px activation distance, and drag
- * until the DRAGGED ROW's center sits on `target` — then lift.
- *
- * The finger does not stop at `target` itself: solid-dnd's collision
- * reference is the dragged element's transformed CENTER, which keeps the
- * grip-to-center offset it had at the press. A grip press therefore carries
- * the reference half a row past the finger, and a drop aimed at the finger's
- * position resolves a DIFFERENT droppable (observed: the tab-bar zone, a
- * same-tile no-op) whenever the drag runs right-to-left. Aiming the row's
- * center at the target makes the drop land on the target from any direction.
- *
- * `draggedRow` is also the oracle: the drag's start AND end are confirmed
- * against its `tabDragging` class, so a press that somehow never activated —
- * or a lift the drag pipeline never saw — fails HERE instead of as a
- * mysterious unchanged order later.
- */
-async function touchDragGripOnto(
-  grip: { x: number, y: number },
-  target: { x: number, y: number },
-  page: Page,
-  draggedRow: Locator,
-) {
-  const rowBox = (await draggedRow.boundingBox())!
-  // The collision reference sits this far right of the finger for the whole
-  // gesture (grip press): aim the finger so the reference lands on target.
-  const referenceOffsetX = rowBox.x + rowBox.width / 2 - grip.x
-  const fingerTarget = { x: target.x - referenceOffsetX, y: target.y }
-
-  const finger = await touchDown(page, grip.x, grip.y)
-  try {
-    // A move comfortably past the sensor's 10px activation distance, then a
-    // short pause for the drag to start before the move to the target —
-    // solid-dnd recomputes droppable collisions on every move, the same
-    // shape the mouse-driven reorder specs use.
-    await finger.moveTo(grip.x + 8, grip.y + 20)
-    await expect(draggedRow).toHaveClass(/tabDragging/)
-    const steps = 12
-    for (let step = 1; step <= steps; step++) {
-      await finger.moveTo(
-        grip.x + 8 + ((fingerTarget.x - grip.x - 8) * step) / steps,
-        grip.y + 20 + ((fingerTarget.y - grip.y - 20) * step) / steps,
-      )
-    }
-    // Settle before lifting, or a lift that races the final dragOver resolves
-    // the drop prematurely.
-    await settleFrames(page)
-  }
-  finally {
-    await finger.end()
-  }
-  // The lift ended the drag: a press whose pointerup the pipeline lost would
-  // leave the row lifted and the reorder would never be attempted.
-  await expect(draggedRow).not.toHaveClass(/tabDragging/)
 }
 
 test.describe('mobile tab sheet (phone)', () => {
@@ -190,12 +128,13 @@ test.describe('mobile tab sheet (phone)', () => {
     const grip = alphaRow.locator('[data-drag-handle]')
     const gripBox = (await grip.boundingBox())!
     const targetBox = (await rows.filter({ hasText: 'Beta' }).boundingBox())!
-    await touchDragGripOnto(
-      { x: gripBox.x + gripBox.width / 2, y: gripBox.y + gripBox.height / 2 },
-      { x: targetBox.x + targetBox.width / 2, y: targetBox.y + targetBox.height / 2 },
+    await touchDragGripOnto({
       page,
-      alphaRow,
-    )
+      grip: { x: gripBox.x + gripBox.width / 2, y: gripBox.y + gripBox.height / 2 },
+      target: { x: targetBox.x + targetBox.width / 2, y: targetBox.y + targetBox.height / 2 },
+      draggedRow: alphaRow,
+      draggingClass: /tabDragging/,
+    })
     await expect.poll(async () => await textIndex(rows, 'Beta') < await textIndex(rows, 'Alpha')).toBe(true)
   })
 
@@ -405,10 +344,27 @@ test.describe('soft-keyboard viewport contract (phone)', () => {
     const transcript = page.locator('[data-chat-scroll-container="true"]')
     const size = page.viewportSize()!
 
-    /** A tap: down and up at one point. `dx` drags instead, past the slop. */
+    /**
+     * A tap: down and up at one point. `dx` drags instead, past the slop.
+     *
+     * BOTH events go out in ONE evaluate. The recognizer refuses a press that
+     * lasts `motion.longPress` (500ms) or more, because that gesture belongs to
+     * text selection -- and two `dispatchEvent` calls are two CDP round trips,
+     * which under load spend that entire budget before the release arrives. The
+     * tap then reads as a long press and the keyboard stays up: a failure of the
+     * driving, not of the app. One evaluate puts the two events microseconds
+     * apart, whatever the machine is doing.
+     *
+     * `pointerId` and `isPrimary` are explicit for the same reason -- the
+     * recognizer keys its press on both, and neither has a useful default on
+     * `PointerEvent`.
+     */
     const tapTranscript = async (dx = 0) => {
-      await transcript.dispatchEvent('pointerdown', { clientX: 100, clientY: 100 })
-      await transcript.dispatchEvent('pointerup', { clientX: 100 + dx, clientY: 100 })
+      await transcript.evaluate((el, moveX) => {
+        const shared = { bubbles: true, isPrimary: true, pointerId: 1, clientY: 100 }
+        el.dispatchEvent(new PointerEvent('pointerdown', { ...shared, clientX: 100 }))
+        el.dispatchEvent(new PointerEvent('pointerup', { ...shared, clientX: 100 + moveX }))
+      }, dx)
     }
 
     await editor.click()
@@ -539,12 +495,13 @@ test.describe('tablet touch (desktop layout)', () => {
     await expect(grip).toBeVisible()
     const gripBox = (await grip.boundingBox())!
     const betaBox = (await betaTab.boundingBox())!
-    await touchDragGripOnto(
-      { x: gripBox.x + gripBox.width / 2, y: gripBox.y + gripBox.height / 2 },
-      { x: betaBox.x + betaBox.width / 2, y: betaBox.y + betaBox.height / 2 },
+    await touchDragGripOnto({
       page,
-      alphaTab,
-    )
+      grip: { x: gripBox.x + gripBox.width / 2, y: gripBox.y + gripBox.height / 2 },
+      target: { x: betaBox.x + betaBox.width / 2, y: betaBox.y + betaBox.height / 2 },
+      draggedRow: alphaTab,
+      draggingClass: /tabDragging/,
+    })
     // Dropping Alpha ONTO Beta inserts it at Beta's slot — landing AFTER
     // Beta, from any starting order. Polled: the reorder lands when the
     // store confirms it, which can be after the lift.

--- a/frontend/tests/e2e/helpers/touch.ts
+++ b/frontend/tests/e2e/helpers/touch.ts
@@ -1,5 +1,5 @@
-import type { Page } from '@playwright/test'
-import { devices } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
+import { devices, expect } from '@playwright/test'
 
 /**
  * Real touch input for the E2E specs, plus the device metrics that give Blink a coarse pointer.
@@ -132,4 +132,74 @@ export async function touchSwipe(
   finally {
     await finger.end()
   }
+}
+
+/** Wait two animation frames, so a transform the drag just wrote is on screen. */
+export async function settleFrames(page: Page): Promise<void> {
+  await page.evaluate(() => new Promise<void>(resolve =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  ))
+}
+
+/**
+ * Touch-press `grip`, travel past the 10px activation distance, and drag until
+ * the DRAGGED ROW's center sits on `target` -- then lift.
+ *
+ * The finger does not stop at `target` itself: solid-dnd's collision reference
+ * is the dragged element's transformed CENTER, which keeps the grip-to-center
+ * offset it had at the press. A grip press therefore carries the reference half
+ * a row past the finger, and a drop aimed at the finger's position resolves a
+ * DIFFERENT droppable (observed: the tab-bar zone, a same-tile no-op) whenever
+ * the drag runs right-to-left. Aiming the row's center at the target makes the
+ * drop land on the target from any direction.
+ *
+ * `draggedRow` is also the oracle: the drag's start AND end are confirmed
+ * against `draggingClass`, so a press that somehow never activated -- or a lift
+ * the drag pipeline never saw -- fails HERE instead of as a mysterious
+ * unchanged order later. Each surface names that class itself, because the
+ * class is the surface's own (`tabDragging`, `itemDragging`).
+ *
+ * Shared by every grip-drag spec. The gesture's shape is not obvious -- the
+ * reference offset above is the part a second copy would get wrong -- so it has
+ * ONE home.
+ */
+export async function touchDragGripOnto(opts: {
+  page: Page
+  grip: TouchPoint
+  target: TouchPoint
+  draggedRow: Locator
+  draggingClass: RegExp
+}): Promise<void> {
+  const { page, grip, target, draggedRow, draggingClass } = opts
+  const rowBox = (await draggedRow.boundingBox())!
+  // The collision reference sits this far right of the finger for the whole
+  // gesture (grip press): aim the finger so the reference lands on target.
+  const referenceOffsetX = rowBox.x + rowBox.width / 2 - grip.x
+  const fingerTarget = { x: target.x - referenceOffsetX, y: target.y }
+
+  const finger = await touchDown(page, grip.x, grip.y)
+  try {
+    // A move comfortably past the sensor's 10px activation distance, then a
+    // short pause for the drag to start before the move to the target --
+    // solid-dnd recomputes droppable collisions on every move, the same shape
+    // the mouse-driven reorder specs use.
+    await finger.moveTo(grip.x + 8, grip.y + 20)
+    await expect(draggedRow).toHaveClass(draggingClass)
+    const steps = 12
+    for (let step = 1; step <= steps; step++) {
+      await finger.moveTo(
+        grip.x + 8 + ((fingerTarget.x - grip.x - 8) * step) / steps,
+        grip.y + 20 + ((fingerTarget.y - grip.y - 20) * step) / steps,
+      )
+    }
+    // Settle before lifting, or a lift that races the final dragOver resolves
+    // the drop prematurely.
+    await settleFrames(page)
+  }
+  finally {
+    await finger.end()
+  }
+  // The lift ended the drag: a press whose pointerup the pipeline lost would
+  // leave the row lifted and the reorder would never be attempted.
+  await expect(draggedRow).not.toHaveClass(draggingClass)
 }

--- a/frontend/tests/e2e/helpers/touch.ts
+++ b/frontend/tests/e2e/helpers/touch.ts
@@ -134,7 +134,19 @@ export async function touchSwipe(
   }
 }
 
-/** Wait two animation frames, so a transform the drag just wrote is on screen. */
+/**
+ * Wait until the input events already dispatched are RENDERED.
+ *
+ * CDP acknowledges the dispatch of a pointer event, not its processing on the
+ * main thread, so a lift issued straight after the last move can race the
+ * dragOver that decides where the drop lands. Two frames is the guarantee: the
+ * first callback runs after the main thread consumes the pending work, the
+ * second after that work paints.
+ *
+ * This is what a drag settles on instead of a sleep. A wall-clock wait elapses
+ * on schedule however far behind the main thread runs, which makes it exactly
+ * wrong under load -- the condition it exists to cover.
+ */
 export async function settleFrames(page: Page): Promise<void> {
   await page.evaluate(() => new Promise<void>(resolve =>
     requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
@@ -156,7 +168,7 @@ export async function settleFrames(page: Page): Promise<void> {
  * `draggedRow` is also the oracle: the drag's start AND end are confirmed
  * against `draggingClass`, so a press that somehow never activated -- or a lift
  * the drag pipeline never saw -- fails HERE instead of as a mysterious
- * unchanged order later. Each surface names that class itself, because the
+ * unchanged order later. Each surface specifies that class itself, because the
  * class is the surface's own (`tabDragging`, `itemDragging`).
  *
  * Shared by every grip-drag spec. The gesture's shape is not obvious -- the


### PR DESCRIPTION
## Motivation
The input queue row used four text buttons (Move Up, Move Down, Edit, Retry), and each button took real width — enough to push a row past the width of a phone. Delete had no confirmation step, so one accidental click discarded a queued message. The queue gave no reason when it paused, and its drag used native HTML5 drag events, which never fire on a touch device, so its grip offered a gesture a phone could not perform.

A deep code review of that feature then found defects in the row's layout, in its list keys, and in its drag reach at a scrolled edge — several of which its own tests could not see. The review's end-to-end runs also surfaced an unrelated bug already on `main`: the tab bar's context-menu Rename command did nothing at all.

## Modifications

**Input queue.** Icon-only outline buttons replace the text buttons; a tooltip and the accessibility tree state each button's purpose. Delete now needs two clicks: the first arms it (the bin becomes a warning sign and the outline turns red), and the second confirms. A new `AgentInputQueuePauseBanner` states the pause reason, one sentence for each `AgentInputQueuePauseReason` in a `satisfies Record<...>` table, with its own Resume button; it reads `paused` alone rather than the item count, because the case that needs it most is the empty one. The drag moves onto the same solid-dnd sortable the workspace list uses, so it works by touch. Five drifting copies of the reorder-legality rule — two arrow handlers, two `disabled` props, and the drop arithmetic — collapse into one `resolveQueueMove` in a new `agentInputQueueDrop.ts` with its own unit test.

Three defects the review corrected in that row. It was a three-track CSS grid, and the pointer-only drag handle is `display: none` on a fine pointer — a hidden *grid* item still reserves its track, so the actions column collapsed to zero and the buttons were pushed out of the row whenever a preview was long; the row is now flex. The list was a reference-keyed `<For>`, and every Worker snapshot replaces the whole array with new objects, so every row was rebuilt on every queue event: an armed Delete lost its armed state between the user's two clicks, and a drag in flight lost its drop preview. And Steer keeps its word at every width, because a tooltip never opens on touch and that icon carries no meaning alone.

**Composer column.** The vertical spacing now comes from one flex-column `gap`, replacing per-child padding that stacked into an uneven 8px/4px mix depending on which optional children rendered. The compact icon-only layout switches on a CSS **container** query keyed to the composer's own width rather than a viewport media query, so a 260px composer in a split pane or a floating window goes compact even on a 1200px display. Two review fixes here: an empty composer no longer opens in the tall expanded layout (the action row's width cap drives the collapsed text width to exactly zero, which the expand comparison then satisfied), and the action cluster now actually wraps instead of overflowing its cap and painting over the `[+]` button.

**Shared components.** `ConfirmButton` now always owns its own tooltip and takes `blocked: { reason, reasonId }`. A caller can no longer wrap it in its own `<Tooltip>`: one `<Tooltip>` nested in another does not add a second description, it *disables* the outer one — the outer resolves the inner wrapper `<span>` as its target and gives up. `LastTabCloseDialog` and `DeleteBranchDialog` migrate to `blocked`. Its prop type now also omits `onBlur` and `type`, which it silently shadowed, and `confirmTooltip` can no longer appear without `tooltip`. `<Tooltip>` stops publishing an offscreen description that merely repeats the accessible name — a disabled icon-only control announced "Move Up, button, unavailable, Move Up", and every by-text lookup found two elements.

**Drag stack.** A new `~/lib/dragAutoScroll.ts` adds edge auto-scroll to the shared pointer sensor, so it reaches every draggable surface in the app. Each one sits inside a scroller, and solid-dnd moves the row with a transform *inside* that box, so a row was clipped at the edge and every slot past the fold was unreachable — a native HTML5 drag got this from the browser for free. The row-body guard also learnt about `[data-tooltip-box]`: `<Tooltip>` gives a *disabled* control a real box, so the wrapper span became the hit-test target and a press on a disabled row button dragged the whole row.

**Unrelated fix, already on `main`.** The tab bar's context-menu Rename now commits only once its input has held the caret, not on any focus change. The Rename item sits in a popover, and closing that popover hands focus back to the tab — the old rule read the gesture that *opened* the rename as the user leaving it, so the input was gone before it could take the caret. A pointerdown still counts at once, because nothing but the user presses a pointer. This affects the desktop tab strip and the mobile tab sheet; the double-click rename never hit it, because it opens no popover.

## Result
A queued row fits on a phone, and each action states its name to a tooltip and to a screen reader instead of spending width on a word. Deleting a queued input takes a deliberate second click, and that armed state now survives the queue events that arrive while you decide. A paused queue tells you why, with Resume beside the sentence. Reordering works with a finger, reaches past the fold of a scrolled list, and no longer starts from a button the row draws as unavailable. A long queued message no longer pushes the row's buttons off screen, and an empty composer no longer opens at double height in a narrow pane. The tab bar's Rename works again from the context menu, on the desktop strip and the mobile sheet alike.
