### PR TITLE
fix(chat): Re-anchor oversized catch-up gaps and skip the wasted replay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ before building).
   trigger and hard wrap bound), and the frame length prefix. `headers.json` —
   cross-program HTTP headers (both elevation headers,
   credential-rejected). `retry.json` — the events-rejection retry policy.
+  `chat-history.json` — the message page limit and browser catch-up gap limit.
   `worker-vocab.json` — notification-type tokens, the notification-thread
   discriminator, the Codex rate-limit token, and the model sentinels.
   `goose-protocol.json` — Goose permission modes. `copilot-permissions.json` —

--- a/backend/internal/cli/control/cmd/agent_messages.go
+++ b/backend/internal/cli/control/cmd/agent_messages.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/cli/control"
 	"github.com/leapmux/leapmux/internal/cli/control/streamevents"
@@ -39,7 +40,7 @@ func RunAgentMessages(rawCtx any, args []string) error {
 			// three mutually-exclusive flags -- you can't pick two pages at once.
 			fs.StringVar(&anchor, "anchor", "latest", "page to fetch: latest, oldest, before, or after")
 			fs.Int64Var(&cursorSeq, "cursor-seq", 0, "exclusive seq bound for --anchor before/after")
-			fs.IntVar(&limit, "limit", 50, "max messages per page (hub caps at 50)")
+			fs.IntVar(&limit, "limit", contracts.MessagePageLimit, fmt.Sprintf("max messages per page (worker caps at %d)", contracts.MessagePageLimit))
 			fs.BoolVar(&follow, "follow", false, "tail new messages indefinitely")
 		},
 		noDeadline: true,
