### PR TITLE
fix(claude): Keep one background-task row for a restarted subagent

### DIFF
--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -411,6 +411,21 @@ type OutputSink interface {
 	// pooled fallback name.
 	EnsureChildAgent(spawnSpanID, providerChildKey, title string) (childAgentID string, err error)
 
+	// ChildSpawnSpan returns the tool_use span in THIS sink's transcript that
+	// spawned childAgentID -- the first argument EnsureChildAgent took, read
+	// back. Answers "" for an id no child transcript carries.
+	//
+	// It exists because that span is the ONLY durable link between a provider's
+	// events and its forwarded output, and a provider's own index of it is
+	// per-process. Claude needs it when the CLI restarts a finished subagent: the
+	// restart event identifies the call that restarted the task (the parent's
+	// SendMessage, or nothing at all for a shell wake), while the restarted run
+	// still forwards every envelope under the ORIGINAL spawn.
+	//
+	// err is non-nil when the row could not be READ, which is a third answer and
+	// not a miss, for the reason LookupBackgroundTask states.
+	ChildSpawnSpan(childAgentID string) (spawnSpanID string, err error)
+
 	// ChildSink returns an OutputSink bound to the child agent's transcript.
 	// The child sink has its OWN span tracker; transcript primitives act on the
 	// child. Registry primitives on a child sink write under the same ROOT owner.

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -178,7 +178,7 @@ type SpanInfo struct {
 	// a subagent spawn. Its SpanColor of 0 is the ANSWER, not a gap to fill, so
 	// the persist path must not substitute the connector's color for it. Without
 	// this the spawn card takes a rail color that matches no rail anywhere,
-	// whenever its ParentSpanID happens to name a span that is still open.
+	// whenever its ParentSpanID happens to identify a span that is still open.
 	NoSpan bool
 }
 
@@ -412,15 +412,16 @@ type OutputSink interface {
 	EnsureChildAgent(spawnSpanID, providerChildKey, title string) (childAgentID string, err error)
 
 	// ChildSpawnSpan returns the tool_use span in THIS sink's transcript that
-	// spawned childAgentID -- the first argument EnsureChildAgent took, read
-	// back. Answers "" for an id no child transcript carries.
+	// spawned childAgentID. It is the first argument EnsureChildAgent took, read
+	// back. The answer is "" for an id this sink spawned no child under.
 	//
-	// It exists because that span is the ONLY durable link between a provider's
-	// events and its forwarded output, and a provider's own index of it is
-	// per-process. Claude needs it when the CLI restarts a finished subagent: the
-	// restart event identifies the call that restarted the task (the parent's
-	// SendMessage, or nothing at all for a shell wake), while the restarted run
-	// still forwards every envelope under the ORIGINAL spawn.
+	// It exists because that span is the only DURABLE link between a provider's
+	// events and its forwarded output. A provider indexes the span in memory, and
+	// that index cannot survive a worker restart; the child row can.
+	//
+	// A provider needs it when its CLI restarts a finished subagent under an id
+	// that is not the original spawn. See the Claude implementation for the shape
+	// that motivated it.
 	//
 	// err is non-nil when the row could not be READ, which is a third answer and
 	// not a miss, for the reason LookupBackgroundTask states.
@@ -614,7 +615,7 @@ type Agent interface {
 	//   - A protocol with no acknowledgement (Claude, over stdin): the write to
 	//     the process IS the delivery. Return once it lands.
 	//   - A protocol that acknowledges (Codex's `turn/started`): return on the
-	//     ack, or report the delivery unconfirmed after a bounded wait. Send the
+	//     ack, or report the delivery unconfirmed after a limited wait. Send the
 	//     request itself without waiting on its response, because a protocol
 	//     whose response arrives at TURN END answers a different question.
 	//

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -322,7 +322,7 @@ func (a *ClaudeCodeAgent) processAssistantBlocks(env *messageEnvelope) {
 	// recipient before the tool runs, because the task_started it produces cannot
 	// be told from a session resume's hydration burst on its own. This is the
 	// ROOT transcript, so the arms are scoped to it ("").
-	a.claudeArmRevivesFromBlocks(env, "")
+	a.claudeArmRestartsFromBlocks(env, "")
 
 	toolUseCount := 0
 	planFileProcessed := false
@@ -622,7 +622,7 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 
 		// Reset all span tracking so the next turn starts clean.
 		a.sink.ResetSpans()
-		// Drop the ROOT's SendMessage revive arms with it. A revive's task_started
+		// Drop the ROOT's SendMessage restart arms with it. A restart's task_started
 		// lands inside the turn that sent the message (the tool awaits the
 		// restart), so an arm still standing here addressed a live subagent, a
 		// recipient outside this session, or a send the CLI refused -- and none of
@@ -631,7 +631,7 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		// Only the root's. A subagent runs past this boundary and clears its own
 		// arms at its own turn end, so wiping every arm here would drop a live
 		// subagent's before its task_started arrived.
-		a.tasks.clearClaudeRevives("")
+		a.tasks.clearClaudeRestarts("")
 		notifyInputReady(a.sink)
 	}
 }

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -179,7 +179,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// re-registration, and two decisions below turn on it.
 	//
 	// The CLI emits task_started again for the same task_id in two cases: it
-	// revived a finished subagent, or a resumed session is re-announcing the
+	// restarted a finished subagent, or a resumed session is re-announcing the
 	// tasks it once ran. Both re-register, and in both the event's tool_use_id
 	// identifies the tool call that runs NOW, not the original spawn.
 	known := lookupClaudeKnownTask(a.sink, ev.TaskID)
@@ -315,7 +315,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// task". The registry is durable and the call index is not, so a row that
 	// outlived a worker restart, or one a reordered task_notification opened
 	// first, would suppress the close for a genuine spawn and strand its rail
-	// open for the rest of the transcript. claudeArmRevivesFromBlocks records
+	// open for the rest of the transcript. claudeArmRestartsFromBlocks records
 	// every SendMessage tool_use id as the block is parsed, and each transcript
 	// drops its own at its own turn end -- so this reads "restart call" exactly
 	// when the event re-registers a task, and nothing otherwise.
@@ -324,7 +324,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// its span type on that CHILD's tracker (routeSubagentMessage), while this
 	// runs on the ROOT sink, which answers "" for an id it never saw -- and ""
 	// is indistinguishable from a spawn here. So a sibling-to-sibling send, the
-	// case the revive exists to support, read as a spawn at both guards.
+	// case the restart exists to support, read as a spawn at both guards.
 	//
 	// An unreadable registry suppresses the close too: it cannot prove this is a
 	// spawn, and freeing a rail that is still in use is the worse of the two
@@ -439,9 +439,9 @@ func (a *ClaudeCodeAgent) openClaudeTaskChild(ev *claudeTaskEnvelope, known clau
 	case err != nil:
 		slog.Warn("claude task_started ensure child failed", "task_id", ev.TaskID, "error", err)
 	case childID == "":
-		// No transcript, and none this event can open. The revive arm is left
+		// No transcript, and none this event can open. The restart arm is left
 		// STANDING rather than consumed: the row is still finished, so a later
-		// task_started for this task in the same turn is still a revive and
+		// task_started for this task in the same turn is still a restart and
 		// deserves the retry -- the same reason a failed registry write puts
 		// its arm back.
 		slog.Warn("claude task_started resolved no child transcript",
@@ -451,11 +451,11 @@ func (a *ClaudeCodeAgent) openClaudeTaskChild(ev *claudeTaskEnvelope, known clau
 		handled, err := a.reviveClaudeSubagent(ev, childID, known, restart)
 		switch {
 		case err != nil:
-			// It WAS a revive; only the registry write failed. The delivered
+			// It WAS a restart; only the registry write failed. The delivered
 			// message is already in the transcript and the arm is back, so the
 			// first-start path below must not run -- PersistChildPrompt says
 			// nothing on a transcript that already has messages anyway.
-			slog.Warn("claude revive background task failed", "task_id", ev.TaskID, "error", err)
+			slog.Warn("claude restart background task failed", "task_id", ev.TaskID, "error", err)
 		case handled:
 			// The prompt was the message the parent just sent, appended to the
 			// running transcript rather than prepended as the opening instruction.
@@ -532,7 +532,7 @@ func lookupClaudeKnownTask(sink OutputSink, taskID string) claudeKnownTask {
 //
 // Three conditions must all hold, and each excludes a different impostor:
 //
-//   - the registry already holds this task -- a first start is not a revive;
+//   - the registry already holds this task -- a first start is not a restart;
 //   - the row is in a FINISHED status -- a duplicate task_started for a running
 //     task changes nothing;
 //   - a SendMessage this turn addressed this task id -- which is what a resumed
@@ -552,10 +552,10 @@ func lookupClaudeKnownTask(sink OutputSink, taskID string) claudeKnownTask {
 // all, and it arrives on the one event that also proves the restart happened, so
 // a send the CLI refused records nothing.
 //
-// Reports `handled` -- whether this event WAS a revive -- separately from the
+// Reports `handled` -- whether this event WAS a restart -- separately from the
 // error, because the two answer different questions. The caller skips the
 // first-start prompt path on handled, and a failed registry write does not make
-// the event any less a revive: falling back there would hand the delivered
+// the event any less a restart: falling back there would hand the delivered
 // message to PersistChildPrompt, which says nothing once the transcript has
 // messages, and the arm is spent by then.
 func (a *ClaudeCodeAgent) reviveClaudeSubagent(ev *claudeTaskEnvelope, childID string, known claudeKnownTask, restart claudeRestartEvidence) (handled bool, err error) {
@@ -571,10 +571,10 @@ func (a *ClaudeCodeAgent) reviveClaudeSubagent(ev *claudeTaskEnvelope, childID s
 	//
 	// The evidence arrives as a parameter, because the caller reads it before it
 	// derives the row title from the same event. Two reads of one fact would let
-	// the title and the revive disagree about what this event is. This is also
+	// the title and the restart disagree about what this event is. This is also
 	// the ONE decision that reads a single form rather than restarted(): only a
 	// SendMessage delivers text, so a wake reopens the row and writes nothing.
-	delivered := a.tasks.takeClaudeRevive(ev.TaskID)
+	delivered := a.tasks.takeClaudeRestart(ev.TaskID)
 	if !delivered && !restart.wake {
 		return false, nil
 	}
@@ -584,18 +584,18 @@ func (a *ClaudeCodeAgent) reviveClaudeSubagent(ev *claudeTaskEnvelope, childID s
 	// never written is gone, and nothing retries it.
 	if delivered {
 		if err := a.sink.PersistChildUserMessage(childID, ev.Prompt); err != nil {
-			slog.Warn("claude revive persist message failed", "child", childID, "error", err)
+			slog.Warn("claude restart persist message failed", "child", childID, "error", err)
 		}
 	}
 	if err := a.sink.ReviveBackgroundTask(ev.TaskID); err != nil {
 		// Put a consumed DELIVERY arm back. The row is still finished, so a later
-		// task_started for this task in the same turn is still a revive and
+		// task_started for this task in the same turn is still a restart and
 		// deserves the retry that a consumed arm would deny it. Re-armed at ROOT
 		// scope ("") because this runs on the root stream and the root's turn end
 		// is the later of the two boundaries -- the retry window is never cut
 		// short. A wake consumed nothing, so it has nothing to give back.
 		if delivered {
-			a.tasks.armClaudeRevive(ev.TaskID, "")
+			a.tasks.armClaudeRestart(ev.TaskID, "")
 		}
 		return true, err
 	}
@@ -723,7 +723,7 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	// tool_use, then a task_started carrying the message as its prompt. The
 	// delivered text rides on exactly two envelopes -- the parent's own tool_use
 	// input, and task_started.prompt -- and never on a forwarded one. So a
-	// recipient is always FINISHED by delivery time, the revive path is the whole
+	// recipient is always FINISHED by delivery time, the restart path is the whole
 	// mechanism, and there is no live-delivery case for this guard to drop.
 	if msgType == claudeMsgTypeUser && !hasToolResultBlock(env) {
 		return
@@ -828,7 +828,7 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 		// This subagent's turn ended, so drop the arms IT set. Its own result is
 		// the boundary for them; the root's is not, because this transcript
 		// outlives the root turn that spawned it.
-		a.tasks.clearClaudeRevives(spawnSpanID)
+		a.tasks.clearClaudeRestarts(spawnSpanID)
 		return
 	}
 
@@ -854,11 +854,11 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	// parent transcript: its output goes to a transcript of its own.
 	if msgType == claudeMsgTypeAssistant {
 		// A subagent can message another agent, so its SendMessage calls arm a
-		// revive exactly as the parent's do. The arms live on the agent, not on a
+		// restart exactly as the parent's do. The arms live on the agent, not on a
 		// sink, because the task_started that fires them arrives on the root
 		// stream whichever transcript sent the message. They carry this
 		// transcript's spawn span, so the root's turn end cannot drop them.
-		a.claudeArmRevivesFromBlocks(env, spawnSpanID)
+		a.claudeArmRestartsFromBlocks(env, spawnSpanID)
 		for _, block := range env.ContentBlocks() {
 			if block.Type == "tool_use" && block.ID != "" {
 				childSink.SetSpanType(block.ID, block.Name)
@@ -942,9 +942,9 @@ type claudeTaskIndex struct {
 	// result can race past a reordered task_started). Keyed by spawn tool_use id
 	// so the late task_started can close the row it just opened. Guarded by i.mu.
 	pendingTaskEnd map[string]bgtask.Status // spawn tool_use_id -> final status
-	// pendingRevive holds the task ids the in-flight SendMessage calls addressed.
+	// pendingRestart holds the task ids the in-flight SendMessage calls addressed.
 	// A task_started for a task already in a final status is a REVIVE only when
-	// the id is armed here; see claudeArmRevivesFromBlocks for why the tool call
+	// the id is armed here; see claudeArmRestartsFromBlocks for why the tool call
 	// is the evidence and the event alone is not. Guarded by i.mu.
 	//
 	// The VALUE is the SET of transcripts that armed it: "" for the root, the
@@ -958,7 +958,7 @@ type claudeTaskIndex struct {
 	// inside a single root turn. With one scope the second sender overwrote the
 	// first, and whichever turn ended first dropped an arm the other still
 	// needed.
-	pendingRevive map[string]map[string]struct{} // task_id -> the spawn spans that armed it ("" == root)
+	pendingRestart map[string]map[string]struct{} // task_id -> the spawn spans that armed it ("" == root)
 	// sendMessageCalls holds the tool_use id of every in-flight SendMessage call,
 	// with the transcript that made it. handleClaudeTaskStarted asks it whether
 	// an event's tool_use_id is a restart call rather than the spawn span that
@@ -971,7 +971,7 @@ type claudeTaskIndex struct {
 	// spawn also answers there. Recording the call where the block is parsed
 	// covers both transcripts with one index.
 	//
-	// NOT cleared at a turn end, although pendingRevive is. A tool_use id is
+	// NOT cleared at a turn end, although pendingRestart is. A tool_use id is
 	// unique per call, so an id recorded as a SendMessage can never later identify
 	// a spawn -- which is the only thing a retained entry could get wrong. Clearing
 	// it made the answer depend on WHICH TURN the task_started landed in: a CLI
@@ -1227,15 +1227,15 @@ type claudeSendMessageInput struct {
 	To string `json:"to"`
 }
 
-// claudeArmRevivesFromBlocks records the task ids an assistant envelope's
+// claudeArmRestartsFromBlocks records the task ids an assistant envelope's
 // SendMessage calls addressed, so a following task_started for one of them is
-// recognized as a revive.
+// recognized as a restart.
 //
 // The tool call is the evidence, and the event alone cannot be. A resumed
 // session re-emits task_started for EVERY subagent it once ran, to rebuild the
 // CLI's own task registry, and those tasks are all in a final status here. So
 // "task_started for a finished row" describes the hydration burst exactly as
-// well as it describes a revive, and acting on it would resurrect every old
+// well as it describes a restart, and acting on it would resurrect every old
 // subagent with no close ever arriving. A SendMessage that gives that task id is
 // what separates the two, because the hydration burst carries none.
 //
@@ -1247,7 +1247,7 @@ type claudeSendMessageInput struct {
 // another agent, and its tool_use blocks arrive through routeSubagentMessage.
 // `armedBy` separates the two -- "" for the root, the spawn span id for a
 // subagent -- so each transcript's turn end drops only the arms it set.
-func (a *ClaudeCodeAgent) claudeArmRevivesFromBlocks(env *messageEnvelope, armedBy string) {
+func (a *ClaudeCodeAgent) claudeArmRestartsFromBlocks(env *messageEnvelope, armedBy string) {
 	for _, block := range env.ContentBlocks() {
 		if block.Type != "tool_use" || block.Name != ToolNameClaudeSendMessage {
 			continue
@@ -1263,7 +1263,7 @@ func (a *ClaudeCodeAgent) claudeArmRevivesFromBlocks(env *messageEnvelope, armed
 			slog.Warn("claude SendMessage input unmarshal failed", "agent_id", a.agentID, "error", err)
 			continue
 		}
-		a.tasks.armClaudeRevive(input.To, armedBy)
+		a.tasks.armClaudeRestart(input.To, armedBy)
 	}
 }
 
@@ -1332,7 +1332,7 @@ func (a *ClaudeCodeAgent) restartEvidenceFor(ev *claudeTaskEnvelope) claudeResta
 	}
 }
 
-// armClaudeRevive records one recipient id as revivable until the turn end of
+// armClaudeRestart records one recipient id as restartable until the turn end of
 // the transcript that sent the message. armedBy is "" for the root and the
 // spawn span id for a subagent.
 //
@@ -1343,41 +1343,41 @@ func (a *ClaudeCodeAgent) restartEvidenceFor(ev *claudeTaskEnvelope) claudeResta
 // arm under ITS scope, and the root's send found nothing to fire: the row stayed
 // finished for the whole restarted run and the delivered text never reached the
 // transcript, which is the failure the arm exists to prevent.
-func (i *claudeTaskIndex) armClaudeRevive(to, armedBy string) {
+func (i *claudeTaskIndex) armClaudeRestart(to, armedBy string) {
 	if to == "" {
 		return
 	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	if i.pendingRevive == nil {
-		i.pendingRevive = make(map[string]map[string]struct{})
+	if i.pendingRestart == nil {
+		i.pendingRestart = make(map[string]map[string]struct{})
 	}
-	if i.pendingRevive[to] == nil {
-		i.pendingRevive[to] = make(map[string]struct{})
+	if i.pendingRestart[to] == nil {
+		i.pendingRestart[to] = make(map[string]struct{})
 	}
-	i.pendingRevive[to][armedBy] = struct{}{}
+	i.pendingRestart[to][armedBy] = struct{}{}
 }
 
-// takeClaudeRevive reports whether an in-flight SendMessage addressed taskID,
-// and consumes every arm on it so one restart cannot revive the same row twice.
+// takeClaudeRestart reports whether an in-flight SendMessage addressed taskID,
+// and consumes every arm on it so one restart cannot reopen the same row twice.
 //
 // The whole set goes, not one scope: the arms are proof that a restart is
 // expected, and the CLI restarts the recipient ONCE however many senders queued
 // a message for it.
-func (i *claudeTaskIndex) takeClaudeRevive(taskID string) bool {
+func (i *claudeTaskIndex) takeClaudeRestart(taskID string) bool {
 	if taskID == "" {
 		return false
 	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	if _, ok := i.pendingRevive[taskID]; !ok {
+	if _, ok := i.pendingRestart[taskID]; !ok {
 		return false
 	}
-	delete(i.pendingRevive, taskID)
+	delete(i.pendingRestart, taskID)
 	return true
 }
 
-// clearClaudeRevives drops the arms that ONE transcript set, at that
+// clearClaudeRestarts drops the arms that ONE transcript set, at that
 // transcript's turn end. A SendMessage to a LIVE subagent, to a recipient
 // outside this session, or one the CLI refused emits no task_started, so
 // without this the arms would accumulate for the agent's life.
@@ -1386,18 +1386,18 @@ func (i *claudeTaskIndex) takeClaudeRevive(taskID string) bool {
 // root's result is not its turn boundary. Clearing everything there dropped a
 // live subagent's arm before its task_started could fire it, which left the
 // recipient's row finished and its transcript looking dead -- the exact bug the
-// revive exists to fix.
-func (i *claudeTaskIndex) clearClaudeRevives(armedBy string) {
+// restart exists to fix.
+func (i *claudeTaskIndex) clearClaudeRestarts(armedBy string) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	// One scope leaves each recipient's set, and the recipient goes only when its
 	// last sender does. A recipient two transcripts addressed stays armed until
 	// both of their turns end, so the earlier one cannot cancel the later one's
 	// restart.
-	for to, scopes := range i.pendingRevive {
+	for to, scopes := range i.pendingRestart {
 		delete(scopes, armedBy)
 		if len(scopes) == 0 {
-			delete(i.pendingRevive, to)
+			delete(i.pendingRestart, to)
 		}
 	}
 	// The CALLS do not go with the arms. An arm is a permission to reopen a row,

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"maps"
 	"strings"
 	"sync"
 
@@ -49,7 +48,7 @@ func claudeToolSpawnsSubagent(toolName string) bool {
 // shell, which is NOT the same as a BACKGROUNDED shell; local_agent is a Task
 // subagent; local_workflow is a Workflow run. Only local_bash is NOT a spawn, so
 // the code tests for that one and treats every other value -- including one this
-// list does not name -- as a spawn that owns no span and gets a child
+// list does not carry -- as a spawn that owns no span and gets a child
 // transcript.
 //
 // A foreground shell reports local_bash too, once the command runs for 2
@@ -154,10 +153,12 @@ func (a *ClaudeCodeAgent) claudeHandleTaskEvent(content []byte) bool {
 // claudePreStartRowKey keys the registry row for a subagent whose forwarded
 // envelope arrived BEFORE its task_started, when no task id exists yet.
 //
-// Prefixed rather than the bare spawn span, so the key can only ever name a row
-// this path opened. handleClaudeTaskStarted then renames unconditionally: an
-// ordinary start, and a re-registration whose tool_use_id is the parent's
-// SendMessage rather than the spawn, both find nothing and change nothing.
+// Prefixed rather than the bare spawn span, so the key can only ever identify a
+// row this path opened. handleClaudeTaskStarted then renames unconditionally. An
+// ordinary start finds nothing, because its own envelope arrived after the
+// task_started. A RESTART keyed on the original spawn span does find the row,
+// and folding it back in is the point -- see the rename there for what happens
+// when the task id it moves onto already exists.
 func claudePreStartRowKey(spawnSpanID string) string {
 	if spawnSpanID == "" {
 		return ""
@@ -192,69 +193,55 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	if ev.TaskType == claudeTaskTypeBash {
 		startedKind = bgtask.KindShell
 	}
-	// The span every forwarded envelope of THIS run will carry, which is what
-	// the tool_use index has to hold. On a first start the event's own
-	// tool_use_id is that span. On a re-registration it is not, and the two
-	// disagree in every restart form the CLI has: it registers the task under
-	// the call that restarted it (the parent's SendMessage) or under no call at
-	// all (a shell wake), while it runs the agent under the toolUseId recorded
-	// at the ORIGINAL spawn -- so the restarted run keeps forwarding under that
-	// one. Indexing the event's id there left the run unresolvable, and every
-	// envelope of it opened a second registry row keyed by the spawn span (see
-	// routeSubagentMessage) that stood for the transcript the first row already
-	// carried.
+	// The span every forwarded envelope of THIS run carries, which is what the
+	// tool_use index has to hold. On a first start the event's own tool_use_id is
+	// that span. On a re-registration it is not.
+	//
+	// The two disagree in every restart form the CLI has. It registers the task
+	// under the call that restarted it (the parent's SendMessage), or under no
+	// call at all (a shell wake). It runs the agent under the toolUseId recorded
+	// at the ORIGINAL spawn, so the restarted run keeps forwarding under that one.
+	//
+	// Indexing the event's id there left the run unresolvable. Every envelope of
+	// it then opened a second registry row keyed by the spawn span, which stood
+	// for the transcript the first row already carried. See
+	// routeSubagentMessage.
+	//
+	// A row that already carries a CHILD TRANSCRIPT triggers the read too, and it
+	// is positive evidence rather than the absence of an impostor: only an earlier
+	// registration of this same task id can have linked one. Nothing opens a row
+	// keyed ev.TaskID with a child before the first task_started for it, because
+	// routeSubagentMessage keys its early row under the spawn span, so a genuine
+	// first start reads known.childID == "" and this branch does not run. It
+	// matters because the restart evidence is PER-PROCESS: a shell wake carries no
+	// tool_use_id and its proof lives in a map the previous process owned, so
+	// without this the run indexes no id at all and every envelope of it opens a
+	// second row.
 	spawnSpanID := ev.ToolUseID
-	if restart.restarted() {
+	if restart.restarted() || known.childID != "" {
 		spawnSpanID = a.claudeRestartSpawnSpan(known.childID)
 	}
 	// Both ids: the spawn span the restarted run forwards under, and the id the
 	// event itself carried. See claudeTaskIndex.taskToolUse for why a restart
 	// needs each of them. They are the same string on a first start.
 	pendingEnd, hasPending := a.tasks.startTask(ev.TaskID, startedKind, spawnSpanID, ev.ToolUseID)
+	if restart.restarted() {
+		// A pending close describes the run that ENDED, and this event announces a
+		// new one. The spawn span keys that close and survives every run of the
+		// subagent, so a close the previous run left unconsumed -- a result whose
+		// task_started never followed, which a fresh process reaches because both
+		// the tool_use index and childTask start empty -- would otherwise close the
+		// row reviveClaudeSubagent is about to reopen. The subagent then reads
+		// Completed in the sidebar for the whole restarted run.
+		//
+		// Dropped here rather than left in the map: startTask already deleted the
+		// entry, so refusing it now cannot leave it to fire against a later run.
+		hasPending = false
+	}
 
-	kind := startedKind
 	groupKey, groupLabel := a.workflowGroup(ev)
 
-	// Some task_started events omit description but carry the spawn prompt;
-	// fall back to the prompt's first line so the row never has an empty title.
-	//
-	// For a local_bash task the description is what the row shows, and it is
-	// left out of Description here: copying the title into it rendered the row's
-	// secondary line as a verbatim echo of its own title. task_notification
-	// later fills it with the shell's output_file, which the title does not say.
-	//
-	// TitleIsCommand stays FALSE for it. BashTool sends `description || command`
-	// (src/tools/BashTool/BashTool.tsx), and task_started forwards only that one
-	// resolved string (src/utils/task/framework.ts) -- so the title is the
-	// model's prose whenever it wrote any, the raw command when it did not, and
-	// nothing on the wire says which. Prose set in the monospace face reads
-	// worse than a command set in the normal one, so the ambiguous case takes
-	// the normal one.
-	//
-	// The prompt fallback is for a FIRST start only. On a re-registration the
-	// prompt is the message the parent just sent, and a non-blank title
-	// overwrites the row's own (PreservingBlanksFrom keeps only a BLANK one), so
-	// the Background-tasks entry would rename itself to a chat message while the
-	// child agents row -- which EnsureChildAgent never rewrites -- kept the real
-	// title. A blank title here is the correct value for a row that already has
-	// one.
-	//
-	// Positive restart evidence suppresses the fallback, and an UNREADABLE
-	// registry is not evidence. Keying on the read failure had the asymmetry
-	// backwards: a read fails most often on the first registry touch of a
-	// process, where a first start is the overwhelmingly common event, and the
-	// row then took a blank title that nothing rewrites -- and EnsureChildAgent,
-	// given the same blank, took the tab name from the pool instead of from the
-	// prompt.
-	//
-	// The WAKE half of the evidence matters here even though `known.exists`
-	// usually answers for it: a wake against a registry this process cannot read
-	// leaves exists false, and the fallback then renamed the row to the wake
-	// block itself -- a literal <task-notification> in the sidebar.
-	title := ev.Description
-	if title == "" && !known.exists && !restart.restarted() {
-		title = bgtask.FirstLine(ev.Prompt)
-	}
+	title := claudeTaskStartedTitle(ev, known, restart)
 
 	// A forwarded child envelope that ARRIVED FIRST opened a row keyed by the
 	// spawn span, because no task id existed yet (see routeSubagentMessage). Move
@@ -269,7 +256,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		// nothing and leave that row standing beside this one.
 		//
 		// The prefixed key is why this is safe to run unconditionally. It can only
-		// name a row routeSubagentMessage opened, so the ordinary flow finds
+		// identify a row routeSubagentMessage opened, so the ordinary flow finds
 		// nothing and the rename is a no-op.
 		if err := a.sink.RenameBackgroundTask(claudePreStartRowKey(spawnSpanID), ev.TaskID); err != nil {
 			slog.Warn("claude task_started rename failed",
@@ -277,11 +264,24 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		}
 	}
 
+	// For a local_bash task the description is what the row shows, and it is
+	// left out of Description here: copying the title into it rendered the row's
+	// secondary line as a verbatim echo of its own title. task_notification
+	// later fills it with the shell's output_file, which the title does not say.
+	//
+	// TitleIsCommand stays FALSE for it. BashTool sends `description || command`
+	// (src/tools/BashTool/BashTool.tsx), and task_started forwards only that one
+	// resolved string (src/utils/task/framework.ts) -- so the title is the
+	// model's prose whenever it wrote any, the raw command when it did not, and
+	// nothing on the wire says which. Prose set in the monospace face reads
+	// worse than a command set in the normal one, so the ambiguous case takes
+	// the normal one.
+	//
 	// Registry upsert (kind shell -> registry only; local_workflow -> registry
 	// only, grouped; local_agent -> registry + child transcript below).
 	upsert := bgtask.Upsert{
 		RowKey:        ev.TaskID,
-		Kind:          kind,
+		Kind:          startedKind,
 		ParentAgentID: a.agentID,
 		Title:         title,
 		GroupKey:      groupKey,
@@ -343,74 +343,7 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// local_bash (shell) and local_workflow have no transcript; their envelopes
 	// are never forwarded.
 	if ev.TaskType != claudeTaskTypeBash && ev.TaskType != claudeTaskTypeWorkflow {
-		// The registry's own linkage FIRST, and EnsureChildAgent only when the row
-		// carries none. On a re-registration ev.ToolUseID is the SendMessage call,
-		// not the spawn span, so handing it to EnsureChildAgent walks past the
-		// row-key fast path (which misses whenever the row lost its linkage),
-		// fails GetChildAgentBySpawnSpan, and CREATES a second transcript keyed by
-		// that id -- then re-links the row to the orphan. Reading known.childID
-		// makes the two resolutions one, so they cannot disagree.
-		childID, err := known.childID, error(nil)
-		//
-		// Never from a SendMessage id. EnsureChildAgent takes a SPAWN SPAN, and a
-		// re-registration's tool_use_id is the call that RESTARTED the task -- so
-		// handing it over walks past the row-key fast path, fails
-		// GetChildAgentBySpawnSpan, and CREATES a child keyed by a non-spawn id,
-		// which a later forwarded envelope under the real spawn span then
-		// duplicates.
-		//
-		// A linked row never reaches this test, because the registry row that
-		// carries the child outlives the display cap. What reaches it is a row
-		// that holds no linkage at all: an EnsureChildAgent that a DB failure
-		// defeated at spawn time, or a registry this process could not read. The
-		// in-flight SendMessage calls are the only positive evidence available in
-		// either state, and refusing an unproven id costs a transcript the
-		// subagent never had -- creating one under the wrong key costs the
-		// transcript it does have.
-		//
-		// The restart evidence and not a span-type read: the span tracker answers for one
-		// transcript, and a subagent's own SendMessage lands on that child's
-		// tracker rather than the root's. See the guard above.
-		if childID == "" && ev.ToolUseID != "" && !restart.restarted() {
-			childID, err = a.sink.EnsureChildAgent(ev.ToolUseID, ev.TaskID, title)
-		}
-		if childID != "" {
-			a.tasks.rememberTaskChild(ev.TaskID, childID)
-		}
-		switch {
-		case err != nil:
-			slog.Warn("claude task_started ensure child failed", "task_id", ev.TaskID, "error", err)
-		case childID == "":
-			// No transcript, and none this event can open. The revive arm is left
-			// STANDING rather than consumed: the row is still finished, so a later
-			// task_started for this task in the same turn is still a revive and
-			// deserves the retry -- the same reason a failed registry write puts
-			// its arm back.
-			slog.Warn("claude task_started resolved no child transcript",
-				"task_id", ev.TaskID, "tool_use_id", ev.ToolUseID,
-				"row_exists", known.exists, "registry_unreadable", known.unreadable)
-		default:
-			handled, err := a.reviveClaudeSubagent(ev, childID, known, restart)
-			switch {
-			case err != nil:
-				// It WAS a revive; only the registry write failed. The delivered
-				// message is already in the transcript and the arm is back, so the
-				// first-start path below must not run -- PersistChildPrompt says
-				// nothing on a transcript that already has messages anyway.
-				slog.Warn("claude revive background task failed", "task_id", ev.TaskID, "error", err)
-			case handled:
-				// The prompt was the message the parent just sent, appended to the
-				// running transcript rather than prepended as the opening instruction.
-			default:
-				if err := a.sink.PersistChildPrompt(childID, ev.Prompt); err != nil {
-					// task_started is the only Claude event that carries the spawn
-					// prompt, and it lands before any forwarded envelope, so the child
-					// transcript opens on the instruction rather than on the reply.
-					// Losing it costs the first message, not the transcript.
-					slog.Warn("claude task_started persist prompt failed", "task_id", ev.TaskID, "error", err)
-				}
-			}
-		}
+		a.openClaudeTaskChild(ev, known, restart, title)
 	}
 
 	// Apply a pending close from a result that arrived before this
@@ -420,6 +353,121 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 		logRegistryRefusal("claude", "status", a.sink.UpdateBackgroundTaskStatus(ev.TaskID, pendingEnd, ""))
 		logRegistryRefusal("claude", "close", a.sink.CloseBackgroundTask(ev.TaskID, pendingEnd))
 		a.tasks.forgetTaskIndex(ev.TaskID)
+	}
+}
+
+// claudeTaskStartedTitle picks the registry row title for a task_started.
+//
+// Some task_started events omit description but carry the spawn prompt;
+// fall back to the prompt's first line so the row never has an empty title.
+//
+// The prompt fallback is for a FIRST start only. On a re-registration the
+// prompt is the message the parent just sent, and a non-blank title
+// overwrites the row's own (PreservingBlanksFrom keeps only a BLANK one), so
+// the Background-tasks entry would rename itself to a chat message while the
+// child agents row -- which EnsureChildAgent never rewrites -- kept the real
+// title. A blank title here is the correct value for a row that already has
+// one.
+//
+// Positive restart evidence suppresses the fallback, and an UNREADABLE
+// registry is not evidence. Keying on the read failure had the asymmetry
+// backwards: a read fails most often on the first registry touch of a
+// process, where a first start is the overwhelmingly common event, and the
+// row then took a blank title that nothing rewrites -- and EnsureChildAgent,
+// given the same blank, took the tab name from the pool instead of from the
+// prompt.
+//
+// The WAKE half of the evidence matters here even though `known.exists`
+// usually answers for it: a wake against a registry this process cannot read
+// leaves exists false, and the fallback then renamed the row to the wake
+// block itself -- a literal <task-notification> in the sidebar.
+func claudeTaskStartedTitle(ev *claudeTaskEnvelope, known claudeKnownTask, restart claudeRestartEvidence) string {
+	if ev.Description != "" {
+		return ev.Description
+	}
+	if known.exists || restart.restarted() {
+		return ""
+	}
+	return bgtask.FirstLine(ev.Prompt)
+}
+
+// openClaudeTaskChild resolves the child transcript of a task_started and puts
+// the event's prompt into it. The registry row's own linkage answers first, and
+// EnsureChildAgent runs only for a row that carries none. A restart appends the
+// delivered message through reviveClaudeSubagent; a first start prepends the
+// spawn prompt.
+//
+// The caller keeps the task-type test, because a local_bash and a local_workflow
+// task have no transcript at all. `open` and not `start`: startTask already owns
+// that verb in this file, for the index write.
+func (a *ClaudeCodeAgent) openClaudeTaskChild(ev *claudeTaskEnvelope, known claudeKnownTask, restart claudeRestartEvidence, title string) {
+	// The registry's own linkage FIRST, and EnsureChildAgent only when the row
+	// carries none. On a re-registration ev.ToolUseID is the SendMessage call,
+	// not the spawn span, so handing it to EnsureChildAgent walks past the
+	// row-key fast path (which misses whenever the row lost its linkage),
+	// fails GetChildAgentBySpawnSpan, and CREATES a second transcript keyed by
+	// that id -- then re-links the row to the orphan. Reading known.childID
+	// makes the two resolutions one, so they cannot disagree.
+	childID, err := known.childID, error(nil)
+	//
+	// Never from a SendMessage id. EnsureChildAgent takes a SPAWN SPAN, and a
+	// re-registration's tool_use_id is the call that RESTARTED the task -- so
+	// handing it over walks past the row-key fast path, fails
+	// GetChildAgentBySpawnSpan, and CREATES a child keyed by a non-spawn id,
+	// which a later forwarded envelope under the real spawn span then
+	// duplicates.
+	//
+	// A linked row never reaches this test, because the registry row that
+	// carries the child outlives the display cap. What reaches it is a row
+	// that holds no linkage at all: an EnsureChildAgent that a DB failure
+	// defeated at spawn time, or a registry this process could not read. The
+	// in-flight SendMessage calls are the only positive evidence available in
+	// either state, and refusing an unproven id costs a transcript the
+	// subagent never had -- creating one under the wrong key costs the
+	// transcript it does have.
+	//
+	// The restart evidence and not a span-type read: the span tracker answers for one
+	// transcript, and a subagent's own SendMessage lands on that child's
+	// tracker rather than the root's. See the guard above.
+	if childID == "" && ev.ToolUseID != "" && !restart.restarted() {
+		childID, err = a.sink.EnsureChildAgent(ev.ToolUseID, ev.TaskID, title)
+	}
+	if childID != "" {
+		a.tasks.rememberTaskChild(ev.TaskID, childID)
+	}
+	switch {
+	case err != nil:
+		slog.Warn("claude task_started ensure child failed", "task_id", ev.TaskID, "error", err)
+	case childID == "":
+		// No transcript, and none this event can open. The revive arm is left
+		// STANDING rather than consumed: the row is still finished, so a later
+		// task_started for this task in the same turn is still a revive and
+		// deserves the retry -- the same reason a failed registry write puts
+		// its arm back.
+		slog.Warn("claude task_started resolved no child transcript",
+			"task_id", ev.TaskID, "tool_use_id", ev.ToolUseID,
+			"row_exists", known.exists, "registry_unreadable", known.unreadable)
+	default:
+		handled, err := a.reviveClaudeSubagent(ev, childID, known, restart)
+		switch {
+		case err != nil:
+			// It WAS a revive; only the registry write failed. The delivered
+			// message is already in the transcript and the arm is back, so the
+			// first-start path below must not run -- PersistChildPrompt says
+			// nothing on a transcript that already has messages anyway.
+			slog.Warn("claude revive background task failed", "task_id", ev.TaskID, "error", err)
+		case handled:
+			// The prompt was the message the parent just sent, appended to the
+			// running transcript rather than prepended as the opening instruction.
+		default:
+			if err := a.sink.PersistChildPrompt(childID, ev.Prompt); err != nil {
+				// task_started is the only Claude event that carries the spawn
+				// prompt, and it lands before any forwarded envelope, so the child
+				// transcript opens on the instruction rather than on the reply.
+				// Losing it costs the first message, not the transcript.
+				slog.Warn("claude task_started persist prompt failed", "task_id", ev.TaskID, "error", err)
+			}
+		}
 	}
 }
 
@@ -450,17 +498,18 @@ type claudeKnownTask struct {
 // when the in-memory index cannot answer.
 //
 // Answers "" for a row that carries no transcript and for a read that FAILED.
-// Both leave the run out of the tool_use index, which is the state the code
-// already handles -- routeSubagentMessage opens a pre-start row for it. The
-// alternative, indexing the id the event did carry, is worse: it files the run
-// under a call that is not a spawn, which no forwarded envelope will ever name.
+// Both leave the SPAWN SPAN out of the tool_use index. The caller still files
+// the id the event carried, so the run stays resolvable from the parent's side;
+// what it loses is the id every forwarded envelope of the restarted run
+// identifies itself by. routeSubagentMessage covers that gap from the CHILD,
+// which is why neither answer opens a second registry row.
 func (a *ClaudeCodeAgent) claudeRestartSpawnSpan(childID string) string {
 	if childID == "" {
 		return ""
 	}
 	span, err := a.sink.ChildSpawnSpan(childID)
 	if err != nil {
-		slog.Warn("claude task_started: child spawn span lookup failed",
+		slog.Warn("claude task_started: cannot read the spawn span of the child",
 			"child", childID, "error", err)
 		return ""
 	}
@@ -694,15 +743,28 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	// Key the row by the SPAWN SPAN, which is known now and identifies the same
 	// run. handleClaudeTaskStarted renames it to the task id when that finally
 	// arrives, so one row carries the run from end to end.
-	registryKey := taskID
-	if registryKey == "" {
-		registryKey = claudePreStartRowKey(spawnSpanID)
-	}
-
-	childID, err := a.sink.EnsureChildAgent(spawnSpanID, registryKey, "")
+	//
+	// A blank key links nothing, so resolving the child costs no registry write
+	// while the run is still unidentified.
+	childID, err := a.sink.EnsureChildAgent(spawnSpanID, taskID, "")
 	if err != nil {
 		slog.Warn("claude route subagent: ensure child failed", "spawn_span", spawnSpanID, "error", err)
 		return
+	}
+	if taskID == "" {
+		// The CHILD answers when the tool_use index cannot. A transcript is the one
+		// identifier stable across every run of a subagent and across both of a
+		// restart's tool_use ids, so it resolves the run whenever handleClaudeTaskStarted
+		// could not file the spawn span -- an unlinked registry row, or a child row
+		// the process could not read. Without this the envelope opens a SECOND row
+		// for a transcript the first row already carries, and nothing closes it: the
+		// result path resolves the real row through this same map and closes THAT
+		// one, so the stray row sits Running for good.
+		taskID = a.tasks.taskIDForChild(childID)
+	}
+	registryKey := taskID
+	if registryKey == "" {
+		registryKey = claudePreStartRowKey(spawnSpanID)
 	}
 	if taskID == "" {
 		// Opened RUNNING, because the envelope that got us here is the subagent
@@ -715,11 +777,9 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 			slog.Warn("claude route subagent: open pre-start row failed", "spawn_span", spawnSpanID, "error", err)
 		}
 	}
-	// Only an index-derived id is recorded here. Resolving the task FROM the
-	// child and then writing the pair back would be a no-op write, and it would
-	// leave two copies of the child-keyed fallback -- the result branch below
-	// holds the one that earns its place, where a revived run's result is the
-	// only reader that needs it.
+	// Idempotent for an id the resolution above already read out of this same
+	// map, and the write that matters for an index-derived one. A blank taskID is
+	// dropped by rememberTaskChild.
 	a.tasks.rememberTaskChild(taskID, childID)
 
 	// Resolve the span metadata and reserve the tool_use's color with the SAME
@@ -741,23 +801,18 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 		if err := childSink.PersistTurnEnd(content, spanInfo); err != nil {
 			slog.Warn("claude route subagent turn-end failed", "child", childID, "error", err)
 		}
-		if taskID == "" {
-			// The last resort for a RESTARTED run whose result the CLI forwarded
-			// under the ORIGINAL spawn span. handleClaudeTaskStarted normally files
-			// that span in the tool_use index, by reading it back from this same
-			// child; this branch covers the two states where it could not -- a
-			// registry row that carries no transcript, and a child row the process
-			// could not read. The child transcript is the same across every run of
-			// the subagent, so it still identifies the row. Without this the
-			// reopened row stays Running for good whenever no task_notification
-			// follows.
-			taskID = a.tasks.taskIDForChild(childID)
+		// Both branches below report the same outcome, so one reading of IsError
+		// serves them and a later third reader cannot disagree with it.
+		//
+		// taskID already carries the child-derived answer: the resolution above
+		// runs it for every envelope, which is what a RESTARTED run needs when
+		// handleClaudeTaskStarted could not file the spawn span. So "" here means
+		// no run is identifiable at all, not that the tool_use index missed.
+		status := bgtask.StatusCompleted
+		if env.IsError {
+			status = bgtask.StatusFailed
 		}
 		if taskID != "" {
-			status := bgtask.StatusCompleted
-			if env.IsError {
-				status = bgtask.StatusFailed
-			}
 			logRegistryRefusal("claude", "status", a.sink.UpdateBackgroundTaskStatus(taskID, status, ""))
 			logRegistryRefusal("claude", "close", a.sink.CloseBackgroundTask(taskID, status))
 			// Drop the index entry on the fallback path too (a task that ends
@@ -768,10 +823,6 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 			// status keyed by the spawn span so the late task_started can close
 			// the row it opens. Without this, task_started upserts a Running row
 			// that nothing ever closes (the result already passed through).
-			status := bgtask.StatusCompleted
-			if env.IsError {
-				status = bgtask.StatusFailed
-			}
 			a.tasks.recordPendingTaskEnd(spawnSpanID, status)
 		}
 		// This subagent's turn ended, so drop the arms IT set. Its own result is
@@ -859,12 +910,13 @@ type claudeTaskIndex struct {
 	toolUseTask map[string]string              // tool_use_id -> task_id
 	// childTask indexes the same link from the CHILD transcript side, so a
 	// forwarded envelope resolves its registry row when the tool_use index
-	// cannot. A revive re-registers the task under the SendMessage tool_use id,
-	// and the first completion already dropped the spawn span, so a run-2 result
-	// forwarded under the ORIGINAL spawn resolves no task and leaves the row the
-	// revive reopened Running for the agent's life. Guarded by i.mu, and NOT
-	// dropped at a completion: the entry describes the transcript, which outlives
-	// every run of it.
+	// cannot. routeSubagentMessage reads it for EVERY envelope whose spawn span
+	// the tool_use index misses, which is the state a restart leaves whenever
+	// handleClaudeTaskStarted could not read the spawn span back -- an unlinked
+	// registry row, or a child row the read failed on. Without it the envelope
+	// opens a second registry row for a transcript the first row already carries.
+	// Guarded by i.mu, and NOT dropped at a completion: the entry describes the
+	// transcript, which outlives every run of it.
 	childTask map[string]string // child_agent_id -> task_id
 	// finishedTasks holds the id of every backgrounded SHELL this process gave a
 	// final status. A wake block identifies the shell whose completion restarted
@@ -917,58 +969,57 @@ type claudeTaskIndex struct {
 	// span type on that child's tracker, while handleClaudeTaskStarted reads the
 	// ROOT sink -- which answers "" for an id it never saw, and "" is what a
 	// spawn also answers there. Recording the call where the block is parsed
-	// covers both transcripts with one index. Guarded by i.mu, and cleared with
-	// pendingRevive at the turn end of the transcript that set it.
-	sendMessageCalls map[string]string // tool_use_id -> the spawn span that made it ("" == root)
+	// covers both transcripts with one index.
+	//
+	// NOT cleared at a turn end, although pendingRevive is. A tool_use id is
+	// unique per call, so an id recorded as a SendMessage can never later identify
+	// a spawn -- which is the only thing a retained entry could get wrong. Clearing
+	// it made the answer depend on WHICH TURN the task_started landed in: a CLI
+	// that concludes the recipient's run first can emit the event after the sending
+	// turn ended, and every decision below then read the id as a spawn. That opened
+	// a child transcript keyed by a call that is not a spawn, and freed a rail the
+	// call still holds. Limited to the SendMessage calls of one session, the same
+	// limit finishedTasks accepts. Guarded by i.mu.
+	sendMessageCalls map[string]struct{} // tool_use ids of SendMessage calls
 }
 
 // startTask records what a task_started says a task IS, indexes every tool_use
 // id that identifies the run, and takes any pending close that a reordered final
 // result left for it.
 //
-// One critical section for all three maps, because they describe one event: the
+// One critical section for four maps, because they describe one event: the
 // task_id <-> tool_use_id links, the kind, and the reordered close. No link is
-// cleared at a turn end -- a background task outlives the turn that spawned it
-// -- and forgetTaskIndex drops all three on the closing notification.
+// cleared at a turn end -- a background task outlives the turn that spawned it.
+// forgetTaskIndex drops the links and the kind on the closing notification; a
+// start takes the pending close, which is the only path that drops one.
 //
-// toolUseIDs are the ids this event says identify the run, most authoritative
-// first: the SPAWN span, then the id the event itself carried. The two differ
-// only on a restart, and a blank one is skipped -- so a first start indexes one
-// id and a task_started with no tool_use_id at all indexes none.
+// spawnSpanID is the span the run forwards under, and eventToolUseID is the id
+// the event itself carried. They hold the same string on a first start and
+// differ only on a restart. The loop skips a blank one, so a first start indexes
+// one id and a task_started with no tool_use_id at all indexes none.
 //
 // The pending close is keyed by the tool_use id a forwarded envelope carried: a
 // final result can arrive BEFORE the task_started it belongs to, and taking it
 // here lets the caller close the row this event is about to open, so the row
-// cannot leak Running. Each id is tried in turn, because which of them the early
-// envelope carried is the very thing that is not known.
-func (i *claudeTaskIndex) startTask(taskID string, kind bgtask.Kind, toolUseIDs ...string) (bgtask.Status, bool) {
+// cannot leak Running. The loop tries each id, because nothing here knows which
+// of them the early envelope carried. The SPAWN span decides the status, and the
+// loop still visits the rest, so a close under the other id is consumed rather
+// than left to fire against a future run of this same task.
+func (i *claudeTaskIndex) startTask(taskID string, kind bgtask.Kind, spawnSpanID, eventToolUseID string) (bgtask.Status, bool) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	if i.taskKind == nil {
 		i.taskKind = make(map[string]bgtask.Kind)
 	}
 	i.taskKind[taskID] = kind
-	var pending bgtask.Status
+	pending := bgtask.StatusPending
 	found := false
-	for _, toolUseID := range toolUseIDs {
+	// The spawn span first, so it decides the status when both ids hold a close.
+	for _, toolUseID := range [2]string{spawnSpanID, eventToolUseID} {
 		if toolUseID == "" {
 			continue
 		}
-		if i.taskToolUse == nil {
-			i.taskToolUse = make(map[string]map[string]struct{})
-		}
-		if i.toolUseTask == nil {
-			i.toolUseTask = make(map[string]string)
-		}
-		if i.taskToolUse[taskID] == nil {
-			i.taskToolUse[taskID] = make(map[string]struct{})
-		}
-		i.taskToolUse[taskID][toolUseID] = struct{}{}
-		i.toolUseTask[toolUseID] = taskID
-		// The FIRST id that holds a close decides the status, and the loop still
-		// visits the rest -- so every id lands in the index, and a close under a
-		// later id is consumed here rather than left to fire against a future run
-		// of this same task.
+		i.indexToolUseLocked(taskID, toolUseID)
 		if status, ok := i.pendingTaskEnd[toolUseID]; ok {
 			delete(i.pendingTaskEnd, toolUseID)
 			if !found {
@@ -977,6 +1028,22 @@ func (i *claudeTaskIndex) startTask(taskID string, kind bgtask.Kind, toolUseIDs 
 		}
 	}
 	return pending, found
+}
+
+// indexToolUseLocked records one tool_use id as an identifier of taskID, in both
+// directions. Caller must hold i.mu.
+func (i *claudeTaskIndex) indexToolUseLocked(taskID, toolUseID string) {
+	if i.taskToolUse == nil {
+		i.taskToolUse = make(map[string]map[string]struct{})
+	}
+	if i.toolUseTask == nil {
+		i.toolUseTask = make(map[string]string)
+	}
+	if i.taskToolUse[taskID] == nil {
+		i.taskToolUse[taskID] = make(map[string]struct{})
+	}
+	i.taskToolUse[taskID][toolUseID] = struct{}{}
+	i.toolUseTask[toolUseID] = taskID
 }
 
 // taskIDForToolUse resolves the registry row_key (Claude task_id) for a
@@ -1119,14 +1186,23 @@ func (i *claudeTaskIndex) forgetTaskIndex(taskID string) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	for tuid := range i.taskToolUse[taskID] {
-		delete(i.toolUseTask, tuid)
+		// Only an id that still resolves to THIS task. A restart reads its spawn
+		// span back from the child row, so a task can index an id its own event
+		// never carried, and two tasks can hold the same id in their sets. The
+		// later writer owns toolUseTask, and dropping its entry here would leave
+		// every forwarded envelope of a LIVE run unresolved.
+		if i.toolUseTask[tuid] == taskID {
+			delete(i.toolUseTask, tuid)
+		}
 	}
 	delete(i.taskToolUse, taskID)
 	// childTask deliberately SURVIVES. It describes the transcript, not the run,
-	// and a transcript is permanent: a revived run's forwarded envelopes still
-	// have to name this row, and the spawn span the tool_use index carried is
-	// gone by then. Limited to the number of subagents this agent spawned, which
-	// is the same bound as the child sinks the sink already holds.
+	// and a transcript is permanent: a restarted run's forwarded envelopes still
+	// have to identify this row, and the spawn span the tool_use index carried is
+	// gone by then. routeSubagentMessage reads it on every index miss, so this is
+	// the entry that keeps a restart from opening a second row. Limited to the
+	// number of subagents this agent spawned, which is the same limit as the
+	// child sinks the sink already holds.
 	delete(i.taskKind, taskID)
 }
 
@@ -1181,7 +1257,7 @@ func (a *ClaudeCodeAgent) claudeArmRevivesFromBlocks(env *messageEnvelope, armed
 		// restart call rather than a spawn span", and that answer does not depend
 		// on the recipient resolving -- an input this code cannot parse is still
 		// not a spawn.
-		a.tasks.rememberSendMessageCall(block.ID, armedBy)
+		a.tasks.rememberSendMessageCall(block.ID)
 		var input claudeSendMessageInput
 		if err := json.Unmarshal(block.Input, &input); err != nil {
 			slog.Warn("claude SendMessage input unmarshal failed", "agent_id", a.agentID, "error", err)
@@ -1191,27 +1267,27 @@ func (a *ClaudeCodeAgent) claudeArmRevivesFromBlocks(env *messageEnvelope, armed
 	}
 }
 
-// rememberSendMessageCall records one in-flight SendMessage tool_use id with the
-// transcript that made it, until that transcript's turn end.
-func (i *claudeTaskIndex) rememberSendMessageCall(toolUseID, armedBy string) {
+// rememberSendMessageCall records one SendMessage tool_use id for the life of the
+// agent. See claudeTaskIndex.sendMessageCalls for why it outlives the turn.
+func (i *claudeTaskIndex) rememberSendMessageCall(toolUseID string) {
 	if toolUseID == "" {
 		return
 	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	if i.sendMessageCalls == nil {
-		i.sendMessageCalls = make(map[string]string)
+		i.sendMessageCalls = make(map[string]struct{})
 	}
-	i.sendMessageCalls[toolUseID] = armedBy
+	i.sendMessageCalls[toolUseID] = struct{}{}
 }
 
 // claudeRestartCall reports whether toolUseID is an in-flight SendMessage call,
 // which is what separates a task_started that RE-REGISTERS a task from the spawn
 // that created one.
 //
-// It is not consumed. Both guards in handleClaudeTaskStarted read it, and a
-// second task_started for the same call inside the turn must get the same
-// answer; the turn end of the transcript that made the call drops it.
+// It is not consumed, and it does not expire. Every decision in
+// handleClaudeTaskStarted that asks it must get one answer for one id, whichever
+// turn the event arrives in.
 func (i *claudeTaskIndex) claudeRestartCall(toolUseID string) bool {
 	if toolUseID == "" {
 		return false
@@ -1324,12 +1400,10 @@ func (i *claudeTaskIndex) clearClaudeRevives(armedBy string) {
 			delete(i.pendingRevive, to)
 		}
 	}
-	// The calls go with the arms. Both describe the same in-flight SendMessage
-	// tool calls and carry the same scope, so one boundary ends both -- and a
-	// call left standing would keep answering "restart" for an id whose turn
-	// ended, which suppresses the span close for a later genuine spawn. The
-	// tool_use id is unique per call, so this side needs no set.
-	maps.DeleteFunc(i.sendMessageCalls, func(_, scope string) bool { return scope == armedBy })
+	// The CALLS do not go with the arms. An arm is a permission to reopen a row,
+	// and it must expire with the turn that granted it. A recorded call is a FACT
+	// about one tool_use id, and a tool_use id is unique per call, so the fact
+	// stays true for the life of the agent. See claudeTaskIndex.sendMessageCalls.
 }
 
 // recordPendingTaskEnd remembers a final status for a Task subagent whose

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -192,7 +192,25 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	if ev.TaskType == claudeTaskTypeBash {
 		startedKind = bgtask.KindShell
 	}
-	pendingEnd, hasPending := a.tasks.startTask(ev.TaskID, ev.ToolUseID, startedKind)
+	// The span every forwarded envelope of THIS run will carry, which is what
+	// the tool_use index has to hold. On a first start the event's own
+	// tool_use_id is that span. On a re-registration it is not, and the two
+	// disagree in every restart form the CLI has: it registers the task under
+	// the call that restarted it (the parent's SendMessage) or under no call at
+	// all (a shell wake), while it runs the agent under the toolUseId recorded
+	// at the ORIGINAL spawn -- so the restarted run keeps forwarding under that
+	// one. Indexing the event's id there left the run unresolvable, and every
+	// envelope of it opened a second registry row keyed by the spawn span (see
+	// routeSubagentMessage) that stood for the transcript the first row already
+	// carried.
+	spawnSpanID := ev.ToolUseID
+	if restart.restarted() {
+		spawnSpanID = a.claudeRestartSpawnSpan(known.childID)
+	}
+	// Both ids: the spawn span the restarted run forwards under, and the id the
+	// event itself carried. See claudeTaskIndex.taskToolUse for why a restart
+	// needs each of them. They are the same string on a first start.
+	pendingEnd, hasPending := a.tasks.startTask(ev.TaskID, startedKind, spawnSpanID, ev.ToolUseID)
 
 	kind := startedKind
 	groupKey, groupLabel := a.workflowGroup(ev)
@@ -244,14 +262,18 @@ func (a *ClaudeCodeAgent) handleClaudeTaskStarted(ev *claudeTaskEnvelope) {
 	// gaining a second one that leaves the first orphaned and the child counted
 	// twice. The rename runs BEFORE the upsert, so the fields below land on the
 	// renamed row.
-	if ev.ToolUseID != "" {
+	if spawnSpanID != "" {
+		// The SPAWN span, which a re-registration's own tool_use_id is not. A
+		// restarted run whose first envelope outran this event opened its pre-start
+		// row under the original spawn, so the key the event carries would find
+		// nothing and leave that row standing beside this one.
+		//
 		// The prefixed key is why this is safe to run unconditionally. It can only
-		// name a row routeSubagentMessage opened, so the ordinary flow -- and a
-		// re-registration, whose ToolUseID is the parent's SendMessage rather than
-		// the spawn -- finds nothing and the rename is a no-op.
-		if err := a.sink.RenameBackgroundTask(claudePreStartRowKey(ev.ToolUseID), ev.TaskID); err != nil {
+		// name a row routeSubagentMessage opened, so the ordinary flow finds
+		// nothing and the rename is a no-op.
+		if err := a.sink.RenameBackgroundTask(claudePreStartRowKey(spawnSpanID), ev.TaskID); err != nil {
 			slog.Warn("claude task_started rename failed",
-				"spawn_span", ev.ToolUseID, "task_id", ev.TaskID, "error", err)
+				"spawn_span", spawnSpanID, "task_id", ev.TaskID, "error", err)
 		}
 	}
 
@@ -420,6 +442,29 @@ type claudeKnownTask struct {
 	// as "this is a first start" is wrong when the truth is unknown, so they test
 	// this first.
 	unreadable bool
+}
+
+// claudeRestartSpawnSpan resolves the ORIGINAL spawn span of a task the CLI just
+// re-registered, from the child transcript the registry row carries. The child
+// row is where that span survives a worker restart, and a restart is exactly
+// when the in-memory index cannot answer.
+//
+// Answers "" for a row that carries no transcript and for a read that FAILED.
+// Both leave the run out of the tool_use index, which is the state the code
+// already handles -- routeSubagentMessage opens a pre-start row for it. The
+// alternative, indexing the id the event did carry, is worse: it files the run
+// under a call that is not a spawn, which no forwarded envelope will ever name.
+func (a *ClaudeCodeAgent) claudeRestartSpawnSpan(childID string) string {
+	if childID == "" {
+		return ""
+	}
+	span, err := a.sink.ChildSpawnSpan(childID)
+	if err != nil {
+		slog.Warn("claude task_started: child spawn span lookup failed",
+			"child", childID, "error", err)
+		return ""
+	}
+	return span
 }
 
 func lookupClaudeKnownTask(sink OutputSink, taskID string) claudeKnownTask {
@@ -697,12 +742,15 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 			slog.Warn("claude route subagent turn-end failed", "child", childID, "error", err)
 		}
 		if taskID == "" {
-			// The tool_use index answers "" for a REVIVED run whose result the CLI
-			// forwarded under the ORIGINAL spawn span: the first completion dropped
-			// that span, and the revive re-registered the task under the SendMessage
-			// call. The child transcript is the same across both runs, so it still
-			// identifies the row. Without this the reopened row stays Running for
-			// good whenever no task_notification follows.
+			// The last resort for a RESTARTED run whose result the CLI forwarded
+			// under the ORIGINAL spawn span. handleClaudeTaskStarted normally files
+			// that span in the tool_use index, by reading it back from this same
+			// child; this branch covers the two states where it could not -- a
+			// registry row that carries no transcript, and a child row the process
+			// could not read. The child transcript is the same across every run of
+			// the subagent, so it still identifies the row. Without this the
+			// reopened row stays Running for good whenever no task_notification
+			// follows.
 			taskID = a.tasks.taskIDForChild(childID)
 		}
 		if taskID != "" {
@@ -790,14 +838,25 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 // that build a ClaudeCodeAgent without StartClaudeCode need no constructor.
 type claudeTaskIndex struct {
 	mu sync.Mutex
-	// Subagent (Task/Workflow) index. Maps a Claude task_id <-> the spawning
-	// tool_use id (parent_tool_use_id on forwarded envelopes). Used to route
-	// forwarded subagent output into the right child transcript and to drive
-	// the background-task registry. Guarded by i.mu. NOT cleared at turn end
+	// Subagent (Task/Workflow) index. Maps a Claude task_id <-> every tool_use id
+	// that identifies its run. Used to route forwarded subagent output into the
+	// right child transcript and to drive the background-task registry.
+	//
+	// One id normally: the SPAWN span, which every forwarded envelope carries as
+	// parent_tool_use_id. A RESTART collects a second one, because task_started
+	// re-registers the task under the call that restarted it (the parent's
+	// SendMessage) while the CLI keeps running the agent under the toolUseId it
+	// recorded at the original spawn. Indexing the restart call ALONE left the
+	// restarted run unresolvable and gave it a second registry row; indexing the
+	// spawn alone would strand a forwarded envelope that ever arrived under the
+	// restart call. So both go in, and either resolves the run.
+	//
+	// A SET on the task side, so forgetTaskIndex drops every id a run collected
+	// rather than the last one written. Guarded by i.mu. NOT cleared at turn end
 	// (background tasks outlive turns); entries dropped on the final
 	// task_notification.
-	taskToolUse map[string]string // task_id -> tool_use_id
-	toolUseTask map[string]string // tool_use_id -> task_id
+	taskToolUse map[string]map[string]struct{} // task_id -> tool_use ids
+	toolUseTask map[string]string              // tool_use_id -> task_id
 	// childTask indexes the same link from the CHILD transcript side, so a
 	// forwarded envelope resolves its registry row when the tool_use index
 	// cannot. A revive re-registers the task under the SendMessage tool_use id,
@@ -863,48 +922,66 @@ type claudeTaskIndex struct {
 	sendMessageCalls map[string]string // tool_use_id -> the spawn span that made it ("" == root)
 }
 
-// taskIDForToolUse resolves the registry row_key (Claude task_id) for a
-// spawning tool_use id, recorded at task_started. Returns "" when unknown
-
-// startTask records what a task_started says a task IS, and takes any pending
-// close that a reordered final result left for it.
+// startTask records what a task_started says a task IS, indexes every tool_use
+// id that identifies the run, and takes any pending close that a reordered final
+// result left for it.
 //
 // One critical section for all three maps, because they describe one event: the
-// task_id <-> tool_use_id pair, the kind, and the reordered close. Neither pair
-// is cleared at a turn end -- a background task outlives the turn that spawned
-// it -- and forgetTaskIndex drops all three on the closing notification.
+// task_id <-> tool_use_id links, the kind, and the reordered close. No link is
+// cleared at a turn end -- a background task outlives the turn that spawned it
+// -- and forgetTaskIndex drops all three on the closing notification.
 //
-// The pending close is keyed by the spawn span: a final result can arrive
-// BEFORE the task_started it belongs to, and taking it here lets the caller
-// close the row this event is about to open, so the row cannot leak Running.
-func (i *claudeTaskIndex) startTask(taskID, toolUseID string, kind bgtask.Kind) (bgtask.Status, bool) {
+// toolUseIDs are the ids this event says identify the run, most authoritative
+// first: the SPAWN span, then the id the event itself carried. The two differ
+// only on a restart, and a blank one is skipped -- so a first start indexes one
+// id and a task_started with no tool_use_id at all indexes none.
+//
+// The pending close is keyed by the tool_use id a forwarded envelope carried: a
+// final result can arrive BEFORE the task_started it belongs to, and taking it
+// here lets the caller close the row this event is about to open, so the row
+// cannot leak Running. Each id is tried in turn, because which of them the early
+// envelope carried is the very thing that is not known.
+func (i *claudeTaskIndex) startTask(taskID string, kind bgtask.Kind, toolUseIDs ...string) (bgtask.Status, bool) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	if toolUseID != "" {
-		if i.taskToolUse == nil {
-			i.taskToolUse = make(map[string]string)
-		}
-		if i.toolUseTask == nil {
-			i.toolUseTask = make(map[string]string)
-		}
-		i.taskToolUse[taskID] = toolUseID
-		i.toolUseTask[toolUseID] = taskID
-	}
 	if i.taskKind == nil {
 		i.taskKind = make(map[string]bgtask.Kind)
 	}
 	i.taskKind[taskID] = kind
-	if toolUseID == "" {
-		return bgtask.StatusPending, false
+	var pending bgtask.Status
+	found := false
+	for _, toolUseID := range toolUseIDs {
+		if toolUseID == "" {
+			continue
+		}
+		if i.taskToolUse == nil {
+			i.taskToolUse = make(map[string]map[string]struct{})
+		}
+		if i.toolUseTask == nil {
+			i.toolUseTask = make(map[string]string)
+		}
+		if i.taskToolUse[taskID] == nil {
+			i.taskToolUse[taskID] = make(map[string]struct{})
+		}
+		i.taskToolUse[taskID][toolUseID] = struct{}{}
+		i.toolUseTask[toolUseID] = taskID
+		// The FIRST id that holds a close decides the status, and the loop still
+		// visits the rest -- so every id lands in the index, and a close under a
+		// later id is consumed here rather than left to fire against a future run
+		// of this same task.
+		if status, ok := i.pendingTaskEnd[toolUseID]; ok {
+			delete(i.pendingTaskEnd, toolUseID)
+			if !found {
+				pending, found = status, true
+			}
+		}
 	}
-	status, ok := i.pendingTaskEnd[toolUseID]
-	if ok {
-		delete(i.pendingTaskEnd, toolUseID)
-	}
-	return status, ok
+	return pending, found
 }
 
-// (a reorder or a pre-task_started forwarded envelope).
+// taskIDForToolUse resolves the registry row_key (Claude task_id) for a
+// tool_use id that identifies a run, recorded at task_started. Returns "" when
+// unknown (a reorder, or a pre-task_started forwarded envelope).
 func (i *claudeTaskIndex) taskIDForToolUse(toolUseID string) string {
 	if toolUseID == "" {
 		return ""
@@ -1027,20 +1104,24 @@ func (i *claudeTaskIndex) taskIDForChild(childID string) string {
 	return i.childTask[childID]
 }
 
-// forgetTaskIndex drops the task_id <-> tool_use_id pair from both directions
-// of the index. Called when a task reaches a final state via either a
-// task_notification or the result-message fallback, so a task that ends
-// without a notification does not leak its index entries for the agent's life.
+// forgetTaskIndex drops EVERY tool_use id of a task from both directions of the
+// index. Called when a task reaches a final state via either a task_notification
+// or the result-message fallback, so a task that ends without a notification
+// does not leak its index entries for the agent's life.
+//
+// Every id and not the last one written: a restarted run collects the call that
+// restarted it beside its spawn span, and an id left in toolUseTask keeps
+// answering for a task that ended.
 func (i *claudeTaskIndex) forgetTaskIndex(taskID string) {
 	if taskID == "" {
 		return
 	}
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	if tuid, ok := i.taskToolUse[taskID]; ok {
-		delete(i.taskToolUse, taskID)
+	for tuid := range i.taskToolUse[taskID] {
 		delete(i.toolUseTask, tuid)
 	}
+	delete(i.taskToolUse, taskID)
 	// childTask deliberately SURVIVES. It describes the transcript, not the run,
 	// and a transcript is permanent: a revived run's forwarded envelopes still
 	// have to name this row, and the spawn span the tool_use index carried is

--- a/backend/internal/worker/agent/claude_subagent_test.go
+++ b/backend/internal/worker/agent/claude_subagent_test.go
@@ -1205,9 +1205,14 @@ func TestClaude_AChildTurnEndKeepsTheRootArms(t *testing.T) {
 }
 
 // Output forwarded AFTER the revive must land in the transcript the subagent
-// already owns. The registry row key resolves it, so it does not matter whether
-// the CLI tags the forwarded envelope with the original spawn span or with the
-// tool_use id it re-registered under.
+// already owns, whether the CLI tags the envelope with the original spawn span
+// or with the tool_use id it re-registered under. The spawn span resolves the
+// first and the registry row key resolves the second.
+//
+// This is the TRANSCRIPT alone. That one run also keeps one registry row, which
+// TestClaude_RestartedSubagentKeepsOneRegistryRow pins: the two answers came
+// apart once, and a second row standing for this same transcript is what the
+// user saw in the background-task list.
 func TestClaude_RevivedSubagentOutputStaysInOneTranscript(t *testing.T) {
 	t.Parallel()
 
@@ -1237,6 +1242,11 @@ func TestClaude_RevivedSubagentOutputStaysInOneTranscript(t *testing.T) {
 			msgs := child.Messages()
 			require.Len(t, msgs, before+2, "the revive message and the new reply both land here")
 			assert.Contains(t, string(msgs[len(msgs)-1].Content), "Checked them.")
+			// One transcript is half the answer. The row that STANDS for it must stay
+			// one too, whichever id the envelope carried: a second row linked to this
+			// same child lists the subagent twice and opens one tab from both entries.
+			assert.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
+				"and the run keeps the single row it already had")
 		})
 	}
 }
@@ -1794,14 +1804,218 @@ func TestClaude_StartTaskWithoutAToolUseIDStillRecordsTheKind(t *testing.T) {
 
 	var idx claudeTaskIndex
 
-	pending, hasPending := idx.startTask("task-1", "", bgtask.KindSubagent)
+	pending, hasPending := idx.startTask("task-1", bgtask.KindSubagent, "", "")
 	assert.False(t, hasPending, "no spawn span means no pending close to take")
 	assert.Equal(t, bgtask.StatusPending, pending)
 	assert.Equal(t, bgtask.KindSubagent, idx.kindForTask("task-1"))
 	assert.Empty(t, idx.taskIDForToolUse(""), "no pair is written under an empty key")
 
 	// And with a spawn span the pair IS written, both ways.
-	idx.startTask("task-2", "tu-2", bgtask.KindShell)
+	idx.startTask("task-2", bgtask.KindShell, "tu-2")
 	assert.Equal(t, "task-2", idx.taskIDForToolUse("tu-2"))
 	assert.Equal(t, bgtask.KindShell, idx.kindForTask("task-2"))
+}
+
+// A restart hands startTask two ids: the spawn span the restarted run forwards
+// under, and the call the event re-registered the task under. BOTH resolve the
+// run, and the closing notification drops BOTH -- an id left behind keeps
+// answering for a task that ended, which routes the NEXT subagent's output into
+// the finished one's transcript.
+func TestClaude_StartTaskIndexesEveryToolUseIDOfARun(t *testing.T) {
+	t.Parallel()
+
+	var idx claudeTaskIndex
+
+	idx.startTask("task-1", bgtask.KindSubagent, "tu-spawn", "tu-send")
+	assert.Equal(t, "task-1", idx.taskIDForToolUse("tu-spawn"))
+	assert.Equal(t, "task-1", idx.taskIDForToolUse("tu-send"))
+
+	idx.forgetTaskIndex("task-1")
+	assert.Empty(t, idx.taskIDForToolUse("tu-spawn"), "the closing notification drops the spawn span")
+	assert.Empty(t, idx.taskIDForToolUse("tu-send"), "and the call that restarted the task")
+}
+
+// A final result can arrive before the task_started it belongs to, keyed by
+// whichever tool_use id that envelope carried. The late task_started must find
+// the close whichever id it was, so the row it opens cannot leak Running.
+func TestClaude_StartTaskTakesAPendingCloseUnderEitherToolUseID(t *testing.T) {
+	t.Parallel()
+
+	for _, recordedUnder := range []string{"tu-spawn", "tu-send"} {
+		t.Run(recordedUnder, func(t *testing.T) {
+			t.Parallel()
+
+			var idx claudeTaskIndex
+			idx.recordPendingTaskEnd(recordedUnder, bgtask.StatusFailed)
+
+			pending, hasPending := idx.startTask("task-1", bgtask.KindSubagent, "tu-spawn", "tu-send")
+			assert.True(t, hasPending, "the reordered close is taken")
+			assert.Equal(t, bgtask.StatusFailed, pending)
+
+			_, hasPending = idx.startTask("task-1", bgtask.KindSubagent, "tu-spawn", "tu-send")
+			assert.False(t, hasPending, "the close is consumed, not left to fire twice")
+		})
+	}
+}
+
+// The pre-start row exists for a FIRST run whose forwarded output outran its
+// task_started: no task id is known yet, so the row opens under the spawn span.
+// The late task_started renames it, so the run owns ONE row from end to end
+// instead of an orphan beside a fresh one.
+func TestClaude_AFirstStartRenamesItsPreStartRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+
+	// The reorder: the subagent talks before the CLI announces it.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-spawn",
+		"message": {"content": [{"type": "text", "text": "Working."}]}
+	}`))
+	require.Equal(t, []string{"prestart:tu-spawn"}, bgTaskRowKeys(sink),
+		"with no task id the row opens under the spawn span")
+
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-1", "tool_use_id": "tu-spawn",
+		"task_type": "local_agent", "description": "Explore the parser"
+	}`))
+
+	assert.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
+		"the late task_started folds the pre-start row into the run")
+	childID, status, ok, err := sink.LookupBackgroundTask("task-1")
+	require.NoError(t, err)
+	require.True(t, ok, "the renamed row answers under the task id")
+	assert.Equal(t, "child-of-tu-spawn", childID, "and it carries the transcript the pre-start row opened")
+	assert.Equal(t, bgtask.StatusRunning, status)
+}
+
+// The restarted run's first envelope can outrun its task_started, the same
+// reorder the pre-start row exists for. That row opens under the ORIGINAL spawn
+// span, so the late task_started has to rename it from THERE -- the id the event
+// itself carries names no row, and the pre-start row would stand beside the real
+// one for good.
+func TestClaude_ARestartRenamesThePreStartRowOpenedUnderTheSpawnSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+
+	sendMessageTo(a, "tu-send", "task-1")
+	// The reorder: output before the task_started that announces the restart.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-spawn",
+		"message": {"content": [{"type": "text", "text": "Already going."}]}
+	}`))
+	require.Contains(t, bgTaskRowKeys(sink), "prestart:tu-spawn",
+		"the reorder opens the pre-start row this test is about")
+
+	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+
+	assert.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
+		"the late task_started folds the pre-start row back into the run")
+}
+
+// The repair reads the spawn span from the child transcript, and that read can
+// fail. A restart must still deliver its message and reopen its row: the span is
+// an optimization for the ROUTING, and refusing the restart over it would lose
+// the text the parent sent, which nothing retries.
+func TestClaude_ARestartSurvivesAnUnreadableSpawnSpan(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{spawnSpanErr: errors.New("boom")}
+	a := newTestAgent(sink)
+	child := spawnAndFinishSubagent(t, a, sink)
+	before := len(child.Messages())
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+
+	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(), "the row still reopens")
+	require.Len(t, child.Messages(), before+1, "the delivered message still lands")
+}
+
+// A row whose child linkage a failed upsert lost has no transcript to read the
+// spawn span from. The restart must not fall back to indexing the call that
+// restarted the task under a spawn it is not -- and it must not create a child
+// keyed by that call either.
+func TestClaude_ARestartOfAnUnlinkedRowOpensNoChildUnderTheRestartCall(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+	sink.UnlinkBackgroundTask("task-1")
+
+	sendMessageTo(a, "tu-send", "task-1")
+	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+
+	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
+		"a re-registration's tool_use id is not a spawn span")
+}
+
+// bgTaskRowKeys lists the registry row keys this sink holds, sorted. The KEYS
+// and not the count: a duplicate row is only recognizable by the key it took.
+func bgTaskRowKeys(sink *testSink) []string {
+	rows := sink.BackgroundTasks()
+	keys := make([]string, 0, len(rows))
+	for _, row := range rows {
+		keys = append(keys, row.RowKey)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// A restarted subagent forwards its new output under the ORIGINAL spawn span,
+// while its task_started re-registered the task under the call that restarted
+// it. The run must still own ONE registry row. A second row keyed by the spawn
+// span carries the SAME child transcript, so the background-task list shows the
+// subagent twice and both entries open one tab.
+//
+// Both restart forms are here: the CLI drops the original spawn span from the
+// event in each of them, so neither can rely on the other's discriminator.
+func TestClaude_RestartedSubagentKeepsOneRegistryRow(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		restart func(a *ClaudeCodeAgent)
+		// want is every row key the run legitimately leaves behind, sorted. The
+		// wake case runs a shell of its own, so it owns one more.
+		want []string
+	}{
+		{"SendMessage", func(a *ClaudeCodeAgent) {
+			sendMessageTo(a, "tu-send", "task-1")
+			reviveTaskStarted(a, "tu-send", "Also check the tests.")
+		}, []string{"task-1"}},
+		{"shell wake", func(a *ClaudeCodeAgent) {
+			finishShellTask(a, "shell-1")
+			a.HandleOutput([]byte(`{
+				"type": "system", "subtype": "task_started",
+				"task_id": "task-1", "task_type": "local_agent",
+				"prompt": ` + strconv.Quote(wakePrompt("shell-1")) + `
+			}`))
+		}, []string{"shell-1", "task-1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			a := newTestAgent(sink)
+			spawnAndFinishSubagent(t, a, sink)
+			tc.restart(a)
+			a.HandleOutput([]byte(`{
+				"type": "assistant",
+				"parent_tool_use_id": "tu-spawn",
+				"message": {"content": [{"type": "text", "text": "Checked them."}]}
+			}`))
+
+			assert.Equal(t, tc.want, bgTaskRowKeys(sink),
+				"the restarted run keeps the row it already had")
+		})
+	}
 }

--- a/backend/internal/worker/agent/claude_subagent_test.go
+++ b/backend/internal/worker/agent/claude_subagent_test.go
@@ -719,7 +719,7 @@ func TestClaude_AgentTaskStartedLeavesNoSpanOpen(t *testing.T) {
 	assert.Empty(t, msgs[1].SpansOpenAtPersist, "the spawn left no rail behind")
 }
 
-// task_started is the authority, so a task type this code does not name is
+// task_started is the authority, so a task type this code does not list is
 // still a spawn and still gives its span back. Matching only the tool name left
 // such a run's rail open for the whole child run -- the exact defect the change
 // removes for the names it does know.
@@ -761,7 +761,7 @@ func TestClaude_UnknownTaskTypeGivesTheSpanBack(t *testing.T) {
 	assert.Empty(t, msgs[1].SpansOpenAtPersist, "the unknown spawn's rail is gone")
 }
 
-// A workflow event without a tool_use_id has no span to name, so it discards
+// A workflow event without a tool_use_id has no span to identify, so it discards
 // nothing rather than discarding the empty id.
 func TestClaude_WorkflowTaskStartedWithoutToolUseIDClosesNothing(t *testing.T) {
 	t.Parallel()
@@ -806,7 +806,7 @@ func TestClaude_ChildTranscriptReservesUnderTheSpawnSpan(t *testing.T) {
 
 // A spawn row reports span_color 0 as its ANSWER, so the persist path must not
 // fill it from the connector. Claude resolves a top-level envelope's parent span
-// from its own tool_use_id, so a spawn CAN carry a ParentSpanID naming a span
+// from its own tool_use_id, so a spawn CAN carry a ParentSpanID that identifies a span
 // that is still open -- and the connector-colour fallback would then tint the
 // spawn card with a colour no rail anywhere draws.
 func TestClaude_SpawnRowUnderAnOpenParentStillTakesTheNeutralBorder(t *testing.T) {
@@ -1401,7 +1401,7 @@ func TestClaude_ReviveWithAnUnlinkedRowOpensNoSecondTranscript(t *testing.T) {
 
 	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
 		"a SendMessage id must never open a transcript")
-	assert.Len(t, child.Messages(), before, "nothing is written to a transcript the row does not name")
+	assert.Len(t, child.Messages(), before, "the router writes nothing to a transcript the row does not identify")
 
 	// Refusing the SendMessage id costs no transcript: the subagent's own output
 	// still resolves the real one through the spawn span.
@@ -1808,12 +1808,41 @@ func TestClaude_StartTaskWithoutAToolUseIDStillRecordsTheKind(t *testing.T) {
 	assert.False(t, hasPending, "no spawn span means no pending close to take")
 	assert.Equal(t, bgtask.StatusPending, pending)
 	assert.Equal(t, bgtask.KindSubagent, idx.kindForTask("task-1"))
-	assert.Empty(t, idx.taskIDForToolUse(""), "no pair is written under an empty key")
+	// The MAPS, not taskIDForToolUse(""), which answers "" from its own guard
+	// before it reads either one -- so it holds whatever startTask wrote.
+	assert.Empty(t, idx.toolUseTask, "no reverse entry is written under an empty key")
+	assert.Empty(t, idx.taskToolUse, "and no forward set either")
 
 	// And with a spawn span the pair IS written, both ways.
-	idx.startTask("task-2", bgtask.KindShell, "tu-2")
+	idx.startTask("task-2", bgtask.KindShell, "tu-2", "tu-2")
 	assert.Equal(t, "task-2", idx.taskIDForToolUse("tu-2"))
 	assert.Equal(t, bgtask.KindShell, idx.kindForTask("task-2"))
+}
+
+// The title rule, reached directly. Through the handler it takes six sink calls
+// to arrange each branch, and three of the four are only reachable there by a
+// failure the fake has to inject.
+func TestClaude_TaskStartedTitleRule(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "desc",
+		claudeTaskStartedTitle(&claudeTaskEnvelope{Description: "desc", Prompt: "p\nq"}, claudeKnownTask{}, claudeRestartEvidence{}),
+		"a description wins outright")
+	assert.Equal(t, "p",
+		claudeTaskStartedTitle(&claudeTaskEnvelope{Prompt: "p\nq"}, claudeKnownTask{}, claudeRestartEvidence{}),
+		"a first start falls back to the prompt's first line")
+	assert.Empty(t,
+		claudeTaskStartedTitle(&claudeTaskEnvelope{Prompt: "p"}, claudeKnownTask{exists: true}, claudeRestartEvidence{}),
+		"a row that already exists keeps the title it has")
+	assert.Empty(t,
+		claudeTaskStartedTitle(&claudeTaskEnvelope{Prompt: "p"}, claudeKnownTask{}, claudeRestartEvidence{wake: true}),
+		"and a wake never renames the row to its own block")
+	assert.Empty(t,
+		claudeTaskStartedTitle(&claudeTaskEnvelope{Prompt: "p"}, claudeKnownTask{}, claudeRestartEvidence{sendMessage: true}),
+		"nor does the message the parent just sent")
+	assert.Equal(t, "p",
+		claudeTaskStartedTitle(&claudeTaskEnvelope{Prompt: "p"}, claudeKnownTask{unreadable: true}, claudeRestartEvidence{}),
+		"an UNREADABLE registry is not evidence, so the fallback still runs")
 }
 
 // A restart hands startTask two ids: the spawn span the restarted run forwards
@@ -1858,6 +1887,40 @@ func TestClaude_StartTaskTakesAPendingCloseUnderEitherToolUseID(t *testing.T) {
 	}
 }
 
+// BOTH ids can hold a close, and then the SPAWN span decides: it is the id every
+// forwarded envelope of the run carries, so its result describes the run. The
+// other entry is still consumed, because an entry left behind fires against a
+// future run of this same task -- the spawn span outlives every one of them.
+func TestClaude_StartTakesTheSpawnSpansCloseWhenBothIDsHoldOne(t *testing.T) {
+	t.Parallel()
+
+	var idx claudeTaskIndex
+	idx.recordPendingTaskEnd("tu-spawn", bgtask.StatusFailed)
+	idx.recordPendingTaskEnd("tu-send", bgtask.StatusStopped)
+
+	pending, hasPending := idx.startTask("task-1", bgtask.KindSubagent, "tu-spawn", "tu-send")
+	assert.True(t, hasPending)
+	assert.Equal(t, bgtask.StatusFailed, pending, "the spawn span decides, not the last id visited")
+	assert.Empty(t, idx.pendingTaskEnd, "and both entries are consumed")
+}
+
+// A restart reads its spawn span back from the child row, so a task can index an
+// id its own event never carried -- and two tasks can then hold one id. The
+// LATER writer owns the reverse entry, and the earlier task's closing
+// notification must not drop it: every forwarded envelope of the live run
+// resolves through exactly that entry.
+func TestClaude_ForgetTaskIndexKeepsAnIDAnotherTaskNowOwns(t *testing.T) {
+	t.Parallel()
+
+	var idx claudeTaskIndex
+	idx.startTask("task-A", bgtask.KindSubagent, "tu-spawn", "")
+	idx.startTask("task-B", bgtask.KindSubagent, "tu-spawn", "")
+
+	idx.forgetTaskIndex("task-A")
+	assert.Equal(t, "task-B", idx.taskIDForToolUse("tu-spawn"),
+		"the id still resolves to the task that owns it")
+}
+
 // The pre-start row exists for a FIRST run whose forwarded output outran its
 // task_started: no task id is known yet, so the row opens under the spawn span.
 // The late task_started renames it, so the run owns ONE row from end to end
@@ -1893,11 +1956,16 @@ func TestClaude_AFirstStartRenamesItsPreStartRow(t *testing.T) {
 }
 
 // The restarted run's first envelope can outrun its task_started, the same
-// reorder the pre-start row exists for. That row opens under the ORIGINAL spawn
-// span, so the late task_started has to rename it from THERE -- the id the event
-// itself carries names no row, and the pre-start row would stand beside the real
-// one for good.
-func TestClaude_ARestartRenamesThePreStartRowOpenedUnderTheSpawnSpan(t *testing.T) {
+// reorder the pre-start row exists for. A RESTART needs no such row: the
+// subagent already owns a transcript, so routeSubagentMessage resolves the run
+// from the CHILD and writes straight to the row that run already has.
+//
+// The stronger property, and the reason it is worth pinning: the second row is
+// IMPOSSIBLE here rather than opened and renamed away. A rename can only repair
+// the duplicate afterwards, and its destination key is always occupied on this
+// path -- see TestBgTask_RenameOntoOccupiedKeyDropsALoserTheWinnerSupersedes for
+// what that costs when the reorder outlives the process that could resolve it.
+func TestClaude_ARestartReorderOpensNoPreStartRow(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -1911,13 +1979,68 @@ func TestClaude_ARestartRenamesThePreStartRowOpenedUnderTheSpawnSpan(t *testing.
 		"parent_tool_use_id": "tu-spawn",
 		"message": {"content": [{"type": "text", "text": "Already going."}]}
 	}`))
-	require.Contains(t, bgTaskRowKeys(sink), "prestart:tu-spawn",
-		"the reorder opens the pre-start row this test is about")
+	require.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
+		"the child resolves the run, so no pre-start row opens")
 
 	reviveTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
-		"the late task_started folds the pre-start row back into the run")
+		"and the late task_started leaves it at one")
+	child, _ := sink.ChildSink("child-of-tu-spawn").(*testSink)
+	require.NotNil(t, child)
+	assert.Contains(t, string(child.Messages()[len(child.Messages())-1].Content), "Also check the tests.",
+		"the delivered message still reaches the transcript the row carries")
+}
+
+// A wake whose shell ran in an EARLIER process is a re-registration this one
+// cannot prove: the evidence for it lives in maps the previous process owned,
+// and a wake carries no tool_use_id of its own. The registry row is durable
+// though, and it still carries the child transcript -- so the spawn span is
+// readable whether or not this process can prove the restart.
+func TestClaude_ARestartWithNoPerProcessEvidenceStillKeepsOneRow(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	spawnAndFinishSubagent(t, newTestAgent(sink), sink)
+
+	// A fresh agent over the SAME sink models the worker restart: the registry row
+	// and the child row survive, the tool_use index and childTask do not.
+	a := newTestAgent(sink)
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-spawn",
+		"message": {"content": [{"type": "text", "text": "Back at it."}]}
+	}`))
+	a.HandleOutput([]byte(`{
+		"type": "system", "subtype": "task_started",
+		"task_id": "task-1", "task_type": "local_agent",
+		"description": "Explore the parser"
+	}`))
+
+	assert.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
+		"the durable spawn span folds the pre-start row back into the run")
+}
+
+// A tool_use id is unique per call, so an id recorded as a SendMessage can never
+// later identify a spawn. The guards that refuse it must therefore not depend on
+// the task_started landing inside the sending turn -- the CLI concludes the
+// recipient's run before it delivers, so the event can arrive after it.
+func TestClaude_ARestartCallIsRefusedAfterTheTurnEnd(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	a := newTestAgent(sink)
+	spawnAndFinishSubagent(t, a, sink)
+	sink.UnlinkBackgroundTask("task-1")
+
+	sendMessageTo(a, "tu-send", "task-1")
+	a.HandleOutput([]byte(`{"type": "result", "subtype": "success", "result": "ok"}`))
+	reviveTaskStarted(a, "tu-send", "too late")
+
+	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
+		"a SendMessage id is not a spawn span, whichever turn its task_started lands in")
+	assert.NotContains(t, sink.ClosedSpans(), "tu-send",
+		"and its rail is not freed either")
 }
 
 // The repair reads the spawn span from the child transcript, and that read can
@@ -1937,6 +2060,18 @@ func TestClaude_ARestartSurvivesAnUnreadableSpawnSpan(t *testing.T) {
 
 	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(), "the row still reopens")
 	require.Len(t, child.Messages(), before+1, "the delivered message still lands")
+
+	// And the run still owns ONE row. With no spawn span the tool_use index cannot
+	// resolve the forwarded envelope, so routeSubagentMessage falls to the CHILD --
+	// without that fallback this envelope opens prestart:tu-spawn for the very
+	// transcript task-1 already carries, and nothing ever closes it.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-spawn",
+		"message": {"content": [{"type": "text", "text": "Checked them."}]}
+	}`))
+	assert.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
+		"an unreadable spawn span still costs no second row")
 }
 
 // A row whose child linkage a failed upsert lost has no transcript to read the
@@ -1956,18 +2091,17 @@ func TestClaude_ARestartOfAnUnlinkedRowOpensNoChildUnderTheRestartCall(t *testin
 
 	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
 		"a re-registration's tool_use id is not a spawn span")
-}
 
-// bgTaskRowKeys lists the registry row keys this sink holds, sorted. The KEYS
-// and not the count: a duplicate row is only recognizable by the key it took.
-func bgTaskRowKeys(sink *testSink) []string {
-	rows := sink.BackgroundTasks()
-	keys := make([]string, 0, len(rows))
-	for _, row := range rows {
-		keys = append(keys, row.RowKey)
-	}
-	slices.Sort(keys)
-	return keys
+	// The row that HAS no child link still keeps its identity: the forwarded
+	// envelope resolves the run through childTask, which the first start filled
+	// and no completion drops, so no pre-start row opens beside it.
+	a.HandleOutput([]byte(`{
+		"type": "assistant",
+		"parent_tool_use_id": "tu-spawn",
+		"message": {"content": [{"type": "text", "text": "Checked them."}]}
+	}`))
+	assert.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
+		"an unlinked row still costs no second row")
 }
 
 // A restarted subagent forwards its new output under the ORIGINAL spawn span,

--- a/backend/internal/worker/agent/claude_subagent_test.go
+++ b/backend/internal/worker/agent/claude_subagent_test.go
@@ -870,18 +870,18 @@ func TestClaude_NestedSpawnOpensNoSpanInTheChildTranscript(t *testing.T) {
 		"the nested spawn's type is still recorded for its tool_result")
 }
 
-// --- SendMessage revive ---
+// --- SendMessage restart ---
 //
 // Claude restarts a FINISHED subagent when the parent messages it, and says so by
 // emitting task_started again for the same task_id. The event alone cannot drive
-// the revive: a resumed session re-announces every task it once ran the same way,
+// the restart: a resumed session re-announces every task it once ran the same way,
 // with all of them finished. So the SendMessage tool_use arms a recipient and the
 // task_started fires it. These tests pin both halves and each impostor the pair
 // excludes.
 
 // spawnAndFinishSubagent replays a full first run -- spawn, one reply, final
 // notification -- and returns the child sink the subagent wrote into. Starting
-// from the real lifecycle rather than a seeded row is what makes the revive
+// from the real lifecycle rather than a seeded row is what makes the restart
 // assertions meaningful: the transcript already holds its closing divider's
 // registry state, and the row already carries the child linkage.
 func spawnAndFinishSubagent(t *testing.T, a *ClaudeCodeAgent, sink *testSink) *testSink {
@@ -925,7 +925,7 @@ func spanIDs(opens []testSinkSpanOpen) []string {
 	return ids
 }
 
-// sendMessageTo is the parent's SendMessage tool_use, which arms the revive.
+// sendMessageTo is the parent's SendMessage tool_use, which arms the restart.
 func sendMessageTo(a *ClaudeCodeAgent, toolUseID, recipient string) {
 	a.HandleOutput([]byte(`{
 		"type": "assistant",
@@ -938,11 +938,11 @@ func sendMessageTo(a *ClaudeCodeAgent, toolUseID, recipient string) {
 	}`))
 }
 
-// reviveTaskStarted is the event the CLI emits once the restart happened. Its
+// restartTaskStarted is the event the CLI emits once the restart happened. Its
 // tool_use_id is the SENDMESSAGE call, not the original spawn -- the CLI
 // re-registers the task under the tool call that restarted it -- and its prompt
 // is the text the subagent actually received.
-func reviveTaskStarted(a *ClaudeCodeAgent, toolUseID, prompt string) {
+func restartTaskStarted(a *ClaudeCodeAgent, toolUseID, prompt string) {
 	a.HandleOutput([]byte(`{
 		"type": "system",
 		"subtype": "task_started",
@@ -963,7 +963,7 @@ func TestClaude_SendMessageRevivesAFinishedSubagent(t *testing.T) {
 	before := len(child.Messages())
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	restartTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
 		"the armed task_started reopens the registry row")
@@ -981,7 +981,7 @@ func TestClaude_SendMessageRevivesAFinishedSubagent(t *testing.T) {
 		"a mid-transcript message carries a scroll-rail mark; the opening prompt does not")
 }
 
-// The revive's task_started identifies the SendMessage call, which still runs in
+// The restart's task_started identifies the SendMessage call, which still runs in
 // the parent transcript. Closing its span would free the rail mid-flight and
 // leave its own tool_result drawing a connector_end with nothing above it.
 func TestClaude_ReviveDoesNotCloseTheSendMessageSpan(t *testing.T) {
@@ -993,7 +993,7 @@ func TestClaude_ReviveDoesNotCloseTheSendMessageSpan(t *testing.T) {
 
 	sendMessageTo(a, "tu-send", "task-1")
 	require.Contains(t, spanIDs(sink.OpenSpans()), "tu-send", "SendMessage owns an ordinary span")
-	reviveTaskStarted(a, "tu-send", "more work")
+	restartTaskStarted(a, "tu-send", "more work")
 
 	assert.NotContains(t, sink.ClosedSpans(), "tu-send",
 		"a re-registration's tool_use_id is not a spawn span")
@@ -1030,7 +1030,7 @@ func TestClaude_TaskStartedWithoutASendMessageDoesNotRevive(t *testing.T) {
 	child := spawnAndFinishSubagent(t, a, sink)
 	before := len(child.Messages())
 
-	reviveTaskStarted(a, "tu-spawn", "(resumed agent)")
+	restartTaskStarted(a, "tu-spawn", "(resumed agent)")
 
 	assert.Empty(t, sink.RevivedTasks(), "an unarmed re-registration is not a revive")
 	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
@@ -1039,7 +1039,7 @@ func TestClaude_TaskStartedWithoutASendMessageDoesNotRevive(t *testing.T) {
 	assert.Len(t, child.Messages(), before, "nothing is appended to the transcript")
 }
 
-// An arm lives for one turn. A revive's task_started lands inside the turn that
+// An arm lives for one turn. A restart's task_started lands inside the turn that
 // sent the message, so an arm still standing at the turn end addressed a live
 // subagent, a foreign recipient, or a send the CLI refused.
 func TestClaude_SendMessageArmExpiresAtTheTurnEnd(t *testing.T) {
@@ -1051,7 +1051,7 @@ func TestClaude_SendMessageArmExpiresAtTheTurnEnd(t *testing.T) {
 
 	sendMessageTo(a, "tu-send", "task-1")
 	a.HandleOutput([]byte(`{"type": "result", "subtype": "success", "result": "ok"}`))
-	reviveTaskStarted(a, "tu-send", "too late")
+	restartTaskStarted(a, "tu-send", "too late")
 
 	assert.Empty(t, sink.RevivedTasks(), "the arm did not survive the turn")
 	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
@@ -1070,7 +1070,7 @@ func TestClaude_SendMessageToAnUnknownRecipientIsInert(t *testing.T) {
 	before := len(child.Messages())
 
 	sendMessageTo(a, "tu-send", "bridge:some-other-machine")
-	reviveTaskStarted(a, "tu-send", "not for us")
+	restartTaskStarted(a, "tu-send", "not for us")
 
 	assert.Empty(t, sink.RevivedTasks())
 	assert.Len(t, child.Messages(), before)
@@ -1093,7 +1093,7 @@ func TestClaude_SendMessageToARunningSubagentDoesNotRevive(t *testing.T) {
 	}`))
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "more work")
+	restartTaskStarted(a, "tu-send", "more work")
 
 	assert.Empty(t, sink.RevivedTasks(), "an active row has nothing to revive")
 	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
@@ -1121,10 +1121,10 @@ func TestClaude_SendMessageFromAChildTranscriptArms(t *testing.T) {
 			"input": {"to": "task-1", "message": "keep going"}
 		}]}
 	}`))
-	reviveTaskStarted(a, "tu-send", "from a sibling")
+	restartTaskStarted(a, "tu-send", "from a sibling")
 
 	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
-		"a subagent's SendMessage arms the same revive the parent's does")
+		"a subagent's SendMessage arms the same restart the parent's does")
 }
 
 // sendMessageFromChild is a subagent's SendMessage, forwarded under its spawn
@@ -1155,7 +1155,7 @@ func TestClaude_AChildArmSurvivesTheRootTurnEnd(t *testing.T) {
 
 	sendMessageFromChild(a, "tu-other-spawn", "tu-send", "task-1")
 	a.HandleOutput([]byte(`{"type": "result", "subtype": "success", "result": "ok"}`))
-	reviveTaskStarted(a, "tu-send", "from a sibling")
+	restartTaskStarted(a, "tu-send", "from a sibling")
 
 	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
 		"the root's turn end drops only the root's own arms")
@@ -1177,7 +1177,7 @@ func TestClaude_AChildArmExpiresAtTheChildTurnEnd(t *testing.T) {
 		"subtype": "success",
 		"result": "ok"
 	}`))
-	reviveTaskStarted(a, "tu-send", "too late")
+	restartTaskStarted(a, "tu-send", "too late")
 
 	assert.Empty(t, sink.RevivedTasks(), "the arm did not survive the sending transcript's turn")
 }
@@ -1198,13 +1198,13 @@ func TestClaude_AChildTurnEndKeepsTheRootArms(t *testing.T) {
 		"subtype": "success",
 		"result": "ok"
 	}`))
-	reviveTaskStarted(a, "tu-send", "still armed")
+	restartTaskStarted(a, "tu-send", "still armed")
 
 	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
 		"a subagent's turn end leaves the root's arms alone")
 }
 
-// Output forwarded AFTER the revive must land in the transcript the subagent
+// Output forwarded AFTER the restart must land in the transcript the subagent
 // already owns, whether the CLI tags the envelope with the original spawn span
 // or with the tool_use id it re-registered under. The spawn span resolves the
 // first and the registry row key resolves the second.
@@ -1213,7 +1213,7 @@ func TestClaude_AChildTurnEndKeepsTheRootArms(t *testing.T) {
 // TestClaude_RestartedSubagentKeepsOneRegistryRow pins: the two answers came
 // apart once, and a second row standing for this same transcript is what the
 // user saw in the background-task list.
-func TestClaude_RevivedSubagentOutputStaysInOneTranscript(t *testing.T) {
+func TestClaude_RestartedSubagentOutputStaysInOneTranscript(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -1232,7 +1232,7 @@ func TestClaude_RevivedSubagentOutputStaysInOneTranscript(t *testing.T) {
 			before := len(child.Messages())
 
 			sendMessageTo(a, "tu-send", "task-1")
-			reviveTaskStarted(a, "tu-send", "Also check the tests.")
+			restartTaskStarted(a, "tu-send", "Also check the tests.")
 			a.HandleOutput([]byte(`{
 				"type": "assistant",
 				"parent_tool_use_id": "` + tc.parentToolUseID + `",
@@ -1240,7 +1240,7 @@ func TestClaude_RevivedSubagentOutputStaysInOneTranscript(t *testing.T) {
 			}`))
 
 			msgs := child.Messages()
-			require.Len(t, msgs, before+2, "the revive message and the new reply both land here")
+			require.Len(t, msgs, before+2, "the restart message and the new reply both land here")
 			assert.Contains(t, string(msgs[len(msgs)-1].Content), "Checked them.")
 			// One transcript is half the answer. The row that STANDS for it must stay
 			// one too, whichever id the envelope carried: a second row linked to this
@@ -1251,7 +1251,7 @@ func TestClaude_RevivedSubagentOutputStaysInOneTranscript(t *testing.T) {
 	}
 }
 
-// A revive with no prompt still reopens the row. The subagent runs again, so its
+// A restart with no prompt still reopens the row. The subagent runs again, so its
 // thinking indicator is owed even when there is no text to show.
 func TestClaude_ReviveWithoutAPromptStillReopensTheRow(t *testing.T) {
 	t.Parallel()
@@ -1262,13 +1262,13 @@ func TestClaude_ReviveWithoutAPromptStillReopensTheRow(t *testing.T) {
 	before := len(child.Messages())
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "   ")
+	restartTaskStarted(a, "tu-send", "   ")
 
 	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks())
 	assert.Len(t, child.Messages(), before, "a blank prompt persists no bubble")
 }
 
-// One SendMessage arms one revive. A second task_started for the same task must
+// One SendMessage arms one restart. A second task_started for the same task must
 // not reopen a row that closed again in between.
 func TestClaude_OneSendMessageArmsOneRevive(t *testing.T) {
 	t.Parallel()
@@ -1278,7 +1278,7 @@ func TestClaude_OneSendMessageArmsOneRevive(t *testing.T) {
 	spawnAndFinishSubagent(t, a, sink)
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "first")
+	restartTaskStarted(a, "tu-send", "first")
 	a.HandleOutput([]byte(`{
 		"type": "system",
 		"subtype": "task_notification",
@@ -1286,7 +1286,7 @@ func TestClaude_OneSendMessageArmsOneRevive(t *testing.T) {
 		"tool_use_id": "tu-send",
 		"status": "completed"
 	}`))
-	reviveTaskStarted(a, "tu-send", "second")
+	restartTaskStarted(a, "tu-send", "second")
 
 	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(), "the arm was consumed by the first")
 }
@@ -1328,7 +1328,7 @@ func TestClaude_SendMessageArmsEveryRecipientInOneMessage(t *testing.T) {
 	}
 
 	assert.ElementsMatch(t, []string{"task-tu-spawn-a", "task-tu-spawn-b"}, sink.RevivedTasks(),
-		"a parallel pair of sends arms a revive for each recipient")
+		"a parallel pair of sends arms a restart for each recipient")
 }
 
 // A SendMessage whose input this code cannot read must not stop the turn or arm
@@ -1354,7 +1354,7 @@ func TestClaude_SendMessageWithUnreadableInputArmsNothing(t *testing.T) {
 				"input": ` + input + `
 			}]}
 		}`))
-		reviveTaskStarted(a, "tu-send", "should not land")
+		restartTaskStarted(a, "tu-send", "should not land")
 
 		assert.Empty(t, sink.RevivedTasks(), "input %s must arm nothing", input)
 	}
@@ -1362,7 +1362,7 @@ func TestClaude_SendMessageWithUnreadableInputArmsNothing(t *testing.T) {
 
 // An unreadable registry is a THIRD answer, not a miss. Folding it into
 // "no such row" made the first registry read of a process -- exactly what a
-// worker restart leaves for a revive's task_started -- close the still-running
+// worker restart leaves for a restart's task_started -- close the still-running
 // SendMessage span and treat a finished subagent as brand new.
 func TestClaude_AnUnreadableRegistryDoesNotFreeTheSendMessageSpan(t *testing.T) {
 	t.Parallel()
@@ -1372,7 +1372,7 @@ func TestClaude_AnUnreadableRegistryDoesNotFreeTheSendMessageSpan(t *testing.T) 
 
 	sendMessageTo(a, "tu-send", "task-1")
 	require.Contains(t, spanIDs(sink.OpenSpans()), "tu-send")
-	reviveTaskStarted(a, "tu-send", "more work")
+	restartTaskStarted(a, "tu-send", "more work")
 
 	assert.NotContains(t, sink.ClosedSpans(), "tu-send",
 		"a registry it could not read cannot prove this is a spawn")
@@ -1380,7 +1380,7 @@ func TestClaude_AnUnreadableRegistryDoesNotFreeTheSendMessageSpan(t *testing.T) 
 		"nor can it prove the id is a spawn span worth opening a transcript from")
 }
 
-// A row that identifies no transcript is the one state left in which a revive cannot
+// A row that identifies no transcript is the one state left in which a restart cannot
 // resolve its child, and only a failed registry write produces it: cap eviction
 // does not, because a linked row survives the display cap in the store. The
 // event's tool_use id is the SendMessage call, so handing it to EnsureChildAgent
@@ -1397,7 +1397,7 @@ func TestClaude_ReviveWithAnUnlinkedRowOpensNoSecondTranscript(t *testing.T) {
 	sink.UnlinkBackgroundTask("task-1")
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	restartTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
 		"a SendMessage id must never open a transcript")
@@ -1416,7 +1416,7 @@ func TestClaude_ReviveWithAnUnlinkedRowOpensNoSecondTranscript(t *testing.T) {
 	assert.Contains(t, string(msgs[before].Content), "Checked them.")
 }
 
-// The revive arm is spent only by a revive that resolved a transcript. A
+// The restart arm is spent only by a restart that resolved a transcript. A
 // task_started that resolved none leaves it standing, so the retry a later
 // task_started deserves is still armed -- the same rule a failed registry write
 // follows.
@@ -1429,18 +1429,18 @@ func TestClaude_ATaskStartedThatResolvesNoChildKeepsTheArm(t *testing.T) {
 	sink.UnlinkBackgroundTask("task-1")
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	restartTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.Empty(t, sink.RevivedTasks(), "no transcript resolved, so no revive happened")
-	assert.True(t, a.tasks.takeClaudeRevive("task-1"), "the arm is still standing for a retry")
+	assert.True(t, a.tasks.takeClaudeRestart("task-1"), "the arm is still standing for a retry")
 }
 
-// The CLI may stamp a revived run's forwarded result with the ORIGINAL spawn
+// The CLI may stamp a restarted run's forwarded result with the ORIGINAL spawn
 // span. The first completion dropped that span from the tool_use index, and the
-// revive re-registered the task under the SendMessage call -- so without a
-// child-keyed fallback the result identifies no row and the row the revive just
+// restart re-registered the task under the SendMessage call -- so without a
+// child-keyed fallback the result identifies no row and the row the restart just
 // reopened stays Running for the agent's life.
-func TestClaude_ARevivedResultUnderTheSpawnSpanClosesTheRow(t *testing.T) {
+func TestClaude_ARestartedResultUnderTheSpawnSpanClosesTheRow(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -1448,10 +1448,10 @@ func TestClaude_ARevivedResultUnderTheSpawnSpanClosesTheRow(t *testing.T) {
 	spawnAndFinishSubagent(t, a, sink)
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	restartTaskStarted(a, "tu-send", "Also check the tests.")
 	_, status, ok, _ := sink.LookupBackgroundTask("task-1")
 	require.True(t, ok)
-	require.Equal(t, bgtask.StatusRunning, status, "the revive reopened the row")
+	require.Equal(t, bgtask.StatusRunning, status, "the restart reopened the row")
 
 	a.HandleOutput([]byte(`{
 		"type": "result",
@@ -1462,10 +1462,10 @@ func TestClaude_ARevivedResultUnderTheSpawnSpanClosesTheRow(t *testing.T) {
 	_, status, ok, _ = sink.LookupBackgroundTask("task-1")
 	require.True(t, ok)
 	assert.Equal(t, bgtask.StatusCompleted, status,
-		"the revived run's result closes the row it reopened")
+		"the restarted run's result closes the row it reopened")
 }
 
-// --- Wake revive ---
+// --- Wake restart ---
 //
 // A SendMessage is not the CLI's only restart. Captured against 2.1.233: when a
 // subagent's own backgrounded shell finishes, the CLI re-registers that finished
@@ -1539,7 +1539,7 @@ func TestClaude_AWakeNamingAnUnseenShellDoesNotRevive(t *testing.T) {
 // tags. The safety is NOT here -- claudeWakeRestartedTask corroborates the id
 // against the shells THIS process finished, and reviveClaudeSubagent acts only
 // on a row already in a finished status. So the parse errs toward reading a
-// wake, because missing one restores the whole bug the revive exists to fix.
+// wake, because missing one restores the whole bug the restart exists to fix.
 func TestClaude_WakeTaskIDReadsTheBlockWhateverItsShape(t *testing.T) {
 	t.Parallel()
 
@@ -1571,7 +1571,7 @@ func TestClaude_WakeTaskIDReadsTheBlockWhateverItsShape(t *testing.T) {
 // The shape the edge-anchored parse dropped: the CLI emits the whole block on
 // ONE line. Nothing about that makes it less of a restart, and refusing it left
 // the row reading "finished" for the entire second run, with no closing divider
-// -- exactly the state the revive exists to repair.
+// -- exactly the state the restart exists to repair.
 func TestClaude_AOneLineWakeBlockRevivesTheRow(t *testing.T) {
 	t.Parallel()
 
@@ -1593,7 +1593,7 @@ func TestClaude_AOneLineWakeBlockRevivesTheRow(t *testing.T) {
 	assert.Equal(t, bgtask.StatusRunning, status)
 }
 
-// A revive resolves the transcript from the REGISTRY ROW, never from the event's
+// A restart resolves the transcript from the REGISTRY ROW, never from the event's
 // tool_use id. On a re-registration that id is the SendMessage call, so handing
 // it to EnsureChildAgent walks past the row-key fast path, fails the
 // spawn-span lookup, and creates a SECOND transcript keyed by the wrong span --
@@ -1607,7 +1607,7 @@ func TestClaude_ReviveResolvesTheChildFromTheRegistryRow(t *testing.T) {
 	before := len(child.Messages())
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	restartTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
 		"the SendMessage id must not open a transcript of its own")
@@ -1627,12 +1627,12 @@ func TestClaude_AFailedReviveKeepsTheMessageAndRearms(t *testing.T) {
 	before := len(child.Messages())
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	restartTaskStarted(a, "tu-send", "Also check the tests.")
 
 	msgs := child.Messages()
 	require.Len(t, msgs, before+1, "the delivered message is recorded although the row write failed")
 	assert.JSONEq(t, `{"content":"Also check the tests."}`, string(msgs[len(msgs)-1].Content))
-	assert.True(t, a.tasks.takeClaudeRevive("task-1"), "the arm is back, so a later task_started can retry")
+	assert.True(t, a.tasks.takeClaudeRestart("task-1"), "the arm is back, so a later task_started can retry")
 }
 
 // A subagent can message a finished SIBLING, and that send must be recognized as
@@ -1658,7 +1658,7 @@ func TestClaude_ASiblingSendOpensNoSecondTranscript(t *testing.T) {
 	sink.UnlinkBackgroundTask("task-1")
 
 	sendMessageFromChild(a, "tu-spawn-2", "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "keep going")
+	restartTaskStarted(a, "tu-send", "keep going")
 
 	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
 		"a sibling's SendMessage id must never reach EnsureChildAgent")
@@ -1681,7 +1681,7 @@ func TestClaude_ASiblingSendKeepsItsSpanOpen(t *testing.T) {
 	}`))
 
 	sendMessageFromChild(a, "tu-spawn-2", "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "keep going")
+	restartTaskStarted(a, "tu-send", "keep going")
 
 	assert.NotContains(t, sink.ClosedSpans(), "tu-send",
 		"the restart call still runs in the sibling's transcript")
@@ -1712,7 +1712,7 @@ func TestClaude_ASecondSenderDoesNotCancelTheFirstsArm(t *testing.T) {
 		"type": "result", "parent_tool_use_id": "tu-spawn-2", "subtype": "success"
 	}`))
 
-	reviveTaskStarted(a, "tu-send-root", "keep going")
+	restartTaskStarted(a, "tu-send-root", "keep going")
 
 	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(),
 		"the root's arm survives the sibling's turn end")
@@ -1982,7 +1982,7 @@ func TestClaude_ARestartReorderOpensNoPreStartRow(t *testing.T) {
 	require.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
 		"the child resolves the run, so no pre-start row opens")
 
-	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	restartTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.Equal(t, []string{"task-1"}, bgTaskRowKeys(sink),
 		"and the late task_started leaves it at one")
@@ -2035,7 +2035,7 @@ func TestClaude_ARestartCallIsRefusedAfterTheTurnEnd(t *testing.T) {
 
 	sendMessageTo(a, "tu-send", "task-1")
 	a.HandleOutput([]byte(`{"type": "result", "subtype": "success", "result": "ok"}`))
-	reviveTaskStarted(a, "tu-send", "too late")
+	restartTaskStarted(a, "tu-send", "too late")
 
 	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
 		"a SendMessage id is not a spawn span, whichever turn its task_started lands in")
@@ -2056,7 +2056,7 @@ func TestClaude_ARestartSurvivesAnUnreadableSpawnSpan(t *testing.T) {
 	before := len(child.Messages())
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	restartTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.Equal(t, []string{"task-1"}, sink.RevivedTasks(), "the row still reopens")
 	require.Len(t, child.Messages(), before+1, "the delivered message still lands")
@@ -2087,7 +2087,7 @@ func TestClaude_ARestartOfAnUnlinkedRowOpensNoChildUnderTheRestartCall(t *testin
 	sink.UnlinkBackgroundTask("task-1")
 
 	sendMessageTo(a, "tu-send", "task-1")
-	reviveTaskStarted(a, "tu-send", "Also check the tests.")
+	restartTaskStarted(a, "tu-send", "Also check the tests.")
 
 	assert.NotContains(t, sink.ChildAgentIDs(), "child-of-tu-send",
 		"a re-registration's tool_use id is not a spawn span")
@@ -2124,7 +2124,7 @@ func TestClaude_RestartedSubagentKeepsOneRegistryRow(t *testing.T) {
 	}{
 		{"SendMessage", func(a *ClaudeCodeAgent) {
 			sendMessageTo(a, "tu-send", "task-1")
-			reviveTaskStarted(a, "tu-send", "Also check the tests.")
+			restartTaskStarted(a, "tu-send", "Also check the tests.")
 		}, []string{"task-1"}},
 		{"shell wake", func(a *ClaudeCodeAgent) {
 			finishShellTask(a, "shell-1")

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -29,6 +31,15 @@ type testSinkSettingsRefreshed struct {
 type testSinkModeChange struct {
 	Old string
 	New string
+}
+
+// childSpawnSpanTable is the child-agent-id -> spawn-span map the whole sink
+// tree shares. It stands in for the `agents` row, which is one table the worker
+// reads by primary key however it got there -- so a root sink, a child sink and
+// a sink built after a restart must all give one answer.
+type childSpawnSpanTable struct {
+	mu        sync.Mutex
+	byChildID map[string]string
 }
 
 // testSink is a test implementation of OutputSink that records calls.
@@ -81,11 +92,18 @@ type testSink struct {
 	planModeToolUses        sync.Map
 	// childSinkMu + children let testSink serve ChildSink as a per-child testSink
 	// so provider tests can assert what got routed into a subagent transcript.
-	childSinkMu  sync.Mutex
-	children     map[string]*testSink
-	childIDMu    sync.Mutex
-	childIDVal   string
-	spawnSpanVal string
+	childSinkMu sync.Mutex
+	children    map[string]*testSink
+	childIDMu   sync.Mutex
+	childIDVal  string
+	// spawnSpans is the child-agent-id -> spawn-span table ChildSpawnSpan reads.
+	// Every sink of one tree holds the SAME pointer, because production answers
+	// the same for a root sink, a child sink and a sink built after a restart.
+	// EnsureChildAgent creates it under childSinkMu, so a sink that never spawned
+	// a child holds nil and answers "" -- which is what production answers for an
+	// id no row carries. Nil is therefore a usable zero value, and a bare
+	// &testSink{} needs no constructor.
+	spawnSpans *childSpawnSpanTable
 	// bgTasks records the latest registry state per row key (owner == this sink).
 	bgTasks map[string]bgtask.Item
 	// bgTaskStatuses records distinct status values per row key, in order.
@@ -537,7 +555,13 @@ func (s *testSink) EnsureChildAgent(spawnSpanID, providerChildKey, title string)
 	cid := "child-of-" + spawnSpanID
 	child := &testSink{}
 	child.setChildAgentID(cid)
-	child.setSpawnSpanID(spawnSpanID)
+	// Recorded BEFORE the child takes the pointer, so the child inherits a table
+	// that already exists. The child shares that table and the injected read
+	// failure, so a child handle answers exactly as the root does -- production
+	// reaches the same row through the same query whichever sink holds it.
+	s.recordSpawnSpan(cid, spawnSpanID)
+	child.spawnSpans = s.spawnSpans
+	child.spawnSpanErr = s.spawnSpanErr
 	s.children[spawnSpanID] = child
 	if providerChildKey != "" {
 		// Normalized here for the reason the other three registry methods do it:
@@ -578,40 +602,44 @@ func (s *testSink) setChildAgentID(id string) {
 	s.childIDVal = id
 }
 
-// spawnSpanID is the span this child was created for, recorded beside the child
-// id rather than re-derived from the parent's `children` map. That map also
-// holds the "late:" keys ChildSink mints for a child nobody spawned, and those
-// keys are not spans -- a scan of it would report one.
-func (s *testSink) spawnSpanID() string {
-	s.childIDMu.Lock()
-	defer s.childIDMu.Unlock()
-	return s.spawnSpanVal
-}
-
-func (s *testSink) setSpawnSpanID(span string) {
-	s.childIDMu.Lock()
-	defer s.childIDMu.Unlock()
-	s.spawnSpanVal = span
-}
-
-// ChildSpawnSpan mirrors the real sink: it answers from what EnsureChildAgent
-// recorded on the CHILD, so a child reached any other way answers "" exactly as
-// a row with no spawn span does.
-func (s *testSink) ChildSpawnSpan(childAgentID string) (string, error) {
-	if s.spawnSpanErr != nil {
-		return "", s.spawnSpanErr
+// recordSpawnSpan files the span EnsureChildAgent created a child for, in the
+// table every sink of this tree shares. Caller must hold s.childSinkMu, which is
+// what makes the lazy creation safe.
+func (s *testSink) recordSpawnSpan(childAgentID, span string) {
+	if s.spawnSpans == nil {
+		s.spawnSpans = &childSpawnSpanTable{}
 	}
+	s.spawnSpans.mu.Lock()
+	defer s.spawnSpans.mu.Unlock()
+	if s.spawnSpans.byChildID == nil {
+		s.spawnSpans.byChildID = make(map[string]string)
+	}
+	s.spawnSpans.byChildID[childAgentID] = span
+}
+
+// ChildSpawnSpan mirrors the real sink: production runs a PRIMARY KEY read that
+// ignores which sink asks (TestChildSpawnSpan_AnswersFromTheChildRow pins it by
+// asking a sink built from a fresh OutputHandler), so this answers from the
+// shared table rather than from the receiver's own `children`. A per-sink scan
+// answered "" for a child sink asking about itself, and it read whichever entry
+// Go's random map order reached first once ChildSink minted a "late:" child
+// carrying the same id.
+//
+// The empty id comes FIRST, as production has it: an empty id asks nothing of
+// the database, so no read can fail for one.
+func (s *testSink) ChildSpawnSpan(childAgentID string) (string, error) {
 	if childAgentID == "" {
 		return "", nil
 	}
-	s.childSinkMu.Lock()
-	defer s.childSinkMu.Unlock()
-	for _, c := range s.children {
-		if c.childAgentID() == childAgentID {
-			return c.spawnSpanID(), nil
-		}
+	if s.spawnSpanErr != nil {
+		return "", s.spawnSpanErr
 	}
-	return "", nil
+	if s.spawnSpans == nil {
+		return "", nil
+	}
+	s.spawnSpans.mu.Lock()
+	defer s.spawnSpans.mu.Unlock()
+	return s.spawnSpans.byChildID[childAgentID], nil
 }
 
 // ChildSink returns the per-child testSink created by EnsureChildAgent (or a
@@ -885,24 +913,55 @@ func (s *testSink) RevivedTasks() []string {
 }
 
 func (s *testSink) RenameBackgroundTask(oldKey, newKey string) error {
+	// The empty-key no-op FIRST, as production does: NormalizeRowKey("") derives a
+	// digest, so normalizing first would rename onto a key no registry stores.
+	if oldKey == "" || newKey == "" {
+		return nil
+	}
 	// BOTH keys, as production does: normalizing one and not the other is how a
 	// rename stops finding its own row.
 	oldKey, newKey = bgtask.NormalizeRowKey(oldKey), bgtask.NormalizeRowKey(newKey)
 	s.bgTasksMu.Lock()
 	defer s.bgTasksMu.Unlock()
-	if item, ok := s.bgTasks[oldKey]; ok {
-		delete(s.bgTasks, oldKey)
-		item.RowKey = newKey
-		s.bgTasks[newKey] = item
+	item, ok := s.bgTasks[oldKey]
+	if !ok || oldKey == newKey {
+		return nil
 	}
+	// (owner, row_key) is the PRIMARY KEY, so production resolves a rename onto an
+	// OCCUPIED key by keeping the row already at newKey -- it carries the lifecycle
+	// that reached the rename -- and dropping the duplicate at oldKey. A fake that
+	// overwrote the destination instead let a test assert the opposite outcome
+	// under the same row key, which is exactly what the key-set assertions cannot
+	// see: Claude's restart rename reaches this collision on every reorder.
+	if _, occupied := s.bgTasks[newKey]; occupied {
+		delete(s.bgTasks, oldKey)
+		return nil
+	}
+	delete(s.bgTasks, oldKey)
+	item.RowKey = newKey
+	s.bgTasks[newKey] = item
 	return nil
+}
+
+// bgTaskRowKeys lists the registry row keys this sink holds, sorted. The KEYS
+// and not the count: a duplicate row is only recognizable by the key it took.
+func bgTaskRowKeys(sink *testSink) []string {
+	rows := sink.BackgroundTasks()
+	keys := make([]string, 0, len(rows))
+	for _, row := range rows {
+		keys = append(keys, row.RowKey)
+	}
+	return keys
 }
 
 // CleanupChildAgent is a no-op on the test fake: tests that exercise the
 // per-child cleanup use the real OutputHandler via svc.Output.NewSink.
 func (s *testSink) CleanupChildAgent(childAgentID string) {}
 
-// BackgroundTasks returns a snapshot of the recorded registry rows (test helper).
+// BackgroundTasks returns a snapshot of the recorded registry rows, SORTED by
+// row key. The rows live in a map, so an unsorted snapshot ordered them at
+// random and every caller that wanted a specific row scanned the slice by hand.
+// A stable order lets a test assert the whole list.
 func (s *testSink) BackgroundTasks() []bgtask.Item {
 	s.bgTasksMu.Lock()
 	defer s.bgTasksMu.Unlock()
@@ -910,6 +969,7 @@ func (s *testSink) BackgroundTasks() []bgtask.Item {
 	for _, item := range s.bgTasks {
 		out = append(out, item)
 	}
+	slices.SortFunc(out, func(a, b bgtask.Item) int { return cmp.Compare(a.RowKey, b.RowKey) })
 	return out
 }
 

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -81,10 +81,11 @@ type testSink struct {
 	planModeToolUses        sync.Map
 	// childSinkMu + children let testSink serve ChildSink as a per-child testSink
 	// so provider tests can assert what got routed into a subagent transcript.
-	childSinkMu sync.Mutex
-	children    map[string]*testSink
-	childIDMu   sync.Mutex
-	childIDVal  string
+	childSinkMu  sync.Mutex
+	children     map[string]*testSink
+	childIDMu    sync.Mutex
+	childIDVal   string
+	spawnSpanVal string
 	// bgTasks records the latest registry state per row key (owner == this sink).
 	bgTasks map[string]bgtask.Item
 	// bgTaskStatuses records distinct status values per row key, in order.
@@ -110,7 +111,12 @@ type testSink struct {
 	// answer -- the "registry unreadable" third case, which a miss cannot stand
 	// in for. Read without the lock: set at construction.
 	lookupErr error
-	bgTasksMu sync.Mutex
+	// spawnSpanErr, when set, is what ChildSpawnSpan returns instead of a span --
+	// the same "could not be read" third case lookupErr covers, and the only way
+	// to reach the branch that decides what a restart does when the child's spawn
+	// span is unknowable. Read without the lock: set at construction.
+	spawnSpanErr error
+	bgTasksMu    sync.Mutex
 	// notifSuppressBroadcast makes PersistNotification report broadcast=false,
 	// simulating the service layer collapsing a flapping notification
 	// byte-identically into the existing thread tail (no frontend clear). Default
@@ -531,6 +537,7 @@ func (s *testSink) EnsureChildAgent(spawnSpanID, providerChildKey, title string)
 	cid := "child-of-" + spawnSpanID
 	child := &testSink{}
 	child.setChildAgentID(cid)
+	child.setSpawnSpanID(spawnSpanID)
 	s.children[spawnSpanID] = child
 	if providerChildKey != "" {
 		// Normalized here for the reason the other three registry methods do it:
@@ -569,6 +576,42 @@ func (s *testSink) setChildAgentID(id string) {
 	s.childIDMu.Lock()
 	defer s.childIDMu.Unlock()
 	s.childIDVal = id
+}
+
+// spawnSpanID is the span this child was created for, recorded beside the child
+// id rather than re-derived from the parent's `children` map. That map also
+// holds the "late:" keys ChildSink mints for a child nobody spawned, and those
+// keys are not spans -- a scan of it would report one.
+func (s *testSink) spawnSpanID() string {
+	s.childIDMu.Lock()
+	defer s.childIDMu.Unlock()
+	return s.spawnSpanVal
+}
+
+func (s *testSink) setSpawnSpanID(span string) {
+	s.childIDMu.Lock()
+	defer s.childIDMu.Unlock()
+	s.spawnSpanVal = span
+}
+
+// ChildSpawnSpan mirrors the real sink: it answers from what EnsureChildAgent
+// recorded on the CHILD, so a child reached any other way answers "" exactly as
+// a row with no spawn span does.
+func (s *testSink) ChildSpawnSpan(childAgentID string) (string, error) {
+	if s.spawnSpanErr != nil {
+		return "", s.spawnSpanErr
+	}
+	if childAgentID == "" {
+		return "", nil
+	}
+	s.childSinkMu.Lock()
+	defer s.childSinkMu.Unlock()
+	for _, c := range s.children {
+		if c.childAgentID() == childAgentID {
+			return c.spawnSpanID(), nil
+		}
+	}
+	return "", nil
 }
 
 // ChildSink returns the per-child testSink created by EnsureChildAgent (or a
@@ -1120,6 +1163,7 @@ func (noopSink) PublishGoalCapabilities()                                       
 func (noopSink) ScheduleAutoContinue(AutoContinueSchedule)                         {}
 func (noopSink) CancelAutoContinue(AutoContinueReason)                             {}
 func (noopSink) EnsureChildAgent(string, string, string) (string, error)           { return "", nil }
+func (noopSink) ChildSpawnSpan(string) (string, error)                             { return "", nil }
 func (noopSink) ChildSink(string) OutputSink                                       { return noopSink{} }
 func (noopSink) PersistChildMessage(string, leapmuxv1.MessageSource, []byte, SpanInfo) error {
 	return nil

--- a/backend/internal/worker/db/queries/agent_background_tasks.sql
+++ b/backend/internal/worker/db/queries/agent_background_tasks.sql
@@ -182,8 +182,15 @@ SELECT * FROM agent_background_tasks WHERE owner_agent_id = ? AND row_key = ?;
 
 -- GetAgentBackgroundTaskByChildAgentID is the reverse lookup behind
 -- send-to-subagent and interrupt routing: child agent id -> (owner, row_key).
+--
+-- idx_agent_background_tasks_child is not UNIQUE, so this :one picks a row out of
+-- a set the schema permits to hold more than one. ORDER BY makes the pick
+-- DEFINED rather than left to the plan: without it an index change or a VACUUM
+-- silently moves the answer, and a caller that steers or interrupts through it
+-- addresses a different row than it did yesterday. The lowest seq is the OLDEST
+-- row, which is the run that opened the transcript.
 -- name: GetAgentBackgroundTaskByChildAgentID :one
-SELECT * FROM agent_background_tasks WHERE child_agent_id = ?;
+SELECT * FROM agent_background_tasks WHERE child_agent_id = ? ORDER BY seq LIMIT 1;
 
 -- MarkAgentBackgroundTasksEnded gives every still-active row owned by an agent a
 -- final status (used on clean process exit).

--- a/backend/internal/worker/db/queries/agents.sql
+++ b/backend/internal/worker/db/queries/agents.sql
@@ -246,18 +246,21 @@ INSERT INTO agents (id, parent_agent_id, spawn_span_id, working_dir, home_dir, t
 -- name: GetChildAgentBySpawnSpan :one
 SELECT * FROM agents WHERE parent_agent_id = ? AND spawn_span_id = ?;
 
--- GetChildAgentSpawnSpan is the reverse of GetChildAgentBySpawnSpan, and the
--- only DURABLE copy of a spawn span: a provider's own index of them is
--- per-process, while the child row keeps it for the life of the transcript.
--- Claude reads it back when the CLI restarts a finished subagent, because the
--- restart event identifies the call that restarted the task while the restarted
--- run's output still arrives under the original spawn.
+-- GetChildAgentSpawnSpan is the reverse of GetChildAgentBySpawnSpan. It reads
+-- the only DURABLE copy of a spawn span. A provider's own index of them is
+-- per-process, while the child row keeps its span for the life of the
+-- transcript. Claude reads it back when the CLI restarts a finished subagent.
+--
+-- Scoped by parent_agent_id, exactly as GetChildAgentBySpawnSpan is. A span
+-- belongs to the transcript that spawned the child, so an unscoped read answers
+-- for a child of another root and files a run under a span from a transcript the
+-- caller does not own. A root agent matches no parent and correctly misses.
 --
 -- One narrow column, for the reason GetAgentTitle states: GetAgentByID answers
 -- the same question with a SELECT * that deserializes the options and
 -- option_groups JSON blobs this caller never reads.
 -- name: GetChildAgentSpawnSpan :one
-SELECT spawn_span_id FROM agents WHERE id = ?;
+SELECT spawn_span_id FROM agents WHERE id = ? AND parent_agent_id = ?;
 
 -- GetRootAgentID walks parent_agent_id up to the root main agent. A root row
 -- has parent_agent_id IS NULL.
@@ -345,7 +348,7 @@ WHERE closed_at IS NULL AND parent_agent_id IS NULL AND workspace_archived = 0;
 -- makes the exclusion set complete. A handle can be open under one directory
 -- while a provider's store files it under another: the store records the
 -- directory the session was CREATED in, and a user who resumes it elsewhere
--- leaves an open row that carries the second directory. Restricting both arms
+-- leaves an open row that carries the second directory. Restricting both branches
 -- to one directory hid exactly that row, and the store then offered the live
 -- handle back.
 --

--- a/backend/internal/worker/db/queries/agents.sql
+++ b/backend/internal/worker/db/queries/agents.sql
@@ -246,6 +246,19 @@ INSERT INTO agents (id, parent_agent_id, spawn_span_id, working_dir, home_dir, t
 -- name: GetChildAgentBySpawnSpan :one
 SELECT * FROM agents WHERE parent_agent_id = ? AND spawn_span_id = ?;
 
+-- GetChildAgentSpawnSpan is the reverse of GetChildAgentBySpawnSpan, and the
+-- only DURABLE copy of a spawn span: a provider's own index of them is
+-- per-process, while the child row keeps it for the life of the transcript.
+-- Claude reads it back when the CLI restarts a finished subagent, because the
+-- restart event identifies the call that restarted the task while the restarted
+-- run's output still arrives under the original spawn.
+--
+-- One narrow column, for the reason GetAgentTitle states: GetAgentByID answers
+-- the same question with a SELECT * that deserializes the options and
+-- option_groups JSON blobs this caller never reads.
+-- name: GetChildAgentSpawnSpan :one
+SELECT spawn_span_id FROM agents WHERE id = ?;
+
 -- GetRootAgentID walks parent_agent_id up to the root main agent. A root row
 -- has parent_agent_id IS NULL.
 -- name: GetRootAgentID :one

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -299,6 +299,20 @@ func (h *OutputHandler) CancelBackgroundCtx() {
 // bgTaskCtx returns the shutdown-aware context for background-task DB work.
 // Falls back to context.Background() when no shutdown context is wired (a
 // hand-built OutputHandler in a test that never shuts down).
+//
+// It carries NO DEADLINE, deliberately. Every caller reaches it from the agent's
+// stdout-parse goroutine, so a stalled database blocks that goroutine and the
+// agent parses no further output. Two facts make a deadline the worse trade.
+// The store opens SQLite with busy_timeout=60s, so lock contention -- the stall
+// that actually happens -- already resolves or fails on its own. And a caller
+// here only LOGS a refused write, so a deadline that fires on a slow but working
+// database drops a close or a status update for good, and the row then reads
+// Running for the life of the agent. That is the failure the registry exists to
+// prevent, traded for a hang nobody has observed.
+//
+// The case a deadline would cover is a stall SQLite cannot time out, such as a
+// hung filesystem. Add one only with a limit ABOVE the busy timeout, so no
+// statement that beats SQLite's own wait can lose to it.
 func (h *OutputHandler) bgTaskCtx() context.Context {
 	if h.shutdownCtx != nil {
 		return h.shutdownCtx

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -675,10 +675,13 @@ func (s *agentOutputSink) EnsureChildAgent(spawnSpanID, providerChildKey, title 
 
 // ChildSpawnSpan reads back the spawn span recorded on the child's agent row.
 //
-// It reads the ROW and not the registry cache: the cache holds the display list,
-// and a child transcript outlives that cap -- so the hundredth subagent of a
-// session has to answer exactly like the first. The row is a PRIMARY KEY lookup
-// of one column, and only a restart event asks.
+// It reads the ROW and not the registry cache. The cache holds the display list,
+// and a child transcript outlives that cap, so the hundredth subagent of a
+// session has to answer exactly like the first. The read is one indexed column,
+// and only a restart event asks for it.
+//
+// Scoped to THIS sink's children, so the answer can only be a span from the
+// transcript the caller owns. A child of another root misses.
 //
 // An unknown id is a MISS ("" and no error), the same answer the caller gets for
 // a child that carries no span. A read that FAILS returns the error, because a
@@ -687,7 +690,10 @@ func (s *agentOutputSink) ChildSpawnSpan(childAgentID string) (string, error) {
 	if childAgentID == "" {
 		return "", nil
 	}
-	span, err := s.h.queries.GetChildAgentSpawnSpan(s.h.bgTaskCtx(), childAgentID)
+	span, err := s.h.queries.GetChildAgentSpawnSpan(s.h.bgTaskCtx(), db.GetChildAgentSpawnSpanParams{
+		ID:            childAgentID,
+		ParentAgentID: sqlString(s.agentID),
+	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}
@@ -782,7 +788,7 @@ func (s *agentOutputSink) ensureChildAgentLocked(ctx context.Context, spawnSpanI
 	// routeSubagentMessage passes "" by design, and Codex's collabChildTitle
 	// answers "" for a thread it has not titled yet), or cleaning removed
 	// every character of the one it gave. Both take the SAME fallback
-	// OpenAgent takes, so one rule names every untitled agent row, and two
+	// OpenAgent takes, so one rule titles every untitled agent row, and two
 	// untitled subagents stay apart in the tab strip -- a fixed literal would
 	// label them identically.
 	//
@@ -1172,9 +1178,9 @@ func (s *agentOutputSink) CleanupChildAgent(childAgentID string) {
 // The log line is the only trace a derived key leaves. The key it stores is a
 // stable digest, so the sidebar row appears and stays addressable, but its
 // LABEL falls back to that digest when the provider sent no title -- and
-// nothing else on the path would tell an operator why a row is named after a
-// hash. `what` names the call site, because a rename normalizes two keys and
-// the reason can differ between them.
+// nothing else on the path would tell an operator why a row carries a hash as
+// its key. `what` identifies the call site, because a rename normalizes two keys
+// and the reason can differ between them.
 func (s *agentOutputSink) normalizeRowKey(rowKey, what string) string {
 	normalized := bgtask.NormalizeRowKey(rowKey)
 	if normalized != rowKey {
@@ -1394,17 +1400,47 @@ func (s *agentOutputSink) RenameBackgroundTask(oldKey, newKey string) error {
 			cache.Mu.Unlock()
 			return nil
 		}
+		// Does the WINNER already carry the loser's child transcript? Read both
+		// rows through the retention loader, so a row the display cap evicted still
+		// answers. A read failure leaves supersededChild false, which retains the
+		// loser -- the conservative half, because an orphaned child costs a
+		// transcript nobody can reopen while a retained row costs one stale entry.
+		supersededChild := false
+		if loser, found, err := s.h.loadStoredBgTask(ctx, s.rootAgentID, oldKey); err != nil {
+			slog.Warn("bgtask rename: read the losing row failed",
+				"owner", s.rootAgentID, "row_key", oldKey, "error", err)
+		} else if found && loser.ChildAgentID != "" {
+			winner, wfound, err := s.h.loadStoredBgTask(ctx, s.rootAgentID, newKey)
+			switch {
+			case err != nil:
+				slog.Warn("bgtask rename: read the winning row failed",
+					"owner", s.rootAgentID, "row_key", newKey, "error", err)
+			case wfound:
+				supersededChild = winner.ChildAgentID == loser.ChildAgentID
+			}
+		}
 		// deleteRowLocked, not a delete of this caller's own: whether the loser's
 		// PERSISTED row goes with it is the question eviction asks, and the answer
 		// is the same, so both ask registryRetention.keep through one function. A
 		// row that carries a child transcript is the only index from that child
-		// agent id back to (owner, row_key), so it is retained and only hidden. No
-		// caller reaches this with a linked row today -- the ACP providers that
-		// rename (OpenCode, Kilo) drop child sessions over ACP and never report a
-		// ChildAgentKey -- but the invariant belongs to every row, not to the ones
-		// a caller happens to produce, and the next delete path added must not
-		// have to remember it.
-		dropped, err := cache.deleteRowLocked(ctx, s.rootAgentID, oldKey)
+		// agent id back to (owner, row_key), so it is retained and only hidden.
+		//
+		// Claude's restart rename reaches this with a LINKED loser: a restarted
+		// run whose forwarded envelope outran its task_started opened a pre-start
+		// row under the original spawn span, and that row carries the child. The
+		// ACP providers that rename (OpenCode, Kilo) drop child sessions over ACP
+		// and never report a ChildAgentKey, so their loser is unlinked.
+		//
+		// A loser that carries the SAME child as the winner is deleted outright.
+		// Retention exists to keep the one index from a child agent id back to
+		// (owner, row_key); the winner already IS that index, so keeping the loser
+		// preserves nothing and costs a permanent second row. Nothing closes it --
+		// the run's result closes the winner -- so it survives every reclaim pass
+		// (`child_agent_id = ''` excludes it, and it never reaches a finished
+		// status in this process), and the next cold-start seed reads it back
+		// beside the winner. The sidebar then lists one subagent twice, which is
+		// the failure the rename exists to prevent.
+		dropped, err := cache.deleteRowLocked(ctx, s.rootAgentID, oldKey, supersededChild)
 		if err != nil {
 			cache.Mu.Unlock()
 			return err

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -673,6 +673,30 @@ func (s *agentOutputSink) EnsureChildAgent(spawnSpanID, providerChildKey, title 
 	return childID, nil
 }
 
+// ChildSpawnSpan reads back the spawn span recorded on the child's agent row.
+//
+// It reads the ROW and not the registry cache: the cache holds the display list,
+// and a child transcript outlives that cap -- so the hundredth subagent of a
+// session has to answer exactly like the first. The row is a PRIMARY KEY lookup
+// of one column, and only a restart event asks.
+//
+// An unknown id is a MISS ("" and no error), the same answer the caller gets for
+// a child that carries no span. A read that FAILS returns the error, because a
+// caller must not read a database it could not reach as "no such child".
+func (s *agentOutputSink) ChildSpawnSpan(childAgentID string) (string, error) {
+	if childAgentID == "" {
+		return "", nil
+	}
+	span, err := s.h.queries.GetChildAgentSpawnSpan(s.h.bgTaskCtx(), childAgentID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read spawn span of child %s: %w", childAgentID, err)
+	}
+	return span, nil
+}
+
 // ensureChildAgentLocked resolves (and creates on first sight) the virtual
 // child agent for a spawn. It keeps DB I/O OUTSIDE the per-root cache mutex so
 // a slow DB round-trip during one spawn does not serialize every other registry

--- a/backend/internal/worker/service/output_bgtasks_test.go
+++ b/backend/internal/worker/service/output_bgtasks_test.go
@@ -576,11 +576,11 @@ func TestBgTask_RenameOntoOccupiedKeyDropsTheDuplicate(t *testing.T) {
 }
 
 // The losing duplicate leaves the display list, but its PERSISTED row goes only
-// when it carries no child. A row that identifies a transcript is that child's one
-// index back to (owner, row_key), and the rename is no more entitled to destroy
-// it than eviction is. No provider reaches this today -- OpenCode and Kilo are
-// the only renamers, and both drop child sessions over ACP -- so the invariant
-// is pinned here rather than left to the callers that happen to exist.
+// when it carries no child THE WINNER ALSO CARRIES. A row that identifies a
+// transcript no other row identifies is that child's one index back to
+// (owner, row_key), and the rename is no more entitled to destroy it than
+// eviction is. Here the winner carries no child at all, so the loser holds the
+// only index and survives.
 func TestBgTask_RenameOntoOccupiedKeyRetainsALinkedDuplicate(t *testing.T) {
 	t.Parallel()
 
@@ -604,6 +604,42 @@ func TestBgTask_RenameOntoOccupiedKeyRetainsALinkedDuplicate(t *testing.T) {
 	row, err := svc.Queries.GetAgentBackgroundTaskByChildAgentID(ctx, "child-1")
 	require.NoError(t, err, "the child keeps its index")
 	assert.Equal(t, "spawn-key", row.RowKey)
+}
+
+// When the winner carries the SAME child as the loser, the loser is deleted
+// outright. Retention exists to preserve the one index from a child agent id
+// back to (owner, row_key); the winner already IS that index, so keeping the
+// loser stores a permanent duplicate instead of an only copy.
+//
+// Claude's restart reaches exactly this shape whenever the reorder outlives the
+// process that could have resolved it from the child: the pre-start row and the
+// task row both carry the subagent's transcript. A retained loser is never
+// reclaimed -- it stays Running, and every reclaim pass wants a finished row
+// with no child -- so the next cold-start seed reads it back and the sidebar
+// lists one subagent twice.
+func TestBgTask_RenameOntoOccupiedKeyDropsALoserTheWinnerSupersedes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, sink, ownerID, listRows := setupBgTaskTestWithService(t)
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "task-1", Kind: bgtask.KindSubagent, Title: "spawn",
+		ChildAgentID: "child-1", Status: bgtask.StatusRunning,
+	}))
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "prestart:tu-spawn", Kind: bgtask.KindSubagent,
+		ChildAgentID: "child-1", Status: bgtask.StatusRunning,
+	}))
+
+	require.NoError(t, sink.RenameBackgroundTask("prestart:tu-spawn", "task-1"))
+
+	assert.NotContains(t, displayedRowKeys(t, svc, ownerID), "prestart:tu-spawn",
+		"the duplicate leaves the display list")
+	assert.NotContains(t, rowKeySet(listRows()), "prestart:tu-spawn",
+		"and its row goes too, because the winner already indexes that child")
+	row, err := svc.Queries.GetAgentBackgroundTaskByChildAgentID(ctx, "child-1")
+	require.NoError(t, err, "the child keeps its index")
+	assert.Equal(t, "task-1", row.RowKey, "on the row that survived")
 }
 
 // TestBgTask_RenameOnColdCacheRekeysDBRow verifies the rename seeds the cache

--- a/backend/internal/worker/service/output_child_agent_test.go
+++ b/backend/internal/worker/service/output_child_agent_test.go
@@ -36,6 +36,20 @@ func setupRootSink(t *testing.T, rootID string) (*Service, agent.OutputSink) {
 	return svc, svc.Output.NewSink(rootID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
 }
 
+// newRootAgent adds a SECOND root to an existing service, so a test can ask one
+// root's sink about the other's children. The worker keeps every root in one
+// agents table, which is what makes an unscoped read answer across them.
+func newRootAgent(t *testing.T, svc *Service, rootID string) agent.OutputSink {
+	t.Helper()
+	require.NoError(t, svc.Queries.CreateAgent(context.Background(), db.CreateAgentParams{
+		ID:            rootID,
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	return svc.Output.NewSink(rootID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+}
+
 func TestEnsureChildAgent_CreatesOnce(t *testing.T) {
 	t.Parallel()
 
@@ -158,13 +172,39 @@ func TestChildSpawnSpan_AnswersFromTheChildRow(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "span-1", span)
 
-	// A fresh handler models a worker restart: no cache exists, and the answer
-	// must be the same one.
+	// Past the DISPLAY cap, which is the property the method exists for: the
+	// registry shows a bounded list while a child transcript is permanent, so the
+	// hundredth subagent of a session has to answer exactly like the first. An
+	// implementation that read cache.Rows passes every assertion above and fails
+	// this one.
+	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
+	span, err = sink.ChildSpawnSpan(childID)
+	require.NoError(t, err)
+	assert.Equal(t, "span-1", span, "the row outlives the display cap")
+
+	// A fresh handler models a worker restart: no cache exists, and the row still
+	// answers, because the span lives in the agents table and not in memory.
 	svc.Output = NewOutputHandler(svc.DB, svc.Queries, svc.Watchers, svc.Agents, nil)
 	sink2 := svc.Output.NewSink("root-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
 	span, err = sink2.ChildSpawnSpan(childID)
 	require.NoError(t, err)
 	assert.Equal(t, "span-1", span, "the spawn span survives the process that recorded it")
+}
+
+// The read is scoped to the caller's own children. A worker holds every root's
+// agents in ONE table, so an unscoped read answers with a span from a transcript
+// the caller does not own -- and the caller then files a run under it.
+func TestChildSpawnSpan_DoesNotAnswerForAnotherRootsChild(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "build feature")
+	require.NoError(t, err)
+
+	other := newRootAgent(t, svc, "root-2")
+	span, err := other.ChildSpawnSpan(childID)
+	require.NoError(t, err)
+	assert.Empty(t, span, "another root's child is a miss, not a span")
 }
 
 // An id no child row carries is a MISS, not an error: the caller separates "no

--- a/backend/internal/worker/service/output_child_agent_test.go
+++ b/backend/internal/worker/service/output_child_agent_test.go
@@ -143,6 +143,59 @@ func TestEnsureChildAgent_SpawnSpanFallbackAfterRegistryLoss(t *testing.T) {
 	assert.Equal(t, id1, id2, "spawn-span fallback reattaches the existing child")
 }
 
+// ChildSpawnSpan is how a provider re-derives the spawn span of a subagent it
+// restarted, so it must answer from the child ROW rather than from the display
+// list: the row outlives the cap, and it outlives the worker process.
+func TestChildSpawnSpan_AnswersFromTheChildRow(t *testing.T) {
+	t.Parallel()
+
+	svc, sink := setupRootSink(t, "root-1")
+
+	childID, err := sink.EnsureChildAgent("span-1", "task-1", "build feature")
+	require.NoError(t, err)
+
+	span, err := sink.ChildSpawnSpan(childID)
+	require.NoError(t, err)
+	assert.Equal(t, "span-1", span)
+
+	// A fresh handler models a worker restart: no cache exists, and the answer
+	// must be the same one.
+	svc.Output = NewOutputHandler(svc.DB, svc.Queries, svc.Watchers, svc.Agents, nil)
+	sink2 := svc.Output.NewSink("root-1", leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	span, err = sink2.ChildSpawnSpan(childID)
+	require.NoError(t, err)
+	assert.Equal(t, "span-1", span, "the spawn span survives the process that recorded it")
+}
+
+// An id no child row carries is a MISS, not an error: the caller separates "no
+// such child" from "the registry could not be read", and only the second one
+// makes it refuse to act.
+func TestChildSpawnSpan_UnknownIDMisses(t *testing.T) {
+	t.Parallel()
+
+	_, sink := setupRootSink(t, "root-1")
+
+	span, err := sink.ChildSpawnSpan("no-such-child")
+	require.NoError(t, err)
+	assert.Empty(t, span)
+
+	span, err = sink.ChildSpawnSpan("")
+	require.NoError(t, err)
+	assert.Empty(t, span, "an empty id asks nothing of the database")
+}
+
+// A ROOT agent carries no spawn span, and reading one back must not invent a
+// value: the column is empty for it, and empty is the honest answer.
+func TestChildSpawnSpan_ARootAgentHasNone(t *testing.T) {
+	t.Parallel()
+
+	_, sink := setupRootSink(t, "root-1")
+
+	span, err := sink.ChildSpawnSpan("root-1")
+	require.NoError(t, err)
+	assert.Empty(t, span)
+}
+
 func TestChildSink_PersistsIntoChildSeqSpace(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/worker/service/registry_cache.go
+++ b/backend/internal/worker/service/registry_cache.go
@@ -297,7 +297,12 @@ func (c *registryCache[T]) admitRowLocked(ctx context.Context, ownerID string, r
 // reclaim is the one delete that cannot route here -- it is a set-based
 // statement over rows the cache never loaded -- so it mirrors the rule in its
 // own WHERE clause instead.
-func (c *registryCache[T]) deleteRowLocked(ctx context.Context, ownerID, key string) (bool, error) {
+// superseded says a row that SURVIVES already carries whatever index retention
+// protects for this row, so keeping this one preserves nothing. Only a caller
+// that can compare the two rows knows it, which is why it is a parameter and not
+// a rule inside retention.keep: the predicate sees one row and cannot tell an
+// only index from a second copy of one. Pass false when nothing replaces the row.
+func (c *registryCache[T]) deleteRowLocked(ctx context.Context, ownerID, key string, superseded bool) (bool, error) {
 	row, idx, found, err := c.findRowLocked(ctx, ownerID, key)
 	if err != nil {
 		return false, err
@@ -305,7 +310,7 @@ func (c *registryCache[T]) deleteRowLocked(ctx context.Context, ownerID, key str
 	if !found {
 		return false, nil
 	}
-	if err := c.dropStoredRowLocked(ctx, ownerID, row); err != nil {
+	if err := c.dropStoredRowLocked(ctx, ownerID, row, superseded); err != nil {
 		return false, fmt.Errorf("delete %s: %w", c.ops.label, err)
 	}
 	// Gone from the registry, so it is nobody's running work now.
@@ -381,7 +386,7 @@ func (c *registryCache[T]) evictFirstMatchLocked(ctx context.Context, ownerID st
 // reachable through rowIndexLocked. Caller must hold c.Mu.
 func (c *registryCache[T]) evictAtLocked(ctx context.Context, ownerID string, evictIdx int) (T, bool, error) {
 	evicted := c.Rows[evictIdx]
-	if err := c.dropStoredRowLocked(ctx, ownerID, evicted); err != nil {
+	if err := c.dropStoredRowLocked(ctx, ownerID, evicted, false); err != nil {
 		var zero T
 		return zero, false, fmt.Errorf("evict %s: %w", c.ops.label, err)
 	}
@@ -412,9 +417,14 @@ func (c *registryCache[T]) EvictedActiveCount() int32 {
 
 // dropStoredRowLocked deletes the persisted row unless ops.retention keeps it,
 // and is the ONE place that asks the question. A registry without retention
-// deletes every row. Caller must hold c.Mu.
-func (c *registryCache[T]) dropStoredRowLocked(ctx context.Context, ownerID string, row T) error {
-	if c.ops.retention != nil && c.ops.retention.keep(row) {
+// deletes every row.
+//
+// superseded overrides retention: a surviving row already holds the index this
+// row would be kept for, so keeping it stores a permanent duplicate instead of
+// an only copy. See deleteRowLocked for why the caller decides this.
+// Caller must hold c.Mu.
+func (c *registryCache[T]) dropStoredRowLocked(ctx context.Context, ownerID string, row T, superseded bool) error {
+	if !superseded && c.ops.retention != nil && c.ops.retention.keep(row) {
 		return nil
 	}
 	return c.ops.deleteByKey(ctx, ownerID, c.ops.keyOf(row))

--- a/frontend/src/components/chat/AgentInputQueue.tsx
+++ b/frontend/src/components/chat/AgentInputQueue.tsx
@@ -5,10 +5,10 @@ import type { AgentInputQueueSnapshot, QueuedAgentInput } from '~/generated/prot
 import { closestCenter, DragDropProvider, SortableProvider } from '@thisbeyond/solid-dnd'
 import ArrowDown from 'lucide-solid/icons/arrow-down'
 import ArrowUp from 'lucide-solid/icons/arrow-up'
-import Navigation from 'lucide-solid/icons/navigation'
 import Pencil from 'lucide-solid/icons/pencil'
 import PencilOff from 'lucide-solid/icons/pencil-off'
 import RotateCcw from 'lucide-solid/icons/rotate-ccw'
+import SendHorizontal from 'lucide-solid/icons/send-horizontal'
 import SquarePen from 'lucide-solid/icons/square-pen'
 import Trash2 from 'lucide-solid/icons/trash-2'
 import TriangleAlert from 'lucide-solid/icons/triangle-alert'
@@ -338,7 +338,7 @@ export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
           <Show when={isHead() && props.supportsSteering && item().canSteer}>
             <Tooltip text="Steer" ariaLabel>
               <button class={styles.steerAction} type="button" onClick={() => props.onSteer(item())}>
-                <Icon icon={Navigation} size="xs" />
+                <Icon icon={SendHorizontal} size="xs" />
                 <span>Steer</span>
               </button>
             </Tooltip>


### PR DESCRIPTION
## Motivation

The Claude CLI restarts a finished subagent under a different `tool_use` id
than the one every forwarded envelope of that run keeps using (the original
spawn span). The worker resolved a run's registry row from an in-process map
keyed by whichever id `task_started` carried. When that map could not
answer — because the spawn span was already dropped, or a worker restart
wiped it — a forwarded envelope opened a second `prestart:<span>` row for a
transcript the first row already owned, and nothing closed it. The sidebar
listed the subagent twice, and the stray row stayed Running forever.

The branch carries the initial fix, then a deep code review's follow-up
fixes, then a naming decision — three commits as one logical unit, which is
why the diff spans 13 files.

## Modifications

- **Durable source of truth for a restart.** `handleClaudeTaskStarted` reads
  the original spawn span back from the child agent row (`ChildSpawnSpan`)
  whenever restart evidence exists, or the row already carries a child, and
  indexes both ids. `routeSubagentMessage` resolves the task from the child
  transcript (`taskIDForChild`) before it opens a pre-start row, so the
  duplicate row is impossible, not just repaired after the fact.
- **Index and lifecycle corrections.** `taskToolUse` became a
  `task_id -> set of tool_use ids` map, so every id a run collects is
  dropped together at close. A pending close from a reordered result is
  taken under either id, with the spawn span winning. `sendMessageCalls` no
  longer expires at turn end, because a `tool_use` id is unique per call and
  a late `task_started` after the sending turn must still read as a
  restart, not a new spawn. A restart now refuses a stale pending close
  left by the previous run, which previously marked the reopened row
  Completed by mistake. `forgetTaskIndex` drops a reverse entry only when it
  still maps to the task that is ending.
- **New spawn-span read-back in the service and query layer.**
  `GetChildAgentSpawnSpan` (`SELECT spawn_span_id FROM agents WHERE id = ?
  AND parent_agent_id = ?`), wrapped in `ChildSpawnSpan`, reads the child
  agent row instead of the display-list cache, because the row outlives
  both the display cap and the worker process. It is scoped to the calling
  root's own children: an unmatched or foreign-root id returns a miss, and
  only a real database failure returns an error.
- **Defined ordering for a non-unique reverse lookup.**
  `GetAgentBackgroundTaskByChildAgentID` (send-to-subagent and interrupt
  routing) gains `ORDER BY seq LIMIT 1`; the pick was previously left to the
  query planner, so an index change or a `VACUUM` could silently change
  which row answered.
- **`superseded` threaded through row deletion.** A row that carries a
  child transcript is normally retained past the display cap, because it is
  the only index from child agent id back to `(owner, row_key)`.
  `superseded=true` overrides that once the caller verified another
  surviving row already indexes the same child — otherwise the loser
  becomes a permanent, unreclaimable duplicate. Existing eviction call
  sites are unchanged (`superseded=false`). `RenameBackgroundTask` computes
  `superseded` by loading both rows and comparing `ChildAgentID`; a read
  failure conservatively retains the loser, because an orphaned transcript
  is worse than one stale row.
- **`bgTaskCtx` documents its lack of a deadline.** Every caller runs on the
  stdout-parse goroutine, SQLite's `busy_timeout=60s` already resolves the
  realistic stall, and callers only log a failed write, so an artificial
  deadline would permanently drop a status update and leave a row stuck
  Running.
- **Naming.** RESTART names what the CLI does to the subagent
  (`claudeRestartEvidence`, `armClaudeRestart`,
  `claudeArmRestartsFromBlocks`). REVIVE stays reserved for
  `reviveClaudeSubagent` / `ReviveBackgroundTask`, the cross-provider worker
  action on the registry row. All five renamed identifiers are
  package-private.
- **Test-fake fidelity.** `sink_test.go`'s `RenameBackgroundTask` now
  matches production's primary-key semantics: renaming onto an occupied key
  keeps the destination and drops the source, instead of overwriting it.
  `ChildSpawnSpan` reads from one shared table, so a root sink, a child
  sink, and a sink rebuilt after a restart all answer identically. This
  fidelity is what let the new tests observe the original bug.
- **Frontend.** The input queue's Steer button uses the Send icon
  (`SendHorizontal`) instead of `Navigation`, matching the "send text to a
  running agent" action that it performs.
- New tests: `TestBgTask_RenameOntoOccupiedKeyDropsALoserTheWinnerSupersedes`;
  four `ChildSpawnSpan` tests (answers past the display cap and after a
  simulated worker restart; empty for another root's child; empty for an
  unknown or empty id; empty for a root agent); a `newRootAgent` helper.

## Result

A restarted subagent's transcript resolves back to the row that already
owns it, so the sidebar never lists the same subagent twice and no row is
stuck Running after a restart. The reverse lookup from child agent id to
background-task row is deterministic. A superseded duplicate is now
reclaimed instead of retained forever. `OutputSink.ChildSpawnSpan` is a new
interface method; both in-tree implementations (production and the test
fake) implement it. There are no breaking changes; the renamed identifiers
are unexported. The full backend suite (15023 tests) and all project
linters pass.