@@ -55,7 +56,7 @@ func RunAgentMessages(rawCtx any, args []string) error {
 			// Page 1: history pulled via ListAgentMessages so the user sees
 			// prior context before the live tail starts. WatchEvents can replay the
 			// LATEST page too, but ListAgentMessages is shaped for paginated
-			// history (cap = 50/page), so we keep it for the single-page
+			// history, capped by contracts.MessagePageLimit. Keep it for the single-page
 			// show-history-first behaviour.
 			var resp leapmuxv1.ListAgentMessagesResponse
 			if err := callInnerRPC(ctx, c, workerID, "ListAgentMessages", req, &resp); err != nil {
@@ -136,7 +137,7 @@ func followSelectorError(follow bool, anchor leapmuxv1.MessagePageAnchor) error 
 
 // clampInt32 saturates an int to the int32 range so the conversion can't wrap.
 // A value above MaxInt32 becomes MaxInt32 and one below MinInt32 becomes
-// MinInt32; both land outside the hub's [1,50] window and are clamped there.
+// MinInt32. Both values land outside the worker's valid page-limit range.
 func clampInt32(v int) int32 {
 	if v > math.MaxInt32 {
 		return math.MaxInt32
@@ -157,7 +158,7 @@ func listMessagesPageRequest(agentID, anchor string, cursorSeq int64, limit int)
 	if cursorSeq < 0 {
 		return nil, errors.New("--cursor-seq must be non-negative")
 	}
-	// A non-positive --limit would be silently clamped to the hub default (50);
+	// A non-positive --limit would be silently clamped to contracts.MessagePageLimit.
 	// reject it loudly so a typo fails the same way --cursor-seq and --anchor do
 	// instead of quietly returning a full page.
 	if limit <= 0 {
@@ -167,8 +168,8 @@ func listMessagesPageRequest(agentID, anchor string, cursorSeq int64, limit int)
 	req := &leapmuxv1.ListAgentMessagesRequest{
 		AgentId: agentID,
 		// Clamp to the int32 wire range so a huge --limit can't wrap to a small
-		// positive that slips past the hub's <=50 cap (e.g. int32(2^32+1)==1).
-		// The hub does the real [1,50] clamp; the CLI only guards the conversion.
+		// positive that slips past the worker's cap. For example, int32(2^32+1) is 1.
+		// The worker applies the page-limit clamp. The CLI only guards the conversion.
 		Limit: clampInt32(limit),
 	}
 	switch strings.ToLower(strings.TrimSpace(anchor)) {
@@ -330,10 +331,6 @@ func (b *reconnectBackoff) afterSession(deliveredEvent bool) time.Duration {
 	return wait
 }
 
-// followDrainPageLimit bounds each backlog-drain page. The hub clamps the page
-// size to 50 regardless; matching it keeps one page to one round-trip.
-const followDrainPageLimit = 50
-
 // messagePager fetches one ascending page of messages with seq > afterSeq and
 // reports whether more remain past it. Injected so the reconnect drain loop is
 // unit-testable without a live worker RPC.
@@ -341,7 +338,7 @@ type messagePager func(ctx context.Context, afterSeq int64) (msgs []*leapmuxv1.A
 type messageEmitter func(*leapmuxv1.AgentChatMessage) error
 
 // drainBacklog forwards every message between the cursor and the live tail that
-// the capped WatchEvents replay (<= maxMessagePageLimit per reconnect) would
+// the capped WatchEvents replay (at most contracts.MessagePageLimit per reconnect) would
 // otherwise skip. It pages forward from the cursor until caught up, emitting each
 // message and advancing the cursor so the subsequent subscription replay only has
 // to cover the small remaining gap.
@@ -451,7 +448,7 @@ func tailAgentMessages(ctx context.Context, c *control.Client, workerID, agentID
 	drainFetch := func(ctx context.Context, afterSeq int64) ([]*leapmuxv1.AgentChatMessage, bool, error) {
 		req := &leapmuxv1.ListAgentMessagesRequest{
 			AgentId: agentID,
-			Limit:   followDrainPageLimit,
+			Limit:   contracts.MessagePageLimit,
 		}
 		if streamevents.IsResumeCursor(afterSeq) {
 			req.Anchor = leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER
@@ -477,18 +474,13 @@ func tailAgentMessages(ctx context.Context, c *control.Client, workerID, agentID
 	)
 	backoff := newReconnectBackoff(initialBackoff, maxBackoff)
 	for {
-		// Before EVERY (re)subscribe -- including the first -- bridge the gap the capped
-		// WatchEvents replay (<= maxMessagePageLimit per connect) can't cover, by paging
-		// ListAgentMessages forward from the cursor. On a RECONNECT this is the
-		// disconnect gap; on the FIRST connect it is a burst created between page-1's
-		// snapshot and the watcher registering that overflows the 50-row replay -- page-1
-		// shows recent history but does NOT cover a >50 in-flight burst, so without this
-		// drain those middle messages are silently skipped (the replay caps at 50 and the
-		// live stream resumes from the newest). The drain pages AFTER the cursor (strict
-		// seq > cursor), so it never re-emits a page-1 message. Best-effort: if the drain
-		// can't reach the worker yet it returns early and the resubscribe/backoff below
-		// retries -- the cursor only advances past emitted messages, so the next
-		// reconnect's drain re-attempts the gap.
+		// Before each subscription, bridge the gap that the capped WatchEvents replay
+		// cannot cover. The replay sends at most contracts.MessagePageLimit messages.
+		// ListAgentMessages pages forward from the cursor. On a reconnect, it fills the
+		// disconnect gap. On the first connection, it fills messages created between the
+		// page 1 snapshot and watcher registration. The drain uses AFTER, so it does not
+		// emit a page 1 message again. A failed fetch returns early. The next reconnect
+		// retries from the last message that the command emitted.
 		drained, drainErr := drainBacklog(ctx, agentID, cursor, drainFetch, emitMsg)
 		if drainErr != nil {
 			return drainErr

--- a/backend/internal/cli/control/cmd/agent_messages.go
+++ b/backend/internal/cli/control/cmd/agent_messages.go
@@ -158,9 +158,9 @@ func listMessagesPageRequest(agentID, anchor string, cursorSeq int64, limit int)
 	if cursorSeq < 0 {
 		return nil, errors.New("--cursor-seq must be non-negative")
 	}
-	// A non-positive --limit would be silently clamped to contracts.MessagePageLimit.
-	// reject it loudly so a typo fails the same way --cursor-seq and --anchor do
-	// instead of quietly returning a full page.
+	// The worker would silently clamp a non-positive --limit to
+	// contracts.MessagePageLimit. Reject it loudly so a typo fails the same way
+	// --cursor-seq and --anchor do instead of quietly returning a full page.
 	if limit <= 0 {
 		return nil, errors.New("--limit must be greater than 0")
 	}
@@ -478,9 +478,11 @@ func tailAgentMessages(ctx context.Context, c *control.Client, workerID, agentID
 		// cannot cover. The replay sends at most contracts.MessagePageLimit messages.
 		// ListAgentMessages pages forward from the cursor. On a reconnect, it fills the
 		// disconnect gap. On the first connection, it fills messages created between the
-		// page 1 snapshot and watcher registration. The drain uses AFTER, so it does not
-		// emit a page 1 message again. A failed fetch returns early. The next reconnect
-		// retries from the last message that the command emitted.
+		// page 1 snapshot and watcher registration. Without the drain, a first-connect
+		// burst past the cap is lost silently: the replay keeps only the newest page,
+		// and the live stream resumes from the newest message. The drain uses AFTER, so
+		// it does not emit a page 1 message again. A failed fetch returns early. The
+		// next reconnect retries from the last message that the command emitted.
 		drained, drainErr := drainBacklog(ctx, agentID, cursor, drainFetch, emitMsg)
 		if drainErr != nil {
 			return drainErr

--- a/backend/internal/cli/control/cmd/agent_messages_follow_test.go
+++ b/backend/internal/cli/control/cmd/agent_messages_follow_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/cli/control/streamevents"
 )
@@ -399,9 +400,8 @@ func seqRange(n int) []int64 {
 	return out
 }
 
-// TestDrainBacklog_PagesUntilCaughtUp: a reconnect with a >50-message gap must
-// drain EVERY message in seq order across pages (not just the first 50 the capped
-// replay would deliver) and leave the cursor at the live tail.
+// TestDrainBacklog_PagesUntilCaughtUp verifies that a multi-page reconnect gap
+// drains every message in sequence order and leaves the cursor at the live tail.
 func TestDrainBacklog_PagesUntilCaughtUp(t *testing.T) {
 	cursor := streamevents.NewAgentCursor()
 	cursor.Track("a-1", 0)
@@ -411,7 +411,7 @@ func TestDrainBacklog_PagesUntilCaughtUp(t *testing.T) {
 		return nil
 	}
 
-	drained, err := drainBacklog(context.Background(), "a-1", cursor, pagingFetch(seqRange(120), followDrainPageLimit), emit)
+	drained, err := drainBacklog(context.Background(), "a-1", cursor, pagingFetch(seqRange(120), contracts.MessagePageLimit), emit)
 	require.NoError(t, err)
 	require.True(t, drained)
 
@@ -430,7 +430,7 @@ func TestDrainBacklog_ReportsWhetherItEmitted(t *testing.T) {
 		cursor := streamevents.NewAgentCursor()
 		cursor.Track("a-1", 0)
 		drained, err := drainBacklog(context.Background(), "a-1", cursor,
-			pagingFetch(seqRange(60), followDrainPageLimit), func(*leapmuxv1.AgentChatMessage) error { return nil })
+			pagingFetch(seqRange(60), contracts.MessagePageLimit), func(*leapmuxv1.AgentChatMessage) error { return nil })
 		require.NoError(t, err)
 		assert.True(t, drained, "a drain that emitted messages reports activity")
 	})
@@ -438,7 +438,7 @@ func TestDrainBacklog_ReportsWhetherItEmitted(t *testing.T) {
 		cursor := streamevents.NewAgentCursor()
 		cursor.Track("a-1", 60)
 		drained, err := drainBacklog(context.Background(), "a-1", cursor,
-			pagingFetch(seqRange(60), followDrainPageLimit), func(*leapmuxv1.AgentChatMessage) error { return nil })
+			pagingFetch(seqRange(60), contracts.MessagePageLimit), func(*leapmuxv1.AgentChatMessage) error { return nil })
 		require.NoError(t, err)
 		assert.False(t, drained, "a drain with nothing past the cursor reports no activity")
 	})
@@ -465,7 +465,7 @@ func TestDrainBacklog_DrainsOnlyPastCursor(t *testing.T) {
 		return nil
 	}
 
-	drained, err := drainBacklog(context.Background(), "a-1", cursor, pagingFetch(seqRange(120), followDrainPageLimit), emit)
+	drained, err := drainBacklog(context.Background(), "a-1", cursor, pagingFetch(seqRange(120), contracts.MessagePageLimit), emit)
 	require.NoError(t, err)
 	require.True(t, drained)
 
@@ -550,7 +550,7 @@ func TestDrainBacklog_ReturnsEmitError(t *testing.T) {
 	errWrite := errors.New("write failed")
 
 	drained, err := drainBacklog(context.Background(), "a-1", cursor,
-		pagingFetch([]int64{1, 2}, followDrainPageLimit),
+		pagingFetch([]int64{1, 2}, contracts.MessagePageLimit),
 		func(*leapmuxv1.AgentChatMessage) error { return errWrite },
 	)
 

--- a/backend/internal/cli/control/cmd/agent_messages_request_test.go
+++ b/backend/internal/cli/control/cmd/agent_messages_request_test.go
@@ -81,17 +81,19 @@ func TestListMessagesPageRequest(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("an over-range positive limit saturates instead of wrapping past the hub cap", func(t *testing.T) {
+	t.Run("an over-range positive limit saturates instead of wrapping past the worker cap", func(t *testing.T) {
 		// int32(math.MaxInt32+1) would wrap to a small/negative value that could
-		// slip past the hub's <=50 clamp; saturating keeps it out of [1,50].
+		// slip past the worker's page-limit clamp; saturating keeps it out of the
+		// valid page-limit range.
 		req, err := listMessagesPageRequest("a-1", "latest", 0, math.MaxInt32+1)
 		require.NoError(t, err)
 		assert.Equal(t, int32(math.MaxInt32), req.GetLimit())
 	})
 
-	t.Run("a non-positive limit is rejected, not silently clamped to the hub default", func(t *testing.T) {
-		// A zero/negative --limit would be silently clamped to 50 by the hub;
-		// reject it loudly so a typo fails the same way --cursor-seq and --anchor do.
+	t.Run("a non-positive limit is rejected, not silently clamped by the worker", func(t *testing.T) {
+		// The worker would silently clamp a zero/negative --limit to
+		// contracts.MessagePageLimit; reject it loudly so a typo fails the same
+		// way --cursor-seq and --anchor do.
 		_, err := listMessagesPageRequest("a-1", "latest", 0, 0)
 		require.Error(t, err)
 		_, err = listMessagesPageRequest("a-1", "latest", 0, -5)

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1271,8 +1271,15 @@ func (svc *Service) replayAgentCatchUp(
 	// Replay up to contracts.MessagePageLimit messages. AFTER_CURSOR and
 	// AFTER_CURSOR_OR_NONE use the forward page after cursor_seq. LATEST and
 	// UNSPECIFIED use the newest page. The capped mode skips the page when the
-	// browser will re-anchor instead.
-	if !shouldSkipCatchUpReplay(agentEntry.GetReplay(), agentEntry.GetCursorSeq(), replayStartTail) {
+	// browser will re-anchor instead. The skip measures the gap from the
+	// DECLARED window tail when the client sends one: the browser re-anchors on
+	// the gap from its loaded tail, and the resume cursor can lead that tail
+	// (frames observed but dropped while scrolled away).
+	skipGapBase := agentEntry.GetCursorSeq()
+	if agentEntry.WindowTailSeq != nil {
+		skipGapBase = agentEntry.GetWindowTailSeq()
+	}
+	if !shouldSkipCatchUpReplay(agentEntry.GetReplay(), agentEntry.GetCursorSeq(), skipGapBase, replayStartTail) {
 		replayAnchor := replayPageAnchor(agentEntry.GetReplay(), agentEntry.GetCursorSeq())
 		replayPlan := resolveMessagePage(replayAnchor, agentEntry.GetCursorSeq(), contracts.MessagePageLimit)
 		replayMessages, replayErr := svc.fetchMessagePageRows(bgCtx(), agentID, replayPlan.mode, replayPlan.bound, replayPlan.limit)
@@ -3423,7 +3430,9 @@ type messagePagePlan struct {
 // replayPageAnchor maps a WatchEvents resume (replay mode + cursor) to the
 // MessagePageAnchor that its replay query uses. Both cursor replay modes use
 // AFTER with a positive cursor. All other inputs use LATEST. Sequence values
-// start at 1, so a non-positive cursor does not identify a resume point.
+// start at 1, so a non-positive cursor does not identify a resume point. AFTER
+// with a non-positive cursor would scan seq > 0 and return the OLDEST page,
+// which splices the first messages in front of the latest window.
 func replayPageAnchor(replay leapmuxv1.WatchReplayMode, cursorSeq int64) leapmuxv1.MessagePageAnchor {
 	if cursorSeq > 0 && (replay == leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR ||
 		replay == leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE) {
@@ -3433,11 +3442,13 @@ func replayPageAnchor(replay leapmuxv1.WatchReplayMode, cursorSeq int64) leapmux
 }
 
 // shouldSkipCatchUpReplay reports whether a windowed client will discard the
-// replay page and re-anchor. An absent tail keeps the replay because the client
-// cannot calculate the gap or know that it must re-anchor.
-func shouldSkipCatchUpReplay(replay leapmuxv1.WatchReplayMode, cursorSeq int64, latestSeq *int64) bool {
+// replay page and re-anchor. skipGapBase is the seq the client measures the gap
+// from: its declared window tail, or the resume cursor when it declares none.
+// An absent tail keeps the replay because the client cannot calculate the gap
+// or know that it must re-anchor.
+func shouldSkipCatchUpReplay(replay leapmuxv1.WatchReplayMode, cursorSeq, skipGapBase int64, latestSeq *int64) bool {
 	return replay == leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE &&
-		cursorSeq > 0 && latestSeq != nil && *latestSeq-cursorSeq > contracts.CatchUpGapLimit
+		cursorSeq > 0 && latestSeq != nil && *latestSeq-skipGapBase > contracts.CatchUpGapLimit
 }
 
 // maxSeqOrNil reads the agent's live-tail seq on a background context, returning nil

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1201,7 +1201,7 @@ func (svc *Service) resolveChildRegistryRow(agentID string, sender channel.Respo
 }
 
 // replayAgentCatchUp replays one verified agent's catch-up burst to a freshly
-// (re)subscribed watcher: a CatchUpStart pre-trim marker, the bounded message replay,
+// (re)subscribed watcher: a CatchUpStart marker, an optional capped message replay,
 // the authoritative to-do snapshot, the status marker, pending control requests, and
 // the CatchUpComplete sentinel -- in that order. The CatchUpStart/CatchUpComplete
 // tail reads bracket the replay so a reconnecting client reaps only the
@@ -1268,40 +1268,32 @@ func (svc *Service) replayAgentCatchUp(
 		return
 	}
 
-	// Replay up to maxMessagePageLimit messages so a just-subscribed client
-	// has recent context. A RESUMING subscriber (replay == AFTER_CURSOR) gets
-	// the forward catch-up (seq > cursor_seq). A FRESH subscriber (LATEST, or
-	// UNSPECIFIED defaulting to it) gets the LATEST page, matching the
-	// windowing client's own initial latest-page load (ListAgentMessages
-	// LATEST) so the two dedup -- replaying the OLDEST page here instead would
-	// splice the first messages in front of the latest window and tear a gap
-	// into the loaded history.
-	// Route the resume mode through the SAME resolveMessagePage the paginated
-	// ListAgentMessages handler uses (replayPageAnchor picks the anchor, mirroring
-	// the client's AgentWatchEntry), rather than hand-rolling the query choice.
-	replayAnchor := replayPageAnchor(agentEntry.GetReplay(), agentEntry.GetCursorSeq())
-	replayPlan := resolveMessagePage(replayAnchor, agentEntry.GetCursorSeq(), maxMessagePageLimit)
-	replayMessages, replayErr := svc.fetchMessagePageRows(bgCtx(), agentID, replayPlan.mode, replayPlan.bound, replayPlan.limit)
-	// A LATEST plan comes back newest-first; reverse to ascending so the replay
-	// broadcasts oldest-to-newest like the forward path. (No has_more trim: the
-	// replay is a bounded best-effort burst, not a paginated read.)
-	if replayPlan.mode.descending() {
-		reverseMessages(replayMessages)
-	}
-	if replayErr != nil {
-		slog.Error("failed to list messages for replay", "agent_id", agentID, "error", replayErr)
-	} else {
-		for j := range replayMessages {
-			broadcastReplayAgentEvent(sink, &leapmuxv1.AgentEvent{
-				AgentId: agentID,
-				// No replayed flag: message seqs are monotonic (a deleted seq is
-				// never reused, see message_seq_hwm), so a live frame is ALWAYS
-				// at seq > the consumer's forwarded high-water and a plain
-				// seq <= cursor dedup drops only true replay duplicates.
-				Event: &leapmuxv1.AgentEvent_AgentMessage{
-					AgentMessage: messageToProto(&replayMessages[j]),
-				},
-			})
+	// Replay up to contracts.MessagePageLimit messages. AFTER_CURSOR and
+	// AFTER_CURSOR_OR_NONE use the forward page after cursor_seq. LATEST and
+	// UNSPECIFIED use the newest page. The capped mode skips the page when the
+	// browser will re-anchor instead.
+	if !shouldSkipCatchUpReplay(agentEntry.GetReplay(), agentEntry.GetCursorSeq(), replayStartTail) {
+		replayAnchor := replayPageAnchor(agentEntry.GetReplay(), agentEntry.GetCursorSeq())
+		replayPlan := resolveMessagePage(replayAnchor, agentEntry.GetCursorSeq(), contracts.MessagePageLimit)
+		replayMessages, replayErr := svc.fetchMessagePageRows(bgCtx(), agentID, replayPlan.mode, replayPlan.bound, replayPlan.limit)
+		// A LATEST plan returns newest-first. Reverse it so all replay modes send
+		// messages in ascending sequence order.
+		if replayPlan.mode.descending() {
+			reverseMessages(replayMessages)
+		}
+		if replayErr != nil {
+			slog.Error("failed to list messages for replay", "agent_id", agentID, "error", replayErr)
+		} else {
+			for j := range replayMessages {
+				broadcastReplayAgentEvent(sink, &leapmuxv1.AgentEvent{
+					AgentId: agentID,
+					// Sequence values increase monotonically. A deleted value stays
+					// unused, so cursor dedup removes only replay duplicates.
+					Event: &leapmuxv1.AgentEvent_AgentMessage{
+						AgentMessage: messageToProto(&replayMessages[j]),
+					},
+				})
+			}
 		}
 	}
 
@@ -3393,11 +3385,6 @@ func buildAgentControlRequest(agentID string, provider leapmuxv1.AgentProvider, 
 	}
 }
 
-// maxMessagePageLimit is the hub-enforced ceiling on a ListAgentMessages page
-// size: a request asking for more (or for a non-positive count) is clamped to
-// this. Mirrored in the proto doc comment and the CLI flag help.
-const maxMessagePageLimit = 50
-
 // messagePageMode is the DB scan resolveMessagePage selects for an anchor.
 type messagePageMode int
 
@@ -3434,19 +3421,23 @@ type messagePagePlan struct {
 }
 
 // replayPageAnchor maps a WatchEvents resume (replay mode + cursor) to the
-// MessagePageAnchor its replay query uses -- the worker-side mirror of the client's
-// AgentWatchEntry (which maps the resume cursor to the replay mode). AFTER_CURSOR with
-// a real (positive) cursor pages forward (AFTER seq > cursor); everything else -- a
-// fresh LATEST/UNSPECIFIED subscribe, OR an AFTER_CURSOR whose cursor is non-positive
-// (a malformed client: seqs are assigned from 1, so "after <= 0" specifies no resume
-// point) -- replays the LATEST page. Mapping a non-positive AFTER_CURSOR to AFTER
-// instead would scan seq > 0 and return the OLDEST page, splicing the first messages
-// in front of the latest window. Pure, so the routing is unit-testable.
+// MessagePageAnchor that its replay query uses. Both cursor replay modes use
+// AFTER with a positive cursor. All other inputs use LATEST. Sequence values
+// start at 1, so a non-positive cursor does not identify a resume point.
 func replayPageAnchor(replay leapmuxv1.WatchReplayMode, cursorSeq int64) leapmuxv1.MessagePageAnchor {
-	if replay == leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR && cursorSeq > 0 {
+	if cursorSeq > 0 && (replay == leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR ||
+		replay == leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE) {
 		return leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER
 	}
 	return leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_LATEST
+}
+
+// shouldSkipCatchUpReplay reports whether a windowed client will discard the
+// replay page and re-anchor. An absent tail keeps the replay because the client
+// cannot calculate the gap or know that it must re-anchor.
+func shouldSkipCatchUpReplay(replay leapmuxv1.WatchReplayMode, cursorSeq int64, latestSeq *int64) bool {
+	return replay == leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE &&
+		cursorSeq > 0 && latestSeq != nil && *latestSeq-cursorSeq > contracts.CatchUpGapLimit
 }
 
 // maxSeqOrNil reads the agent's live-tail seq on a background context, returning nil
@@ -3475,8 +3466,8 @@ func (svc *Service) maxSeqOrNil(agentID, logMsg string) *int64 {
 // malformed and clamps to 0; with bound 0 the natural boundary results hold
 // (AFTER returns from the oldest message, BEFORE returns empty).
 func resolveMessagePage(anchor leapmuxv1.MessagePageAnchor, cursorSeq, limit int64) messagePagePlan {
-	if limit <= 0 || limit > maxMessagePageLimit {
-		limit = maxMessagePageLimit
+	if limit <= 0 || limit > contracts.MessagePageLimit {
+		limit = contracts.MessagePageLimit
 	}
 	if cursorSeq < 0 {
 		cursorSeq = 0

--- a/backend/internal/worker/service/list_messages_plan_test.go
+++ b/backend/internal/worker/service/list_messages_plan_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
@@ -73,24 +74,24 @@ func TestResolveMessagePage(t *testing.T) {
 			want: messagePagePlan{mode: messagePageAscending, bound: 0, limit: 10}, wantReverse: false,
 		},
 		{
-			name:   "zero limit clamps to 50",
+			name:   "zero limit clamps to the page limit",
 			anchor: latest, cursorSeq: 0, limit: 0,
-			want: messagePagePlan{mode: messagePageLatest, bound: 0, limit: 50}, wantReverse: true,
+			want: messagePagePlan{mode: messagePageLatest, bound: 0, limit: contracts.MessagePageLimit}, wantReverse: true,
 		},
 		{
-			name:   "negative limit clamps to 50",
+			name:   "negative limit clamps to the page limit",
 			anchor: after, cursorSeq: 3, limit: -10,
-			want: messagePagePlan{mode: messagePageAscending, bound: 3, limit: 50}, wantReverse: false,
+			want: messagePagePlan{mode: messagePageAscending, bound: 3, limit: contracts.MessagePageLimit}, wantReverse: false,
 		},
 		{
-			name:   "over-cap limit clamps to 50",
+			name:   "over-cap limit clamps to the page limit",
 			anchor: after, cursorSeq: 3, limit: 1000,
-			want: messagePagePlan{mode: messagePageAscending, bound: 3, limit: 50}, wantReverse: false,
+			want: messagePagePlan{mode: messagePageAscending, bound: 3, limit: contracts.MessagePageLimit}, wantReverse: false,
 		},
 		{
 			name:   "limit at the cap is preserved",
-			anchor: after, cursorSeq: 3, limit: 50,
-			want: messagePagePlan{mode: messagePageAscending, bound: 3, limit: 50}, wantReverse: false,
+			anchor: after, cursorSeq: 3, limit: contracts.MessagePageLimit,
+			want: messagePagePlan{mode: messagePageAscending, bound: 3, limit: contracts.MessagePageLimit}, wantReverse: false,
 		},
 	}
 
@@ -116,11 +117,45 @@ func TestReplayPageAnchor(t *testing.T) {
 		after   = leapmuxv1.MessagePageAnchor_MESSAGE_PAGE_ANCHOR_AFTER
 		mLatest = leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_LATEST
 		mAfter  = leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR
+		mCapped = leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE
 		mUnspec = leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_UNSPECIFIED
 	)
 	assert.Equal(t, after, replayPageAnchor(mAfter, 5), "AFTER_CURSOR with a positive cursor pages forward")
+	assert.Equal(t, after, replayPageAnchor(mCapped, 5), "AFTER_CURSOR_OR_NONE with a positive cursor pages forward")
 	assert.Equal(t, latest, replayPageAnchor(mAfter, 0), "AFTER_CURSOR with cursor 0 falls back to LATEST")
+	assert.Equal(t, latest, replayPageAnchor(mCapped, 0), "AFTER_CURSOR_OR_NONE with cursor 0 falls back to LATEST")
 	assert.Equal(t, latest, replayPageAnchor(mAfter, -1), "AFTER_CURSOR with a negative cursor falls back to LATEST")
 	assert.Equal(t, latest, replayPageAnchor(mLatest, 99), "LATEST ignores the cursor")
 	assert.Equal(t, latest, replayPageAnchor(mUnspec, 99), "UNSPECIFIED defaults to LATEST")
+}
+
+func TestShouldSkipCatchUpReplay(t *testing.T) {
+	t.Parallel()
+
+	farTail := int64(10 + contracts.CatchUpGapLimit + 1)
+	atLimitTail := int64(10 + contracts.CatchUpGapLimit)
+	emptyTail := int64(0)
+	cases := []struct {
+		name      string
+		replay    leapmuxv1.WatchReplayMode
+		cursorSeq int64
+		latestSeq *int64
+		want      bool
+	}{
+		{"unspecified mode", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_UNSPECIFIED, 10, &farTail, false},
+		{"latest mode", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_LATEST, 10, &farTail, false},
+		{"after cursor mode", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR, 10, &farTail, false},
+		{"capped mode with cursor zero", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 0, &farTail, false},
+		{"capped mode with nil latest seq", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, nil, false},
+		{"capped mode with empty latest seq", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, &emptyTail, false},
+		{"capped mode at the limit", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, &atLimitTail, false},
+		{"capped mode one past the limit", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, &farTail, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, shouldSkipCatchUpReplay(tc.replay, tc.cursorSeq, tc.latestSeq))
+		})
+	}
 }

--- a/backend/internal/worker/service/list_messages_plan_test.go
+++ b/backend/internal/worker/service/list_messages_plan_test.go
@@ -135,27 +135,35 @@ func TestShouldSkipCatchUpReplay(t *testing.T) {
 	farTail := int64(10 + contracts.CatchUpGapLimit + 1)
 	atLimitTail := int64(10 + contracts.CatchUpGapLimit)
 	emptyTail := int64(0)
+	// A resume cursor that LEADS the loaded window tail (frames observed but
+	// dropped): the declared tail is the gap base, not the cursor.
+	leadingCursor := int64(40)
+	windowTail := int64(10)
 	cases := []struct {
-		name      string
-		replay    leapmuxv1.WatchReplayMode
-		cursorSeq int64
-		latestSeq *int64
-		want      bool
+		name        string
+		replay      leapmuxv1.WatchReplayMode
+		cursorSeq   int64
+		skipGapBase int64
+		latestSeq   *int64
+		want        bool
 	}{
-		{"unspecified mode", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_UNSPECIFIED, 10, &farTail, false},
-		{"latest mode", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_LATEST, 10, &farTail, false},
-		{"after cursor mode", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR, 10, &farTail, false},
-		{"capped mode with cursor zero", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 0, &farTail, false},
-		{"capped mode with nil latest seq", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, nil, false},
-		{"capped mode with empty latest seq", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, &emptyTail, false},
-		{"capped mode at the limit", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, &atLimitTail, false},
-		{"capped mode one past the limit", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, &farTail, true},
+		{"unspecified mode", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_UNSPECIFIED, 10, 10, &farTail, false},
+		{"latest mode", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_LATEST, 10, 10, &farTail, false},
+		{"after cursor mode", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR, 10, 10, &farTail, false},
+		{"capped mode with cursor zero", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 0, 10, &farTail, false},
+		{"capped mode with nil latest seq", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, 10, nil, false},
+		{"capped mode with empty latest seq", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, 10, &emptyTail, false},
+		{"capped mode at the limit", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, 10, &atLimitTail, false},
+		{"capped mode one past the limit", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 10, 10, &farTail, true},
+		{"capped mode skips on a window tail the cursor leads", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, leadingCursor, windowTail, &farTail, true},
+		{"capped mode replays when the window-tail gap fits", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, leadingCursor, windowTail, &atLimitTail, false},
+		{"capped mode with a declared empty window skips past the limit", leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE, 5, 0, &farTail, true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.want, shouldSkipCatchUpReplay(tc.replay, tc.cursorSeq, tc.latestSeq))
+			assert.Equal(t, tc.want, shouldSkipCatchUpReplay(tc.replay, tc.cursorSeq, tc.skipGapBase, tc.latestSeq))
 		})
 	}
 }

--- a/backend/internal/worker/service/watch_events.go
+++ b/backend/internal/worker/service/watch_events.go
@@ -16,10 +16,10 @@ import (
 // replaySink sends catch-up events to one subscriber and stops as soon
 // as the transport underneath it dies.
 //
-// The catch-up burst is by far the largest thing the worker sends: per
-// agent a CatchUpStart, up to maxMessagePageLimit messages, a todo
-// refresh, a status, every pending control request and a CatchUpComplete
-// -- then a screen snapshot and a status per terminal. Each send used to
+// The catch-up burst is the largest group that the worker sends. The worker sends
+// a CatchUpStart and up to contracts.MessagePageLimit messages for each agent.
+// It then sends a to-do refresh, a status, each pending control request, and a
+// CatchUpComplete. Each terminal gets a screen snapshot and a status. Each send used to
 // discard its error, so a client that dropped at the start of a page
 // refresh had the worker marshal, encrypt and hand every remaining event
 // to a transport that was already gone, and only the next LIVE broadcast

--- a/backend/internal/worker/service/watch_events_test.go
+++ b/backend/internal/worker/service/watch_events_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/leapmux/leapmux/generated/contracts"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/util/userid"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
@@ -421,6 +422,86 @@ func TestWatchEvents_PromoteNotifyToFullReplaysOnce(t *testing.T) {
 		return a.GetUpdateId() == 2
 	})
 	assert.Equal(t, 1, countCatchUpCompletes(w), "identical FULL restatement must not replay again")
+}
+
+func TestWatchEvents_PromoteWithCappedCursorReplay(t *testing.T) {
+	tests := []struct {
+		name             string
+		messageCount     int
+		wantReplayFrames int
+	}{
+		{
+			name:             "gap over limit skips message replay",
+			messageCount:     contracts.CatchUpGapLimit + 2,
+			wantReplayFrames: 0,
+		},
+		{
+			name:             "gap inside limit replays messages",
+			messageCount:     3,
+			wantReplayFrames: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			svc, d, w := setupTestService(t)
+			require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+				ID: "agent-1", WorkingDir: "/tmp", HomeDir: "/tmp",
+			}))
+
+			seqs := make([]int64, 0, tc.messageCount)
+			for i := range tc.messageCount {
+				seq, err := createMessageRow(ctx, svc.Queries, db.CreateMessageParams{
+					ID:            fmt.Sprintf("msg-%d", i+1),
+					AgentID:       "agent-1",
+					Source:        leapmuxv1.MessageSource_MESSAGE_SOURCE_USER,
+					Content:       []byte("hi"),
+					AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+				})
+				require.NoError(t, err)
+				seqs = append(seqs, seq)
+			}
+
+			dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+				Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "agent-1", Mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}},
+			}, w)
+			waitAgentWatchCount(t, svc, "agent-1", 1)
+
+			promote, err := proto.Marshal(&leapmuxv1.WatchEventsRequest{
+				UpdateId: 1,
+				Agents: []*leapmuxv1.WatchAgentEntry{{
+					AgentId:   "agent-1",
+					Mode:      leapmuxv1.WatchMode_WATCH_MODE_FULL,
+					Replay:    leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE,
+					CursorSeq: seqs[0],
+				}},
+			})
+			require.NoError(t, err)
+			w.deliverStreamRequest(promote, false)
+
+			require.Eventually(t, func() bool {
+				return countCatchUpCompletes(w) == 1
+			}, time.Second, 10*time.Millisecond, "promotion must finish its catch-up stages")
+
+			var start *leapmuxv1.CatchUpStart
+			replayed := 0
+			for _, event := range decodeAgentEvents(w) {
+				if event.GetCatchUpStart() != nil {
+					start = event.GetCatchUpStart()
+				}
+				if event.GetAgentMessage() != nil {
+					replayed++
+				}
+			}
+			require.NotNil(t, start)
+			require.NotNil(t, start.LatestSeq)
+			assert.Equal(t, seqs[len(seqs)-1], start.GetLatestSeq())
+			assert.Equal(t, tc.wantReplayFrames, replayed)
+		})
+	}
 }
 
 func TestWatchEvents_DemoteThenRepromoteReplaysAgain(t *testing.T) {

--- a/backend/internal/worker/service/watch_events_test.go
+++ b/backend/internal/worker/service/watch_events_test.go
@@ -426,19 +426,36 @@ func TestWatchEvents_PromoteNotifyToFullReplaysOnce(t *testing.T) {
 
 func TestWatchEvents_PromoteWithCappedCursorReplay(t *testing.T) {
 	tests := []struct {
-		name             string
-		messageCount     int
+		name         string
+		messageCount int
+		// cursorFromEnd picks the resume cursor by offset from the NEWEST seq
+		// (0 = oldest message); windowTailIdx (when >= 0) declares
+		// window_tail_seq at that message's seq.
+		cursorFromEnd    int
+		windowTailIdx    int
 		wantReplayFrames int
 	}{
 		{
 			name:             "gap over limit skips message replay",
 			messageCount:     contracts.CatchUpGapLimit + 2,
+			cursorFromEnd:    contracts.CatchUpGapLimit + 1,
 			wantReplayFrames: 0,
 		},
 		{
 			name:             "gap inside limit replays messages",
 			messageCount:     3,
+			cursorFromEnd:    2,
 			wantReplayFrames: 2,
+		},
+		{
+			// The cursor LEADS the declared window tail: the cursor gap fits
+			// the limit (so the fallback base would replay), but the
+			// window-tail gap exceeds it, so the declared base must skip.
+			name:             "declared window tail skips when the cursor leads it past the limit",
+			messageCount:     contracts.CatchUpGapLimit + 2,
+			cursorFromEnd:    10,
+			windowTailIdx:    0,
+			wantReplayFrames: 0,
 		},
 	}
 
@@ -476,13 +493,18 @@ func TestWatchEvents_PromoteWithCappedCursorReplay(t *testing.T) {
 			}, w)
 			waitAgentWatchCount(t, svc, "agent-1", 1)
 
+			var windowTail *int64
+			if tc.windowTailIdx >= 0 {
+				windowTail = &seqs[tc.windowTailIdx]
+			}
 			promote, err := proto.Marshal(&leapmuxv1.WatchEventsRequest{
 				UpdateId: 1,
 				Agents: []*leapmuxv1.WatchAgentEntry{{
-					AgentId:   "agent-1",
-					Mode:      leapmuxv1.WatchMode_WATCH_MODE_FULL,
-					Replay:    leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE,
-					CursorSeq: seqs[0],
+					AgentId:       "agent-1",
+					Mode:          leapmuxv1.WatchMode_WATCH_MODE_FULL,
+					Replay:        leapmuxv1.WatchReplayMode_WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE,
+					CursorSeq:     seqs[len(seqs)-1-tc.cursorFromEnd],
+					WindowTailSeq: windowTail,
 				}},
 			})
 			require.NoError(t, err)

--- a/backend/internal/worker/service/watch_events_test.go
+++ b/backend/internal/worker/service/watch_events_test.go
@@ -464,6 +464,12 @@ func TestWatchEvents_PromoteWithCappedCursorReplay(t *testing.T) {
 				require.NoError(t, err)
 				seqs = append(seqs, seq)
 			}
+			require.NoError(t, svc.Queries.CreateControlRequest(ctx, db.CreateControlRequestParams{
+				AgentID:    "agent-1",
+				RequestID:  "request-1",
+				Payload:    []byte(`{"type":"permission","id":"request-1"}`),
+				ClaimToken: "instance-token-1",
+			}))
 
 			dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
 				Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "agent-1", Mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}},
@@ -488,6 +494,10 @@ func TestWatchEvents_PromoteWithCappedCursorReplay(t *testing.T) {
 
 			var start *leapmuxv1.CatchUpStart
 			replayed := 0
+			sawActivity := false
+			sawTodos := false
+			sawStatus := false
+			sawControl := false
 			for _, event := range decodeAgentEvents(w) {
 				if event.GetCatchUpStart() != nil {
 					start = event.GetCatchUpStart()
@@ -495,11 +505,19 @@ func TestWatchEvents_PromoteWithCappedCursorReplay(t *testing.T) {
 				if event.GetAgentMessage() != nil {
 					replayed++
 				}
+				sawActivity = sawActivity || event.GetActivityChanged() != nil
+				sawTodos = sawTodos || event.GetTodosChanged() != nil
+				sawStatus = sawStatus || event.GetStatusChange() != nil
+				sawControl = sawControl || event.GetControlRequest() != nil
 			}
 			require.NotNil(t, start)
 			require.NotNil(t, start.LatestSeq)
 			assert.Equal(t, seqs[len(seqs)-1], start.GetLatestSeq())
 			assert.Equal(t, tc.wantReplayFrames, replayed)
+			assert.True(t, sawActivity, "the replay decision must not skip the activity snapshot")
+			assert.True(t, sawTodos, "the replay decision must not skip the to-do snapshot")
+			assert.True(t, sawStatus, "the replay decision must not skip the status marker")
+			assert.True(t, sawControl, "the replay decision must not skip pending control requests")
 		})
 	}
 }

--- a/contracts/chat-history.json
+++ b/contracts/chat-history.json
@@ -1,5 +1,5 @@
 {
-  "_readme": "Chat history limits consumed by the Go programs and the TypeScript browser. messagePageLimit caps one history page. catchUpGapLimit sets the largest sequence gap that the browser drains before it re-anchors on the newest page. The gap limit matches the browser's live-tail window because older drained messages do not remain in that window.",
+  "_readme": "Chat history limits consumed by the Go programs and the TypeScript browser. messagePageLimit caps one history page. catchUpGapLimit sets the largest sequence gap that the browser drains before it re-anchors on the newest page. The gap limit matches the browser's live-tail window because older drained messages do not remain in that window. The gap counts sequence distance, not rows: a sequence that a delete or a notification-thread reseq frees still counts toward the gap even when no loadable row sits there, so a hole-heavy gap can re-anchor the window where a one-page drain would also close it.",
   "messagePageLimit": 50,
   "catchUpGapLimit": 150
 }

--- a/contracts/chat-history.json
+++ b/contracts/chat-history.json
@@ -1,0 +1,5 @@
+{
+  "_readme": "Chat history limits consumed by the Go programs and the TypeScript browser. messagePageLimit caps one history page. catchUpGapLimit sets the largest sequence gap that the browser drains before it re-anchors on the newest page. The gap limit matches the browser's live-tail window because older drained messages do not remain in that window.",
+  "messagePageLimit": 50,
+  "catchUpGapLimit": 150
+}

--- a/contracts/chat-history.schema.json
+++ b/contracts/chat-history.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "chat-history.schema.json",
+  "title": "cross-language chat history limit contract",
+  "description": "Limits for history pages and browser catch-up gaps.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["_readme", "messagePageLimit", "catchUpGapLimit"],
+  "properties": {
+    "_readme": { "type": "string", "minLength": 1 },
+    "messagePageLimit": { "type": "integer", "minimum": 1 },
+    "catchUpGapLimit": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/frontend/src/hooks/useWorkspaceConnection.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.test.ts
@@ -1,4 +1,4 @@
-import type { AgentControlRequest, AgentStatusChange, AgentStreamChunk, AgentStreamEnd, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
+import type { AgentChatMessage, AgentControlRequest, AgentStatusChange, AgentStreamChunk, AgentStreamEnd, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { TerminalStatusChange } from '~/generated/proto/leapmux/v1/terminal_pb'
 import type { AgentTab, Tab, TerminalTab } from '~/stores/tab.types'
 import { createRoot, mapArray } from 'solid-js'
@@ -1754,12 +1754,12 @@ describe('reconcileLaggingTails', () => {
     expect(resume).toEqual([])
   })
 
-  it('re-seats an EMPTY window (a full phantom reap) on the latest page instead of forward-filling', () => {
+  it('re-anchors an EMPTY window (a full phantom reap) on the latest page instead of forward-filling', () => {
     const { catchUp, resume, jumps } = run({
       agentTabs: [{ id: 'emptied', workerId: 'w1' }],
       // Not caught up (server content survives), but the loaded window is empty (getLastSeq
       // 0n) -- a full phantom reap dropped every loaded row. There's no anchor to
-      // forward-fill from, so re-seat on the latest page.
+      // forward-fill from, so re-anchor on the latest page.
       caughtUpToLiveTail: () => false,
       getLastSeq: () => 0n,
     })
@@ -1768,7 +1768,7 @@ describe('reconcileLaggingTails', () => {
     expect(resume).toEqual([])
   })
 
-  it('does NOT re-issue the empty-window re-seat while a newer fetch is already in flight', () => {
+  it('does NOT re-issue the empty-window re-anchor while a newer fetch is already in flight', () => {
     const { jumps } = run({
       agentTabs: [{ id: 'emptied', workerId: 'w1' }],
       caughtUpToLiveTail: () => false,
@@ -1778,7 +1778,7 @@ describe('reconcileLaggingTails', () => {
     expect(jumps).toEqual([]) // guarded so the reconcile tick doesn't abort + restart it
   })
 
-  it('re-seats on the latest page when the live-tail gap exceeds the limit', () => {
+  it('re-anchors on the latest page when the live-tail gap exceeds the limit', () => {
     const { catchUp, resume, jumps } = run({
       agentTabs: [{ id: 'lagging', workerId: 'w1' }],
       caughtUpToLiveTail: () => false,
@@ -1814,7 +1814,7 @@ describe('reconcileLaggingTails', () => {
     expect(resume).toEqual([])
   })
 
-  it('re-seats an over-limit deferred gap instead of resuming the fill', () => {
+  it('re-anchors an over-limit deferred gap instead of resuming the fill', () => {
     const { catchUp, resume, jumps } = run({
       agentTabs: [{ id: 'deferred', workerId: 'w1' }],
       hasNewerMessages: () => true,
@@ -1824,6 +1824,23 @@ describe('reconcileLaggingTails', () => {
       getLiveTailSeq: () => 10n + CATCH_UP_GAP_LIMIT + 1n,
     })
     expect(jumps).toEqual([{ workerId: 'w1', agentId: 'deferred' }])
+    expect(catchUp).toEqual([])
+    expect(resume).toEqual([])
+  })
+
+  it('does nothing for an over-limit gap on a plain scrolled-away wall', () => {
+    // The reader chose this gap (hasNewerMessages, no deferred fill). An
+    // over-limit re-anchor must not yank them to the bottom: scroll-down
+    // paging recovers the tail on their own schedule.
+    const { catchUp, resume, jumps } = run({
+      agentTabs: [{ id: 'scrolled-away', workerId: 'w1' }],
+      hasNewerMessages: () => true,
+      caughtUpToLiveTail: () => false,
+      isTailFillDeferred: () => false,
+      getLastSeq: () => 10n,
+      getLiveTailSeq: () => 10n + CATCH_UP_GAP_LIMIT + 1n,
+    })
+    expect(jumps).toEqual([])
     expect(catchUp).toEqual([])
     expect(resume).toEqual([])
   })
@@ -2741,6 +2758,47 @@ describe('useWorkspaceConnection chat history load', () => {
     const dispose = mountWithActiveAgent(refusal)
     try {
       await settle()
+      expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to load chat history', refusal)
+    }
+    finally {
+      dispose()
+    }
+  })
+
+  it('announces a failed reconcile-driven re-anchor instead of leaving it unhandled', async () => {
+    // A loaded window whose recorded live tail sits past the catch-up limit:
+    // the reconcile tick re-anchors via jumpToLatestMessages, whose LATEST
+    // fetch rejects. The wiring must catch it and show the same toast -- the
+    // voided promise would otherwise surface as one unhandled rejection per
+    // retry cycle.
+    mockShowWarnToast.mockClear()
+    const refusal = new ChannelError('rpc', 'agent not found', { code: 5 })
+    vi.mocked(workerRpc.listAgentMessages).mockRejectedValue(refusal)
+    const tabs = makeTabStores()
+    tabs.addAgent('a1', { workerId: 'w1' })
+    let dispose!: () => void
+    createRoot((d) => {
+      dispose = d
+      const chatStore = createChatStore()
+      chatStore.setMessages('a1', [{ seq: 10n, id: 'm10', source: MessageSource.AGENT } as AgentChatMessage])
+      chatStore.liveTail.bump('a1', 10n + CATCH_UP_GAP_LIMIT + 1n)
+      useWorkspaceConnection({
+        chatStore,
+        agentInputQueueStore: createAgentInputQueueStore(),
+        view: tabs.view,
+        metadata: tabs.metadata,
+        selection: tabs.selection,
+        controlStore: createControlStore(),
+        agentSessionStore: createAgentSessionStore(),
+        agentActivityStore: createAgentActivityStore(),
+        repoGitStore: createRepoGitStore(),
+        settingsLoading: createLoadingSignal(),
+        getActiveWorkspaceId: () => WS,
+      })
+    })
+    try {
+      await settle()
+      expect(workerRpc.listAgentMessages, 'the re-anchor has to have been attempted').toHaveBeenCalled()
       expect(mockShowWarnToast).toHaveBeenCalledWith('Failed to load chat history', refusal)
     }
     finally {

--- a/frontend/src/hooks/useWorkspaceConnection.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.test.ts
@@ -4,14 +4,14 @@ import type { AgentTab, Tab, TerminalTab } from '~/stores/tab.types'
 import { createRoot, mapArray } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import * as workerRpc from '~/api/workerRpc'
-import { AgentActivityState, AgentProvider, AgentStatus, ContentCompression, MessageSource, WatchReplayMode } from '~/generated/proto/leapmux/v1/agent_pb'
+import { CATCH_UP_GAP_LIMIT } from '~/generated/contracts/chat-history'
+import { AgentActivityState, AgentProvider, AgentStatus, ContentCompression, MessageSource } from '~/generated/proto/leapmux/v1/agent_pb'
 import { TerminalStatus } from '~/generated/proto/leapmux/v1/terminal_pb'
-import { TabType, WatchMode } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { applyAgentLifecycle, applyNotificationMetadata, applyPendingAxisSuppression, buildAgentStatusTabUpdate, clearCompletedSpanStream, handleActivityChanged, handleAgentInactive, handleAgentMessage, handleAgentSessionInfo, handleAgentSettled, handleAgentStatusChange, handleControlRequest, handleResultDivider, handleStreamChunk, handleStreamEnd, resolveSettingsTabFields, shouldClearThinkingTokensForMessage, wireSessionInfoToUpdates } from '~/hooks/agentEvents'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { applyTerminalStatusChange, handleTerminalBell, handleTerminalNotification, handleTerminalProgress, handleTerminalTitleChanged } from '~/hooks/terminalEvents'
 import { clearOfflineAgentState, collectWorkerOfflineTargets, enqueuePendingTerminalData, MAX_PENDING_TERMINAL_FRAMES, reconcileLaggingTails, useWorkspaceConnection } from '~/hooks/useWorkspaceConnection'
-import { agentWatchEntry, watchPlanKey } from '~/hooks/watchPlan'
 import { ChannelError, channelNotOpenError } from '~/lib/channelError'
 import { extractCompactionContextTokens, parseMessageContent } from '~/lib/messageParser'
 import { createAgentActivityStore } from '~/stores/agentActivity.store'
@@ -119,29 +119,6 @@ type TabStores = ReturnType<typeof makeTabStores>
 function simulatePhase(phase: 'catchingUp' | 'live'): 'catchingUp' | 'live' {
   return phase
 }
-
-describe('watch plan helpers', () => {
-  it('maps resume cursors to explicit replay modes', () => {
-    expect(agentWatchEntry('a1', 0n, WatchMode.FULL)).toMatchObject({
-      agentId: 'a1',
-      replay: WatchReplayMode.LATEST,
-      cursorSeq: 0n,
-      mode: WatchMode.FULL,
-    })
-    expect(agentWatchEntry('a1', 42n, WatchMode.NOTIFY)).toMatchObject({
-      agentId: 'a1',
-      replay: WatchReplayMode.AFTER_CURSOR,
-      cursorSeq: 42n,
-      mode: WatchMode.NOTIFY,
-    })
-  })
-
-  it('watchPlanKey moves when a mode changes', () => {
-    const notify = { agents: [{ agentId: 'a1', mode: WatchMode.NOTIFY } as never], terminals: [] as never[], terminalResync: new Set<string>() }
-    const full = { agents: [{ agentId: 'a1', mode: WatchMode.FULL } as never], terminals: [] as never[], terminalResync: new Set<string>() }
-    expect(watchPlanKey(notify)).not.toBe(watchPlanKey(full))
-  })
-})
 
 /**
  * These tests verify the control-request guard in useWorkspaceConnection's
@@ -1686,6 +1663,7 @@ describe('reconcileLaggingTails', () => {
     caughtUpToLiveTail?: (id: string) => boolean
     isTailFillDeferred?: (id: string) => boolean
     getLastSeq?: (id: string) => bigint
+    getLiveTailSeq?: (id: string) => bigint
     isFetchingNewer?: (id: string) => boolean
   }) {
     const catchUp: Array<{ workerId: string, agentId: string, afterSeq: bigint }> = []
@@ -1699,6 +1677,7 @@ describe('reconcileLaggingTails', () => {
       // Default to a NON-empty loaded window (1n); the empty-window (0n) recovery branch
       // is exercised explicitly by its own test.
       getLastSeq: overrides.getLastSeq ?? (() => 1n),
+      getLiveTailSeq: overrides.getLiveTailSeq ?? (() => 1n),
       isFetchingNewer: overrides.isFetchingNewer ?? (() => false),
       catchUpToTail: (workerId, agentId, afterSeq) => catchUp.push({ workerId, agentId, afterSeq }),
       resumeDeferredTailFill: (workerId, agentId) => resume.push({ workerId, agentId }),
@@ -1797,6 +1776,68 @@ describe('reconcileLaggingTails', () => {
       isFetchingNewer: () => true, // jumpToLatest's own fetch is resolving
     })
     expect(jumps).toEqual([]) // guarded so the reconcile tick doesn't abort + restart it
+  })
+
+  it('re-seats on the latest page when the live-tail gap exceeds the limit', () => {
+    const { catchUp, resume, jumps } = run({
+      agentTabs: [{ id: 'lagging', workerId: 'w1' }],
+      caughtUpToLiveTail: () => false,
+      getLastSeq: () => 10n,
+      getLiveTailSeq: () => 10n + CATCH_UP_GAP_LIMIT + 1n,
+    })
+    expect(jumps).toEqual([{ workerId: 'w1', agentId: 'lagging' }])
+    expect(catchUp).toEqual([])
+    expect(resume).toEqual([])
+  })
+
+  it('drains a live-tail gap at the inclusive limit', () => {
+    const { catchUp, jumps } = run({
+      agentTabs: [{ id: 'lagging', workerId: 'w1' }],
+      caughtUpToLiveTail: () => false,
+      getLastSeq: () => 10n,
+      getLiveTailSeq: () => 10n + CATCH_UP_GAP_LIMIT,
+    })
+    expect(catchUp).toEqual([{ workerId: 'w1', agentId: 'lagging', afterSeq: 10n }])
+    expect(jumps).toEqual([])
+  })
+
+  it('does nothing for an over-limit gap while a newer fetch runs', () => {
+    const { catchUp, resume, jumps } = run({
+      agentTabs: [{ id: 'lagging', workerId: 'w1' }],
+      caughtUpToLiveTail: () => false,
+      getLastSeq: () => 10n,
+      getLiveTailSeq: () => 10n + CATCH_UP_GAP_LIMIT + 1n,
+      isFetchingNewer: () => true,
+    })
+    expect(jumps).toEqual([])
+    expect(catchUp).toEqual([])
+    expect(resume).toEqual([])
+  })
+
+  it('re-seats an over-limit deferred gap instead of resuming the fill', () => {
+    const { catchUp, resume, jumps } = run({
+      agentTabs: [{ id: 'deferred', workerId: 'w1' }],
+      hasNewerMessages: () => true,
+      caughtUpToLiveTail: () => false,
+      isTailFillDeferred: () => true,
+      getLastSeq: () => 10n,
+      getLiveTailSeq: () => 10n + CATCH_UP_GAP_LIMIT + 1n,
+    })
+    expect(jumps).toEqual([{ workerId: 'w1', agentId: 'deferred' }])
+    expect(catchUp).toEqual([])
+    expect(resume).toEqual([])
+  })
+
+  it('does nothing for a caught-up tab', () => {
+    const { catchUp, resume, jumps } = run({
+      agentTabs: [{ id: 'caught-up', workerId: 'w1' }],
+      caughtUpToLiveTail: () => true,
+      getLastSeq: () => 10n,
+      getLiveTailSeq: () => 10n,
+    })
+    expect(jumps).toEqual([])
+    expect(catchUp).toEqual([])
+    expect(resume).toEqual([])
   })
 })
 

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -14,6 +14,7 @@ import type { TabView } from '~/stores/tabView'
 import { batch, createEffect, createMemo, createSignal, onCleanup, untrack } from 'solid-js'
 import { showWarnToastUnlessDisconnected } from '~/components/common/Toast'
 import { addTerminalInstanceReadyListener, getTerminalInstance } from '~/components/terminal/TerminalView'
+import { CATCH_UP_GAP_LIMIT } from '~/generated/contracts/chat-history'
 import { AgentStatus } from '~/generated/proto/leapmux/v1/agent_pb'
 import { TerminalStatus } from '~/generated/proto/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
@@ -154,6 +155,7 @@ export function reconcileLaggingTails(deps: {
   caughtUpToLiveTail: (agentId: string) => boolean
   isTailFillDeferred: (agentId: string) => boolean
   getLastSeq: (agentId: string) => bigint
+  getLiveTailSeq: (agentId: string) => bigint
   isFetchingNewer: (agentId: string) => boolean
   catchUpToTail: (workerId: string, agentId: string, afterSeq: bigint) => void
   resumeDeferredTailFill: (workerId: string, agentId: string) => void
@@ -162,18 +164,24 @@ export function reconcileLaggingTails(deps: {
   for (const tab of deps.agentTabs()) {
     if (!tab.workerId)
       continue
-    const atTail = !deps.hasNewerMessages(tab.id)
     const caughtUp = deps.caughtUpToLiveTail(tab.id)
-    const deferred = deps.isTailFillDeferred(tab.id)
     if (caughtUp)
       continue
-    if (deps.getLastSeq(tab.id) === 0n) {
+    const lastSeq = deps.getLastSeq(tab.id)
+    if (lastSeq === 0n) {
       if (!deps.isFetchingNewer(tab.id))
         deps.jumpToLatest(tab.workerId, tab.id)
       continue
     }
+    if (deps.getLiveTailSeq(tab.id) - lastSeq > CATCH_UP_GAP_LIMIT) {
+      if (!deps.isFetchingNewer(tab.id))
+        deps.jumpToLatest(tab.workerId, tab.id)
+      continue
+    }
+    const atTail = !deps.hasNewerMessages(tab.id)
+    const deferred = deps.isTailFillDeferred(tab.id)
     if (atTail)
-      deps.catchUpToTail(tab.workerId, tab.id, deps.getLastSeq(tab.id))
+      deps.catchUpToTail(tab.workerId, tab.id, lastSeq)
     else if (deferred)
       deps.resumeDeferredTailFill(tab.workerId, tab.id)
   }
@@ -609,6 +617,7 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
     caughtUpToLiveTail: id => chatStore.caughtUpToLiveTail(id),
     isTailFillDeferred: id => chatStore.isTailFillDeferred(id),
     getLastSeq: id => chatStore.getLastSeq(id),
+    getLiveTailSeq: id => chatStore.liveTail.get(id),
     isFetchingNewer: id => chatStore.isFetchingNewer(id),
     catchUpToTail: (workerId, agentId, afterSeq) => {
       void chatStore.catchUpToTail(workerId, agentId, afterSeq, abortSignalFor(workerId)).catch(warnChatHistoryLoadFailed)

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -14,11 +14,11 @@ import type { TabView } from '~/stores/tabView'
 import { batch, createEffect, createMemo, createSignal, onCleanup, untrack } from 'solid-js'
 import { showWarnToastUnlessDisconnected } from '~/components/common/Toast'
 import { addTerminalInstanceReadyListener, getTerminalInstance } from '~/components/terminal/TerminalView'
-import { CATCH_UP_GAP_LIMIT } from '~/generated/contracts/chat-history'
 import { AgentStatus } from '~/generated/proto/leapmux/v1/agent_pb'
 import { TerminalStatus } from '~/generated/proto/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { applyTerminalData, bufferHasVisibleContent } from '~/lib/terminal'
+import { exceedsCatchUpGapLimit } from '~/stores/chatLiveTail'
 import { parseTabKey } from '~/stores/tab.helpers'
 import {
   clearPerTurnLiveState,
@@ -168,18 +168,18 @@ export function reconcileLaggingTails(deps: {
     if (caughtUp)
       continue
     const lastSeq = deps.getLastSeq(tab.id)
-    if (lastSeq === 0n) {
-      if (!deps.isFetchingNewer(tab.id))
-        deps.jumpToLatest(tab.workerId, tab.id)
-      continue
-    }
-    if (deps.getLiveTailSeq(tab.id) - lastSeq > CATCH_UP_GAP_LIMIT) {
-      if (!deps.isFetchingNewer(tab.id))
-        deps.jumpToLatest(tab.workerId, tab.id)
-      continue
-    }
     const atTail = !deps.hasNewerMessages(tab.id)
     const deferred = deps.isTailFillDeferred(tab.id)
+    // Re-anchor when forward-fill cannot reach the tail: an empty window, or a
+    // gap beyond the catch-up limit. The drain abandons a gap that large, so
+    // the window re-anchors on the newest page. A deferred tail fill cannot
+    // cross a gap that large either. A plain scrolled-away wall keeps its
+    // window: the reader chose that gap, and scroll-down paging recovers it.
+    if (lastSeq === 0n || (exceedsCatchUpGapLimit(deps.getLiveTailSeq(tab.id), lastSeq) && (atTail || deferred))) {
+      if (!deps.isFetchingNewer(tab.id))
+        deps.jumpToLatest(tab.workerId, tab.id)
+      continue
+    }
     if (atTail)
       deps.catchUpToTail(tab.workerId, tab.id, lastSeq)
     else if (deferred)
@@ -287,6 +287,10 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
       params.getActiveWorkspaceId(),
       tileId => selection.activeKeyForTile(tileId),
       agentId => untrack(() => chatStore.getResumeAfterSeq(agentId)),
+      // Untracked like the resume seq: the loaded tail moves with every message,
+      // and the plan must not re-send a watch update per arrival. The worker
+      // reads it only for the capped-replay skip decision.
+      agentId => untrack(() => chatStore.getLastSeq(agentId)),
       terminalId => untrack(() => metadata.get(terminalId)?.lastOffset ?? 0),
       // Tracked on purpose: the plan must go out the moment a terminal is
       // flagged, and back out when the snapshot lands. Only this field is
@@ -623,10 +627,10 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
       void chatStore.catchUpToTail(workerId, agentId, afterSeq, abortSignalFor(workerId)).catch(warnChatHistoryLoadFailed)
     },
     resumeDeferredTailFill: (workerId, agentId) => {
-      void chatStore.resumeDeferredTailFill(workerId, agentId, abortSignalFor(workerId))
+      void chatStore.resumeDeferredTailFill(workerId, agentId, abortSignalFor(workerId)).catch(warnChatHistoryLoadFailed)
     },
     jumpToLatest: (workerId, agentId) => {
-      void chatStore.jumpToLatestMessages(workerId, agentId, abortSignalFor(workerId))
+      void chatStore.jumpToLatestMessages(workerId, agentId, abortSignalFor(workerId)).catch(warnChatHistoryLoadFailed)
     },
   }))
 

--- a/frontend/src/hooks/watchPlan.test.ts
+++ b/frontend/src/hooks/watchPlan.test.ts
@@ -12,22 +12,32 @@ import {
 } from './watchPlan'
 
 describe('agentWatchEntry', () => {
-  it('uses AFTER_CURSOR_OR_NONE for a positive resume sequence', () => {
-    expect(agentWatchEntry('a1', 42n, WatchMode.FULL)).toMatchObject({
+  it('uses AFTER_CURSOR_OR_NONE and declares the loaded window tail for a positive resume sequence', () => {
+    expect(agentWatchEntry('a1', 42n, 30n, WatchMode.FULL)).toMatchObject({
       agentId: 'a1',
       replay: WatchReplayMode.AFTER_CURSOR_OR_NONE,
       cursorSeq: 42n,
+      windowTailSeq: 30n,
       mode: WatchMode.FULL,
     })
   })
 
-  it('uses LATEST with cursor zero for a cold entry', () => {
-    expect(agentWatchEntry('a1', 0n, WatchMode.FULL)).toMatchObject({
+  it('declares window tail zero on resume: an empty window re-anchors past the limit', () => {
+    expect(agentWatchEntry('a1', 42n, 0n, WatchMode.FULL)).toMatchObject({
+      replay: WatchReplayMode.AFTER_CURSOR_OR_NONE,
+      cursorSeq: 42n,
+      windowTailSeq: 0n,
+    })
+  })
+
+  it('uses LATEST with cursor zero and no window tail for a cold entry', () => {
+    expect(agentWatchEntry('a1', 0n, 30n, WatchMode.FULL)).toMatchObject({
       agentId: 'a1',
       replay: WatchReplayMode.LATEST,
       cursorSeq: 0n,
       mode: WatchMode.FULL,
     })
+    expect(agentWatchEntry('a1', 0n, 30n, WatchMode.FULL)).not.toHaveProperty('windowTailSeq')
   })
 })
 
@@ -159,7 +169,7 @@ describe('buildWatchPlans', () => {
     }
     const getAgentTab = (id: string): AgentTab | undefined =>
       tabs.find(t => t.id === id) as AgentTab | undefined
-    const plans = buildWatchPlans(tabs, 'ws-1', activeKey, () => 0n, () => 0, () => false, getAgentTab)
+    const plans = buildWatchPlans(tabs, 'ws-1', activeKey, () => 0n, () => 0n, () => 0, () => false, getAgentTab)
     const agentIds = plans.get('w1')!.agents.map(a => ({ id: a.agentId, mode: a.mode }))
     // root-1 appears twice (its own FULL + the child-driven NOTIFY). The dedup
     // keeps it to one entry — the root's own tab already placed it.
@@ -179,7 +189,7 @@ describe('buildWatchPlans', () => {
         return { ...child, id: 'root-1', parentAgentId: undefined } as AgentTab
       return undefined
     }
-    const plans = buildWatchPlans([child], 'ws-1', () => '1:child-1', () => 0n, () => 0, () => false, getAgentTab)
+    const plans = buildWatchPlans([child], 'ws-1', () => '1:child-1', () => 0n, () => 0n, () => 0, () => false, getAgentTab)
     const agentIds = plans.get('w1')!.agents.map(a => ({ id: a.agentId, mode: a.mode }))
     // The child's own entry + a NOTIFY root entry.
     expect(agentIds).toContainEqual({ id: 'child-1', mode: WatchMode.FULL })
@@ -203,7 +213,7 @@ describe('buildWatchPlans', () => {
         return { type: TabType.AGENT, id: 'root-1' } as AgentTab
       return tabs.find(t => t.id === id) as AgentTab | undefined
     }
-    const plans = buildWatchPlans(tabs, 'ws-1', activeKey, () => 0n, () => 0, () => false, getAgentTab)
+    const plans = buildWatchPlans(tabs, 'ws-1', activeKey, () => 0n, () => 0n, () => 0, () => false, getAgentTab)
     const rootEntries = plans.get('w1')!.agents.filter(a => a.agentId === 'root-1')
     expect(rootEntries).toHaveLength(1)
     expect(rootEntries[0].mode).toBe(WatchMode.NOTIFY)
@@ -261,6 +271,7 @@ describe('terminal resync plans', () => {
       [tab],
       'ws-1',
       () => '1:t1',
+      () => 0n,
       () => 0n,
       () => 400,
       () => true,

--- a/frontend/src/hooks/watchPlan.test.ts
+++ b/frontend/src/hooks/watchPlan.test.ts
@@ -1,13 +1,35 @@
 import type { AgentTab, Tab } from '~/stores/tab.types'
 import { describe, expect, it } from 'vitest'
+import { WatchReplayMode } from '~/generated/proto/leapmux/v1/agent_pb'
 import { TabType, WatchMode, WatchRejectionReason } from '~/generated/proto/leapmux/v1/workspace_pb'
 import {
+  agentWatchEntry,
   buildWatchPlans,
   isTabOnScreen,
   shouldRetryRejection,
   tabWatchMode,
   watchPlanKey,
 } from './watchPlan'
+
+describe('agentWatchEntry', () => {
+  it('uses AFTER_CURSOR_OR_NONE for a positive resume sequence', () => {
+    expect(agentWatchEntry('a1', 42n, WatchMode.FULL)).toMatchObject({
+      agentId: 'a1',
+      replay: WatchReplayMode.AFTER_CURSOR_OR_NONE,
+      cursorSeq: 42n,
+      mode: WatchMode.FULL,
+    })
+  })
+
+  it('uses LATEST with cursor zero for a cold entry', () => {
+    expect(agentWatchEntry('a1', 0n, WatchMode.FULL)).toMatchObject({
+      agentId: 'a1',
+      replay: WatchReplayMode.LATEST,
+      cursorSeq: 0n,
+      mode: WatchMode.FULL,
+    })
+  })
+})
 
 function agent(overrides: Partial<Extract<Tab, { type: TabType.AGENT }>> = {}): Tab {
   return {

--- a/frontend/src/hooks/watchPlan.ts
+++ b/frontend/src/hooks/watchPlan.ts
@@ -74,15 +74,18 @@ export function isTabOnScreen(
 /**
  * Build a WatchEvents agent entry from a resume cursor and mode. A resume seq
  * of 0n means nothing has been observed yet, so subscribe fresh (LATEST).
- * cursor/replay are only meaningful on the transition INTO FULL.
+ * cursor/replay are only meaningful on the transition INTO FULL. windowTailSeq
+ * declares the loaded window tail so the worker's skip decision measures the
+ * gap from the same seq the browser re-anchors on (the cursor can lead it).
  */
 export function agentWatchEntry(
   agentId: string,
   resumeSeq: bigint,
+  windowTailSeq: bigint,
   mode: WatchMode,
 ): WatchAgentEntry {
   const base = resumeSeq > 0n
-    ? { agentId, replay: WatchReplayMode.AFTER_CURSOR_OR_NONE, cursorSeq: resumeSeq, mode }
+    ? { agentId, replay: WatchReplayMode.AFTER_CURSOR_OR_NONE, cursorSeq: resumeSeq, windowTailSeq, mode }
     : { agentId, replay: WatchReplayMode.LATEST, cursorSeq: BigInt(0), mode }
   return base as WatchAgentEntry
 }
@@ -107,6 +110,7 @@ export function buildWatchPlans(
   activeWorkspaceId: string | null,
   activeKeyForTile: (tileId: string) => string | null,
   agentResumeSeq: (agentId: string) => bigint = () => 0n,
+  agentWindowTailSeq: (agentId: string) => bigint = () => 0n,
   terminalAfterOffset: (terminalId: string) => bigint | number = () => 0,
   terminalNeedsResync: (terminalId: string) => boolean = () => false,
   getAgentTab: ((agentId: string) => AgentTab | undefined) | undefined = undefined,
@@ -139,7 +143,7 @@ export function buildWatchPlans(
     }
     if (tab.type === TabType.AGENT) {
       const seen = agentIdsFor(workerId)
-      plan.agents.push(agentWatchEntry(tab.id, agentResumeSeq(tab.id), mode))
+      plan.agents.push(agentWatchEntry(tab.id, agentResumeSeq(tab.id), agentWindowTailSeq(tab.id), mode))
       seen.add(tab.id)
       // A child tab also needs the root's notification-class events
       // (BackgroundTasksChanged, the root's TodosChanged). These are broadcast
@@ -149,7 +153,7 @@ export function buildWatchPlans(
       if (getAgentTab && tab.parentAgentId) {
         const rootId = rootAgentIdFor(getAgentTab, tab.id)
         if (rootId !== tab.id && !seen.has(rootId)) {
-          plan.agents.push(agentWatchEntry(rootId, 0n, WatchMode.NOTIFY))
+          plan.agents.push(agentWatchEntry(rootId, 0n, 0n, WatchMode.NOTIFY))
           seen.add(rootId)
         }
       }

--- a/frontend/src/hooks/watchPlan.ts
+++ b/frontend/src/hooks/watchPlan.ts
@@ -82,7 +82,7 @@ export function agentWatchEntry(
   mode: WatchMode,
 ): WatchAgentEntry {
   const base = resumeSeq > 0n
-    ? { agentId, replay: WatchReplayMode.AFTER_CURSOR, cursorSeq: resumeSeq, mode }
+    ? { agentId, replay: WatchReplayMode.AFTER_CURSOR_OR_NONE, cursorSeq: resumeSeq, mode }
     : { agentId, replay: WatchReplayMode.LATEST, cursorSeq: BigInt(0), mode }
   return base as WatchAgentEntry
 }

--- a/frontend/src/stores/chat.store.test.ts
+++ b/frontend/src/stores/chat.store.test.ts
@@ -3,9 +3,9 @@ import { create } from '@bufbuild/protobuf'
 import { createRoot } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createClassifiedEntryCache } from '~/components/chat/chatEntryCache'
+import { MESSAGE_PAGE_LIMIT } from '~/generated/contracts/chat-history'
 import { AgentChatMessageSchema, AgentProvider, ContentCompression, MarkType, MessageMarkSchema, MessagePageAnchor, MessageSource, TodoItemSchema, TodoStatus } from '~/generated/proto/leapmux/v1/agent_pb'
 import { createChatStore, MAX_LOADED_CHAT_MESSAGES, MAX_LOADED_CHAT_MESSAGES_CEILING } from '~/stores/chat.store'
-import { MESSAGE_PAGE_SIZE } from '~/stores/chatHistoryPaginator'
 
 // Mock workerRpc for loadInitialMessages / loadOlderMessages / loadNewerPage / catchUpToTail
 const mockListAgentMessages = vi.fn()
@@ -1797,8 +1797,8 @@ describe('createChatStore', () => {
     describe('atWindowCeiling', () => {
       // The filler must stop a full page BEFORE the hard ceiling so its last allowed
       // fetch can't cross it and drop the live tail -- so the threshold is
-      // CEILING - MESSAGE_PAGE_SIZE.
-      const threshold = MAX_LOADED_CHAT_MESSAGES_CEILING - MESSAGE_PAGE_SIZE
+      // CEILING - MESSAGE_PAGE_LIMIT.
+      const threshold = MAX_LOADED_CHAT_MESSAGES_CEILING - MESSAGE_PAGE_LIMIT
 
       it('trips a full page BEFORE the hard ceiling', () => {
         createRoot((dispose) => {
@@ -1807,7 +1807,7 @@ describe('createChatStore', () => {
           store.setMessages('a1', Array.from({ length: threshold - 1 }, (_, i) => makeMessage(`m${i}`, BigInt(i + 1))))
           expect(store.atWindowCeiling('a1')).toBe(false) // one short of the page-margin threshold
           store.addMessage('a1', makeMessage('edge', BigInt(threshold)))
-          expect(store.atWindowCeiling('a1')).toBe(true) // at CEILING - MESSAGE_PAGE_SIZE
+          expect(store.atWindowCeiling('a1')).toBe(true) // at CEILING - MESSAGE_PAGE_LIMIT
           dispose()
         })
       })

--- a/frontend/src/stores/chat.store.test.ts
+++ b/frontend/src/stores/chat.store.test.ts
@@ -3082,7 +3082,7 @@ describe('createChatStore', () => {
           store.setMessages('a1', Array.from({ length: 50 }, (_, i) => makeMessage(`m${i}`, BigInt(i + 1))))
           store.trimNewestEnd('a1', 30) // hasMoreNewer=true, window seq 1..30
 
-          // The reconcile-driven empty-window re-seat / catch-up jump ties its fetch to
+          // The reconcile-driven empty-window re-anchor / catch-up jump ties its fetch to
           // the WatchEvents subscription. Its LATEST fetch hangs, then the subscription
           // tears down (workspace switch) mid-flight -- aborting the fetch with NO
           // superseding beginHistoryFetch to reset the flags.
@@ -3102,7 +3102,7 @@ describe('createChatStore', () => {
 
           // The flag MUST be cleared: a watch-aborted fetch that wasn't superseded
           // otherwise stranded fetchingNewer=true, wedging loadNewerPage and the
-          // empty-window re-seat (both gated on the flag) until an unrelated user fetch.
+          // empty-window re-anchor (both gated on the flag) until an unrelated user fetch.
           expect(store.isFetchingNewer('a1')).toBe(false)
 
           // Proof the wedge is gone: a subsequent loadNewerPage actually fetches.

--- a/frontend/src/stores/chat.store.test.ts
+++ b/frontend/src/stores/chat.store.test.ts
@@ -1331,7 +1331,7 @@ describe('createChatStore', () => {
           expect(store.getMessages('a1')).toHaveLength(50)
           expect(store.hasOlderMessages('a1')).toBe(true)
           expect(store.isInitialLoadComplete('a1')).toBe(true)
-          expect(mockListAgentMessages).toHaveBeenCalledWith('w1', { agentId: 'a1', anchor: MessagePageAnchor.LATEST, limit: 50 })
+          expect(mockListAgentMessages).toHaveBeenCalledWith('w1', { agentId: 'a1', anchor: MessagePageAnchor.LATEST, limit: MESSAGE_PAGE_LIMIT })
           dispose()
         })
       })
@@ -1393,7 +1393,7 @@ describe('createChatStore', () => {
             agentId: 'a1',
             anchor: MessagePageAnchor.BEFORE,
             cursorSeq: 51n,
-            limit: 50,
+            limit: MESSAGE_PAGE_LIMIT,
           })
           dispose()
         })
@@ -1478,7 +1478,7 @@ describe('createChatStore', () => {
             agentId: 'a1',
             anchor: MessagePageAnchor.AFTER,
             cursorSeq: 50n,
-            limit: 50,
+            limit: MESSAGE_PAGE_LIMIT,
           })
           dispose()
         })
@@ -1515,13 +1515,13 @@ describe('createChatStore', () => {
             agentId: 'a1',
             anchor: MessagePageAnchor.AFTER,
             cursorSeq: 50n,
-            limit: 50,
+            limit: MESSAGE_PAGE_LIMIT,
           })
           expect(mockListAgentMessages).toHaveBeenNthCalledWith(2, 'w1', {
             agentId: 'a1',
             anchor: MessagePageAnchor.AFTER,
             cursorSeq: 100n,
-            limit: 50,
+            limit: MESSAGE_PAGE_LIMIT,
           })
           dispose()
         })
@@ -1984,7 +1984,7 @@ describe('createChatStore', () => {
           expect(msgs).toHaveLength(50)
           expect(msgs.at(-1)!.seq).toBe(50n)
           expect(store.hasNewerMessages('a1')).toBe(false)
-          expect(mockListAgentMessages).toHaveBeenLastCalledWith('w1', { agentId: 'a1', anchor: MessagePageAnchor.AFTER, cursorSeq: 30n, limit: 50 })
+          expect(mockListAgentMessages).toHaveBeenLastCalledWith('w1', { agentId: 'a1', anchor: MessagePageAnchor.AFTER, cursorSeq: 30n, limit: MESSAGE_PAGE_LIMIT })
           dispose()
         })
       })
@@ -2891,7 +2891,7 @@ describe('createChatStore', () => {
             agentId: 'a1',
             anchor: MessagePageAnchor.AFTER,
             cursorSeq: 99n, // latestLiveSeq (100) - 1
-            limit: 50,
+            limit: MESSAGE_PAGE_LIMIT,
           })
           expect(store.getLastSeq('a1')).toBe(50n) // still unreachable, so we stuck anyway
           // The unreachable seq 100 is clamped out of latestLiveSeq so a later
@@ -2933,7 +2933,7 @@ describe('createChatStore', () => {
             agentId: 'a1',
             anchor: MessagePageAnchor.AFTER,
             cursorSeq: 51n, // latestLiveSeq (52) - 1
-            limit: 50,
+            limit: MESSAGE_PAGE_LIMIT,
           })
           expect(store.getLastSeq('a1')).toBe(52n) // tail recovered
           expect(store.hasNewerMessages('a1')).toBe(false)
@@ -3033,7 +3033,7 @@ describe('createChatStore', () => {
           expect(msgs.at(-1)!.seq).toBe(50n)
           expect(store.hasOlderMessages('a1')).toBe(false) // at the very start
           expect(store.hasNewerMessages('a1')).toBe(true) // more exist beyond it
-          expect(mockListAgentMessages).toHaveBeenCalledWith('w1', { agentId: 'a1', anchor: MessagePageAnchor.OLDEST, limit: 50 })
+          expect(mockListAgentMessages).toHaveBeenCalledWith('w1', { agentId: 'a1', anchor: MessagePageAnchor.OLDEST, limit: MESSAGE_PAGE_LIMIT })
           dispose()
         })
       })

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -28,7 +28,14 @@ import { createStreamingTextStore } from './chatStreamingText'
 import { createTodoStore } from './chatTodoStore'
 import { createToolProgressStore } from './chatToolProgress'
 
-/** Max number of loaded messages to keep for the visible agent tab window. */
+/**
+ * Max number of loaded messages to keep for the visible agent tab window.
+ * Derives from CATCH_UP_GAP_LIMIT on purpose: the browser drains at most a
+ * window-sized gap before it re-anchors, because the window trims any older
+ * drained rows (see contracts/chat-history.json). Note the reach of this
+ * number: it also scales the 8x ceiling (MAX_LOADED_CHAT_MESSAGES_CEILING),
+ * so a catch-up-gap change resizes the per-tab memory bound.
+ */
 export const MAX_LOADED_CHAT_MESSAGES = Number(CATCH_UP_GAP_LIMIT)
 /**
  * Hard ceiling on the visible-tab window when a scrolled-up reader is being
@@ -196,7 +203,7 @@ export function createChatStore() {
    *
    * `watchSignal` (when given) ties the fetch to the CURRENT WatchEvents
    * subscription, so a workspace switch / worker change that aborts the stream
-   * also aborts this fetch -- used by the reconcile-driven empty-window re-seat
+   * also aborts this fetch -- used by the reconcile-driven empty-window re-anchor
    * (jumpToLatestMessages) so it can't leak a LATEST page into a navigated-away
    * worker's window. A user-driven fetch omits it (already scoped to the active tab).
    */
@@ -246,7 +253,7 @@ export function createChatStore() {
       // missed the case where `watchSignal` (the WatchEvents subscription) aborts us
       // with NO superseding fetch: a workspace switch / worker change that tears the
       // stream down mid-flight then stranded `fetchingNewer = true`, wedging
-      // loadNewerPage (and the empty-window re-seat, both gated on the flag) for that
+      // loadNewerPage (and the empty-window re-anchor, both gated on the flag) for that
       // agent until an unrelated user fetch reset it. Our controller stays installed
       // in that case, so the identity check clears the flag.
       if (fetchAbort.get(agentId)?.signal === signal) {

--- a/frontend/src/stores/chat.store.ts
+++ b/frontend/src/stores/chat.store.ts
@@ -9,6 +9,7 @@ import { createStore, produce, unwrap } from 'solid-js/store'
 import { getAgentMessage } from '~/api/workerRpc'
 import { forgetMarkPreview } from '~/components/chat/chatMarkPreview'
 import { invalidateMessageClassificationCache } from '~/components/chat/messageClassification'
+import { CATCH_UP_GAP_LIMIT, MESSAGE_PAGE_LIMIT } from '~/generated/contracts/chat-history'
 import { AgentChatMessageSchema, MarkType } from '~/generated/proto/leapmux/v1/agent_pb'
 import { lowerBoundBySeq } from '~/lib/binarySearch'
 import { invalidateMessageParseCache } from '~/lib/messageParser'
@@ -16,7 +17,7 @@ import { createBackgroundTaskStore } from './chatBackgroundTaskStore'
 import { createCommandStreamStore } from './chatCommandStreams'
 import { createContentVersionStore } from './chatContentVersions'
 import { createGoalStore } from './chatGoalStore'
-import { createHistoryPaginator, linkWatchSignal, MESSAGE_PAGE_SIZE } from './chatHistoryPaginator'
+import { createHistoryPaginator, linkWatchSignal } from './chatHistoryPaginator'
 import { createLiveTailTracker } from './chatLiveTail'
 import { createMessageMarksStore, resolveRailRange } from './chatMessageMarks'
 import { createMessageMarkSeeder } from './chatMessageMarkSeeder'
@@ -28,7 +29,7 @@ import { createTodoStore } from './chatTodoStore'
 import { createToolProgressStore } from './chatToolProgress'
 
 /** Max number of loaded messages to keep for the visible agent tab window. */
-export const MAX_LOADED_CHAT_MESSAGES = 150
+export const MAX_LOADED_CHAT_MESSAGES = Number(CATCH_UP_GAP_LIMIT)
 /**
  * Hard ceiling on the visible-tab window when a scrolled-up reader is being
  * protected from the live-tail trim (see trimOldestToViewport) AND when the
@@ -95,11 +96,10 @@ export interface ChatStoreState {
   /**
    * Whether a reconnect catch-up is in flight for this agent (per agent): set when the
    * client (re)subscribes via WatchEvents, cleared at CatchUpComplete. During catch-up
-   * the recorded live tail tracks the LOADED tail (the bounded replay's own bumps), not
-   * the true server tail -- and an indeterminate (unset) tail never raises it -- so the
-   * live-append guard falls back to seq-CONTIGUITY while this is set (a non-contiguous
-   * frame is a live arrival past the unfilled replay gap; a contiguous one is the next
-   * in-order replay page). See beyondUnloadedNewerTail.
+   * CatchUpStart normally records the true server tail. An indeterminate (unset) tail
+   * tracks only loaded rows, so the live-append guard uses sequence contiguity while
+   * this is set. A non-contiguous frame is a live arrival past the unfilled replay
+   * gap. A contiguous frame is the next replay message. See beyondUnloadedNewerTail.
    */
   catchingUp: Record<string, boolean>
   /** Whether a fetch for older messages is in progress (per agent). */
@@ -1086,7 +1086,7 @@ export function createChatStore() {
      * oldest end. That trim drops the buffer on the other side, or, at the live tail,
      * the pinned tail row.
      *
-     * The threshold is CEILING - MESSAGE_PAGE_SIZE, not the ceiling itself, on
+     * The threshold is CEILING - MESSAGE_PAGE_LIMIT, not the ceiling itself, on
      * purpose. One 50-row page can take the window length from just under the ceiling
      * (1199) to just over it (1249), and trimNewestEnd flips hasMoreNewer and drops
      * the live tail only after the window length EXCEEDS the ceiling. A stop one full
@@ -1095,7 +1095,7 @@ export function createChatStore() {
      */
     atWindowCeiling(agentId: string): boolean {
       const msgs = state.messagesByAgent[agentId]
-      return !!msgs && msgs.length >= MAX_LOADED_CHAT_MESSAGES_CEILING - MESSAGE_PAGE_SIZE
+      return !!msgs && msgs.length >= MAX_LOADED_CHAT_MESSAGES_CEILING - MESSAGE_PAGE_LIMIT
     },
 
     isFetchingOlder(agentId: string): boolean {

--- a/frontend/src/stores/chatHistoryPaginator.test.ts
+++ b/frontend/src/stores/chatHistoryPaginator.test.ts
@@ -2,13 +2,14 @@ import type { ChatStoreState } from './chat.store'
 import type { AgentChatMessage } from '~/generated/proto/leapmux/v1/agent_pb'
 import { createStore } from 'solid-js/store'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CATCH_UP_GAP_LIMIT, MESSAGE_PAGE_LIMIT } from '~/generated/contracts/chat-history'
 
 // listAgentMessages is the only external dependency; hoist the mock so the factory
 // can reference it (vi.mock is hoisted above imports).
 const { listAgentMessages } = vi.hoisted(() => ({ listAgentMessages: vi.fn() }))
 vi.mock('~/api/workerRpc', () => ({ listAgentMessages }))
 
-const { createHistoryPaginator, linkWatchSignal, MESSAGE_PAGE_SIZE } = await import('./chatHistoryPaginator')
+const { createHistoryPaginator, linkWatchSignal } = await import('./chatHistoryPaginator')
 const { MessagePageAnchor, MessageSource } = await import('~/generated/proto/leapmux/v1/agent_pb')
 
 // The harness's cap/ceiling, distinct so an assertion can prove WHICH was used. The
@@ -20,8 +21,8 @@ function makeMsg(seq: bigint, id?: string): AgentChatMessage {
   return { seq, id: id ?? `m${seq}`, source: MessageSource.AGENT } as AgentChatMessage
 }
 
-function page(messages: AgentChatMessage[], hasMore: boolean) {
-  return { messages, hasMore, todos: [], todosLoaded: false }
+function page(messages: AgentChatMessage[], hasMore: boolean, latestSeq?: bigint) {
+  return { messages, hasMore, latestSeq, todos: [], todosLoaded: false }
 }
 
 function harness(init: {
@@ -62,6 +63,11 @@ function harness(init: {
 
   const settleToWindow = vi.fn()
   const resetToEmptyIfStale = vi.fn()
+  let recordedLiveTail = init.liveGet?.() ?? 0n
+  const bumpLiveTail = vi.fn((_agentId: string, seq: bigint) => {
+    if (seq > recordedLiveTail)
+      recordedLiveTail = seq
+  })
   const applyMessages = vi.fn()
   const replaceBackgroundTasks = vi.fn()
   const markBackgroundTasksLoadFailed = vi.fn()
@@ -89,8 +95,8 @@ function harness(init: {
     mergeFetchedMessages,
     applyMessages,
     liveTail: {
-      get: init.liveGet ?? (() => 0n),
-      bump: vi.fn(),
+      get: init.liveGet ?? (() => recordedLiveTail),
+      bump: bumpLiveTail,
       caughtUp: () => true,
       settleToWindow,
       resetToEmptyIfStale,
@@ -111,7 +117,22 @@ function harness(init: {
     replaceGoal,
   })
 
-  return { state, setState, paginator, trimNewestEnd, trimOldestEnd, addMessage, applyMessages, settleToWindow, resetToEmptyIfStale, replaceBackgroundTasks, markBackgroundTasksLoadFailed, replaceGoal }
+  return {
+    state,
+    setState,
+    paginator,
+    trimNewestEnd,
+    trimOldestEnd,
+    addMessage,
+    applyMessages,
+    settleToWindow,
+    resetToEmptyIfStale,
+    bumpLiveTail,
+    getRecordedLiveTail: () => recordedLiveTail,
+    replaceBackgroundTasks,
+    markBackgroundTasksLoadFailed,
+    replaceGoal,
+  }
 }
 
 describe('chathistorypaginator', () => {
@@ -168,6 +189,68 @@ describe('chathistorypaginator', () => {
 
       expect(h.settleToWindow).not.toHaveBeenCalled()
       expect(h.resetToEmptyIfStale).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('catchuptotail re-anchors an over-limit gap', () => {
+    it('stops after one page, records the live tail, and skips the stale-tail clamp', async () => {
+      const h = harness({ messages: [makeMsg(1n)], hasMoreNewer: false, caughtUp: () => false })
+      const latestSeq = 2n + CATCH_UP_GAP_LIMIT + 1n
+      listAgentMessages
+        .mockResolvedValueOnce(page([makeMsg(2n)], true, latestSeq))
+        .mockResolvedValueOnce(page([makeMsg(3n)], false, latestSeq))
+
+      await h.paginator.catchUpToTail('w', 'a', 1n)
+
+      expect(listAgentMessages).toHaveBeenCalledTimes(1)
+      expect(h.bumpLiveTail).toHaveBeenCalledWith('a', latestSeq)
+      expect(h.getRecordedLiveTail()).toBe(latestSeq)
+      expect(h.getRecordedLiveTail()).toBeGreaterThan(h.state.messagesByAgent.a.at(-1)!.seq)
+      expect(h.settleToWindow).not.toHaveBeenCalled()
+      expect(h.resetToEmptyIfStale).not.toHaveBeenCalled()
+    })
+
+    it('drains a gap at the inclusive limit and finishes at the recorded tail', async () => {
+      const latestSeq = 2n + CATCH_UP_GAP_LIMIT
+      const h = harness({
+        messages: [makeMsg(1n)],
+        hasMoreNewer: false,
+        caughtUp: () => true,
+      })
+      listAgentMessages
+        .mockResolvedValueOnce(page([makeMsg(2n)], true, latestSeq))
+        .mockResolvedValueOnce(page([makeMsg(latestSeq)], false, latestSeq))
+
+      await h.paginator.catchUpToTail('w', 'a', 1n)
+
+      expect(listAgentMessages).toHaveBeenCalledTimes(2)
+      expect(h.getRecordedLiveTail()).toBe(latestSeq)
+      expect(h.state.messagesByAgent.a.at(-1)?.seq).toBe(latestSeq)
+      expect(h.settleToWindow).not.toHaveBeenCalled()
+      expect(h.resetToEmptyIfStale).not.toHaveBeenCalled()
+    })
+
+    it('drains by hasMore when latestSeq is absent', async () => {
+      const h = harness({ messages: [makeMsg(1n)], hasMoreNewer: false })
+      listAgentMessages
+        .mockResolvedValueOnce(page([makeMsg(2n)], true))
+        .mockResolvedValueOnce(page([makeMsg(3n)], false))
+
+      await h.paginator.catchUpToTail('w', 'a', 1n)
+
+      expect(listAgentMessages).toHaveBeenCalledTimes(2)
+      expect(h.bumpLiveTail).not.toHaveBeenCalled()
+    })
+
+    it('does not lower a live tail that a broadcast raised above the page tail', async () => {
+      const h = harness({ messages: [makeMsg(1n)], hasMoreNewer: false })
+      h.bumpLiveTail('a', 300n)
+      listAgentMessages.mockResolvedValue(page([makeMsg(2n)], false, 200n))
+
+      await h.paginator.catchUpToTail('w', 'a', 1n)
+
+      expect(h.bumpLiveTail).toHaveBeenLastCalledWith('a', 200n)
+      expect(h.getRecordedLiveTail()).toBe(300n)
     })
   })
 
@@ -237,12 +320,12 @@ describe('chathistorypaginator', () => {
 
       expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({
         anchor: MessagePageAnchor.LATEST,
-        limit: MESSAGE_PAGE_SIZE,
+        limit: MESSAGE_PAGE_LIMIT,
       }), expect.anything())
       expect(listAgentMessages).toHaveBeenCalledWith('w', expect.objectContaining({
         anchor: MessagePageAnchor.AFTER,
         cursorSeq: maxInt64Seq,
-        limit: MESSAGE_PAGE_SIZE,
+        limit: MESSAGE_PAGE_LIMIT,
       }), expect.anything())
       expect(listAgentMessages).not.toHaveBeenCalledWith('w', expect.objectContaining({
         cursorSeq: maxInt64Seq + 1n,

--- a/frontend/src/stores/chatHistoryPaginator.test.ts
+++ b/frontend/src/stores/chatHistoryPaginator.test.ts
@@ -14,7 +14,7 @@ const { MessagePageAnchor, MessageSource } = await import('~/generated/proto/lea
 
 // The harness's cap/ceiling, distinct so an assertion can prove WHICH was used. The
 // production wiring passes MAX_LOADED_CHAT_MESSAGES / MAX_LOADED_CHAT_MESSAGES_CEILING.
-const BASE = 150
+const BASE = Number(CATCH_UP_GAP_LIMIT)
 const CEILING = 1200
 
 function makeMsg(seq: bigint, id?: string): AgentChatMessage {

--- a/frontend/src/stores/chatHistoryPaginator.test.ts
+++ b/frontend/src/stores/chatHistoryPaginator.test.ts
@@ -68,6 +68,8 @@ function harness(init: {
     if (seq > recordedLiveTail)
       recordedLiveTail = seq
   })
+  const caughtUpToLiveTail = init.caughtUp
+    ?? ((agentId: string) => (lastServer(agentId) ?? 0n) >= recordedLiveTail)
   const applyMessages = vi.fn()
   const replaceBackgroundTasks = vi.fn()
   const markBackgroundTasksLoadFailed = vi.fn()
@@ -107,7 +109,7 @@ function harness(init: {
     getLastSeq: agentId => lastServer(agentId) ?? 0n,
     getFirstMessageSeq: firstServer,
     getLastMessageSeq: lastServer,
-    caughtUpToLiveTail: init.caughtUp ?? (() => true),
+    caughtUpToLiveTail,
     addMessage,
     trimOldestEnd,
     trimNewestEnd,
@@ -128,6 +130,7 @@ function harness(init: {
     settleToWindow,
     resetToEmptyIfStale,
     bumpLiveTail,
+    caughtUpToLiveTail,
     getRecordedLiveTail: () => recordedLiveTail,
     replaceBackgroundTasks,
     markBackgroundTasksLoadFailed,
@@ -194,7 +197,7 @@ describe('chathistorypaginator', () => {
 
   describe('catchuptotail re-anchors an over-limit gap', () => {
     it('stops after one page, records the live tail, and skips the stale-tail clamp', async () => {
-      const h = harness({ messages: [makeMsg(1n)], hasMoreNewer: false, caughtUp: () => false })
+      const h = harness({ messages: [makeMsg(1n)], hasMoreNewer: false })
       const latestSeq = 2n + CATCH_UP_GAP_LIMIT + 1n
       listAgentMessages
         .mockResolvedValueOnce(page([makeMsg(2n)], true, latestSeq))
@@ -206,6 +209,7 @@ describe('chathistorypaginator', () => {
       expect(h.bumpLiveTail).toHaveBeenCalledWith('a', latestSeq)
       expect(h.getRecordedLiveTail()).toBe(latestSeq)
       expect(h.getRecordedLiveTail()).toBeGreaterThan(h.state.messagesByAgent.a.at(-1)!.seq)
+      expect(h.caughtUpToLiveTail('a')).toBe(false)
       expect(h.settleToWindow).not.toHaveBeenCalled()
       expect(h.resetToEmptyIfStale).not.toHaveBeenCalled()
     })
@@ -215,7 +219,6 @@ describe('chathistorypaginator', () => {
       const h = harness({
         messages: [makeMsg(1n)],
         hasMoreNewer: false,
-        caughtUp: () => true,
       })
       listAgentMessages
         .mockResolvedValueOnce(page([makeMsg(2n)], true, latestSeq))
@@ -226,6 +229,7 @@ describe('chathistorypaginator', () => {
       expect(listAgentMessages).toHaveBeenCalledTimes(2)
       expect(h.getRecordedLiveTail()).toBe(latestSeq)
       expect(h.state.messagesByAgent.a.at(-1)?.seq).toBe(latestSeq)
+      expect(h.caughtUpToLiveTail('a')).toBe(true)
       expect(h.settleToWindow).not.toHaveBeenCalled()
       expect(h.resetToEmptyIfStale).not.toHaveBeenCalled()
     })

--- a/frontend/src/stores/chatHistoryPaginator.test.ts
+++ b/frontend/src/stores/chatHistoryPaginator.test.ts
@@ -205,11 +205,11 @@ describe('chathistorypaginator', () => {
 
       await h.paginator.catchUpToTail('w', 'a', 1n)
 
+      // Load-bearing: exactly one page fetched (the over-limit stop), the tail
+      // recorded from resp.latestSeq, and the stale-tail clamp skipped so the
+      // scheduler still sees the gap it must re-anchor.
       expect(listAgentMessages).toHaveBeenCalledTimes(1)
       expect(h.bumpLiveTail).toHaveBeenCalledWith('a', latestSeq)
-      expect(h.getRecordedLiveTail()).toBe(latestSeq)
-      expect(h.getRecordedLiveTail()).toBeGreaterThan(h.state.messagesByAgent.a.at(-1)!.seq)
-      expect(h.caughtUpToLiveTail('a')).toBe(false)
       expect(h.settleToWindow).not.toHaveBeenCalled()
       expect(h.resetToEmptyIfStale).not.toHaveBeenCalled()
     })
@@ -258,9 +258,9 @@ describe('chathistorypaginator', () => {
     })
   })
 
-  describe('jumptolatestmessages ties its re-seat fetch to the watch signal', () => {
+  describe('jumptolatestmessages ties its re-anchor fetch to the watch signal', () => {
     it('does NOT apply the latest page when the watch signal aborts mid-fetch (workspace switch)', async () => {
-      // The empty-window re-seat fires for a backgrounded agent; the user switches
+      // The empty-window re-anchor fires for a backgrounded agent; the user switches
       // workspaces mid-fetch, aborting the WatchEvents subscription. The fetch must
       // discard its result rather than write a LATEST page into the navigated-away
       // agent's window (the leak this signal threading closes).
@@ -276,7 +276,7 @@ describe('chathistorypaginator', () => {
       expect(h.applyMessages).not.toHaveBeenCalled()
     })
 
-    it('applies the latest page on a normal re-seat (no watch abort)', async () => {
+    it('applies the latest page on a normal re-anchor (no watch abort)', async () => {
       const h = harness({ messages: [], hasMoreNewer: false, caughtUp: () => true, liveGet: () => 0n })
       listAgentMessages.mockResolvedValue(page([makeMsg(10n)], false))
 

--- a/frontend/src/stores/chatHistoryPaginator.ts
+++ b/frontend/src/stores/chatHistoryPaginator.ts
@@ -3,10 +3,8 @@ import type { ChatStoreState } from './chat.store'
 import type { LiveTailTracker } from './chatLiveTail'
 import type { AgentChatMessage, AgentGoal as ProtoAgentGoal, AgentGoalAction as ProtoAgentGoalAction, BackgroundTaskItem as ProtoBackgroundTaskItem, TodoItem as ProtoTodoItem } from '~/generated/proto/leapmux/v1/agent_pb'
 import { listAgentMessages } from '~/api/workerRpc'
+import { CATCH_UP_GAP_LIMIT, MESSAGE_PAGE_LIMIT } from '~/generated/contracts/chat-history'
 import { MessagePageAnchor } from '~/generated/proto/leapmux/v1/agent_pb'
-
-/** Per-page size for the windowed history fetch (the hub caps the page at 50). */
-export const MESSAGE_PAGE_SIZE = 50
 /**
  * Max forward-fill rounds before forwardFillToLiveTail settles regardless, so a
  * genuinely-vanished live seq stops the loop instead of spinning.
@@ -67,7 +65,7 @@ function listMessagesAfter(workerId: string, agentId: string, cursorSeq: bigint)
     agentId,
     anchor: MessagePageAnchor.AFTER,
     cursorSeq,
-    limit: MESSAGE_PAGE_SIZE,
+    limit: MESSAGE_PAGE_LIMIT,
   })
 }
 
@@ -200,7 +198,7 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
         resp = await listAgentMessages(workerId, {
           agentId,
           anchor: MessagePageAnchor.LATEST,
-          limit: MESSAGE_PAGE_SIZE,
+          limit: MESSAGE_PAGE_LIMIT,
         })
       }
       catch (err) {
@@ -249,7 +247,7 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
         agentId,
         anchor: MessagePageAnchor.BEFORE,
         cursorSeq: firstSeq,
-        limit: MESSAGE_PAGE_SIZE,
+        limit: MESSAGE_PAGE_LIMIT,
       })
       if (signal.aborted)
         return
@@ -333,9 +331,9 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
   }
 
   /**
-   * Fetch messages forward from a given seq, looping until all are retrieved.
-   * Used after WatchEvents catch-up replay to fill any gap beyond the
-   * 50-message replay limit.
+   * Fetch messages forward from a given sequence while the authoritative gap
+   * fits in the live-tail window. A response that identifies a larger gap stops
+   * the drain and records the tail. The scheduler then re-anchors on LATEST.
    *
    * No-op when the window is scrolled away from the live tail (hasMoreNewer):
    * refilling the tail would defeat the bidirectional window. The live deltas
@@ -353,9 +351,8 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
    * so an in-flight page is discarded the moment the user takes over the tail --
    * the two never race on the window.
    *
-   * Each page is trimmed as it lands -- trim the OLDEST end to the CEILING (not the
-   * base), mirroring loadNewerPage -- so a large reconnect gap is bounded by the
-   * ceiling rather than growing without limit. Capping to the ceiling (not the base)
+   * Each page is trimmed as it lands. Trim the OLDEST end to the CEILING, not the
+   * base, to match loadNewerPage. Capping to the ceiling instead of the base
    * is what spares a SCROLLED-UP reader: the loop runs while at the live tail
    * (hasMoreNewer false), but the reader can be scrolled up into a ceiling-grown older
    * buffer, and a base trim would reap that buffer (and rows below their anchor). The
@@ -365,12 +362,12 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
    */
   async function catchUpToTail(workerId: string, agentId: string, afterSeq: bigint, watchSignal?: AbortSignal): Promise<void> {
     // Idempotent under the continuous reconcile effect (runSingleFlightTailLoop no-ops
-    // while a loop is draining this agent): the loop itself keeps fetching while
-    // resp.hasMore, so a lag that grows mid-fill (a live arrival dropped beyond the
-    // window) is closed by the running loop, not a re-kick. A user fetch still
-    // supersedes via catchUpAbort/beginHistoryFetch.
+    // while a loop drains this agent). The loop fetches while resp.hasMore and
+    // the authoritative gap fits in the live-tail window. A user fetch still
+    // supersedes it through catchUpAbort and beginHistoryFetch.
     await runSingleFlightTailLoop(agentId, watchSignal, async (signal, liveSeqAtEntry) => {
       let cursor = afterSeq
+      let stoppedForOverLimitGap = false
       while (!signal.aborted && !state.hasMoreNewer[agentId]) {
         const resp = await listMessagesAfter(workerId, agentId, cursor)
         // Superseded mid-flight (a user jump/scroll, or subscription teardown):
@@ -379,6 +376,10 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
           return
         for (const msg of resp.messages) {
           deps.addMessage(agentId, msg)
+        }
+        if (resp.latestSeq !== undefined) {
+          deps.liveTail.bump(agentId, resp.latestSeq)
+          stoppedForOverLimitGap = resp.latestSeq - deps.getLastSeq(agentId) > CATCH_UP_GAP_LIMIT
         }
         // Cap the window as we go: trim the oldest end (sets hasMoreOlder; leaves
         // hasMoreNewer false so the loop and the live-append guard keep working). Cap to
@@ -391,6 +392,8 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
         // (trimOldestToViewport) brings a FOLLOWED tail back to the lean base; a
         // scrolled-up reader keeps their buffer up to the ceiling.
         deps.trimOldestEnd(agentId, deps.maxLoadedCeiling)
+        if (stoppedForOverLimitGap)
+          break
         if (!resp.hasMore || resp.messages.length === 0)
           break
         // The server returns each page ordered ascending by seq (ORDER BY seq
@@ -398,16 +401,11 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
         // for the next forward page.
         cursor = resp.messages.at(-1)!.seq
       }
-      // The loop drained the server's forward pages (reached has_more=false or an empty
-      // page) while at the tail (hasMoreNewer stayed false). If the recorded live tail
-      // STILL sits ahead of the loaded window, it points at a seq the server can no
-      // longer give us. A server-side history change can leave this client with a
-      // stale high-water value. Without clamping it,
-      // caughtUpToLiveTail never resolves, so the continuous reconcile re-issues this
-      // empty fetch on EVERY tick and the scroll-to-bottom affordance stays lit forever.
-      // Clamp it to the window (mirrors loadNewerPage's dedup-stall settle); an empty
-      // window resets to empty (mirrors jumpToLatestMessages' authoritative-empty path).
-      if (!signal.aborted && !state.hasMoreNewer[agentId] && !deps.caughtUpToLiveTail(agentId)) {
+      // An over-limit stop keeps the recorded gap for the scheduler. Otherwise,
+      // the loop drained the forward pages. A remaining gap points at a sequence
+      // that the server cannot return. Clamp that stale tail to the window, or
+      // reset it when the window is empty. This prevents repeated empty fetches.
+      if (!stoppedForOverLimitGap && !signal.aborted && !state.hasMoreNewer[agentId] && !deps.caughtUpToLiveTail(agentId)) {
         const windowTail = deps.getLastSeq(agentId)
         if (windowTail > 0n)
           deps.liveTail.settleToWindow(agentId, liveSeqAtEntry, windowTail)
@@ -656,7 +654,7 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
       const liveSeqAtEntry = deps.liveTail.get(agentId)
       // Always re-anchor on a fresh latest page so the window is contiguous
       // up to the tail regardless of how far it had drifted.
-      const latest = await listAgentMessages(workerId, { agentId, anchor: MessagePageAnchor.LATEST, limit: MESSAGE_PAGE_SIZE })
+      const latest = await listAgentMessages(workerId, { agentId, anchor: MessagePageAnchor.LATEST, limit: MESSAGE_PAGE_LIMIT })
       if (signal.aborted)
         return
       applyLatestPage(agentId, latest)
@@ -682,7 +680,7 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
    */
   async function jumpToOldestMessages(workerId: string, agentId: string): Promise<void> {
     await deps.runHistoryFetch(agentId, 'fetchingOlder', async (signal) => {
-      const oldest = await listAgentMessages(workerId, { agentId, anchor: MessagePageAnchor.OLDEST, limit: MESSAGE_PAGE_SIZE })
+      const oldest = await listAgentMessages(workerId, { agentId, anchor: MessagePageAnchor.OLDEST, limit: MESSAGE_PAGE_LIMIT })
       if (signal.aborted)
         return
       // applyMessages sets hasMoreOlder from its `hasMore` argument and
@@ -715,8 +713,8 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
       // fetch raises it past this, and hasMoreNewer/resetToEmptyIfStale must respect that.
       const liveSeqAtEntry = deps.liveTail.get(agentId)
       const beforeRequest = seq >= MAX_INT64_SEQ
-        ? { agentId, anchor: MessagePageAnchor.LATEST, limit: MESSAGE_PAGE_SIZE }
-        : { agentId, anchor: MessagePageAnchor.BEFORE, cursorSeq: seq + 1n, limit: MESSAGE_PAGE_SIZE }
+        ? { agentId, anchor: MessagePageAnchor.LATEST, limit: MESSAGE_PAGE_LIMIT }
+        : { agentId, anchor: MessagePageAnchor.BEFORE, cursorSeq: seq + 1n, limit: MESSAGE_PAGE_LIMIT }
       // Both requests carry `signal`, so an abort ends them at the transport rather than only
       // discarding what they return. That is what makes a seek genuinely abandonable: the caller
       // that gave up (the rail, when its scrub leaves this target) stops the round trip instead
@@ -725,7 +723,7 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
       try {
         [before, after] = await Promise.all([
           listAgentMessages(workerId, beforeRequest, { signal }),
-          listAgentMessages(workerId, { agentId, anchor: MessagePageAnchor.AFTER, cursorSeq: seq, limit: MESSAGE_PAGE_SIZE }, { signal }),
+          listAgentMessages(workerId, { agentId, anchor: MessagePageAnchor.AFTER, cursorSeq: seq, limit: MESSAGE_PAGE_LIMIT }, { signal }),
         ])
       }
       catch (err) {

--- a/frontend/src/stores/chatHistoryPaginator.ts
+++ b/frontend/src/stores/chatHistoryPaginator.ts
@@ -3,8 +3,9 @@ import type { ChatStoreState } from './chat.store'
 import type { LiveTailTracker } from './chatLiveTail'
 import type { AgentChatMessage, AgentGoal as ProtoAgentGoal, AgentGoalAction as ProtoAgentGoalAction, BackgroundTaskItem as ProtoBackgroundTaskItem, TodoItem as ProtoTodoItem } from '~/generated/proto/leapmux/v1/agent_pb'
 import { listAgentMessages } from '~/api/workerRpc'
-import { CATCH_UP_GAP_LIMIT, MESSAGE_PAGE_LIMIT } from '~/generated/contracts/chat-history'
+import { MESSAGE_PAGE_LIMIT } from '~/generated/contracts/chat-history'
 import { MessagePageAnchor } from '~/generated/proto/leapmux/v1/agent_pb'
+import { exceedsCatchUpGapLimit } from './chatLiveTail'
 /**
  * Max forward-fill rounds before forwardFillToLiveTail settles regardless, so a
  * genuinely-vanished live seq stops the loop instead of spinning.
@@ -18,7 +19,7 @@ const MAX_INT64_SEQ = 9223372036854775807n
  * tears the stream down -- the fetch must stop running against a worker the reader
  * navigated away from, instead of leaking until its pages reject). Aborts immediately
  * if the signal is already aborted. Shared by the two background forward-fill loops
- * (catchUpToTail, resumeDeferredTailFill) and the empty-window re-seat
+ * (catchUpToTail, resumeDeferredTailFill) and the empty-window re-anchor
  * (jumpToLatestMessages, via the store's beginHistoryFetch).
  */
 export function linkWatchSignal(controller: AbortController, watchSignal?: AbortSignal): () => void {
@@ -351,7 +352,7 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
    * so an in-flight page is discarded the moment the user takes over the tail --
    * the two never race on the window.
    *
-   * Each page is trimmed as it lands. Trim the OLDEST end to the CEILING, not the
+   * Trim each page as it lands: the OLDEST end to the CEILING, not the
    * base, to match loadNewerPage. Capping to the ceiling instead of the base
    * is what spares a SCROLLED-UP reader: the loop runs while at the live tail
    * (hasMoreNewer false), but the reader can be scrolled up into a ceiling-grown older
@@ -367,7 +368,6 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
     // supersedes it through catchUpAbort and beginHistoryFetch.
     await runSingleFlightTailLoop(agentId, watchSignal, async (signal, liveSeqAtEntry) => {
       let cursor = afterSeq
-      let stoppedForOverLimitGap = false
       while (!signal.aborted && !state.hasMoreNewer[agentId]) {
         const resp = await listMessagesAfter(workerId, agentId, cursor)
         // Superseded mid-flight (a user jump/scroll, or subscription teardown):
@@ -377,10 +377,8 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
         for (const msg of resp.messages) {
           deps.addMessage(agentId, msg)
         }
-        if (resp.latestSeq !== undefined) {
+        if (resp.latestSeq !== undefined)
           deps.liveTail.bump(agentId, resp.latestSeq)
-          stoppedForOverLimitGap = resp.latestSeq - deps.getLastSeq(agentId) > CATCH_UP_GAP_LIMIT
-        }
         // Cap the window as we go: trim the oldest end (sets hasMoreOlder; leaves
         // hasMoreNewer false so the loop and the live-append guard keep working). Cap to
         // the CEILING, not the base -- mirroring loadNewerPage: this runs while the
@@ -392,8 +390,11 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
         // (trimOldestToViewport) brings a FOLLOWED tail back to the lean base; a
         // scrolled-up reader keeps their buffer up to the ceiling.
         deps.trimOldestEnd(agentId, deps.maxLoadedCeiling)
-        if (stoppedForOverLimitGap)
-          break
+        // An over-limit gap keeps the recorded tail for the scheduler, which
+        // re-anchors on LATEST (see reconcileLaggingTails). Return before the
+        // stale-tail clamp below: it must not erase a gap the scheduler needs.
+        if (resp.latestSeq !== undefined && exceedsCatchUpGapLimit(resp.latestSeq, deps.getLastSeq(agentId)))
+          return
         if (!resp.hasMore || resp.messages.length === 0)
           break
         // The server returns each page ordered ascending by seq (ORDER BY seq
@@ -401,11 +402,10 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
         // for the next forward page.
         cursor = resp.messages.at(-1)!.seq
       }
-      // An over-limit stop keeps the recorded gap for the scheduler. Otherwise,
-      // the loop drained the forward pages. A remaining gap points at a sequence
+      // The loop drained the forward pages. A remaining gap points at a sequence
       // that the server cannot return. Clamp that stale tail to the window, or
       // reset it when the window is empty. This prevents repeated empty fetches.
-      if (!stoppedForOverLimitGap && !signal.aborted && !state.hasMoreNewer[agentId] && !deps.caughtUpToLiveTail(agentId)) {
+      if (!signal.aborted && !state.hasMoreNewer[agentId] && !deps.caughtUpToLiveTail(agentId)) {
         const windowTail = deps.getLastSeq(agentId)
         if (windowTail > 0n)
           deps.liveTail.settleToWindow(agentId, liveSeqAtEntry, windowTail)
@@ -642,7 +642,7 @@ export function createHistoryPaginator(deps: HistoryPaginatorDeps) {
   async function jumpToLatestMessages(workerId: string, agentId: string, watchSignal?: AbortSignal): Promise<void> {
     // A jump supersedes any in-flight fetch (scroll-load or a prior jump) so
     // a stuck request can't block it -- runHistoryFetch aborts the prior one.
-    // `watchSignal` ties the reconcile-driven empty-window re-seat to the
+    // `watchSignal` ties the reconcile-driven empty-window re-anchor to the
     // WatchEvents subscription so a workspace switch can't leak this fetch (and
     // its forwardFillToLiveTail loop) against a navigated-away worker -- the same
     // teardown guarantee catchUpToTail / resumeDeferredTailFill already carry.

--- a/frontend/src/stores/chatLiveTail.test.ts
+++ b/frontend/src/stores/chatLiveTail.test.ts
@@ -1,6 +1,7 @@
 import { createRoot } from 'solid-js'
 import { describe, expect, it } from 'vitest'
-import { createLiveTailTracker } from '~/stores/chatLiveTail'
+import { CATCH_UP_GAP_LIMIT } from '~/generated/contracts/chat-history'
+import { createLiveTailTracker, exceedsCatchUpGapLimit } from '~/stores/chatLiveTail'
 
 /** Run a body with a fresh tracker inside a reactive root (its store needs an owner). */
 function withTracker(body: (t: ReturnType<typeof createLiveTailTracker>) => void) {
@@ -129,6 +130,18 @@ describe('chatlivetail', () => {
         t.setAuthoritative('a1', 30n, 40n) // 38 is in (30, 40] -> phantom, lower to 30
         expect(t.get('a1')).toBe(30n)
       })
+    })
+  })
+
+  describe('exceedsCatchUpGapLimit', () => {
+    it('drains a gap at the inclusive limit and re-anchors one past it', () => {
+      expect(exceedsCatchUpGapLimit(10n + CATCH_UP_GAP_LIMIT, 10n)).toBe(false)
+      expect(exceedsCatchUpGapLimit(10n + CATCH_UP_GAP_LIMIT + 1n, 10n)).toBe(true)
+    })
+
+    it('treats a tail at or below the window tail as no gap', () => {
+      expect(exceedsCatchUpGapLimit(10n, 10n)).toBe(false)
+      expect(exceedsCatchUpGapLimit(9n, 10n)).toBe(false)
     })
   })
 

--- a/frontend/src/stores/chatLiveTail.ts
+++ b/frontend/src/stores/chatLiveTail.ts
@@ -1,3 +1,4 @@
+import { CATCH_UP_GAP_LIMIT } from '~/generated/contracts/chat-history'
 import { createPerAgentStore } from './chatPerAgentStore'
 
 // ---------------------------------------------------------------------------
@@ -19,6 +20,18 @@ import { createPerAgentStore } from './chatPerAgentStore'
 // (get / set / remove). Only the bump, settle, and authoritative reconcilers
 // below are bespoke high-water logic.
 // ---------------------------------------------------------------------------
+
+/**
+ * Whether the gap from the loaded window tail (`windowTail`) to an authoritative
+ * tail seq exceeds the catch-up limit: the largest sequence gap the browser
+ * drains before it re-anchors on the newest page (contracts/chat-history.json).
+ * The worker mirrors the same boundary when it skips the capped replay
+ * (shouldSkipCatchUpReplay in the worker service), so the strict `>` must agree
+ * on both sides of the wire.
+ */
+export function exceedsCatchUpGapLimit(tailSeq: bigint, windowTail: bigint): boolean {
+  return tailSeq - windowTail > CATCH_UP_GAP_LIMIT
+}
 
 export function createLiveTailTracker() {
   const base = createPerAgentStore<bigint>(0n)

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -603,10 +603,13 @@ enum WatchReplayMode {
   // The reconnect/resume subscription that bridges the disconnect gap.
   WATCH_REPLAY_MODE_AFTER_CURSOR = 2;
   // Replay every message after cursor_seq, as AFTER_CURSOR does, but replay
-  // NOTHING when the gap from cursor_seq to the live tail is larger than
-  // contracts.CatchUpGapLimit. A windowed client abandons a gap that large and
-  // re-anchors on the newest page, so the burst would be pure waste. The client
-  // learns the tail from CatchUpStart.latest_seq, which is sent either way.
+  // NOTHING when the gap to the live tail is larger than
+  // contracts.CatchUpGapLimit. The worker measures the gap from
+  // WatchAgentEntry.window_tail_seq when the client declares it, else from
+  // cursor_seq. A windowed client abandons a gap that large and re-anchors on
+  // the newest page, so the burst would be pure waste. The client learns the
+  // tail from CatchUpStart.latest_seq. The worker sends this field for every
+  // replay mode.
   WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE = 3;
 }
 

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -589,7 +589,7 @@ enum MessagePageAnchor {
 }
 
 // WatchReplayMode selects which history a WatchEvents subscriber replays before
-// the live stream begins. Sibling of MessagePageAnchor, narrowed to the two modes
+// the live stream begins. Sibling of MessagePageAnchor, narrowed to the modes
 // a tail subscription actually supports -- so OLDEST/BEFORE (meaningless for a
 // live tail) are simply unrepresentable rather than rejected at runtime.
 enum WatchReplayMode {
@@ -602,13 +602,19 @@ enum WatchReplayMode {
   // Replay every message after cursor_seq (seq > cursor_seq), then stream live.
   // The reconnect/resume subscription that bridges the disconnect gap.
   WATCH_REPLAY_MODE_AFTER_CURSOR = 2;
+  // Replay every message after cursor_seq, as AFTER_CURSOR does, but replay
+  // NOTHING when the gap from cursor_seq to the live tail is larger than
+  // contracts.CatchUpGapLimit. A windowed client abandons a gap that large and
+  // re-anchors on the newest page, so the burst would be pure waste. The client
+  // learns the tail from CatchUpStart.latest_seq, which is sent either way.
+  WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE = 3;
 }
 
 message ListAgentMessagesRequest {
   string agent_id = 1;
   MessagePageAnchor anchor = 2; // Which page to return; defaults to LATEST.
   int64 cursor_seq = 3;         // Exclusive seq bound for BEFORE/AFTER; ignored for LATEST/OLDEST.
-  int32 limit = 4;              // Max messages to return (Hub enforces max 50).
+  int32 limit = 4;              // Max messages to return (contracts.MessagePageLimit).
 }
 
 message ListAgentMessagesResponse {

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -280,6 +280,15 @@ message WatchAgentEntry {
   // ignored for LATEST / while not transitioning into FULL.
   int64 cursor_seq = 3;
   WatchMode mode = 4;
+  // The subscriber's loaded window tail, used ONLY as the base of the
+  // AFTER_CURSOR_OR_NONE skip decision: a windowed client re-anchors when the
+  // gap from its LOADED tail exceeds contracts.CatchUpGapLimit, and the resume
+  // cursor can lead that tail (frames the client observed but dropped while
+  // scrolled away). UNSET (the CLI, which never skips) keeps cursor_seq as the
+  // base. Never affects the replay query itself: that still pages after
+  // cursor_seq. Present 0 (an empty loaded window) is meaningful -- that client
+  // re-anchors on any gap past the limit.
+  optional int64 window_tail_seq = 5;
 }
 
 message WatchTerminalEntry {

--- a/scripts/generate-contracts.mjs
+++ b/scripts/generate-contracts.mjs
@@ -324,8 +324,11 @@ export function checkRetry(r) {
 // ---------------------------------------------------------------------------
 
 export function checkChatHistory(v) {
-  mustBe(Number.isInteger(v.messagePageLimit) && v.messagePageLimit > 0, 'chat-history.json', 'messagePageLimit must be a positive integer')
-  mustBe(Number.isInteger(v.catchUpGapLimit) && v.catchUpGapLimit >= v.messagePageLimit, 'chat-history.json', 'catchUpGapLimit must be an integer >= messagePageLimit')
+  // Safe integers only: the TS emitter writes the raw value into a bigint
+  // literal, and an unsafe value such as 1e21 stringifies as `1e+21n`, which
+  // is not a valid TypeScript literal.
+  mustBe(Number.isSafeInteger(v.messagePageLimit) && v.messagePageLimit > 0, 'chat-history.json', 'messagePageLimit must be a positive safe integer')
+  mustBe(Number.isSafeInteger(v.catchUpGapLimit) && v.catchUpGapLimit >= v.messagePageLimit, 'chat-history.json', 'catchUpGapLimit must be a safe integer >= messagePageLimit')
   return {}
 }
 
@@ -2368,8 +2371,10 @@ export function emitGoChatHistory(v) {
 // Shared chat history limits. The worker caps pages at MessagePageLimit.
 // The browser re-anchors when a catch-up gap exceeds CatchUpGapLimit.
 const (
-\tMessagePageLimit = ${v.messagePageLimit}
-\tCatchUpGapLimit  = ${v.catchUpGapLimit}
+${goConstBlock([
+  { name: 'MessagePageLimit', value: String(v.messagePageLimit) },
+  { name: 'CatchUpGapLimit', value: String(v.catchUpGapLimit) },
+])}
 )
 `
 }

--- a/scripts/generate-contracts.mjs
+++ b/scripts/generate-contracts.mjs
@@ -320,6 +320,16 @@ export function checkRetry(r) {
 }
 
 // ---------------------------------------------------------------------------
+// chat-history: cross-language page and catch-up limits
+// ---------------------------------------------------------------------------
+
+export function checkChatHistory(v) {
+  mustBe(Number.isInteger(v.messagePageLimit) && v.messagePageLimit > 0, 'chat-history.json', 'messagePageLimit must be a positive integer')
+  mustBe(Number.isInteger(v.catchUpGapLimit) && v.catchUpGapLimit >= v.messagePageLimit, 'chat-history.json', 'catchUpGapLimit must be an integer >= messagePageLimit')
+  return {}
+}
+
+// ---------------------------------------------------------------------------
 // session-info: the agent_session_info wire vocabulary
 // ---------------------------------------------------------------------------
 
@@ -2352,6 +2362,28 @@ export const ${constName} = {
   return `${TS_HEADER('retry.json')}\n${blocks.join('\n')}`
 }
 
+export function emitGoChatHistory(v) {
+  return `${GO_HEADER('chat-history.json')}package contracts
+
+// Shared chat history limits. The worker caps pages at MessagePageLimit.
+// The browser re-anchors when a catch-up gap exceeds CatchUpGapLimit.
+const (
+\tMessagePageLimit = ${v.messagePageLimit}
+\tCatchUpGapLimit  = ${v.catchUpGapLimit}
+)
+`
+}
+
+export function emitTsChatHistory(v) {
+  return `${TS_HEADER('chat-history.json')}
+/** The maximum number of messages in one history page. */
+export const MESSAGE_PAGE_LIMIT = ${v.messagePageLimit} as const
+
+/** The largest sequence gap that the browser drains before it re-anchors. */
+export const CATCH_UP_GAP_LIMIT = ${v.catchUpGapLimit}n
+`
+}
+
 /**
  * One queued agent input's caps. The browser pre-checks a composer draft and
  * the Worker enforces the same numbers, so both must measure ONE quantity:
@@ -2599,6 +2631,15 @@ const DOMAINS = [
       checkRetry(r)
       out['backend/generated/contracts/retry.go'] = emitGoRetry(r)
       out['frontend/src/generated/contracts/retry.ts'] = emitTsRetry(r)
+    },
+  },
+  {
+    name: 'chat-history',
+    emit(out, read) {
+      const v = read('chat-history')
+      checkChatHistory(v)
+      out['backend/generated/contracts/chat-history.go'] = emitGoChatHistory(v)
+      out['frontend/src/generated/contracts/chat-history.ts'] = emitTsChatHistory(v)
     },
   },
   {

--- a/scripts/generate-contracts.test.mjs
+++ b/scripts/generate-contracts.test.mjs
@@ -241,14 +241,14 @@ describe('checkChatHistory', () => {
   it('rejects a non-positive message page limit', () => {
     expectContractError(
       () => checkChatHistory({ ...CHAT_HISTORY, messagePageLimit: 0 }),
-      'messagePageLimit must be a positive integer',
+      'messagePageLimit must be a positive safe integer',
     )
   })
 
   it('rejects a catch-up gap below one page', () => {
     expectContractError(
       () => checkChatHistory({ ...CHAT_HISTORY, catchUpGapLimit: CHAT_HISTORY.messagePageLimit - 1 }),
-      'catchUpGapLimit must be an integer >= messagePageLimit',
+      'catchUpGapLimit must be a safe integer >= messagePageLimit',
     )
   })
 
@@ -262,11 +262,24 @@ describe('checkChatHistory', () => {
   it('rejects fractional limits', () => {
     expectContractError(
       () => checkChatHistory({ ...CHAT_HISTORY, messagePageLimit: 1.5 }),
-      'messagePageLimit must be a positive integer',
+      'messagePageLimit must be a positive safe integer',
     )
     expectContractError(
       () => checkChatHistory({ ...CHAT_HISTORY, catchUpGapLimit: CHAT_HISTORY.catchUpGapLimit + 0.5 }),
-      'catchUpGapLimit must be an integer >= messagePageLimit',
+      'catchUpGapLimit must be a safe integer >= messagePageLimit',
+    )
+  })
+
+  it('rejects unsafe integers, which would emit an invalid TypeScript bigint literal', () => {
+    // 1e21 stringifies as '1e+21', so an emitted `CATCH_UP_GAP_LIMIT = 1e+21n`
+    // would not parse; values past 2^53 - 1 silently round.
+    expectContractError(
+      () => checkChatHistory({ ...CHAT_HISTORY, catchUpGapLimit: 1e21 }),
+      'catchUpGapLimit must be a safe integer >= messagePageLimit',
+    )
+    expectContractError(
+      () => checkChatHistory({ ...CHAT_HISTORY, messagePageLimit: 2 ** 53 }),
+      'messagePageLimit must be a positive safe integer',
     )
   })
 })

--- a/scripts/generate-contracts.test.mjs
+++ b/scripts/generate-contracts.test.mjs
@@ -16,6 +16,7 @@ import { describe, expect, it } from 'bun:test'
 
 import {
   bufDescriptor,
+  checkChatHistory,
   checkCodexBypass,
   checkDesktop,
   checkExternalApps,
@@ -38,6 +39,7 @@ import {
   DESKTOP_RS_BEHAVIOR_NAMES,
   DESKTOP_RS_MACOS_ONLY_EVENTS,
   DESKTOP_TS_BEHAVIOR_NAMES,
+  emitGoChatHistory,
   emitGoDesktop,
   emitGoExternalApps,
   emitGoHeaders,
@@ -48,6 +50,7 @@ import {
   emitGoValidate,
   emitGoWire,
   emitRsDesktop,
+  emitTsChatHistory,
   emitTsDesktop,
   emitTsExternalApps,
   emitTsHeaders,
@@ -81,6 +84,7 @@ const readContract = name => JSON.parse(readFileSync(join(ROOT, 'contracts', `${
 const WIRE = readContract('wire')
 const HEADERS = readContract('headers')
 const RETRY = readContract('retry')
+const CHAT_HISTORY = readContract('chat-history')
 const TRUSTED_PROXIES = readContract('trusted-proxies')
 
 function expectContractError(fn, fragment) {
@@ -229,6 +233,44 @@ describe('checkHeaders / checkRetry', () => {
   })
 })
 
+describe('checkChatHistory', () => {
+  it('accepts the shipped contract', () => {
+    expect(() => checkChatHistory(CHAT_HISTORY)).not.toThrow()
+  })
+
+  it('rejects a non-positive message page limit', () => {
+    expectContractError(
+      () => checkChatHistory({ ...CHAT_HISTORY, messagePageLimit: 0 }),
+      'messagePageLimit must be a positive integer',
+    )
+  })
+
+  it('rejects a catch-up gap below one page', () => {
+    expectContractError(
+      () => checkChatHistory({ ...CHAT_HISTORY, catchUpGapLimit: CHAT_HISTORY.messagePageLimit - 1 }),
+      'catchUpGapLimit must be an integer >= messagePageLimit',
+    )
+  })
+
+  it('accepts a catch-up gap equal to one page', () => {
+    expect(() => checkChatHistory({
+      ...CHAT_HISTORY,
+      catchUpGapLimit: CHAT_HISTORY.messagePageLimit,
+    })).not.toThrow()
+  })
+
+  it('rejects fractional limits', () => {
+    expectContractError(
+      () => checkChatHistory({ ...CHAT_HISTORY, messagePageLimit: 1.5 }),
+      'messagePageLimit must be a positive integer',
+    )
+    expectContractError(
+      () => checkChatHistory({ ...CHAT_HISTORY, catchUpGapLimit: CHAT_HISTORY.catchUpGapLimit + 0.5 }),
+      'catchUpGapLimit must be an integer >= messagePageLimit',
+    )
+  })
+})
+
 describe('name tables', () => {
   it('maps every emitted wire value to distinct Go and TS names', () => {
     expect(new Set(Object.values(WIRE_GO_NAMES)).size).toBe(Object.keys(WIRE_GO_NAMES).length)
@@ -320,6 +362,15 @@ describe('emitters', () => {
     const go = emitGoRetry(RETRY)
     expect(go).toContain('EventsRejectionRetryInitial     = time.Duration(500) * time.Millisecond')
     expect(go).toContain('EventsRejectionRetryMaxAttempts = 8')
+  })
+
+  it('emits the chat history limits for Go and TypeScript', () => {
+    const go = emitGoChatHistory(CHAT_HISTORY)
+    expect(go).toContain('MessagePageLimit = 50')
+    expect(go).toContain('CatchUpGapLimit  = 150')
+    const ts = emitTsChatHistory(CHAT_HISTORY)
+    expect(ts).toContain('MESSAGE_PAGE_LIMIT = 50 as const')
+    expect(ts).toContain('CATCH_UP_GAP_LIMIT = 150n')
   })
 
   it('emits the multiplier on the Go side too, so both sides can consume it', () => {
@@ -600,6 +651,7 @@ describe('generate', () => {
     expect(Object.keys(files).sort()).toEqual([
       'backend/generated/contracts/agent-input.go',
       'backend/generated/contracts/captcha.go',
+      'backend/generated/contracts/chat-history.go',
       'backend/generated/contracts/claude-protocol.go',
       'backend/generated/contracts/codex-bypass.go',
       'backend/generated/contracts/copilot-permissions.go',
@@ -624,6 +676,7 @@ describe('generate', () => {
       'desktop/rust/src/generated/contracts.rs',
       'frontend/src/generated/contracts/agent-input.ts',
       'frontend/src/generated/contracts/captcha.ts',
+      'frontend/src/generated/contracts/chat-history.ts',
       'frontend/src/generated/contracts/claude-protocol.ts',
       'frontend/src/generated/contracts/codex-bypass.ts',
       'frontend/src/generated/contracts/copilot-permissions.ts',


### PR DESCRIPTION
## Motivation

When a browser reconnected (or promoted a tab to FULL) with a large
chat-history gap, two things went wrong. The worker always marshalled and sent
a bounded 50-message replay burst, even though a windowed client abandons a gap
that large and re-anchors on the newest page — the burst was pure waste. And the
browser's forward-fill drain looped page by page until it reached the tail,
regardless of gap size. The page limit (50) and the new catch-up gap limit (150)
were also needed on both sides of the Go/TypeScript boundary, so they belong in
a shared contract instead of hand-written copies.

## Modifications

- New cross-language contract `contracts/chat-history.json` (+ JSON Schema):
  `messagePageLimit: 50`, `catchUpGapLimit: 150`, with the seq-distance gap
  semantics documented in its `_readme`. The generator emits
  `contracts.MessagePageLimit` / `contracts.CatchUpGapLimit` (Go) and
  `MESSAGE_PAGE_LIMIT` / `CATCH_UP_GAP_LIMIT` (TS), replacing the hand-written
  `maxMessagePageLimit` (worker), `followDrainPageLimit` (CLI), and
  `MESSAGE_PAGE_SIZE` (frontend); `MAX_LOADED_CHAT_MESSAGES` now derives from
  `CATCH_UP_GAP_LIMIT`. Validation rejects unsafe integers that would emit
  invalid TS bigint literals.
- New `WatchReplayMode.WATCH_REPLAY_MODE_AFTER_CURSOR_OR_NONE = 3`: replays
  after `cursor_seq` like `AFTER_CURSOR`, but the worker skips the message
  replay when the gap to the live tail exceeds `CatchUpGapLimit`. Only the
  message page is skipped — `CatchUpStart` (carrying `latest_seq`), the
  todo/status/activity snapshots, and pending control requests still replay.
- New optional `WatchAgentEntry.window_tail_seq`: the subscriber's loaded
  window tail, used solely as the skip-decision base (the resume cursor can
  lead the loaded tail, because frames observed while scrolled away are
  dropped). Unset — the CLI, which never skips — keeps `cursor_seq` as the
  base; a present `0` (empty window) is meaningful.
- Frontend: the shared predicate `exceedsCatchUpGapLimit` (chatLiveTail.ts)
  mirrors the worker's strict `>` boundary; `catchUpToTail` records each page's
  authoritative `resp.latestSeq` and stops the drain once the gap exceeds the
  limit, returning before the stale-tail clamp so the scheduler still sees the
  gap; `reconcileLaggingTails` re-anchors over-limit gaps via `jumpToLatest`
  when the tab follows the tail (or holds a deferred fill) — a plain
  scrolled-away wall keeps its window; watch plans send `AFTER_CURSOR_OR_NONE`
  on resume and declare `windowTailSeq` from the loaded tail.
- Failure surfacing: the reconcile-driven `jumpToLatest` and
  `resumeDeferredTailFill` calls now catch errors and show the
  "Failed to load chat history" toast, instead of one silent unhandled
  rejection per retry cycle. A page's `latestSeq` can no longer lower a live
  tail that a broadcast raised mid-drain, and the over-limit re-anchor no
  longer force-jumps a reader deliberately scrolled away from the tail.

## Result

A reconnect with a >150-message gap now lands the chat window on the newest
page in one round trip, and the worker no longer sends a replay burst the
browser would discard. A reader scrolled up into history keeps their position
while they read, a failed re-anchor tells you why instead of failing silently,
and the page/gap limits cannot drift between Go and TypeScript. Tests cover the
skip decision (11-case unit table incl. cursor-leads-tail and empty-window),
the promotion replay over the wire, the drain's over-limit stop, the reconcile
re-anchor gating, the toast-on-failed-re-anchor wiring, and the contract
validation and emitters.
