### PR TITLE
feat(chat): Turn control-request permission choices into pill groups

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.test.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.test.tsx
@@ -2,10 +2,11 @@ import type { AgentEditorPanelProps } from './AgentEditorPanel'
 import type { AgentInfo } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { ControlRequest } from '~/stores/control.store'
 import { create } from '@bufbuild/protobuf'
-import { fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PreferencesProvider } from '~/context/PreferencesContext'
+import { CLAUDE_MODE } from '~/generated/contracts/claude-protocol'
 import { AgentInputKind, AgentInputQueuePauseReason, AgentInputQueueSnapshotSchema, AgentInputState, AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { localStorageLoad, localStorageStore, PREFIX_CONTROL_STATE } from '~/lib/browserStorage'
 import { clearDraft, loadDraft, saveDraft } from '~/lib/editor/draftPersistence'
@@ -76,6 +77,8 @@ interface RenderPanelOptions {
   agentProvider?: AgentProvider
   controlStore?: ReturnType<typeof createControlStore>
   onControlResponse?: AgentEditorPanelProps['onControlResponse']
+  onSettingChange?: AgentEditorPanelProps['onSettingChange']
+  optionGroups?: AgentInfo['optionGroups']
 }
 
 function renderPanel(options: RenderPanelOptions = {}) {
@@ -92,12 +95,17 @@ function renderPanel(options: RenderPanelOptions = {}) {
     <PreferencesProvider>
       <AgentEditorPanel
         agentId="a1"
-        agent={agent({ workerId, agentProvider: options.agentProvider ?? AgentProvider.CLAUDE_CODE })}
+        agent={agent({
+          workerId,
+          agentProvider: options.agentProvider ?? AgentProvider.CLAUDE_CODE,
+          optionGroups: options.optionGroups,
+        })}
         repoGitStore={repoGitStore}
         gitTab={gitTab}
         onSendMessage={() => {}}
         controlRequests={options.controlStore?.getRequests('a1')}
         onControlResponse={options.onControlResponse}
+        onSettingChange={options.onSettingChange}
         branchActions={stubBranchMenuActions()}
         branchWorkerId={workerId}
       />
@@ -351,6 +359,60 @@ describe('agentEditorPanel control request lifecycle', () => {
   // The switch belongs to the request INSTANCE, not to the component that drew
   // it, so it must come back checked -- otherwise Approve silently omits the
   // choice the user made.
+  // The panel's preset memo follows the composer menu's rule: a preset is
+  // offered only when the live catalog carries every axis it sets. Claude's
+  // presets both switch permissionMode, so the pill group appears exactly when
+  // the catalog carries that group.
+  it('draws the permission pills only while the catalog carries the preset axes', async () => {
+    const controlStore = createControlStore()
+    addControlRequest(controlStore, { requestId: 'plan-1', payload: toolRequestPayload('ExitPlanMode'), claimToken: 'claim-1' })
+    const modeGroup = {
+      id: 'permissionMode',
+      label: 'Approval',
+      order: 30,
+      mutable: true,
+      defaultValue: CLAUDE_MODE.Default,
+      currentValue: CLAUDE_MODE.Default,
+      options: Object.values(CLAUDE_MODE).map(mode => ({ id: mode, name: mode })),
+    } as unknown as AgentInfo['optionGroups'][number]
+    renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [modeGroup] })
+    await waitFor(() => expect(screen.getByRole('radiogroup', { name: 'Permissions' })).toBeInTheDocument())
+
+    // The catalog drops the permissionMode group: no preset the banner could
+    // offer is applicable, so the group must disappear rather than draw pills
+    // that would silently do nothing.
+    cleanup()
+    renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [] })
+    await waitFor(() => expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument())
+  })
+
+  // The pill choice belongs to the request INSTANCE like a switch: a rebuild of
+  // the control component must not reset it to Default.
+  it('restores the permission pill choice of the rendered request instance after a remount', async () => {
+    const controlStore = createControlStore()
+    addControlRequest(controlStore, { requestId: 'plan-1', payload: toolRequestPayload('ExitPlanMode'), claimToken: 'claim-1' })
+    const modeGroup = {
+      id: 'permissionMode',
+      label: 'Approval',
+      order: 30,
+      mutable: true,
+      defaultValue: CLAUDE_MODE.Default,
+      currentValue: CLAUDE_MODE.Default,
+      options: Object.values(CLAUDE_MODE).map(mode => ({ id: mode, name: mode })),
+    } as unknown as AgentInfo['optionGroups'][number]
+    const bypassRadio = () => within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass permissions' })
+    const first = renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [modeGroup] })
+
+    fireEvent.click(bypassRadio())
+    expect(bypassRadio()).toBeChecked()
+
+    first.unmount()
+    renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [modeGroup] })
+
+    // Polled: the saved record is read after the remount, not during it.
+    await waitFor(() => expect(bypassRadio()).toBeChecked())
+  })
+
   it('restores the plan switches of the rendered request instance after a remount', async () => {
     const controlStore = createControlStore()
     addControlRequest(controlStore, { requestId: 'plan-1', payload: toolRequestPayload('ExitPlanMode'), claimToken: 'claim-1' })

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -1,7 +1,7 @@
 import type { Component } from 'solid-js'
 import type { FileAttachment, PendingAttachmentFile } from './attachments'
 import type { EditorContentRef } from './controls/types'
-import type { BypassController, ProviderSettingChangeHandler } from './providerSettings'
+import type { PermissionPresetController, ProviderSettingChangeHandler } from './providerSettings'
 import type { BeginQueueEdit } from './queueEditSession'
 import type { WorkingTreeInfo } from '~/components/common/WorkingTree'
 import type { BranchMenuActions } from '~/components/workspace/branchActions'
@@ -353,12 +353,21 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   // Every axis's confirmed value as one generic map keyed by group id, derived from
   // the catalog (the proto AgentInfo carries no scalar model/effort/permission fields).
   const currentOptionValues = () => optionValuesFromGroups(props.agent?.optionGroups)
-  const bypass = createMemo<BypassController | undefined>(() => {
-    const settings = props.agent?.agentProvider
-      ? providerFor(props.agent.agentProvider)?.permissionPresets?.bypass
+  // The permission presets a control request's pill group may apply, gated the
+  // same way the composer `[+]` menu gates its permission items: a preset is
+  // offered only when the live catalog carries every axis it sets. The one
+  // `apply` handler is the shared `onSettingChange`, so a pill selection and the
+  // menu item cannot diverge in what they switch.
+  const permissionPresets = createMemo<PermissionPresetController | undefined>(() => {
+    const presets = props.agent?.agentProvider
+      ? providerFor(props.agent.agentProvider)?.permissionPresets
       : undefined
-    return permissionPresetAvailable(settings, props.agent?.optionGroups) && props.onSettingChange
-      ? { settings, apply: props.onSettingChange }
+    const smartPreset = presets?.smart
+    const bypassPreset = presets?.bypass
+    const smart = permissionPresetAvailable(smartPreset, props.agent?.optionGroups) ? smartPreset : undefined
+    const bypass = permissionPresetAvailable(bypassPreset, props.agent?.optionGroups) ? bypassPreset : undefined
+    return (smart || bypass) && props.onSettingChange
+      ? { smart, bypass, apply: props.onSettingChange }
       : undefined
   })
 
@@ -754,7 +763,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                         hasEditorContent={hasContent()}
                         onTriggerSend={() => { void triggerSend?.() }}
                         editorContentRef={() => editorContentRef}
-                        bypass={bypass()}
+                        presets={permissionPresets()}
                         contextUsage={props.agentSessionInfo?.contextUsage}
                         modelContextWindow={modelContextWindow()}
                       />

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -50,7 +50,7 @@ import { useControlResponseHandling } from './controlResponseHandling'
 import { createControlAnswerState } from './controls/types'
 import { MarkdownEditor } from './markdownEditor/MarkdownEditor'
 import { providerFor } from './providers/registry'
-import { permissionPresetAvailable } from './providerSettings'
+import { usablePresets } from './providerSettings'
 import { createQueueEditSession } from './queueEditSession'
 import {
   OPTION_ID_MODEL,
@@ -353,21 +353,18 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
   // Every axis's confirmed value as one generic map keyed by group id, derived from
   // the catalog (the proto AgentInfo carries no scalar model/effort/permission fields).
   const currentOptionValues = () => optionValuesFromGroups(props.agent?.optionGroups)
-  // The permission presets a control request's pill group may apply, gated the
-  // same way the composer `[+]` menu gates its permission items: a preset is
-  // offered only when the live catalog carries every axis it sets. The one
+  // The permission presets a control request's pill group may apply, offered
+  // under the same rule as the composer `[+]` menu's permission items (`usablePresets`):
+  // a preset is offered only when the live catalog carries every axis it sets. The one
   // `apply` handler is the shared `onSettingChange`, so a pill selection and the
   // menu item cannot diverge in what they switch.
   const permissionPresets = createMemo<PermissionPresetController | undefined>(() => {
     const presets = props.agent?.agentProvider
       ? providerFor(props.agent.agentProvider)?.permissionPresets
       : undefined
-    const smartPreset = presets?.smart
-    const bypassPreset = presets?.bypass
-    const smart = permissionPresetAvailable(smartPreset, props.agent?.optionGroups) ? smartPreset : undefined
-    const bypass = permissionPresetAvailable(bypassPreset, props.agent?.optionGroups) ? bypassPreset : undefined
-    return (smart || bypass) && props.onSettingChange
-      ? { smart, bypass, apply: props.onSettingChange }
+    const usable = usablePresets(presets, props.agent?.optionGroups)
+    return (usable.smart || usable.bypass) && props.onSettingChange
+      ? { ...usable, apply: props.onSettingChange }
       : undefined
   })
 

--- a/frontend/src/components/chat/ControlRequestBanner.css.ts
+++ b/frontend/src/components/chat/ControlRequestBanner.css.ts
@@ -191,10 +191,27 @@ export const controlFooterRight = style({
   gridColumn: 3,
 })
 
+// The leading options cluster of a decision row: the request's switches, then
+// the permission pill group, on ONE line ahead of the decision buttons. The pill
+// group is button-high, so nothing here needs the second line the switch COLUMN
+// used to occupy; the cluster keeps `minWidth: 0` so a narrow composer can
+// compress the pills (they clip inside their own box) before the buttons move.
 export const controlRequestSwitches = style({
   display: 'flex',
-  flexDirection: 'column',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: 'var(--space-1)',
   marginRight: 'var(--space-1)',
+  minWidth: 0,
+})
+
+// The pill group yields width before the decision buttons do: `flexShrink` lets
+// the row compress it, and PillGroup's own `max-width: 100%` + `overflow: hidden`
+// decide what a compressed group shows.
+export const controlRequestPill = style({
+  display: 'flex',
+  minWidth: 0,
+  flexShrink: 1,
 })
 
 export const collapsibleToggle = style({

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
@@ -9,7 +9,7 @@ import Paperclip from 'lucide-solid/icons/paperclip'
 import Plus from 'lucide-solid/icons/plus'
 import { createMemo, createSignal, For, Show } from 'solid-js'
 import { pluginFor } from '~/components/chat/providers/registry'
-import { permissionPresetAvailable } from '~/components/chat/providerSettings'
+import { PERMISSION_PRESET_LABELS, permissionPresetAvailable, usablePresets } from '~/components/chat/providerSettings'
 import { hasOptions, resolvedCurrent } from '~/components/chat/settingsGroups'
 import { DisabledReasonMenuItem } from '~/components/common/DisabledReasonMenuItem'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
@@ -163,21 +163,21 @@ interface PermissionAction {
 }
 
 const PERMISSION_ACTIONS: ReadonlyArray<Omit<PermissionAction, 'preset'>> = [
-  { kind: 'smart', label: 'Smart permissions', testId: 'composer-smart-permissions' },
-  { kind: 'bypass', label: 'Bypass permissions', testId: 'composer-bypass-permissions' },
+  { kind: 'smart', label: PERMISSION_PRESET_LABELS.smart, testId: 'composer-smart-permissions' },
+  { kind: 'bypass', label: PERMISSION_PRESET_LABELS.bypass, testId: 'composer-bypass-permissions' },
 ]
 
 function permissionActionsFor(
   provider: AgentProvider | undefined,
   groups: AvailableOptionGroup[] | undefined,
 ): PermissionAction[] {
-  const presets = pluginFor(provider)?.permissionPresets
-  if (!presets)
-    return []
+  // The same `usablePresets` rule the control-request pill group follows, so the
+  // menu and a banner's pills cannot offer different preset sets.
+  const usable = usablePresets(pluginFor(provider)?.permissionPresets, groups)
   const actions: PermissionAction[] = []
   for (const action of PERMISSION_ACTIONS) {
-    const preset = presets[action.kind]
-    if (permissionPresetAvailable(preset, groups))
+    const preset = usable[action.kind]
+    if (preset)
       actions.push({ ...action, preset })
   }
   return actions

--- a/frontend/src/components/chat/controlResponseHandling.test.ts
+++ b/frontend/src/components/chat/controlResponseHandling.test.ts
@@ -248,6 +248,28 @@ describe('restoring saved answers', () => {
     dispose()
   })
 
+  it('restores a pill group choice, and a choices-only record still lands', async () => {
+    // A record carrying nothing but a pill selection is not blank: the restore
+    // must land it, or a reload would silently reset the user's preset pick.
+    const request = askRequest('ask-3', 'tok-3')
+    localStorageStore(answerKey(request), { choices: { 'control-permissions-pill': 'bypass' } })
+    await flushStorageWrites()
+
+    const answerState = createControlAnswerState()
+    const dispose = createRoot((disposeRoot) => {
+      useControlResponseHandling(
+        { agentId: 'test-agent', controlRequests: [request], onSendMessage: vi.fn() },
+        answerState,
+        () => undefined,
+        vi.fn(),
+      )
+      return disposeRoot
+    })
+
+    await vi.waitFor(() => expect(answerState.choices()).toEqual({ 'control-permissions-pill': 'bypass' }))
+    dispose()
+  })
+
   // THE RESTORE GUARD. A user clicking between two prompts swaps the active
   // request while the first one's answers are still being read. Whichever read
   // the database answers last must not decide what is on screen: landing the

--- a/frontend/src/components/chat/controlResponseHandling.ts
+++ b/frontend/src/components/chat/controlResponseHandling.ts
@@ -57,6 +57,7 @@ function isBlankAnswer(value: ControlAnswerSeed): boolean {
     && Object.keys(value.selections ?? {}).length === 0
     && Object.keys(value.customTexts ?? {}).length === 0
     && Object.keys(value.switches ?? {}).length === 0
+    && Object.keys(value.choices ?? {}).length === 0
 }
 
 export function useControlResponseHandling(
@@ -143,6 +144,7 @@ export function useControlResponseHandling(
     customTexts: answerState.customTexts(),
     currentPage: answerState.currentPage(),
     switches: answerState.switches(),
+    choices: answerState.choices(),
   })
 
   // Reset the user's in-progress answer when the active request INSTANCE changes.
@@ -190,6 +192,7 @@ export function useControlResponseHandling(
       answerState.setCustomTexts({})
       answerState.setCurrentPage(0)
       answerState.setSwitches({})
+      answerState.setChoices({})
       if (!request || !props.agentId) {
         restoringFor = null
         return
@@ -214,6 +217,7 @@ export function useControlResponseHandling(
         answerState.setCustomTexts(saved.customTexts ?? {})
         answerState.setCurrentPage(saved.currentPage ?? 0)
         answerState.setSwitches(saved.switches ?? {})
+        answerState.setChoices(saved.choices ?? {})
       })
     },
   ))

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
@@ -1,7 +1,10 @@
 import type { Accessor, Component } from 'solid-js'
+import type { ControlPermissionPill } from './permissionPresets'
 
+import type { PillOptions } from '~/components/common/PillGroup'
 import { For, Index, Show } from 'solid-js'
 import { CompactSwitch } from '~/components/common/CompactSwitch'
+import { PillGroup } from '~/components/common/PillGroup'
 import { keepFocusOnPress } from '~/lib/focusRetention'
 import * as styles from '../ControlRequestBanner.css'
 import { ControlActionRow } from './ControlActionRow'
@@ -21,6 +24,43 @@ export interface ControlDecisionAction {
   outline?: boolean
 }
 
+/**
+ * The permission pill group a control request's decision row offers: Default /
+ * Smart permissions / Bypass permissions, one row segment shared by the decision
+ * footer and the providers that lay out their own action row (ACP, OpenCode).
+ */
+export const ControlPermissionPillGroup: Component<{ pill: ControlPermissionPill }> = props => (
+  <div class={styles.controlRequestPill} data-testid="control-permissions-pill-group">
+    <PillGroup
+      label="Permissions"
+      options={props.pill.options}
+      selectedKey={props.pill.selected}
+      onSelect={props.pill.onSelect}
+    />
+  </div>
+)
+
+/**
+ * The allow-scope pill group a permission request offers when one allow-once
+ * faces two or more allow-always scopes (Once / Session / Project): the scope
+ * control that REPLACES the Remember switch there, keys being optionIds so a
+ * selection maps straight onto the wire reply.
+ */
+export const ControlAllowScopePillGroup: Component<{
+  options: PillOptions<string>
+  selected: string
+  onSelect: (optionId: string) => void
+}> = props => (
+  <div class={styles.controlRequestPill} data-testid="control-allow-scope-pill-group">
+    <PillGroup
+      label="Allow scope"
+      options={props.options}
+      selectedKey={props.selected}
+      onSelect={props.onSelect}
+    />
+  </div>
+)
+
 /** Renders the shared options and decision layout for a control request. */
 export const ControlDecisionFooter: Component<{
   hasEditorContent: boolean
@@ -28,16 +68,22 @@ export const ControlDecisionFooter: Component<{
   negativeAction: ControlDecisionAction
   positiveAction: ControlDecisionAction
   switches?: Accessor<ControlRequestSwitch[]>
+  /** The permission pill group, or omit it when no preset is available. */
+  permissionPill?: Accessor<ControlPermissionPill | undefined>
   additionalActions?: Accessor<ControlDecisionAction[]>
 }> = (props) => {
   const switches = () => props.switches?.() ?? []
   const additionalActions = () => props.additionalActions?.() ?? []
+  // One leading cluster -- [switches][permission pill] -- so the row reads as
+  // options followed by decisions: a pill is button-high, so it shares the row
+  // with the switches instead of stacking above them.
+  const leadingOptions = () => switches().length > 0 || !!props.permissionPill?.()
 
   return (
     <ControlActionRow
       primary={(
         <>
-          <Show when={!props.hasEditorContent && switches().length > 0}>
+          <Show when={!props.hasEditorContent && leadingOptions()}>
             <div class={styles.controlRequestSwitches}>
               <Index each={switches()}>
                 {item => (
@@ -52,6 +98,9 @@ export const ControlDecisionFooter: Component<{
                   </CompactSwitch>
                 )}
               </Index>
+              <Show when={props.permissionPill?.()}>
+                {pill => <ControlPermissionPillGroup pill={pill()} />}
+              </Show>
             </div>
           </Show>
           <button

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
@@ -1,13 +1,12 @@
 import type { Accessor, Component } from 'solid-js'
 import type { ControlPermissionPill } from './permissionPresets'
 
-import type { PillOptions } from '~/components/common/PillGroup'
 import { For, Index, Show } from 'solid-js'
 import { CompactSwitch } from '~/components/common/CompactSwitch'
-import { PillGroup } from '~/components/common/PillGroup'
 import { keepFocusOnPress } from '~/lib/focusRetention'
 import * as styles from '../ControlRequestBanner.css'
 import { ControlActionRow } from './ControlActionRow'
+import { ControlPermissionPillGroup } from './ControlPillGroups'
 
 export interface ControlRequestSwitch {
   id: string
@@ -23,43 +22,6 @@ export interface ControlDecisionAction {
   onSelect: () => void | Promise<void>
   outline?: boolean
 }
-
-/**
- * The permission pill group a control request's decision row offers: Default /
- * Smart permissions / Bypass permissions, one row segment shared by the decision
- * footer and the providers that lay out their own action row (ACP, OpenCode).
- */
-export const ControlPermissionPillGroup: Component<{ pill: ControlPermissionPill }> = props => (
-  <div class={styles.controlRequestPill} data-testid="control-permissions-pill-group">
-    <PillGroup
-      label="Permissions"
-      options={props.pill.options}
-      selectedKey={props.pill.selected}
-      onSelect={props.pill.onSelect}
-    />
-  </div>
-)
-
-/**
- * The allow-scope pill group a permission request offers when one allow-once
- * faces two or more allow-always scopes (Once / Session / Project): the scope
- * control that REPLACES the Remember switch there, keys being optionIds so a
- * selection maps straight onto the wire reply.
- */
-export const ControlAllowScopePillGroup: Component<{
-  options: PillOptions<string>
-  selected: string
-  onSelect: (optionId: string) => void
-}> = props => (
-  <div class={styles.controlRequestPill} data-testid="control-allow-scope-pill-group">
-    <PillGroup
-      label="Allow scope"
-      options={props.options}
-      selectedKey={props.selected}
-      onSelect={props.onSelect}
-    />
-  </div>
-)
 
 /** Renders the shared options and decision layout for a control request. */
 export const ControlDecisionFooter: Component<{

--- a/frontend/src/components/chat/controls/ControlPillGroups.tsx
+++ b/frontend/src/components/chat/controls/ControlPillGroups.tsx
@@ -1,0 +1,46 @@
+import type { Component } from 'solid-js'
+import type { ControlPermissionPill } from './permissionPresets'
+
+import type { PillOptions } from '~/components/common/PillGroup'
+import { PillGroup } from '~/components/common/PillGroup'
+import { Tooltip } from '~/components/common/Tooltip'
+import * as styles from '../ControlRequestBanner.css'
+
+/**
+ * The permission pill group a control request's decision row offers: Default /
+ * Smart permissions / Bypass permissions, one row segment shared by the decision
+ * footer and the providers that lay out their own action row (ACP, OpenCode).
+ */
+export const ControlPermissionPillGroup: Component<{ pill: ControlPermissionPill }> = props => (
+  <Tooltip text="The selected preset applies when you allow or approve this request">
+    <div class={styles.controlRequestPill} data-testid="control-permissions-pill-group">
+      <PillGroup
+        label="Permissions"
+        options={props.pill.options}
+        selectedKey={props.pill.selected}
+        onSelect={props.pill.onSelect}
+      />
+    </div>
+  </Tooltip>
+)
+
+/**
+ * The allow-scope pill group a permission request offers when one allow-once
+ * faces one or more allow-always scopes (Once / Always, or Once / Session /
+ * Project): the scope control for HOW LONG an allow lasts, keys being optionIds
+ * so a selection maps straight onto the wire reply.
+ */
+export const ControlAllowScopePillGroup: Component<{
+  options: PillOptions<string>
+  selected: string
+  onSelect: (optionId: string) => void
+}> = props => (
+  <div class={styles.controlRequestPill} data-testid="control-allow-scope-pill-group">
+    <PillGroup
+      label="Allow scope"
+      options={props.options}
+      selectedKey={props.selected}
+      onSelect={props.onSelect}
+    />
+  </div>
+)

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
@@ -1,5 +1,5 @@
 import type { ControlRequest } from '~/stores/control.store'
-import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { ExitPlanModeActions } from '~/components/chat/controls/ExitPlanModeControl'
 import { createControlAnswerState } from './types'
@@ -14,8 +14,12 @@ function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
   }
 }
 
+function permissionPill() {
+  return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
+}
+
 describe('exitPlanModeActions', () => {
-  it('shows Reject, Approve, and the plan switches when no editor content', () => {
+  it('shows Reject, Approve, the Clear Context switch, and the permission pills when no editor content', () => {
     render(() => (
       <ExitPlanModeActions
         request={makeRequest()}
@@ -23,7 +27,11 @@ describe('exitPlanModeActions', () => {
         onRespond={vi.fn().mockResolvedValue(undefined)}
         hasEditorContent={false}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+        presets={{
+          smart: { sets: { permissionMode: 'auto' } },
+          bypass: { sets: { permissionMode: 'bypassPermissions' } },
+          apply: vi.fn(),
+        }}
         contextUsage={{ inputTokens: 300, cacheCreationInputTokens: 0, cacheReadInputTokens: 0 }}
         modelContextWindow={1000}
       />
@@ -32,7 +40,9 @@ describe('exitPlanModeActions', () => {
     expect(screen.getByTestId('plan-reject-btn')).toBeInTheDocument()
     expect(screen.getByTestId('plan-approve-btn')).toBeInTheDocument()
     expect(screen.getByTestId('plan-clear-context-checkbox')).toHaveTextContent('Clear Context (30%)')
-    expect(screen.getByTestId('plan-bypass-permissions-checkbox')).toBeInTheDocument()
+    expect(permissionPill().getByRole('radio', { name: 'Default' })).toBeChecked()
+    expect(permissionPill().getByRole('radio', { name: 'Smart permissions' })).toBeInTheDocument()
+    expect(permissionPill().getByRole('radio', { name: 'Bypass permissions' })).toBeInTheDocument()
   })
 
   it('shows only Send feedback when editor has content', () => {
@@ -43,7 +53,7 @@ describe('exitPlanModeActions', () => {
         onRespond={vi.fn().mockResolvedValue(undefined)}
         hasEditorContent={true}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
       />
     ))
 
@@ -51,7 +61,7 @@ describe('exitPlanModeActions', () => {
     expect(screen.getByTestId('plan-reject-btn')).toHaveTextContent('Send feedback')
     expect(screen.queryByTestId('plan-approve-btn')).not.toBeInTheDocument()
     expect(screen.queryByTestId('plan-clear-context-checkbox')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('plan-bypass-permissions-checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument()
   })
 
   it('sends clearContext when Clear Context is checked', () => {
@@ -64,7 +74,7 @@ describe('exitPlanModeActions', () => {
         onRespond={onRespond}
         hasEditorContent={false}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
       />
     ))
 
@@ -77,7 +87,7 @@ describe('exitPlanModeActions', () => {
     expect(decoded.response.response.behavior).toBe('allow')
   })
 
-  it('sends allow response with permissionMode when the bypass switch is checked', () => {
+  it('sends allow response with the bypass mode when Bypass permissions is selected', () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     const request = makeRequest('req-99', 'agent-3')
 
@@ -88,13 +98,12 @@ describe('exitPlanModeActions', () => {
         onRespond={onRespond}
         hasEditorContent={false}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
       />
     ))
 
-    // Enable bypass permissions, then approve.
-    const bypassSwitch = screen.getByTestId('plan-bypass-permissions-checkbox').querySelector('input')!
-    fireEvent.click(bypassSwitch)
+    // Select bypass permissions, then approve.
+    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
     fireEvent.click(screen.getByTestId('plan-approve-btn'))
 
     expect(onRespond).toHaveBeenCalledOnce()
@@ -105,12 +114,37 @@ describe('exitPlanModeActions', () => {
     expect(decoded.permissionMode).toBe('bypassPermissions')
   })
 
-  // A preset that switches some axis OTHER than the permission mode cannot be applied
-  // through this banner at all: the approval travels as one control response, and the
-  // only part of a preset that response can carry is the mode. Copilot's bypass sets
-  // `allow_all`, so the switch must not be drawn -- drawing it produced a checkbox that
-  // silently did nothing once the preset type stopped guaranteeing a permissionMode key.
-  it('draws no bypass switch for a preset that carries no permission mode', () => {
+  it('sends allow response with the smart mode when Smart permissions is selected', () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+
+    render(() => (
+      <ExitPlanModeActions
+        request={makeRequest()}
+        answerState={createControlAnswerState()}
+        onRespond={onRespond}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        presets={{
+          smart: { sets: { permissionMode: 'auto' } },
+          bypass: { sets: { permissionMode: 'bypassPermissions' } },
+          apply: vi.fn(),
+        }}
+      />
+    ))
+
+    fireEvent.click(permissionPill().getByRole('radio', { name: 'Smart permissions' }))
+    fireEvent.click(screen.getByTestId('plan-approve-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).permissionMode).toBe('auto')
+  })
+
+  // A preset that switches some axis OTHER than the permission mode cannot act
+  // through this banner at all: the approval travels as one control response, and
+  // the only part of a preset that response can carry is the mode. Copilot's
+  // bypass sets `allow_all`, so its pill is not drawn here -- drawing it would
+  // produce a pill that silently did nothing on a plan approval.
+  it('draws no pills for presets that carry no permission mode', () => {
     render(() => (
       <ExitPlanModeActions
         request={makeRequest('req-77', 'agent-7')}
@@ -118,11 +152,11 @@ describe('exitPlanModeActions', () => {
         onRespond={vi.fn().mockResolvedValue(undefined)}
         hasEditorContent={false}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { allow_all: 'on' } }, apply: vi.fn() }}
+        presets={{ bypass: { sets: { allow_all: 'on' } }, apply: vi.fn() }}
       />
     ))
 
-    expect(screen.queryByTestId('plan-bypass-permissions-checkbox')).toBeNull()
+    expect(screen.queryByTestId('control-permissions-pill-group')).toBeNull()
     expect(screen.getByTestId('plan-clear-context-checkbox')).toBeInTheDocument()
   })
 
@@ -137,7 +171,7 @@ describe('exitPlanModeActions', () => {
         onRespond={onRespond}
         hasEditorContent={false}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
       />
     ))
 
@@ -151,7 +185,7 @@ describe('exitPlanModeActions', () => {
     expect(decoded.permissionMode).toBeUndefined()
   })
 
-  it('does not show the bypass switch when bypass settings are absent', () => {
+  it('does not show the permission pills when presets are absent', () => {
     render(() => (
       <ExitPlanModeActions
         request={makeRequest()}
@@ -162,6 +196,7 @@ describe('exitPlanModeActions', () => {
       />
     ))
 
-    expect(screen.queryByTestId('plan-bypass-permissions-checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument()
+    expect(screen.getByTestId('plan-clear-context-checkbox')).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
@@ -1,7 +1,8 @@
 import type { ControlRequest } from '~/stores/control.store'
-import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { ExitPlanModeActions } from '~/components/chat/controls/ExitPlanModeControl'
+import { permissionPillGroup } from '~/test-support/controlRequests'
 import { createControlAnswerState } from './types'
 
 function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
@@ -12,10 +13,6 @@ function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
       request: { tool_name: 'ExitPlanMode', input: {} },
     },
   }
-}
-
-function permissionPill() {
-  return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
 }
 
 describe('exitPlanModeActions', () => {
@@ -40,9 +37,9 @@ describe('exitPlanModeActions', () => {
     expect(screen.getByTestId('plan-reject-btn')).toBeInTheDocument()
     expect(screen.getByTestId('plan-approve-btn')).toBeInTheDocument()
     expect(screen.getByTestId('plan-clear-context-checkbox')).toHaveTextContent('Clear Context (30%)')
-    expect(permissionPill().getByRole('radio', { name: 'Default' })).toBeChecked()
-    expect(permissionPill().getByRole('radio', { name: 'Smart permissions' })).toBeInTheDocument()
-    expect(permissionPill().getByRole('radio', { name: 'Bypass permissions' })).toBeInTheDocument()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Default' })).toBeChecked()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Smart permissions' })).toBeInTheDocument()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' })).toBeInTheDocument()
   })
 
   it('shows only Send feedback when editor has content', () => {
@@ -89,6 +86,7 @@ describe('exitPlanModeActions', () => {
 
   it('sends allow response with the bypass mode when Bypass permissions is selected', () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
+    const apply = vi.fn()
     const request = makeRequest('req-99', 'agent-3')
 
     render(() => (
@@ -98,12 +96,12 @@ describe('exitPlanModeActions', () => {
         onRespond={onRespond}
         hasEditorContent={false}
         onTriggerSend={() => {}}
-        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply }}
       />
     ))
 
     // Select bypass permissions, then approve.
-    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
     fireEvent.click(screen.getByTestId('plan-approve-btn'))
 
     expect(onRespond).toHaveBeenCalledOnce()
@@ -112,10 +110,14 @@ describe('exitPlanModeActions', () => {
     expect(decoded.response.request_id).toBe('req-99')
     expect(decoded.response.response.behavior).toBe('allow')
     expect(decoded.permissionMode).toBe('bypassPermissions')
+    // The mode travels INSIDE the response; a second settings change would race
+    // the restart a context-clearing approval triggers, so the handler never fires.
+    expect(apply).not.toHaveBeenCalled()
   })
 
   it('sends allow response with the smart mode when Smart permissions is selected', () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
+    const apply = vi.fn()
 
     render(() => (
       <ExitPlanModeActions
@@ -127,16 +129,17 @@ describe('exitPlanModeActions', () => {
         presets={{
           smart: { sets: { permissionMode: 'auto' } },
           bypass: { sets: { permissionMode: 'bypassPermissions' } },
-          apply: vi.fn(),
+          apply,
         }}
       />
     ))
 
-    fireEvent.click(permissionPill().getByRole('radio', { name: 'Smart permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Smart permissions' }))
     fireEvent.click(screen.getByTestId('plan-approve-btn'))
 
     const [bytes] = onRespond.mock.calls[0]
     expect(JSON.parse(new TextDecoder().decode(bytes)).permissionMode).toBe('auto')
+    expect(apply).not.toHaveBeenCalled()
   })
 
   // A preset that switches some axis OTHER than the permission mode cannot act

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.tsx
@@ -92,6 +92,7 @@ export const ExitPlanModeActions: Component<ActionsProps> = (props) => {
       negativeAction={{ label: 'Reject', testId: 'plan-reject-btn', onSelect: handleReject }}
       positiveAction={{ label: 'Approve', testId: 'plan-approve-btn', onSelect: handleApprove }}
       switches={() => planApprovalSwitches(planApproval)}
+      permissionPill={planApproval.permissionPill}
     />
   )
 }

--- a/frontend/src/components/chat/controls/GenericToolControl.test.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.test.tsx
@@ -1,7 +1,9 @@
 import type { ControlRequest } from '~/stores/control.store'
-import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { GenericToolActions } from '~/components/chat/controls/GenericToolControl'
+import { hoverForTooltip } from '~/test-support/clipStub'
+import { permissionPillGroup } from '~/test-support/controlRequests'
 import { createControlAnswerState } from './types'
 
 function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
@@ -12,10 +14,6 @@ function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
       request: { tool_name: 'Bash', input: { command: 'ls' } },
     },
   }
-}
-
-function permissionPill() {
-  return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
 }
 
 describe('genericToolActions', () => {
@@ -45,8 +43,8 @@ describe('genericToolActions', () => {
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Deny')
     expect(screen.getByTestId('control-allow-btn')).toBeInTheDocument()
     expect(screen.getByTestId('control-permissions-pill-group')).toBeInTheDocument()
-    expect(permissionPill().getByRole('radio', { name: 'Default' })).toBeChecked()
-    expect(permissionPill().getByRole('radio', { name: 'Bypass permissions' })).not.toBeChecked()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Default' })).toBeChecked()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' })).not.toBeChecked()
   })
 
   it('shows only Send feedback when editor has content', () => {
@@ -136,7 +134,7 @@ describe('genericToolActions', () => {
       />
     ))
 
-    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
     // The handler AWAITS the allow before applying the preset, so the assertion
     // waits for that microtask -- ordering is the point of the fix.
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
@@ -172,7 +170,7 @@ describe('genericToolActions', () => {
       />
     ))
 
-    fireEvent.click(permissionPill().getByRole('radio', { name: 'Smart permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Smart permissions' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'auto' } })
@@ -193,7 +191,7 @@ describe('genericToolActions', () => {
       />
     ))
 
-    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
     await fireEvent.click(screen.getByTestId('control-deny-btn'))
 
     expect(apply).not.toHaveBeenCalled()
@@ -212,5 +210,23 @@ describe('genericToolActions', () => {
 
     expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument()
     expect(screen.queryByRole('radiogroup', { name: 'Permissions' })).not.toBeInTheDocument()
+  })
+
+  // The group carries the one explanation of its consequence: a selected preset
+  // applies when the request is allowed, so the hover text must stay attached.
+  it('explains through a tooltip that the selected preset applies on allow', () => {
+    render(() => (
+      <GenericToolActions
+        request={makeRequest()}
+        answerState={createControlAnswerState()}
+        onRespond={vi.fn().mockResolvedValue(undefined)}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+      />
+    ))
+
+    const tooltip = hoverForTooltip(screen.getByTestId('control-permissions-pill-group'))
+    expect(tooltip?.textContent).toContain('selected preset applies')
   })
 })

--- a/frontend/src/components/chat/controls/GenericToolControl.test.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.test.tsx
@@ -1,5 +1,5 @@
 import type { ControlRequest } from '~/stores/control.store'
-import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { GenericToolActions } from '~/components/chat/controls/GenericToolControl'
 import { createControlAnswerState } from './types'
@@ -14,6 +14,10 @@ function makeRequest(requestId = 'req-1', agentId = 'agent-1'): ControlRequest {
   }
 }
 
+function permissionPill() {
+  return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
+}
+
 describe('genericToolActions', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -25,7 +29,7 @@ describe('genericToolActions', () => {
     vi.restoreAllMocks()
   })
 
-  it('shows Deny, Allow, and the Bypass Permissions switch when no editor content', () => {
+  it('shows Deny, Allow, and the permission pills when no editor content', () => {
     render(() => (
       <GenericToolActions
         request={makeRequest()}
@@ -33,14 +37,16 @@ describe('genericToolActions', () => {
         onRespond={vi.fn().mockResolvedValue(undefined)}
         hasEditorContent={false}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
       />
     ))
 
     expect(screen.getByTestId('control-deny-btn')).toBeInTheDocument()
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Deny')
     expect(screen.getByTestId('control-allow-btn')).toBeInTheDocument()
-    expect(screen.getByTestId('control-bypass-permissions-checkbox')).toBeInTheDocument()
+    expect(screen.getByTestId('control-permissions-pill-group')).toBeInTheDocument()
+    expect(permissionPill().getByRole('radio', { name: 'Default' })).toBeChecked()
+    expect(permissionPill().getByRole('radio', { name: 'Bypass permissions' })).not.toBeChecked()
   })
 
   it('shows only Send feedback when editor has content', () => {
@@ -51,18 +57,19 @@ describe('genericToolActions', () => {
         onRespond={vi.fn().mockResolvedValue(undefined)}
         hasEditorContent={true}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
       />
     ))
 
     expect(screen.getByTestId('control-deny-btn')).toBeInTheDocument()
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Send feedback')
     expect(screen.queryByTestId('control-allow-btn')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('control-bypass-permissions-checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument()
   })
 
-  it('sends allow response with original tool input when allow is clicked', () => {
+  it('sends allow response with original tool input when allow is clicked', async () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
+    const apply = vi.fn()
     const request = makeRequest('req-10', 'agent-3')
 
     render(() => (
@@ -72,11 +79,11 @@ describe('genericToolActions', () => {
         onRespond={onRespond}
         hasEditorContent={false}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply }}
       />
     ))
 
-    fireEvent.click(screen.getByTestId('control-allow-btn'))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     expect(onRespond).toHaveBeenCalledOnce()
     const [bytes] = onRespond.mock.calls[0]
@@ -84,6 +91,8 @@ describe('genericToolActions', () => {
     expect(decoded.response.request_id).toBe('req-10')
     expect(decoded.response.response.behavior).toBe('allow')
     expect(decoded.response.response.updatedInput).toEqual({ command: 'ls' })
+    // Default applies nothing -- the answer is the whole decision.
+    expect(apply).not.toHaveBeenCalled()
   })
 
   it('sends deny response when deny is clicked with an empty editor', () => {
@@ -107,9 +116,9 @@ describe('genericToolActions', () => {
     })
   })
 
-  it('sends allow response and changes permission mode when bypass is clicked', async () => {
+  it('sends allow response and applies the bypass preset when Bypass permissions is selected', async () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
-    const applyBypass = vi.fn()
+    const apply = vi.fn()
     const request = makeRequest('req-42', 'agent-7')
 
     render(() => (
@@ -119,13 +128,17 @@ describe('genericToolActions', () => {
         onRespond={onRespond}
         hasEditorContent={false}
         onTriggerSend={() => {}}
-        bypass={{ settings: { sets: { permissionMode: 'bypassPermissions' } }, apply: applyBypass }}
+        presets={{
+          smart: { sets: { permissionMode: 'auto' } },
+          bypass: { sets: { permissionMode: 'bypassPermissions' } },
+          apply,
+        }}
       />
     ))
 
-    // The handler AWAITS the allow before switching the mode, so the assertion
+    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
+    // The handler AWAITS the allow before applying the preset, so the assertion
     // waits for that microtask -- ordering is the point of the fix.
-    fireEvent.click(screen.getByTestId('control-bypass-permissions-checkbox').querySelector('input')!)
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     // Verify allow response was sent
@@ -136,11 +149,57 @@ describe('genericToolActions', () => {
     expect(decoded.response.response.behavior).toBe('allow')
     expect(decoded.response.response.updatedInput).toEqual({ command: 'ls' })
 
-    // Verify permission mode change
-    expect(applyBypass).toHaveBeenCalledWith({ sets: { permissionMode: 'bypassPermissions' } })
+    // Verify the preset was applied -- the same change the composer menu item makes.
+    expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'bypassPermissions' } })
   })
 
-  it('does not show the bypass switch without a bypass mode', () => {
+  it('applies the smart preset when Smart permissions is selected', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const apply = vi.fn()
+
+    render(() => (
+      <GenericToolActions
+        request={makeRequest()}
+        answerState={createControlAnswerState()}
+        onRespond={onRespond}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        presets={{
+          smart: { sets: { permissionMode: 'auto' } },
+          bypass: { sets: { permissionMode: 'bypassPermissions' } },
+          apply,
+        }}
+      />
+    ))
+
+    fireEvent.click(permissionPill().getByRole('radio', { name: 'Smart permissions' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'auto' } })
+  })
+
+  it('does not apply a preset when deny is clicked with one selected', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const apply = vi.fn()
+
+    render(() => (
+      <GenericToolActions
+        request={makeRequest()}
+        answerState={createControlAnswerState()}
+        onRespond={onRespond}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply }}
+      />
+    ))
+
+    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
+    await fireEvent.click(screen.getByTestId('control-deny-btn'))
+
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  it('does not show the permission pills without presets', () => {
     render(() => (
       <GenericToolActions
         request={makeRequest()}
@@ -151,6 +210,7 @@ describe('genericToolActions', () => {
       />
     ))
 
-    expect(screen.queryByTestId('control-bypass-permissions-checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument()
+    expect(screen.queryByRole('radiogroup', { name: 'Permissions' })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -6,7 +6,8 @@ import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from
 import * as styles from '../ControlRequestBanner.css'
 import { CollapsibleText } from './CollapsibleText'
 import { ControlDecisionFooter } from './ControlDecisionFooter'
-import { createControlSwitch, sendResponse } from './types'
+import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from './permissionPresets'
+import { sendResponse } from './types'
 
 export const GenericToolContent: Component<{ request: ControlRequest }> = (props) => {
   const toolName = () => getToolName(props.request.payload)
@@ -32,20 +33,19 @@ export const GenericToolContent: Component<{ request: ControlRequest }> = (props
 }
 
 export const GenericToolActions: Component<ActionsProps> = (props) => {
-  const bypassSwitch = createControlSwitch(() => props.answerState, 'control-bypass-permissions-checkbox')
+  const permissionChoice = createPermissionPresetChoice(props)
 
   const handleDeny = () => {
     return sendResponse(props.onRespond, buildDenyResponse(props.request.requestId))
   }
 
-  // Await the allow BEFORE switching the mode. The worker dispatches the two
+  // Await the allow BEFORE applying a preset. The worker dispatches the two
   // concurrently, and applying a permission mode the provider cannot take live
   // relaunches the agent -- a relaunch that won the race killed the session
   // before the allow reached it, so the tool call was never answered.
   const handleAllow = async () => {
     await sendResponse(props.onRespond, buildAllowResponse(props.request.requestId, getToolInput(props.request.payload)))
-    if (bypassSwitch.checked() && props.bypass)
-      await props.bypass.apply(props.bypass.settings)
+    await applyPermissionPreset(props.presets, permissionChoice.choice())
   }
 
   return (
@@ -54,14 +54,7 @@ export const GenericToolActions: Component<ActionsProps> = (props) => {
       onSendFeedback={props.onTriggerSend}
       negativeAction={{ label: 'Deny', testId: 'control-deny-btn', onSelect: handleDeny }}
       positiveAction={{ label: 'Allow', testId: 'control-allow-btn', onSelect: handleAllow }}
-      switches={() => props.bypass
-        ? [{
-            id: 'control-bypass-permissions-checkbox',
-            label: 'Bypass Permissions',
-            checked: bypassSwitch.checked(),
-            onChange: bypassSwitch.set,
-          }]
-        : []}
+      permissionPill={() => buildPermissionPill(props.presets, permissionChoice)}
     />
   )
 }

--- a/frontend/src/components/chat/controls/PermissionDecisionActions.tsx
+++ b/frontend/src/components/chat/controls/PermissionDecisionActions.tsx
@@ -1,0 +1,143 @@
+import type { Component } from 'solid-js'
+import type { WirePermissionOption } from './permissionOptions'
+import type { ActionsProps } from './types'
+
+import { createMemo, For, Show } from 'solid-js'
+import { ButtonGroup } from '~/components/common/ButtonGroup'
+import * as styles from '../ControlRequestBanner.css'
+import { ControlActionRow } from './ControlActionRow'
+import { ControlAllowScopePillGroup, ControlPermissionPillGroup } from './ControlPillGroups'
+import {
+  ALLOW_SCOPE_CHOICE_ID,
+  allowScopePillOptions,
+  decisionLabel,
+  isAllowPermissionKind,
+  isRejectPermissionKind,
+  layoutPermissionOptions,
+  permissionOptionLabel,
+  resolvePermissionOption,
+} from './permissionOptions'
+import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from './permissionPresets'
+import { createControlChoice } from './types'
+
+/** Sends one selected option as the provider's permission reply (ACP- and OpenCode-family envelopes are the same). */
+export type SendPermissionOption = (
+  onRespond: (content: Uint8Array) => Promise<void>,
+  requestId: string,
+  optionId: string,
+) => Promise<void>
+
+/** Reads a request's wire options; each provider extracts its own payload shape. */
+export type PermissionOptionsGetter = (payload: Record<string, unknown>) => WirePermissionOption[]
+
+/**
+ * The shared decision row for a wire-options permission request: scope pills
+ * (Once / Always / Session / Project), the permission pill group (Default /
+ * Smart / Bypass), Deny / Allow, and one extra button per option no slot or
+ * group consumed. The ACP and OpenCode families differ only in their payload
+ * extraction and sender, so each provider passes its `options` getter and `send`
+ * and keeps its wire specifics in its own file.
+ */
+export const PermissionDecisionActions: Component<ActionsProps & {
+  options: PermissionOptionsGetter
+  send: SendPermissionOption
+}> = (props) => {
+  const layout = createMemo(() => layoutPermissionOptions(props.options(props.request.payload)))
+  const permissionChoice = createPermissionPresetChoice(props)
+  const scopeChoice = createControlChoice(() => props.answerState, ALLOW_SCOPE_CHOICE_ID)
+
+  // The scope pills a payload with always options draws (Once / Always, or
+  // Once / Session / Project). The stored selection is clamped to the offered
+  // options: a payload swap must not leave the group reporting an option the
+  // agent no longer offers.
+  const scopeOptions = createMemo(() => {
+    const scope = layout().allowScope
+    return scope ? allowScopePillOptions(scope) : undefined
+  })
+  const selectedScope = () => {
+    const scope = layout().allowScope
+    if (!scope)
+      return undefined
+    return scope.some(option => option.optionId === scopeChoice.choice())
+      ? scopeChoice.choice()
+      : scope[0].optionId
+  }
+  const permissionPill = createMemo(() => buildPermissionPill(props.presets, permissionChoice))
+
+  // The option's response is AWAITED before a permission preset is applied: the
+  // worker dispatches the two concurrently, and a mode change the provider cannot
+  // take live relaunches the agent, which kills the session before an un-awaited
+  // answer reaches it. Only an ALLOW-kind option — the request's positive action
+  // family — applies a preset: an extra answer option decides nothing about
+  // future permissions.
+  const handleOption = async (option: WirePermissionOption | undefined) => {
+    if (!option)
+      return
+    await props.send(props.onRespond, props.request.requestId, option.optionId)
+    if (isAllowPermissionKind(option.kind))
+      await applyPermissionPreset(props.presets, permissionChoice.choice())
+  }
+
+  const handleDecision = (polarity: 'allow' | 'reject') =>
+    handleOption(resolvePermissionOption(layout(), polarity, selectedScope()))
+
+  // The pill cluster is drawn only when a positive action exists to apply it:
+  // with no allow-kind option, no selection the group offers can ever act, and
+  // a drawn control that silently does nothing is the trap this row avoids.
+  const pillCluster = () => layout().positive && (scopeOptions() || permissionPill())
+
+  return (
+    <ControlActionRow
+      primary={(
+        <>
+          <Show when={pillCluster()}>
+            <div class={styles.controlRequestSwitches}>
+              <Show when={scopeOptions()}>
+                {options => (
+                  <ControlAllowScopePillGroup
+                    options={options()}
+                    selected={selectedScope() ?? options()[0].key}
+                    onSelect={scopeChoice.setChoice}
+                  />
+                )}
+              </Show>
+              <Show when={permissionPill()}>
+                {pill => <ControlPermissionPillGroup pill={pill()} />}
+              </Show>
+            </div>
+          </Show>
+          <ButtonGroup>
+            <Show when={layout().negative}>
+              <button
+                class="outline"
+                onClick={() => handleDecision('reject')}
+                data-testid="control-deny-btn"
+              >
+                {decisionLabel(layout(), 'reject')}
+              </button>
+            </Show>
+            <Show when={layout().positive}>
+              <button
+                onClick={() => handleDecision('allow')}
+                data-testid="control-allow-btn"
+              >
+                {decisionLabel(layout(), 'allow')}
+              </button>
+            </Show>
+            <For each={layout().additional}>
+              {option => (
+                <button
+                  class={isRejectPermissionKind(option.kind) ? 'outline' : undefined}
+                  onClick={() => handleOption(option)}
+                  data-testid={`control-decision-${option.optionId}`}
+                >
+                  {permissionOptionLabel(option)}
+                </button>
+              )}
+            </For>
+          </ButtonGroup>
+        </>
+      )}
+    />
+  )
+}

--- a/frontend/src/components/chat/controls/permissionOptions.test.ts
+++ b/frontend/src/components/chat/controls/permissionOptions.test.ts
@@ -1,0 +1,242 @@
+import type { WirePermissionOption } from './permissionOptions'
+import { describe, expect, it } from 'vitest'
+import {
+  allowScopeLabel,
+  allowScopePillOptions,
+  isRejectPermissionKind,
+  layoutPermissionOptions,
+  permissionOptionLabel,
+  resolvePermissionOption,
+  scopeRemembers,
+} from './permissionOptions'
+
+function option(optionId: string, kind: string, name = optionId): WirePermissionOption {
+  return { optionId, kind, name }
+}
+
+// Goose's exact wire shape: four options whose ids, kinds and names are all the
+// same snake_case token, emitted allow-first.
+const GOOSE_OPTIONS: WirePermissionOption[] = [
+  option('allow_always', 'allow_always'),
+  option('allow_once', 'allow_once'),
+  option('reject_once', 'reject_once'),
+  option('reject_always', 'reject_always'),
+]
+
+describe('layoutPermissionOptions', () => {
+  it('maps the canonical kinds to a negative-first pair plus a Once / Always scope group', () => {
+    const layout = layoutPermissionOptions(GOOSE_OPTIONS)
+
+    expect(layout.positive?.optionId).toBe('allow_once')
+    expect(layout.negative?.optionId).toBe('reject_once')
+    expect(layout.allowScope?.map(o => o.optionId)).toEqual(['allow_once', 'allow_always'])
+    // goose is the one agent whose reject_always the scope group also upgrades.
+    expect(layout.rememberReject?.optionId).toBe('reject_always')
+    // The always options are consumed by the group, not rendered as buttons.
+    expect(layout.additional).toEqual([])
+  })
+
+  it('keeps a once-only payload answerable with no scope group', () => {
+    // Kilo's skill-shell prompts and Copilot's factory tool calls offer no
+    // always scope: there is no duration to choose, so Allow is just Allow.
+    const layout = layoutPermissionOptions([
+      option('once', 'allow_once', 'Allow'),
+      option('reject', 'reject_once', 'Reject'),
+    ])
+
+    expect(layout.positive?.optionId).toBe('once')
+    expect(layout.negative?.optionId).toBe('reject')
+    expect(layout.allowScope).toBeUndefined()
+    expect(layout.rememberReject).toBeUndefined()
+  })
+
+  it('grows the scope group with the agent\'s scopes', () => {
+    // OpenCode/Kilo/Cursor/Copilot offer one always scope; no reject_always.
+    const layout = layoutPermissionOptions([
+      option('once', 'allow_once', 'Allow once'),
+      option('always', 'allow_always', 'Always allow'),
+      option('reject', 'reject_once', 'Reject'),
+    ])
+
+    expect(layout.allowScope?.map(o => o.optionId)).toEqual(['once', 'always'])
+    expect(layout.rememberReject).toBeUndefined()
+    expect(layout.additional).toEqual([])
+  })
+
+  it('turns one allow-once facing two or more always scopes into a wider scope group', () => {
+    // Reasonix offers session AND project scopes beside the once option.
+    const layout = layoutPermissionOptions([
+      option('reasonix_write_once', 'allow_once', 'Allow once'),
+      option('reasonix_write_session', 'allow_always', 'Allow these directories for this session'),
+      option('reasonix_write_project', 'allow_always', 'Add to project allow_write'),
+      option('reasonix_write_deny', 'reject_once', 'Reject'),
+    ])
+
+    expect(layout.allowScope?.map(o => o.optionId)).toEqual([
+      'reasonix_write_once',
+      'reasonix_write_session',
+      'reasonix_write_project',
+    ])
+    expect(layout.positive?.optionId).toBe('reasonix_write_once')
+    expect(layout.negative?.optionId).toBe('reasonix_write_deny')
+    expect(layout.additional).toEqual([])
+  })
+
+  it('keeps an all-allow_once payload out of the scope vocabulary', () => {
+    // Cursor routes ask-question answers as plain allow_once options: those are
+    // alternative ANSWERS, not durations, so no scope group is drawn and the
+    // extras beyond the first stay individual buttons.
+    const layout = layoutPermissionOptions([
+      option('opt1', 'allow_once', 'First answer'),
+      option('opt2', 'allow_once', 'Second answer'),
+      option('opt3', 'allow_once', 'Third answer'),
+      option('skip', 'reject_once', 'Skip'),
+    ])
+
+    expect(layout.allowScope).toBeUndefined()
+    expect(layout.positive?.optionId).toBe('opt1')
+    expect(layout.additional.map(o => o.optionId)).toEqual(['opt2', 'opt3'])
+  })
+
+  it('draws no scope group when the once slot is ambiguous', () => {
+    // Two allow_once options face one always: the group cannot know WHICH
+    // once answer a "Once" pill means, so the extras stay individual buttons.
+    const layout = layoutPermissionOptions([
+      option('once_a', 'allow_once', 'Allow once'),
+      option('once_b', 'allow_once', 'Allow once more'),
+      option('always', 'allow_always', 'Always allow'),
+      option('reject', 'reject_once', 'Reject'),
+    ])
+
+    expect(layout.allowScope).toBeUndefined()
+    expect(layout.positive?.optionId).toBe('once_a')
+    expect(layout.additional.map(o => o.optionId)).toEqual(['once_b'])
+  })
+
+  it('classifies an empty payload as no buttons', () => {
+    expect(layoutPermissionOptions([])).toMatchObject({
+      positive: undefined,
+      negative: undefined,
+      allowScope: undefined,
+      additional: [],
+    })
+  })
+})
+
+describe('scopeRemembers', () => {
+  it('is false for Once and true for a scope beyond it', () => {
+    const layout = layoutPermissionOptions(GOOSE_OPTIONS)
+
+    expect(scopeRemembers(layout)).toBe(false)
+    expect(scopeRemembers(layout, 'allow_once')).toBe(false)
+    expect(scopeRemembers(layout, 'allow_always')).toBe(true)
+    // An id the payload no longer offers clamps back to Once.
+    expect(scopeRemembers(layout, 'gone')).toBe(false)
+  })
+
+  it('is always false without a scope group', () => {
+    const layout = layoutPermissionOptions([
+      option('once', 'allow_once', 'Allow'),
+      option('reject', 'reject_once', 'Reject'),
+    ])
+    expect(scopeRemembers(layout, 'once')).toBe(false)
+  })
+})
+
+describe('resolvePermissionOption', () => {
+  it('sends the once options while Once is selected and the always options otherwise', () => {
+    const layout = layoutPermissionOptions(GOOSE_OPTIONS)
+
+    expect(resolvePermissionOption(layout, 'allow', false)?.optionId).toBe('allow_once')
+    expect(resolvePermissionOption(layout, 'allow', false, 'allow_always')?.optionId).toBe('allow_always')
+    expect(resolvePermissionOption(layout, 'reject', false)?.optionId).toBe('reject_once')
+    // A remembering scope (scopeRemembers) upgrades Deny for the agents offering reject_always.
+    expect(resolvePermissionOption(layout, 'reject', true)?.optionId).toBe('reject_always')
+  })
+
+  it('never invents an option the agent did not offer', () => {
+    const layout = layoutPermissionOptions([
+      option('once', 'allow_once', 'Allow once'),
+      option('always', 'allow_always', 'Always allow'),
+      option('reject', 'reject_once', 'Reject'),
+    ])
+
+    // No reject_always exists, so a remembering scope keeps reject_once -- an
+    // unknown optionId is parsed as cancel (goose) or reject (OpenCode), and
+    // the user asked to reject, not to cancel.
+    expect(resolvePermissionOption(layout, 'reject', true)?.optionId).toBe('reject')
+  })
+
+  it('sends the selected scope pill, falling back to the first when none is stored', () => {
+    const layout = layoutPermissionOptions([
+      option('reasonix_write_once', 'allow_once', 'Allow once'),
+      option('reasonix_write_session', 'allow_always', 'Allow these directories for this session'),
+      option('reasonix_write_project', 'allow_always', 'Add to project allow_write'),
+      option('reasonix_write_deny', 'reject_once', 'Reject'),
+    ])
+
+    expect(resolvePermissionOption(layout, 'allow', false)?.optionId).toBe('reasonix_write_once')
+    expect(resolvePermissionOption(layout, 'allow', false, 'reasonix_write_project')?.optionId).toBe('reasonix_write_project')
+    // A stored id the payload no longer offers clamps to the first scope.
+    expect(resolvePermissionOption(layout, 'allow', false, 'gone')?.optionId).toBe('reasonix_write_once')
+    expect(resolvePermissionOption(layout, 'reject', true)?.optionId).toBe('reasonix_write_deny')
+  })
+})
+
+describe('allowScopeLabel', () => {
+  it('reads the duration out of the agent\'s own option name', () => {
+    expect(allowScopeLabel(option('w_once', 'allow_once', 'Allow once'))).toBe('Once')
+    expect(allowScopeLabel(option('w_session', 'allow_always', 'Allow these directories for this session'))).toBe('Session')
+    expect(allowScopeLabel(option('w_project', 'allow_always', 'Add to project allow_write'))).toBe('Project')
+  })
+
+  it('falls back to Always for a name that names no duration', () => {
+    expect(allowScopeLabel(option('always', 'allow_always', 'Always allow'))).toBe('Always')
+    // Goose names options after their kind: no duration, still Always.
+    expect(allowScopeLabel(option('allow_always', 'allow_always'))).toBe('Always')
+  })
+})
+
+describe('allowScopePillOptions', () => {
+  it('keys the pills by optionId so a selection maps onto the wire reply', () => {
+    const scope = [
+      option('w_once', 'allow_once', 'Allow once'),
+      option('w_session', 'allow_always', 'Allow these directories for this session'),
+      option('w_project', 'allow_always', 'Add to project allow_write'),
+    ]
+
+    expect(allowScopePillOptions(scope)).toEqual([
+      { key: 'w_once', label: 'Once' },
+      { key: 'w_session', label: 'Session' },
+      { key: 'w_project', label: 'Project' },
+    ])
+  })
+
+  it('refuses a scope that cannot be a pill group', () => {
+    expect(allowScopePillOptions([])).toBeUndefined()
+    const six = Array.from({ length: 6 }, (_, i) => option(`w${i}`, i === 0 ? 'allow_once' : 'allow_always'))
+    expect(allowScopePillOptions(six)).toBeUndefined()
+  })
+})
+
+describe('permissionOptionLabel', () => {
+  it('shows the agent-provided name when it is a real label', () => {
+    expect(permissionOptionLabel(option('once', 'allow_once', 'Allow once'))).toBe('Allow once')
+  })
+
+  it('falls back to a friendly label for goose, which names options after their kind', () => {
+    expect(permissionOptionLabel(option('allow_once', 'allow_once'))).toBe('Allow once')
+    expect(permissionOptionLabel(option('allow_always', 'allow_always'))).toBe('Allow always')
+    expect(permissionOptionLabel(option('reject_once', 'reject_once'))).toBe('Reject')
+    expect(permissionOptionLabel(option('reject_always', 'reject_always'))).toBe('Reject always')
+  })
+})
+
+describe('isRejectPermissionKind', () => {
+  it('covers both reject kinds', () => {
+    expect(isRejectPermissionKind('reject_once')).toBe(true)
+    expect(isRejectPermissionKind('reject_always')).toBe(true)
+    expect(isRejectPermissionKind('allow_once')).toBe(false)
+    expect(isRejectPermissionKind('allow_always')).toBe(false)
+  })
+})

--- a/frontend/src/components/chat/controls/permissionOptions.test.ts
+++ b/frontend/src/components/chat/controls/permissionOptions.test.ts
@@ -3,11 +3,12 @@ import { describe, expect, it } from 'vitest'
 import {
   allowScopeLabel,
   allowScopePillOptions,
+  decisionLabel,
+  isAllowPermissionKind,
   isRejectPermissionKind,
   layoutPermissionOptions,
   permissionOptionLabel,
   resolvePermissionOption,
-  scopeRemembers,
 } from './permissionOptions'
 
 function option(optionId: string, kind: string, name = optionId): WirePermissionOption {
@@ -98,9 +99,11 @@ describe('layoutPermissionOptions', () => {
     expect(layout.additional.map(o => o.optionId)).toEqual(['opt2', 'opt3'])
   })
 
-  it('draws no scope group when the once slot is ambiguous', () => {
+  it('keeps every option answerable when the once slot is ambiguous', () => {
     // Two allow_once options face one always: the group cannot know WHICH
-    // once answer a "Once" pill means, so the extras stay individual buttons.
+    // once answer a "Once" pill means, so no scope group is drawn and the
+    // extras -- the second once answer AND the always scope -- stay
+    // individual buttons.
     const layout = layoutPermissionOptions([
       option('once_a', 'allow_once', 'Allow once'),
       option('once_b', 'allow_once', 'Allow once more'),
@@ -110,7 +113,56 @@ describe('layoutPermissionOptions', () => {
 
     expect(layout.allowScope).toBeUndefined()
     expect(layout.positive?.optionId).toBe('once_a')
-    expect(layout.additional.map(o => o.optionId)).toEqual(['once_b'])
+    expect(layout.additional.map(o => o.optionId)).toEqual(['once_b', 'always'])
+  })
+
+  it('degrades a scope vocabulary too wide for the pill limit to extra buttons', () => {
+    // One once facing four always scopes cannot draw as pills: no group is
+    // reported, every always scope stays answerable as its own button, and
+    // Allow keeps sending the once option.
+    const layout = layoutPermissionOptions([
+      option('once', 'allow_once', 'Allow once'),
+      ...['session', 'project', 'org', 'forever'].map(scope =>
+        option(`always_${scope}`, 'allow_always', `Always allow for ${scope}`)),
+      option('reject', 'reject_once', 'Reject'),
+    ])
+
+    expect(layout.allowScope).toBeUndefined()
+    expect(layout.positive?.optionId).toBe('once')
+    expect(layout.additional.map(o => o.optionId)).toEqual([
+      'always_session',
+      'always_project',
+      'always_org',
+      'always_forever',
+    ])
+  })
+
+  it('keeps a reject_always answerable when no scope group is drawn', () => {
+    // Without an allow scope there is no remembering scope to upgrade Deny, so
+    // goose's reject_always stays an extra button instead of vanishing.
+    const layout = layoutPermissionOptions([
+      option('allow_once', 'allow_once'),
+      option('reject_once', 'reject_once'),
+      option('reject_always', 'reject_always'),
+    ])
+
+    expect(layout.allowScope).toBeUndefined()
+    expect(layout.rememberReject).toBeUndefined()
+    expect(layout.additional.map(o => o.optionId)).toEqual(['reject_always'])
+  })
+
+  it('drops a duplicate optionId from the scope group and keeps the duplicate answerable', () => {
+    // The reply carries an id, so two options that share one are the same
+    // answer twice; PillGroup also refuses duplicate keys.
+    const layout = layoutPermissionOptions([
+      option('once', 'allow_once'),
+      option('always_a', 'allow_always', 'Always allow here'),
+      option('always_a', 'allow_always', 'Always allow here again'),
+      option('reject', 'reject_once'),
+    ])
+
+    expect(layout.allowScope?.map(o => o.optionId)).toEqual(['once', 'always_a'])
+    expect(layout.additional.map(o => o.optionId)).toEqual(['always_a'])
   })
 
   it('classifies an empty payload as no buttons', () => {
@@ -123,35 +175,17 @@ describe('layoutPermissionOptions', () => {
   })
 })
 
-describe('scopeRemembers', () => {
-  it('is false for Once and true for a scope beyond it', () => {
-    const layout = layoutPermissionOptions(GOOSE_OPTIONS)
-
-    expect(scopeRemembers(layout)).toBe(false)
-    expect(scopeRemembers(layout, 'allow_once')).toBe(false)
-    expect(scopeRemembers(layout, 'allow_always')).toBe(true)
-    // An id the payload no longer offers clamps back to Once.
-    expect(scopeRemembers(layout, 'gone')).toBe(false)
-  })
-
-  it('is always false without a scope group', () => {
-    const layout = layoutPermissionOptions([
-      option('once', 'allow_once', 'Allow'),
-      option('reject', 'reject_once', 'Reject'),
-    ])
-    expect(scopeRemembers(layout, 'once')).toBe(false)
-  })
-})
-
 describe('resolvePermissionOption', () => {
   it('sends the once options while Once is selected and the always options otherwise', () => {
     const layout = layoutPermissionOptions(GOOSE_OPTIONS)
 
-    expect(resolvePermissionOption(layout, 'allow', false)?.optionId).toBe('allow_once')
-    expect(resolvePermissionOption(layout, 'allow', false, 'allow_always')?.optionId).toBe('allow_always')
-    expect(resolvePermissionOption(layout, 'reject', false)?.optionId).toBe('reject_once')
-    // A remembering scope (scopeRemembers) upgrades Deny for the agents offering reject_always.
-    expect(resolvePermissionOption(layout, 'reject', true)?.optionId).toBe('reject_always')
+    expect(resolvePermissionOption(layout, 'allow')?.optionId).toBe('allow_once')
+    expect(resolvePermissionOption(layout, 'allow', 'allow_always')?.optionId).toBe('allow_always')
+    expect(resolvePermissionOption(layout, 'reject')?.optionId).toBe('reject_once')
+    // A scope beyond Once upgrades Deny for the agents offering reject_always.
+    expect(resolvePermissionOption(layout, 'reject', 'allow_always')?.optionId).toBe('reject_always')
+    // An id the payload no longer offers clamps back to the once options.
+    expect(resolvePermissionOption(layout, 'reject', 'gone')?.optionId).toBe('reject_once')
   })
 
   it('never invents an option the agent did not offer', () => {
@@ -164,7 +198,7 @@ describe('resolvePermissionOption', () => {
     // No reject_always exists, so a remembering scope keeps reject_once -- an
     // unknown optionId is parsed as cancel (goose) or reject (OpenCode), and
     // the user asked to reject, not to cancel.
-    expect(resolvePermissionOption(layout, 'reject', true)?.optionId).toBe('reject')
+    expect(resolvePermissionOption(layout, 'reject', 'always')?.optionId).toBe('reject')
   })
 
   it('sends the selected scope pill, falling back to the first when none is stored', () => {
@@ -175,11 +209,48 @@ describe('resolvePermissionOption', () => {
       option('reasonix_write_deny', 'reject_once', 'Reject'),
     ])
 
-    expect(resolvePermissionOption(layout, 'allow', false)?.optionId).toBe('reasonix_write_once')
-    expect(resolvePermissionOption(layout, 'allow', false, 'reasonix_write_project')?.optionId).toBe('reasonix_write_project')
+    expect(resolvePermissionOption(layout, 'allow')?.optionId).toBe('reasonix_write_once')
+    expect(resolvePermissionOption(layout, 'allow', 'reasonix_write_project')?.optionId).toBe('reasonix_write_project')
     // A stored id the payload no longer offers clamps to the first scope.
-    expect(resolvePermissionOption(layout, 'allow', false, 'gone')?.optionId).toBe('reasonix_write_once')
-    expect(resolvePermissionOption(layout, 'reject', true)?.optionId).toBe('reasonix_write_deny')
+    expect(resolvePermissionOption(layout, 'allow', 'gone')?.optionId).toBe('reasonix_write_once')
+    expect(resolvePermissionOption(layout, 'reject', 'reasonix_write_project')?.optionId).toBe('reasonix_write_deny')
+  })
+
+  it('never upgrades a reject without a scope group', () => {
+    const layout = layoutPermissionOptions([
+      option('allow_once', 'allow_once'),
+      option('reject_once', 'reject_once'),
+      option('reject_always', 'reject_always'),
+    ])
+
+    expect(resolvePermissionOption(layout, 'reject', 'reject_always')?.optionId).toBe('reject_once')
+  })
+})
+
+describe('decisionLabel', () => {
+  it('carries the polarity alone while a scope group states the duration', () => {
+    const layout = layoutPermissionOptions(GOOSE_OPTIONS)
+
+    expect(decisionLabel(layout, 'allow')).toBe('Allow')
+    expect(decisionLabel(layout, 'reject')).toBe('Deny')
+  })
+
+  it('states the duration when a slot holds a remember option with no scope group', () => {
+    // The agent offered no once variant, so the button is the only place the
+    // duration can appear; a plain "Allow" would grant a permanent permission
+    // the user cannot see.
+    const layout = layoutPermissionOptions([
+      option('always', 'allow_always', 'Always allow'),
+      option('reject', 'reject_once', 'Reject'),
+    ])
+    expect(decisionLabel(layout, 'allow')).toBe('Always allow')
+
+    const gooseLayout = layoutPermissionOptions([
+      option('allow_always', 'allow_always'),
+      option('reject_always', 'reject_always'),
+    ])
+    expect(decisionLabel(gooseLayout, 'allow')).toBe('Allow always')
+    expect(decisionLabel(gooseLayout, 'reject')).toBe('Reject always')
   })
 })
 
@@ -190,10 +261,14 @@ describe('allowScopeLabel', () => {
     expect(allowScopeLabel(option('w_project', 'allow_always', 'Add to project allow_write'))).toBe('Project')
   })
 
-  it('falls back to Always for a name that names no duration', () => {
+  it('falls back to Always for a name that states no duration', () => {
     expect(allowScopeLabel(option('always', 'allow_always', 'Always allow'))).toBe('Always')
-    // Goose names options after their kind: no duration, still Always.
+    // Goose sets each option's name to its kind: no duration, still Always.
     expect(allowScopeLabel(option('allow_always', 'allow_always'))).toBe('Always')
+  })
+
+  it('tolerates an option whose name is absent', () => {
+    expect(allowScopeLabel({ optionId: 'always', kind: 'allow_always' })).toBe('Always')
   })
 })
 
@@ -217,6 +292,21 @@ describe('allowScopePillOptions', () => {
     const six = Array.from({ length: 6 }, (_, i) => option(`w${i}`, i === 0 ? 'allow_once' : 'allow_always'))
     expect(allowScopePillOptions(six)).toBeUndefined()
   })
+
+  it('shows two indistinguishable scopes their own names instead of one shared label', () => {
+    // Both always scopes read "Always" from the keyword read; identical labels
+    // on distinct answers would let the user pick the wrong permanent grant
+    // with no way to tell the pills apart.
+    const pills = allowScopePillOptions([
+      option('w_plain', 'allow_always', 'Always allow'),
+      option('w_silent', 'allow_always', 'Allow without asking'),
+    ])
+
+    expect(pills).toEqual([
+      { key: 'w_plain', label: 'Always allow' },
+      { key: 'w_silent', label: 'Allow without asking' },
+    ])
+  })
 })
 
 describe('permissionOptionLabel', () => {
@@ -224,11 +314,15 @@ describe('permissionOptionLabel', () => {
     expect(permissionOptionLabel(option('once', 'allow_once', 'Allow once'))).toBe('Allow once')
   })
 
-  it('falls back to a friendly label for goose, which names options after their kind', () => {
+  it('falls back to a friendly label for goose, which sets each option\'s name to its kind', () => {
     expect(permissionOptionLabel(option('allow_once', 'allow_once'))).toBe('Allow once')
     expect(permissionOptionLabel(option('allow_always', 'allow_always'))).toBe('Allow always')
     expect(permissionOptionLabel(option('reject_once', 'reject_once'))).toBe('Reject')
     expect(permissionOptionLabel(option('reject_always', 'reject_always'))).toBe('Reject always')
+  })
+
+  it('falls back to the id when an option has neither name nor known kind', () => {
+    expect(permissionOptionLabel({ optionId: 'opt1', kind: 'answer' })).toBe('opt1')
   })
 })
 
@@ -238,5 +332,15 @@ describe('isRejectPermissionKind', () => {
     expect(isRejectPermissionKind('reject_always')).toBe(true)
     expect(isRejectPermissionKind('allow_once')).toBe(false)
     expect(isRejectPermissionKind('allow_always')).toBe(false)
+  })
+})
+
+describe('isAllowPermissionKind', () => {
+  it('covers both allow kinds and nothing else', () => {
+    expect(isAllowPermissionKind('allow_once')).toBe(true)
+    expect(isAllowPermissionKind('allow_always')).toBe(true)
+    expect(isAllowPermissionKind('reject_once')).toBe(false)
+    expect(isAllowPermissionKind('reject_always')).toBe(false)
+    expect(isAllowPermissionKind('answer')).toBe(false)
   })
 })

--- a/frontend/src/components/chat/controls/permissionOptions.ts
+++ b/frontend/src/components/chat/controls/permissionOptions.ts
@@ -1,11 +1,11 @@
-import type { PillOptions, PillOptionSpec } from '~/components/common/PillGroup'
-
-import { PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
+import type { PillOptions } from '~/components/common/PillGroup'
+import { isPillOptions, PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
 
 export interface WirePermissionOption {
   optionId: string
   kind: string
-  name: string
+  /** Absent on wire payloads that omit it; every reader must tolerate `undefined`. */
+  name?: string
 }
 
 const KIND_ALLOW_ONCE = 'allow_once'
@@ -22,7 +22,12 @@ export function isRejectPermissionKind(kind: string): boolean {
   return kind === KIND_REJECT_ONCE || kind === KIND_REJECT_ALWAYS
 }
 
-/** Goose names every option after its kind (`name === optionId === kind`), which is no label at all. */
+/** The option family the request's positive action sends: only these apply a permission preset. */
+export function isAllowPermissionKind(kind: string): boolean {
+  return kind === KIND_ALLOW_ONCE || kind === KIND_ALLOW_ALWAYS
+}
+
+/** Goose sets every option's name to its kind (`name === optionId === kind`), which is no label at all. */
 const KIND_FALLBACK_LABELS: Record<string, string> = {
   [KIND_ALLOW_ONCE]: 'Allow once',
   [KIND_ALLOW_ALWAYS]: 'Allow always',
@@ -32,9 +37,9 @@ const KIND_FALLBACK_LABELS: Record<string, string> = {
 
 /** The label an extra option's button shows: the agent's own name, unless the name is just the id. */
 export function permissionOptionLabel(option: WirePermissionOption): string {
-  return option.name === option.optionId
-    ? KIND_FALLBACK_LABELS[option.kind] ?? option.name
-    : option.name
+  if (option.name !== undefined && option.name !== option.optionId)
+    return option.name
+  return KIND_FALLBACK_LABELS[option.kind] ?? option.name ?? option.optionId
 }
 
 /**
@@ -46,18 +51,23 @@ export function permissionOptionLabel(option: WirePermissionOption): string {
  * `reasonix_write_session`, ...). The kinds are the only stable discriminator,
  * so this mapping classifies by kind:
  *
- * - the decision buttons carry the polarity alone (Deny / Allow); HOW LONG an
- *   allow lasts is the scope pill group's question, not the button's;
+ * - the decision buttons carry the polarity alone (Deny / Allow) while a scope
+ *   pill group states HOW LONG an allow lasts; a slot that holds a remember
+ *   option with no scope group to qualify it states its own duration instead
+ *   (see `decisionLabel`);
  * - one allow-once beside one or more allow-always options becomes the
- *   `allowScope` group — Once plus each always scope, payload order — whatever
- *   their number: two options draw [Once | Always] (or [Once | Session], per
- *   the agent's own naming), three draw Reasonix's [Once | Session | Project];
+ *   `allowScope` group — Once plus each always scope, once first then payload
+ *   order — while the group fits the pill limit: two options draw
+ *   [Once | Always] (or [Once | Session], per the agent's own option names), three
+ *   draw Reasonix's [Once | Session | Project], a wider vocabulary degrades to
+ *   no group and plain extra buttons;
  * - a scope beyond Once also upgrades Deny to the agent's reject_always when it
- *   offers one (goose is the one agent that does) — the one behavior the
- *   Remember switch this group replaced carried across both polarities;
+ *   offers one (goose is the one agent that does), so one control answers both
+ *   polarities;
  * - the FIRST option of each canonical kind fills that kind's slot; every
- *   option no slot consumed (invented kinds, and duplicates beyond the first of
- *   a kind) stays in `additional`, payload order, so no answerable option is
+ *   option no rendered slot or group consumed (invented kinds, duplicates
+ *   beyond the first of a kind, and every option a degraded layout cannot
+ *   place) stays in `additional`, payload order, so no answerable option is
  *   ever dropped.
  *
  * The BUTTON ORDER is this layout's own (negative first), not the payload's:
@@ -69,12 +79,13 @@ export interface PermissionOptionLayout {
   negative?: WirePermissionOption
   /** The option Allow sends while no scope control overrides it (the once slot, or the only allow). */
   positive?: WirePermissionOption
-  /** The reject_always slot, when the agent offers one beside a reject_once. */
+  /** The reject_always slot, when the agent offers one beside a reject_once AND a scope group is drawn. */
   rememberReject?: WirePermissionOption
   /**
    * The allow options a scope pill group offers — one allow-once plus every
    * allow-always, once first then payload order. Undefined when the agent
-   * offers no always scope at all, or no single once slot to anchor the group.
+   * offers no always scope at all, no single once slot to anchor the group, or
+   * a vocabulary too wide for the pill limit.
    */
   allowScope?: WirePermissionOption[]
   additional: WirePermissionOption[]
@@ -91,36 +102,55 @@ export function layoutPermissionOptions(options: WirePermissionOption[]): Permis
   const rejectOnce = byKind.get(KIND_REJECT_ONCE)
   const rejectAlways = byKind.get(KIND_REJECT_ALWAYS)
 
-  // The scope group needs ONE once slot facing at least one always scope.
-  // Requiring exactly one allow_once keeps payloads with several (Cursor
-  // routes its ask-question options that way, and a Once pill is ambiguous
-  // when two once answers exist) out of the scope vocabulary — those are
-  // alternative answers, not durations.
+  // The scope group needs ONE once slot facing at least one always scope (a
+  // Once pill is ambiguous when two once answers exist — Cursor routes its
+  // ask-question options that way, and those are alternative answers, not
+  // durations), it must fit the pill limit (a group this layout reports is one
+  // the pills can draw, so a too-wide vocabulary degrades HERE and its options
+  // stay answerable as extra buttons), and its ids must be unique (the reply
+  // carries an id, so two options that share one are the same answer twice).
   const allOnces = options.filter(option => option.kind === KIND_ALLOW_ONCE)
   const allAlways = options.filter(option => option.kind === KIND_ALLOW_ALWAYS)
-  const allowScope = allOnces.length === 1 && allAlways.length >= 1
-    ? [allOnces[0]!, ...allAlways]
+  const once = allOnces.length === 1 ? allOnces[0] : undefined
+  const scopeAlways: WirePermissionOption[] = []
+  if (once) {
+    for (const option of allAlways) {
+      if (option.optionId !== once.optionId && !scopeAlways.some(seen => seen.optionId === option.optionId))
+        scopeAlways.push(option)
+    }
+  }
+  const allowScope = once && scopeAlways.length >= 1 && 1 + scopeAlways.length <= PILL_OPTION_LIMIT
+    ? [once, ...scopeAlways]
     : undefined
-  // The reject slots are consumed whether or not a scope group is drawn: a
-  // reject option a decision button already sends is not an extra.
-  const consumed = new Set([...(allowScope ?? [allowOnce, allowAlways]), rejectOnce, rejectAlways])
+
+  // A slot or group is consumed only when the row actually renders it: with a
+  // scope group drawn, its members plus BOTH reject slots are consumed (Deny
+  // sends the once reject; a scope beyond Once upgrades Deny to reject_always).
+  // Without one there is no reject upgrade, so reject_always stays answerable
+  // as its own extra button.
+  const positive = allowOnce ?? allowAlways
+  const negative = rejectOnce ?? rejectAlways
+  const consumed = new Set<WirePermissionOption | undefined>(allowScope ?? [positive, negative])
+  if (allowScope) {
+    consumed.add(rejectOnce)
+    consumed.add(rejectAlways)
+  }
 
   return {
-    positive: allowOnce ?? allowAlways,
-    negative: rejectOnce ?? rejectAlways,
-    rememberReject: rejectOnce && rejectAlways ? rejectAlways : undefined,
+    positive,
+    negative,
+    rememberReject: allowScope && rejectOnce && rejectAlways ? rejectAlways : undefined,
     allowScope,
     additional: options.filter(option => !consumed.has(option)),
   }
 }
 
 /**
- * Whether the selected scope pill picks a scope BEYOND Once — the pill-group
- * reading of the Remember switch this group replaced. This is what upgrades a
- * reject to the agent's reject_always, so the two polarities keep sharing one
- * control exactly as the switch made them share one checkbox.
+ * Whether the selected scope pill picks a scope BEYOND Once. This is what
+ * upgrades a reject to the agent's reject_always, so the two polarities answer
+ * through one control.
  */
-export function scopeRemembers(
+function scopeRemembers(
   layout: PermissionOptionLayout,
   selectedAllowScopeId?: string,
 ): boolean {
@@ -137,7 +167,7 @@ export function scopeRemembers(
  * For Allow, the SELECTED scope pill when a scope group is drawn (falling back
  * to its first option when nothing valid is stored), else the once slot the
  * button displays. For Reject, a scope beyond Once upgrades to the agent's
- * reject_always (`scopeRemembers` is that reading) when it offers one.
+ * reject_always when it offers one.
  *
  * An option the agent did not offer is never sent: the reject upgrade is
  * skipped when its variant is absent, and an unknown optionId is parsed as
@@ -146,7 +176,6 @@ export function scopeRemembers(
 export function resolvePermissionOption(
   layout: PermissionOptionLayout,
   polarity: 'allow' | 'reject',
-  remember: boolean,
   selectedAllowScopeId?: string,
 ): WirePermissionOption | undefined {
   if (polarity === 'allow') {
@@ -156,20 +185,34 @@ export function resolvePermissionOption(
     }
     return layout.positive
   }
-  return remember && layout.rememberReject ? layout.rememberReject : layout.negative
+  return scopeRemembers(layout, selectedAllowScopeId) && layout.rememberReject ? layout.rememberReject : layout.negative
+}
+
+/**
+ * The label a decision button shows. With a scope pill group drawn the button
+ * carries the polarity alone — the pills state how long an allow lasts. Without
+ * one, a slot that holds a REMEMBER option states its own duration through the
+ * agent's own option name (`permissionOptionLabel`): the agent offered no once
+ * variant, so the button is the only place the duration can appear, and a plain
+ * "Allow" would grant a permanent permission the user cannot see.
+ */
+export function decisionLabel(layout: PermissionOptionLayout, polarity: 'allow' | 'reject'): string {
+  const slot = polarity === 'allow' ? layout.positive : layout.negative
+  const rememberKind = polarity === 'allow' ? KIND_ALLOW_ALWAYS : KIND_REJECT_ALWAYS
+  return !layout.allowScope && slot?.kind === rememberKind ? permissionOptionLabel(slot) : polarity === 'allow' ? 'Allow' : 'Deny'
 }
 
 /**
  * One scope pill's label. The once slot is unambiguous; the always scopes read
  * their duration out of the agent's own option name ("...for this session",
- * "Add to project allow_write"), and a name that names no duration is simply
+ * "Add to project allow_write"), and a name that states no duration is simply
  * Always. Names are prose, so this is a keyword read, not a parse — a name with
  * neither keyword still gets a truthful label, just a generic one.
  */
 export function allowScopeLabel(option: WirePermissionOption): string {
   if (option.kind === KIND_ALLOW_ONCE)
     return 'Once'
-  const name = option.name.toLowerCase()
+  const name = (option.name ?? '').toLowerCase()
   if (name.includes('project'))
     return 'Project'
   if (name.includes('session'))
@@ -177,17 +220,22 @@ export function allowScopeLabel(option: WirePermissionOption): string {
   return 'Always'
 }
 
-function isPillOptions(options: readonly PillOptionSpec<string>[]): options is PillOptions<string> {
-  return options.length > 0 && options.length <= PILL_OPTION_LIMIT
-}
-
 /**
  * The scope pill group's options, keyed by optionId so a selection maps
  * straight onto the wire reply. Undefined when the scope group cannot be drawn
  * (fewer than one pill, or more than the pill limit) — the caller then leaves
- * the scope to the plain Allow button.
+ * the scope to the plain Allow button. Two scopes the keyword read cannot tell
+ * apart (both read "Always") show their own names instead, so no two pills of
+ * one group share a label the user cannot distinguish.
  */
 export function allowScopePillOptions(scope: readonly WirePermissionOption[]): PillOptions<string> | undefined {
-  const pills = scope.map(option => ({ key: option.optionId, label: allowScopeLabel(option) }))
+  const labels = scope.map(option => allowScopeLabel(option))
+  const counts = new Map<string, number>()
+  for (const label of labels)
+    counts.set(label, (counts.get(label) ?? 0) + 1)
+  const pills = scope.map((option, index) => ({
+    key: option.optionId,
+    label: (counts.get(labels[index]) ?? 0) > 1 ? permissionOptionLabel(option) : labels[index]!,
+  }))
   return isPillOptions(pills) ? pills : undefined
 }

--- a/frontend/src/components/chat/controls/permissionOptions.ts
+++ b/frontend/src/components/chat/controls/permissionOptions.ts
@@ -1,0 +1,193 @@
+import type { PillOptions, PillOptionSpec } from '~/components/common/PillGroup'
+
+import { PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
+
+export interface WirePermissionOption {
+  optionId: string
+  kind: string
+  name: string
+}
+
+const KIND_ALLOW_ONCE = 'allow_once'
+const KIND_ALLOW_ALWAYS = 'allow_always'
+const KIND_REJECT_ONCE = 'reject_once'
+const KIND_REJECT_ALWAYS = 'reject_always'
+
+const CANONICAL_KINDS = [KIND_ALLOW_ONCE, KIND_ALLOW_ALWAYS, KIND_REJECT_ONCE, KIND_REJECT_ALWAYS]
+
+/** The answer-state key the allow-scope pill group's selection is stored under. */
+export const ALLOW_SCOPE_CHOICE_ID = 'control-allow-scope-pill'
+
+export function isRejectPermissionKind(kind: string): boolean {
+  return kind === KIND_REJECT_ONCE || kind === KIND_REJECT_ALWAYS
+}
+
+/** Goose names every option after its kind (`name === optionId === kind`), which is no label at all. */
+const KIND_FALLBACK_LABELS: Record<string, string> = {
+  [KIND_ALLOW_ONCE]: 'Allow once',
+  [KIND_ALLOW_ALWAYS]: 'Allow always',
+  [KIND_REJECT_ONCE]: 'Reject',
+  [KIND_REJECT_ALWAYS]: 'Reject always',
+}
+
+/** The label an extra option's button shows: the agent's own name, unless the name is just the id. */
+export function permissionOptionLabel(option: WirePermissionOption): string {
+  return option.name === option.optionId
+    ? KIND_FALLBACK_LABELS[option.kind] ?? option.name
+    : option.name
+}
+
+/**
+ * How a permission request's options lay out as one decision row.
+ *
+ * Agents emit their remember semantics as DISTINCT options (an `allow_always`
+ * kind sits beside `allow_once`, not inside it), and the optionId vocabulary is
+ * agent-specific (`allow_always`, `always`, `allow-always`,
+ * `reasonix_write_session`, ...). The kinds are the only stable discriminator,
+ * so this mapping classifies by kind:
+ *
+ * - the decision buttons carry the polarity alone (Deny / Allow); HOW LONG an
+ *   allow lasts is the scope pill group's question, not the button's;
+ * - one allow-once beside one or more allow-always options becomes the
+ *   `allowScope` group — Once plus each always scope, payload order — whatever
+ *   their number: two options draw [Once | Always] (or [Once | Session], per
+ *   the agent's own naming), three draw Reasonix's [Once | Session | Project];
+ * - a scope beyond Once also upgrades Deny to the agent's reject_always when it
+ *   offers one (goose is the one agent that does) — the one behavior the
+ *   Remember switch this group replaced carried across both polarities;
+ * - the FIRST option of each canonical kind fills that kind's slot; every
+ *   option no slot consumed (invented kinds, and duplicates beyond the first of
+ *   a kind) stays in `additional`, payload order, so no answerable option is
+ *   ever dropped.
+ *
+ * The BUTTON ORDER is this layout's own (negative first), not the payload's:
+ * every agent emits allow-first, but the reply carries only an optionId, so
+ * ordering is presentation-only — goose's own desktop client picks options by
+ * kind, and goose's server parses the returned id string.
+ */
+export interface PermissionOptionLayout {
+  negative?: WirePermissionOption
+  /** The option Allow sends while no scope control overrides it (the once slot, or the only allow). */
+  positive?: WirePermissionOption
+  /** The reject_always slot, when the agent offers one beside a reject_once. */
+  rememberReject?: WirePermissionOption
+  /**
+   * The allow options a scope pill group offers — one allow-once plus every
+   * allow-always, once first then payload order. Undefined when the agent
+   * offers no always scope at all, or no single once slot to anchor the group.
+   */
+  allowScope?: WirePermissionOption[]
+  additional: WirePermissionOption[]
+}
+
+export function layoutPermissionOptions(options: WirePermissionOption[]): PermissionOptionLayout {
+  const byKind = new Map<string, WirePermissionOption>()
+  for (const option of options) {
+    if (CANONICAL_KINDS.includes(option.kind) && !byKind.has(option.kind))
+      byKind.set(option.kind, option)
+  }
+  const allowOnce = byKind.get(KIND_ALLOW_ONCE)
+  const allowAlways = byKind.get(KIND_ALLOW_ALWAYS)
+  const rejectOnce = byKind.get(KIND_REJECT_ONCE)
+  const rejectAlways = byKind.get(KIND_REJECT_ALWAYS)
+
+  // The scope group needs ONE once slot facing at least one always scope.
+  // Requiring exactly one allow_once keeps payloads with several (Cursor
+  // routes its ask-question options that way, and a Once pill is ambiguous
+  // when two once answers exist) out of the scope vocabulary — those are
+  // alternative answers, not durations.
+  const allOnces = options.filter(option => option.kind === KIND_ALLOW_ONCE)
+  const allAlways = options.filter(option => option.kind === KIND_ALLOW_ALWAYS)
+  const allowScope = allOnces.length === 1 && allAlways.length >= 1
+    ? [allOnces[0]!, ...allAlways]
+    : undefined
+  // The reject slots are consumed whether or not a scope group is drawn: a
+  // reject option a decision button already sends is not an extra.
+  const consumed = new Set([...(allowScope ?? [allowOnce, allowAlways]), rejectOnce, rejectAlways])
+
+  return {
+    positive: allowOnce ?? allowAlways,
+    negative: rejectOnce ?? rejectAlways,
+    rememberReject: rejectOnce && rejectAlways ? rejectAlways : undefined,
+    allowScope,
+    additional: options.filter(option => !consumed.has(option)),
+  }
+}
+
+/**
+ * Whether the selected scope pill picks a scope BEYOND Once — the pill-group
+ * reading of the Remember switch this group replaced. This is what upgrades a
+ * reject to the agent's reject_always, so the two polarities keep sharing one
+ * control exactly as the switch made them share one checkbox.
+ */
+export function scopeRemembers(
+  layout: PermissionOptionLayout,
+  selectedAllowScopeId?: string,
+): boolean {
+  const scope = layout.allowScope
+  if (!scope)
+    return false
+  const selected = scope.find(option => option.optionId === selectedAllowScopeId)
+  return selected !== undefined && selected.kind === KIND_ALLOW_ALWAYS
+}
+
+/**
+ * The option a decision button sends.
+ *
+ * For Allow, the SELECTED scope pill when a scope group is drawn (falling back
+ * to its first option when nothing valid is stored), else the once slot the
+ * button displays. For Reject, a scope beyond Once upgrades to the agent's
+ * reject_always (`scopeRemembers` is that reading) when it offers one.
+ *
+ * An option the agent did not offer is never sent: the reject upgrade is
+ * skipped when its variant is absent, and an unknown optionId is parsed as
+ * cancel (goose) or reject (OpenCode) on the agent side.
+ */
+export function resolvePermissionOption(
+  layout: PermissionOptionLayout,
+  polarity: 'allow' | 'reject',
+  remember: boolean,
+  selectedAllowScopeId?: string,
+): WirePermissionOption | undefined {
+  if (polarity === 'allow') {
+    if (layout.allowScope) {
+      const selected = layout.allowScope.find(option => option.optionId === selectedAllowScopeId)
+      return selected ?? layout.allowScope[0]
+    }
+    return layout.positive
+  }
+  return remember && layout.rememberReject ? layout.rememberReject : layout.negative
+}
+
+/**
+ * One scope pill's label. The once slot is unambiguous; the always scopes read
+ * their duration out of the agent's own option name ("...for this session",
+ * "Add to project allow_write"), and a name that names no duration is simply
+ * Always. Names are prose, so this is a keyword read, not a parse — a name with
+ * neither keyword still gets a truthful label, just a generic one.
+ */
+export function allowScopeLabel(option: WirePermissionOption): string {
+  if (option.kind === KIND_ALLOW_ONCE)
+    return 'Once'
+  const name = option.name.toLowerCase()
+  if (name.includes('project'))
+    return 'Project'
+  if (name.includes('session'))
+    return 'Session'
+  return 'Always'
+}
+
+function isPillOptions(options: readonly PillOptionSpec<string>[]): options is PillOptions<string> {
+  return options.length > 0 && options.length <= PILL_OPTION_LIMIT
+}
+
+/**
+ * The scope pill group's options, keyed by optionId so a selection maps
+ * straight onto the wire reply. Undefined when the scope group cannot be drawn
+ * (fewer than one pill, or more than the pill limit) — the caller then leaves
+ * the scope to the plain Allow button.
+ */
+export function allowScopePillOptions(scope: readonly WirePermissionOption[]): PillOptions<string> | undefined {
+  const pills = scope.map(option => ({ key: option.optionId, label: allowScopeLabel(option) }))
+  return isPillOptions(pills) ? pills : undefined
+}

--- a/frontend/src/components/chat/controls/permissionPresets.test.ts
+++ b/frontend/src/components/chat/controls/permissionPresets.test.ts
@@ -60,6 +60,19 @@ describe('buildPermissionPill', () => {
     const choice = createPermissionPresetChoice({ answerState: createControlAnswerState() })
     expect(buildPermissionPill(undefined, choice)).toBeUndefined()
   })
+
+  it('clamps a stored choice the catalog no longer offers back to Default', () => {
+    // The catalog withdrew smart while the stored choice still says it: the
+    // group must report Default, not a selection with no radio to check it.
+    const choice = createPermissionPresetChoice({
+      answerState: createControlAnswerState({ choices: { 'control-permissions-pill': 'smart' } }),
+    })
+
+    const pill = buildPermissionPill(controller({ smart: undefined }), choice)!
+
+    expect(pill.options.map(o => o.key)).toEqual(['default', 'bypass'])
+    expect(pill.selected).toBe('default')
+  })
 })
 
 describe('applyPermissionPreset', () => {
@@ -100,6 +113,9 @@ describe('planApprovalPresets', () => {
     const filtered = planApprovalPresets(controller())!
     expect(filtered.smart).toBe(SMART)
     expect(filtered.bypass).toBe(BYPASS)
+    // No `apply` travels with the plan view: the mode rides inside the
+    // response, and the narrower type keeps a settings change out of it.
+    expect('apply' in filtered).toBe(false)
   })
 
   it('drops a preset with no permission mode, keeping the other', () => {

--- a/frontend/src/components/chat/controls/permissionPresets.test.ts
+++ b/frontend/src/components/chat/controls/permissionPresets.test.ts
@@ -1,0 +1,115 @@
+import type { PermissionPresetController } from '../providerSettings'
+import type { ActionsProps } from './types'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyPermissionPreset,
+  buildPermissionPill,
+  createPermissionPresetChoice,
+  permissionPillOptions,
+  planApprovalPresets,
+  presetPermissionMode,
+} from './permissionPresets'
+import { createControlAnswerState } from './types'
+
+const SMART = { sets: { permissionMode: 'auto' } }
+const BYPASS = { sets: { permissionMode: 'bypassPermissions' } }
+const COPILOT_SMART = { sets: { copilot_assisted_approval: 'on' } }
+const COPILOT_BYPASS = { sets: { allow_all: 'on' } }
+
+function controller(partial: Partial<PermissionPresetController> = {}): PermissionPresetController {
+  return { smart: SMART, bypass: BYPASS, apply: vi.fn(), ...partial }
+}
+
+describe('permissionPillOptions', () => {
+  it('offers Default first, then each preset the controller carries', () => {
+    expect(permissionPillOptions(controller())).toEqual([
+      { key: 'default', label: 'Default' },
+      { key: 'smart', label: 'Smart permissions' },
+      { key: 'bypass', label: 'Bypass permissions' },
+    ])
+  })
+
+  it('omits a preset the controller does not carry', () => {
+    // ZCode and Codex ship no smart preset; their group is Default + Bypass.
+    expect(permissionPillOptions(controller({ smart: undefined }))).toEqual([
+      { key: 'default', label: 'Default' },
+      { key: 'bypass', label: 'Bypass permissions' },
+    ])
+  })
+
+  it('offers no group without presets', () => {
+    expect(permissionPillOptions(undefined)).toBeUndefined()
+    expect(permissionPillOptions(controller({ smart: undefined, bypass: undefined }))).toBeUndefined()
+  })
+})
+
+describe('buildPermissionPill', () => {
+  it('renders the stored choice and writes selections back', () => {
+    const props: Pick<ActionsProps, 'answerState'> = { answerState: createControlAnswerState() }
+    const choice = createPermissionPresetChoice(props)
+
+    const pill = buildPermissionPill(controller(), choice)!
+    expect(pill.selected).toBe('default')
+
+    pill.onSelect('bypass')
+    expect(buildPermissionPill(controller(), choice)!.selected).toBe('bypass')
+    expect(props.answerState.choices()).toEqual({ 'control-permissions-pill': 'bypass' })
+  })
+
+  it('builds nothing without presets', () => {
+    const choice = createPermissionPresetChoice({ answerState: createControlAnswerState() })
+    expect(buildPermissionPill(undefined, choice)).toBeUndefined()
+  })
+})
+
+describe('applyPermissionPreset', () => {
+  it('applies the chosen preset as one complete settings change', async () => {
+    const apply = vi.fn()
+    await applyPermissionPreset(controller({ apply }), 'bypass')
+    expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'bypassPermissions' } })
+
+    await applyPermissionPreset(controller({ apply }), 'smart')
+    expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'auto' } })
+  })
+
+  it('applies nothing for Default, a missing controller, or a withdrawn preset', async () => {
+    const apply = vi.fn()
+    await applyPermissionPreset(controller({ apply }), 'default')
+    await applyPermissionPreset(undefined, 'bypass')
+    // The catalog stopped offering smart while the stored choice still says it.
+    await applyPermissionPreset(controller({ apply, smart: undefined }), 'smart')
+    expect(apply).not.toHaveBeenCalled()
+  })
+})
+
+describe('presetPermissionMode', () => {
+  it('reads the mode off the chosen preset and nothing off Default', () => {
+    expect(presetPermissionMode(controller(), 'bypass')).toBe('bypassPermissions')
+    expect(presetPermissionMode(controller(), 'smart')).toBe('auto')
+    expect(presetPermissionMode(controller(), 'default')).toBeUndefined()
+  })
+
+  it('attaches nothing for a preset that switches some other axis', () => {
+    // Copilot's presets are not permission modes at all.
+    expect(presetPermissionMode(controller({ smart: COPILOT_SMART, bypass: COPILOT_BYPASS }), 'bypass')).toBeUndefined()
+  })
+})
+
+describe('planApprovalPresets', () => {
+  it('keeps only the presets a plan approval response can act on', () => {
+    const filtered = planApprovalPresets(controller())!
+    expect(filtered.smart).toBe(SMART)
+    expect(filtered.bypass).toBe(BYPASS)
+  })
+
+  it('drops a preset with no permission mode, keeping the other', () => {
+    const filtered = planApprovalPresets(controller({ smart: COPILOT_SMART }))!
+    expect(filtered.smart).toBeUndefined()
+    expect(filtered.bypass).toBe(BYPASS)
+  })
+
+  it('offers nothing when no preset carries a mode', () => {
+    expect(planApprovalPresets(controller({ smart: COPILOT_SMART, bypass: COPILOT_BYPASS }))).toBeUndefined()
+    expect(planApprovalPresets(undefined)).toBeUndefined()
+  })
+})

--- a/frontend/src/components/chat/controls/permissionPresets.ts
+++ b/frontend/src/components/chat/controls/permissionPresets.ts
@@ -1,0 +1,143 @@
+import type { Accessor } from 'solid-js'
+import type { PermissionPresetController } from '../providerSettings'
+import type { ActionsProps } from './types'
+import type { PillOptions, PillOptionSpec } from '~/components/common/PillGroup'
+import type { PermissionMode } from '~/utils/controlResponse'
+
+import { OPTION_ID_PERMISSION_MODE } from '~/components/chat/settingsGroups'
+import { PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
+import { createControlChoice } from './types'
+
+/** What the permission pill group does when the request's positive action is taken. */
+export type PermissionPresetChoice
+  = | 'default'
+    | 'smart'
+    | 'bypass'
+
+/** The answer-state key the permission pill group's choice is stored under. */
+export const CONTROL_PERMISSION_CHOICE_ID = 'control-permissions-pill'
+
+/** The choice labels, shared with the composer `[+]` menu's permission items. */
+const PILL_LABELS: Record<Exclude<PermissionPresetChoice, 'default'>, string> = {
+  smart: 'Smart permissions',
+  bypass: 'Bypass permissions',
+}
+
+export interface PermissionPresetChoiceState {
+  choice: Accessor<PermissionPresetChoice>
+  setChoice: (choice: PermissionPresetChoice) => void
+}
+
+/**
+ * Binds the permission pill group's selection to the composer's shared answer
+ * record, so a rebuild of the control component cannot discard it.
+ *
+ * `createControlChoice` stores strings; every value this group writes is a
+ * `PermissionPresetChoice` key (its pills carry no other keys), so the read-back
+ * cast cannot surface a foreign string.
+ */
+export function createPermissionPresetChoice(props: Pick<ActionsProps, 'answerState'>): PermissionPresetChoiceState {
+  const { choice, setChoice } = createControlChoice(() => props.answerState, CONTROL_PERMISSION_CHOICE_ID, 'default')
+  return {
+    choice: () => choice() as PermissionPresetChoice,
+    setChoice,
+  }
+}
+
+function isPillOptions(options: readonly PillOptionSpec<PermissionPresetChoice>[]): options is PillOptions<PermissionPresetChoice> {
+  return options.length > 0 && options.length <= PILL_OPTION_LIMIT
+}
+
+/**
+ * The pill group's options: `Default` first (the do-nothing state the group opens
+ * on), then each preset the live catalog offers. A preset the catalog does not
+ * offer has no pill, mirroring the composer menu's hide-when-unavailable rule; when
+ * NEITHER is offered there is no group at all, so a provider without presets (Pi,
+ * OpenCode, Cursor, ...) draws the row it drew before the group existed.
+ */
+export function permissionPillOptions(presets: PermissionPresetController | undefined): PillOptions<PermissionPresetChoice> | undefined {
+  if (!presets)
+    return undefined
+  const options: PillOptionSpec<PermissionPresetChoice>[] = [{ key: 'default', label: 'Default' }]
+  for (const kind of ['smart', 'bypass'] as const) {
+    if (presets[kind])
+      options.push({ key: kind, label: PILL_LABELS[kind] })
+  }
+  // A lone Default pill is no choice at all: a controller whose presets the
+  // catalog stopped offering draws no group, same as no controller.
+  return options.length > 1 && isPillOptions(options) ? options : undefined
+}
+
+/** A render-ready permission pill group, or undefined when it draws no pills. */
+export interface ControlPermissionPill {
+  options: PillOptions<PermissionPresetChoice>
+  selected: PermissionPresetChoice
+  onSelect: (choice: PermissionPresetChoice) => void
+}
+
+export function buildPermissionPill(
+  presets: PermissionPresetController | undefined,
+  choiceState: PermissionPresetChoiceState,
+): ControlPermissionPill | undefined {
+  const options = permissionPillOptions(presets)
+  return options
+    ? { options, selected: choiceState.choice(), onSelect: choiceState.setChoice }
+    : undefined
+}
+
+/**
+ * Applies the chosen preset after a control request's positive answer — the same
+ * `onSettingChange({ sets })` call the composer `[+]` menu's permission items make,
+ * so a pill and the menu item cannot diverge in what they switch.
+ *
+ * The CALLER must await the answer before calling this. The worker dispatches the
+ * response and the settings change concurrently, and applying a permission mode the
+ * provider cannot take live relaunches the agent -- a relaunch that won the race
+ * killed the session before the answer reached it. `Default`, a missing controller
+ * or a preset the catalog stopped offering applies nothing.
+ */
+export function applyPermissionPreset(
+  presets: PermissionPresetController | undefined,
+  choice: PermissionPresetChoice,
+): Promise<void> {
+  const preset = choice === 'default' ? undefined : presets?.[choice]
+  if (!presets || !preset)
+    return Promise.resolve()
+  return Promise.resolve(presets.apply({ sets: { ...preset.sets } }))
+}
+
+/**
+ * The permission mode a PLAN APPROVAL attaches to its allow envelope: the chosen
+ * preset's own mode axis, or nothing for `Default`.
+ *
+ * Plan approvals switch the mode INSIDE the control response rather than through a
+ * separate settings change: the worker applies it atomically with the approval, and
+ * a context-clearing approval restarts the agent targeted at exactly this mode -- a
+ * follow-up settings RPC would race that restart. A preset that switches no
+ * permission mode (Copilot's approval axes) attaches nothing here, and no provider
+ * that offers a plan-approval banner has such a preset today.
+ */
+export function presetPermissionMode(
+  presets: PermissionPresetController | undefined,
+  choice: PermissionPresetChoice,
+): PermissionMode | undefined {
+  return choice === 'default' ? undefined : presets?.[choice]?.sets[OPTION_ID_PERMISSION_MODE]
+}
+
+/**
+ * The presets a PLAN APPROVAL banner may offer: only those that switch the
+ * permission mode, the one axis its single response can carry. A preset naming
+ * some other axis (Copilot's `allow_all`) cannot act there at all, so its pill is
+ * not drawn -- drawn and silently doing nothing is the trap the plan banner's old
+ * bypass switch was narrowed to avoid. No provider with a plan-approval banner
+ * ships such a preset today; this keeps the rule true if one ever does.
+ */
+export function planApprovalPresets(presets: PermissionPresetController | undefined): PermissionPresetController | undefined {
+  if (!presets)
+    return undefined
+  const smart = presets.smart?.sets[OPTION_ID_PERMISSION_MODE] !== undefined ? presets.smart : undefined
+  const bypass = presets.bypass?.sets[OPTION_ID_PERMISSION_MODE] !== undefined ? presets.bypass : undefined
+  return smart || bypass
+    ? { smart, bypass, apply: presets.apply }
+    : undefined
+}

--- a/frontend/src/components/chat/controls/permissionPresets.ts
+++ b/frontend/src/components/chat/controls/permissionPresets.ts
@@ -1,11 +1,12 @@
 import type { Accessor } from 'solid-js'
-import type { PermissionPresetController } from '../providerSettings'
+import type { PermissionPresetController, ProviderPermissionPresets } from '../providerSettings'
 import type { ActionsProps } from './types'
 import type { PillOptions, PillOptionSpec } from '~/components/common/PillGroup'
 import type { PermissionMode } from '~/utils/controlResponse'
 
 import { OPTION_ID_PERMISSION_MODE } from '~/components/chat/settingsGroups'
-import { PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
+import { isPillOptions } from '~/components/common/PillGroup'
+import { PERMISSION_PRESET_LABELS } from '../providerSettings'
 import { createControlChoice } from './types'
 
 /** What the permission pill group does when the request's positive action is taken. */
@@ -15,13 +16,7 @@ export type PermissionPresetChoice
     | 'bypass'
 
 /** The answer-state key the permission pill group's choice is stored under. */
-export const CONTROL_PERMISSION_CHOICE_ID = 'control-permissions-pill'
-
-/** The choice labels, shared with the composer `[+]` menu's permission items. */
-const PILL_LABELS: Record<Exclude<PermissionPresetChoice, 'default'>, string> = {
-  smart: 'Smart permissions',
-  bypass: 'Bypass permissions',
-}
+const CONTROL_PERMISSION_CHOICE_ID = 'control-permissions-pill'
 
 export interface PermissionPresetChoiceState {
   choice: Accessor<PermissionPresetChoice>
@@ -44,10 +39,6 @@ export function createPermissionPresetChoice(props: Pick<ActionsProps, 'answerSt
   }
 }
 
-function isPillOptions(options: readonly PillOptionSpec<PermissionPresetChoice>[]): options is PillOptions<PermissionPresetChoice> {
-  return options.length > 0 && options.length <= PILL_OPTION_LIMIT
-}
-
 /**
  * The pill group's options: `Default` first (the do-nothing state the group opens
  * on), then each preset the live catalog offers. A preset the catalog does not
@@ -55,16 +46,16 @@ function isPillOptions(options: readonly PillOptionSpec<PermissionPresetChoice>[
  * NEITHER is offered there is no group at all, so a provider without presets (Pi,
  * OpenCode, Cursor, ...) draws the row it drew before the group existed.
  */
-export function permissionPillOptions(presets: PermissionPresetController | undefined): PillOptions<PermissionPresetChoice> | undefined {
+export function permissionPillOptions(presets: ProviderPermissionPresets | undefined): PillOptions<PermissionPresetChoice> | undefined {
   if (!presets)
     return undefined
   const options: PillOptionSpec<PermissionPresetChoice>[] = [{ key: 'default', label: 'Default' }]
   for (const kind of ['smart', 'bypass'] as const) {
     if (presets[kind])
-      options.push({ key: kind, label: PILL_LABELS[kind] })
+      options.push({ key: kind, label: PERMISSION_PRESET_LABELS[kind] })
   }
-  // A lone Default pill is no choice at all: a controller whose presets the
-  // catalog stopped offering draws no group, same as no controller.
+  // A lone Default pill is no choice at all: presets the catalog stopped
+  // offering draw no group, same as no presets at all.
   return options.length > 1 && isPillOptions(options) ? options : undefined
 }
 
@@ -76,13 +67,18 @@ export interface ControlPermissionPill {
 }
 
 export function buildPermissionPill(
-  presets: PermissionPresetController | undefined,
+  presets: ProviderPermissionPresets | undefined,
   choiceState: PermissionPresetChoiceState,
 ): ControlPermissionPill | undefined {
   const options = permissionPillOptions(presets)
-  return options
-    ? { options, selected: choiceState.choice(), onSelect: choiceState.setChoice }
-    : undefined
+  if (!options)
+    return undefined
+  // The stored choice is clamped to the offered pills: a preset the catalog
+  // stopped offering while its choice was stored must not leave a group with no
+  // radio checked and an Allow that silently applies nothing.
+  const stored = choiceState.choice()
+  const selected = options.some(option => option.key === stored) ? stored : 'default'
+  return { options, selected, onSelect: choiceState.setChoice }
 }
 
 /**
@@ -118,7 +114,7 @@ export function applyPermissionPreset(
  * that offers a plan-approval banner has such a preset today.
  */
 export function presetPermissionMode(
-  presets: PermissionPresetController | undefined,
+  presets: ProviderPermissionPresets | undefined,
   choice: PermissionPresetChoice,
 ): PermissionMode | undefined {
   return choice === 'default' ? undefined : presets?.[choice]?.sets[OPTION_ID_PERMISSION_MODE]
@@ -126,18 +122,19 @@ export function presetPermissionMode(
 
 /**
  * The presets a PLAN APPROVAL banner may offer: only those that switch the
- * permission mode, the one axis its single response can carry. A preset naming
- * some other axis (Copilot's `allow_all`) cannot act there at all, so its pill is
- * not drawn -- drawn and silently doing nothing is the trap the plan banner's old
- * bypass switch was narrowed to avoid. No provider with a plan-approval banner
- * ships such a preset today; this keeps the rule true if one ever does.
+ * permission mode, the one axis its single response can carry. The result carries
+ * no `apply` handler — a plan approval switches the mode inside its response and
+ * never fires a settings change, and the narrower type keeps that true at compile
+ * time. A preset that switches some other axis (Copilot's `allow_all`) cannot act
+ * there at all, so its pill is not drawn -- drawn and silently doing nothing is the
+ * trap the plan banner's old bypass switch was narrowed to avoid. No provider with
+ * a plan-approval banner ships such a preset today; this keeps the rule true if one
+ * ever does.
  */
-export function planApprovalPresets(presets: PermissionPresetController | undefined): PermissionPresetController | undefined {
+export function planApprovalPresets(presets: PermissionPresetController | undefined): ProviderPermissionPresets | undefined {
   if (!presets)
     return undefined
   const smart = presets.smart?.sets[OPTION_ID_PERMISSION_MODE] !== undefined ? presets.smart : undefined
   const bypass = presets.bypass?.sets[OPTION_ID_PERMISSION_MODE] !== undefined ? presets.bypass : undefined
-  return smart || bypass
-    ? { smart, bypass, apply: presets.apply }
-    : undefined
+  return smart || bypass ? { smart, bypass } : undefined
 }

--- a/frontend/src/components/chat/controls/planApproval.ts
+++ b/frontend/src/components/chat/controls/planApproval.ts
@@ -1,50 +1,44 @@
 import type { Accessor } from 'solid-js'
 import type { ControlRequestSwitch } from './ControlDecisionFooter'
+import type { ControlPermissionPill } from './permissionPresets'
 import type { ActionsProps } from './types'
 import type { PermissionMode } from '~/utils/controlResponse'
 
 import { createMemo } from 'solid-js'
-import { OPTION_ID_PERMISSION_MODE } from '~/components/chat/settingsGroups'
 import { computePercentage } from '~/components/chat/widgets/ContextUsageGrid'
+import { buildPermissionPill, createPermissionPresetChoice, planApprovalPresets, presetPermissionMode } from './permissionPresets'
 import { createControlSwitch } from './types'
 
 export interface PlanApprovalState {
   clearContext: Accessor<boolean>
   setClearContext: (v: boolean) => void
-  bypassPermissions: Accessor<boolean>
-  setBypassPermissions: (v: boolean) => void
+  /** The permission pill group this banner draws, or undefined when no applicable preset exists. */
+  permissionPill: Accessor<ControlPermissionPill | undefined>
   permissionMode: Accessor<PermissionMode | undefined>
-  /**
-   * The permission mode this provider's bypass preset selects, or undefined when the
-   * preset carries no permission mode at all.
-   *
-   * The approval travels as ONE control response, so the only part of a preset this
-   * banner can apply is the mode it puts in that response. A preset that switches some
-   * other axis (Copilot's bypass sets `allow_all`) cannot be applied here, and the
-   * switch is not drawn — rather than drawn and silently doing nothing, which is what
-   * a bare `sets.permissionMode` read produced once the preset type stopped
-   * guaranteeing that key.
-   */
-  bypassMode: Accessor<PermissionMode | undefined>
   contextPct: Accessor<number | null>
 }
 
-/** Creates shared plan approval state (clear context + bypass permissions). */
-export function createPlanApprovalState(props: Pick<ActionsProps, 'contextUsage' | 'modelContextWindow' | 'agentProvider' | 'bypass' | 'answerState'>): PlanApprovalState {
-  // Both switches live in the composer's shared answer record, keyed by the id
-  // that `planApprovalSwitches` below renders them under. See `createControlSwitch`.
+/** Creates shared plan approval state (clear context + permission preset choice). */
+export function createPlanApprovalState(props: Pick<ActionsProps, 'contextUsage' | 'modelContextWindow' | 'agentProvider' | 'presets' | 'answerState'>): PlanApprovalState {
+  // The switch lives in the composer's shared answer record, keyed by the id
+  // that `planApprovalSwitches` below renders it under; the permission pill
+  // choice is stored the same way under its own group id. See
+  // `createControlSwitch` / `createPermissionPresetChoice`.
   const clear = createControlSwitch(() => props.answerState, 'plan-clear-context-checkbox')
-  const bypassSwitch = createControlSwitch(() => props.answerState, 'plan-bypass-permissions-checkbox')
+  const permissionChoice = createPermissionPresetChoice(props)
   const { checked: clearContext, set: setClearContext } = clear
-  const { checked: bypassPermissions, set: setBypassPermissions } = bypassSwitch
   const contextPct = createMemo(() => {
     const pct = computePercentage(props.contextUsage, props.modelContextWindow, props.agentProvider)
     return pct !== null ? Math.round(pct) : null
   })
-  const bypassMode = () => props.bypass?.settings.sets[OPTION_ID_PERMISSION_MODE]
-  const permissionMode = () => bypassPermissions() ? bypassMode() : undefined
+  // A plan approval carries only the preset's permission MODE (see
+  // `planApprovalPresets`), so both the pill it draws and the mode it embeds
+  // read from that filtered view of the controller.
+  const presets = () => planApprovalPresets(props.presets)
+  const permissionMode = () => presetPermissionMode(presets(), permissionChoice.choice())
+  const permissionPill = () => buildPermissionPill(presets(), permissionChoice)
 
-  return { clearContext, setClearContext, bypassPermissions, setBypassPermissions, contextPct, permissionMode, bypassMode }
+  return { clearContext, setClearContext, permissionPill, contextPct, permissionMode }
 }
 
 /** Builds the shared option list for a plan approval. */
@@ -57,13 +51,5 @@ export function planApprovalSwitches(state: PlanApprovalState): ControlRequestSw
       onChange: state.setClearContext,
       suffix: state.contextPct() !== null ? ` (${state.contextPct()}%)` : undefined,
     },
-    ...(state.bypassMode()
-      ? [{
-          id: 'plan-bypass-permissions-checkbox',
-          label: 'Bypass Permissions',
-          checked: state.bypassPermissions(),
-          onChange: state.setBypassPermissions,
-        }]
-      : []),
   ]
 }

--- a/frontend/src/components/chat/controls/types.test.ts
+++ b/frontend/src/components/chat/controls/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createControlAnswerState, createControlSwitch, toRpcId } from './types'
+import { createControlAnswerState, createControlChoice, createControlSwitch, toRpcId } from './types'
 
 describe('toRpcId', () => {
   it('converts numeric string to number', () => {
@@ -30,6 +30,7 @@ describe('createControlAnswerState', () => {
     expect(state.customTexts()).toEqual({})
     expect(state.currentPage()).toBe(0)
     expect(state.switches()).toEqual({})
+    expect(state.choices()).toEqual({})
   })
 
   // A partial seed is the shape that comes back from storage: an older record
@@ -40,6 +41,12 @@ describe('createControlAnswerState', () => {
     expect(state.customTexts()).toEqual({})
     expect(state.currentPage()).toBe(0)
     expect(state.switches()).toEqual({})
+    expect(state.choices()).toEqual({})
+  })
+
+  it('seeds the pill choices like every other field', () => {
+    const state = createControlAnswerState({ choices: { 'control-permissions-pill': 'bypass' } })
+    expect(state.choices()).toEqual({ 'control-permissions-pill': 'bypass' })
   })
 })
 
@@ -64,14 +71,14 @@ describe('createControlSwitch', () => {
   it('keeps two switches of one record apart by id', () => {
     const state = createControlAnswerState()
     const remember = createControlSwitch(() => state, 'control-remember-checkbox')
-    const bypass = createControlSwitch(() => state, 'control-bypass-permissions-checkbox')
+    const clear = createControlSwitch(() => state, 'plan-clear-context-checkbox')
 
     remember.set(true)
-    bypass.set(true)
+    clear.set(true)
     remember.set(false)
 
     expect(remember.checked()).toBe(false)
-    expect(bypass.checked()).toBe(true)
+    expect(clear.checked()).toBe(true)
   })
 
   // The record is captured ONCE, at creation. A caller that builds one inline in
@@ -80,12 +87,58 @@ describe('createControlSwitch', () => {
   it('binds the record it was created with, not the one a later read returns', () => {
     const bound = createControlAnswerState()
     let read = bound
-    const bypass = createControlSwitch(() => read, 'control-bypass-permissions-checkbox')
+    const clear = createControlSwitch(() => read, 'plan-clear-context-checkbox')
 
-    bypass.set(true)
+    clear.set(true)
     read = createControlAnswerState()
 
-    expect(bypass.checked()).toBe(true)
-    expect(bound.switches()).toEqual({ 'control-bypass-permissions-checkbox': true })
+    expect(clear.checked()).toBe(true)
+    expect(bound.switches()).toEqual({ 'plan-clear-context-checkbox': true })
+  })
+})
+
+describe('createControlChoice', () => {
+  it('reports an unset choice as the fallback', () => {
+    const state = createControlAnswerState()
+    expect(createControlChoice(() => state, 'control-permissions-pill', 'default').choice()).toBe('default')
+  })
+
+  it('writes the choice through to the shared record', () => {
+    const state = createControlAnswerState()
+    const pill = createControlChoice(() => state, 'control-permissions-pill', 'default')
+
+    pill.setChoice('bypass')
+
+    expect(pill.choice()).toBe('bypass')
+    expect(state.choices()).toEqual({ 'control-permissions-pill': 'bypass' })
+  })
+
+  // The permission pill's choice and a switch share one RECORD but not one map,
+  // so a choice write must leave the switches untouched and vice versa.
+  it('keeps the choices map apart from the switches map', () => {
+    const state = createControlAnswerState()
+    const pill = createControlChoice(() => state, 'control-permissions-pill', 'default')
+    const remember = createControlSwitch(() => state, 'control-remember-checkbox')
+
+    pill.setChoice('bypass')
+    remember.set(true)
+
+    expect(state.choices()).toEqual({ 'control-permissions-pill': 'bypass' })
+    expect(state.switches()).toEqual({ 'control-remember-checkbox': true })
+  })
+
+  // The record is captured ONCE, at creation, for the same reason as a switch:
+  // an inline `createControlAnswerState()` prop is a getter, and a per-access
+  // read would mint a fresh empty record and lose the user's selection.
+  it('binds the record it was created with, not the one a later read returns', () => {
+    const bound = createControlAnswerState()
+    let read = bound
+    const pill = createControlChoice(() => read, 'control-permissions-pill', 'default')
+
+    pill.setChoice('smart')
+    read = createControlAnswerState()
+
+    expect(pill.choice()).toBe('smart')
+    expect(bound.choices()).toEqual({ 'control-permissions-pill': 'smart' })
   })
 })

--- a/frontend/src/components/chat/controls/types.test.ts
+++ b/frontend/src/components/chat/controls/types.test.ts
@@ -103,6 +103,15 @@ describe('createControlChoice', () => {
     expect(createControlChoice(() => state, 'control-permissions-pill', 'default').choice()).toBe('default')
   })
 
+  it('reads undefined before any selection when no fallback is passed', () => {
+    const state = createControlAnswerState()
+    const scope = createControlChoice(() => state, 'control-allow-scope-pill')
+    expect(scope.choice()).toBeUndefined()
+
+    scope.setChoice('always')
+    expect(scope.choice()).toBe('always')
+  })
+
   it('writes the choice through to the shared record', () => {
     const state = createControlAnswerState()
     const pill = createControlChoice(() => state, 'control-permissions-pill', 'default')

--- a/frontend/src/components/chat/controls/types.ts
+++ b/frontend/src/components/chat/controls/types.ts
@@ -1,5 +1,5 @@
 import type { Accessor, Setter } from 'solid-js'
-import type { BypassController } from '../providerSettings'
+import type { PermissionPresetController } from '../providerSettings'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { ContextUsageInfo } from '~/stores/agentSession.store'
 import type { ControlRequest } from '~/stores/control.store'
@@ -28,10 +28,12 @@ export interface Question {
  * or a reload brings the answer back.
  *
  * `switches` holds every toggle a control offers, by the switch's own id
- * (`plan-clear-context-checkbox`, `control-bypass-permissions-checkbox`,
- * `control-remember-checkbox`). One map covers every control rather than a
- * field per switch, so a new switch needs no change here and cannot be the one
- * that a rebuild silently unchecks.
+ * (`plan-clear-context-checkbox`, `control-remember-checkbox`). One map covers
+ * every control rather than a field per switch, so a new switch needs no change
+ * here and cannot be the one that a rebuild silently unchecks. `choices` is its
+ * one-of-N sibling, holding a pill group's selection by the group's id
+ * (`control-permissions-pill`) — a string, because a pill picks a key, not a
+ * boolean.
  */
 export interface ControlAnswerState {
   selections: Accessor<Record<number, string[]>>
@@ -42,6 +44,8 @@ export interface ControlAnswerState {
   setCurrentPage: Setter<number>
   switches: Accessor<Record<string, boolean>>
   setSwitches: Setter<Record<string, boolean>>
+  choices: Accessor<Record<string, string>>
+  setChoices: Setter<Record<string, string>>
 }
 
 /** The saved shape of a {@link ControlAnswerState}, as it is stored and restored. */
@@ -50,6 +54,7 @@ export interface ControlAnswerSeed {
   customTexts?: Record<number, string>
   currentPage?: number
   switches?: Record<string, boolean>
+  choices?: Record<string, string>
 }
 
 /**
@@ -63,6 +68,7 @@ export function createControlAnswerState(seed: ControlAnswerSeed = {}): ControlA
   const [customTexts, setCustomTexts] = createSignal(seed.customTexts ?? {})
   const [currentPage, setCurrentPage] = createSignal(seed.currentPage ?? 0)
   const [switches, setSwitches] = createSignal(seed.switches ?? {})
+  const [choices, setChoices] = createSignal(seed.choices ?? {})
   return {
     selections,
     setSelections,
@@ -72,6 +78,8 @@ export function createControlAnswerState(seed: ControlAnswerSeed = {}): ControlA
     setCurrentPage,
     switches,
     setSwitches,
+    choices,
+    setChoices,
   }
 }
 
@@ -97,6 +105,20 @@ export function createControlSwitch(state: () => ControlAnswerState, id: string)
   return {
     checked: () => answer.switches()[id] ?? false,
     set: (value: boolean) => answer.setSwitches(prev => ({ ...prev, [id]: value })),
+  }
+}
+
+/**
+ * The one-of-N sibling of {@link createControlSwitch}: binds ONE pill group of a
+ * control to the shared answer record, by the group's own id. The fallback is the
+ * caller's to pass, so a group whose "no choice" state is a meaningful key (the
+ * permission pill's `'default'`) reads as that key rather than `undefined`.
+ */
+export function createControlChoice(state: () => ControlAnswerState, id: string, fallback: string) {
+  const answer = state()
+  return {
+    choice: () => answer.choices()[id] ?? fallback,
+    setChoice: (value: string) => answer.setChoices(prev => ({ ...prev, [id]: value })),
   }
 }
 
@@ -141,8 +163,12 @@ export interface ActionsProps {
    */
   editorContentRef?: () => EditorContentRef | undefined
   agentProvider?: AgentProvider
-  /** Applies the provider's complete bypass settings change. */
-  bypass?: BypassController
+  /**
+   * The provider's usable permission presets and the ONE handler that applies a
+   * settings change. A control request's permission pill group is drawn from this;
+   * selecting a preset applies it when the request's positive action is taken.
+   */
+  presets?: PermissionPresetController
   contextUsage?: ContextUsageInfo
   modelContextWindow?: number
   /**

--- a/frontend/src/components/chat/controls/types.ts
+++ b/frontend/src/components/chat/controls/types.ts
@@ -110,11 +110,13 @@ export function createControlSwitch(state: () => ControlAnswerState, id: string)
 
 /**
  * The one-of-N sibling of {@link createControlSwitch}: binds ONE pill group of a
- * control to the shared answer record, by the group's own id. The fallback is the
- * caller's to pass, so a group whose "no choice" state is a meaningful key (the
- * permission pill's `'default'`) reads as that key rather than `undefined`.
+ * control to the shared answer record, by the group's own id. The optional
+ * fallback is the caller's to pass, and only for a group whose "no choice" state
+ * is a meaningful key (the permission pill's `'default'`): a group with no
+ * meaningful unset key (the allow-scope pill) reads `undefined` until a
+ * selection lands, instead of a sentinel string every reader must know about.
  */
-export function createControlChoice(state: () => ControlAnswerState, id: string, fallback: string) {
+export function createControlChoice(state: () => ControlAnswerState, id: string, fallback?: string) {
   const answer = state()
   return {
     choice: () => answer.choices()[id] ?? fallback,
@@ -220,6 +222,19 @@ export function sendJsonRpcResult(
   result: unknown,
 ): Promise<void> {
   return sendResponse(onRespond, buildJsonRpcResult(requestId, result))
+}
+
+/**
+ * Sends the ACP-family `session/request_permission` reply that selects one
+ * option. The ACP and OpenCode protocols share this envelope, so both providers'
+ * senders delegate here instead of building it twice.
+ */
+export function sendSelectedOptionResponse(
+  onRespond: (content: Uint8Array) => Promise<void>,
+  requestId: string,
+  optionId: string,
+): Promise<void> {
+  return sendJsonRpcResult(onRespond, requestId, { outcome: { outcome: 'selected', optionId } })
 }
 
 /** Convert a string request ID to a numeric JSON-RPC id when possible. */

--- a/frontend/src/components/chat/providerSettings.ts
+++ b/frontend/src/components/chat/providerSettings.ts
@@ -15,8 +15,8 @@ export type ProviderSettingChangeHandler = (change: ProviderSettingChange) => vo
  * one permission mode, Codex switches network, sandbox and approval together, and
  * Copilot switches an axis that is not the permission mode at all. So no key is
  * guaranteed, and a consumer that needs a specific one must check for it (see
- * `./controls/planApproval`, which draws its switch only for a preset that carries a
- * permission mode).
+ * `./controls/permissionPresets`, which reads a preset's permission mode only when
+ * it carries one).
  */
 export type ProviderPermissionPreset = ProviderSettingChange
 
@@ -26,9 +26,15 @@ export interface ProviderPermissionPresets {
   bypass?: ProviderPermissionPreset
 }
 
-/** A usable bypass action. The UI receives it only when both parts exist. */
-export interface BypassController {
-  settings: ProviderPermissionPreset
+/**
+ * The usable permission presets a control request can apply: every preset the live
+ * catalog offers, plus the ONE handler that applies a settings change — the composer's
+ * `onSettingChange`, the same call the `[+]` menu's permission items make. A preset
+ * the catalog does not currently offer is `undefined`, so the pill for it is not drawn.
+ */
+export interface PermissionPresetController {
+  smart?: ProviderPermissionPreset
+  bypass?: ProviderPermissionPreset
   apply: ProviderSettingChangeHandler
 }
 

--- a/frontend/src/components/chat/providerSettings.ts
+++ b/frontend/src/components/chat/providerSettings.ts
@@ -11,7 +11,7 @@ export type ProviderSettingChangeHandler = (change: ProviderSettingChange) => vo
 /**
  * One provider-native permission preset: the complete settings change that selects it.
  *
- * A preset names whatever axes ITS provider needs, and nothing more — Claude switches
+ * A preset sets whatever axes ITS provider needs, and nothing more — Claude switches
  * one permission mode, Codex switches network, sandbox and approval together, and
  * Copilot switches an axis that is not the permission mode at all. So no key is
  * guaranteed, and a consumer that needs a specific one must check for it (see
@@ -24,6 +24,16 @@ export type ProviderPermissionPreset = ProviderSettingChange
 export interface ProviderPermissionPresets {
   smart?: ProviderPermissionPreset
   bypass?: ProviderPermissionPreset
+}
+
+/**
+ * The label each standard preset shows, wherever a preset is offered: the composer
+ * `[+]` menu's permission items and a control request's permission pill group read
+ * this one table, so the two surfaces cannot drift apart on a rename.
+ */
+export const PERMISSION_PRESET_LABELS: Record<keyof ProviderPermissionPresets, string> = {
+  smart: 'Smart permissions',
+  bypass: 'Bypass permissions',
 }
 
 /**
@@ -51,4 +61,20 @@ export function permissionPresetAvailable(
   return entries.every(([groupId, value]) =>
     !!optionGroup(groups, groupId)?.mutable && valueValidForGroup(groups, groupId, value),
   )
+}
+
+/**
+ * The presets the live catalog currently offers: a preset is usable only when the
+ * catalog carries every axis it sets. The ONE implementation of the rule the
+ * composer `[+]` menu's permission items and a control request's permission pill
+ * group both follow, so the two surfaces cannot offer different preset sets.
+ */
+export function usablePresets(
+  presets: ProviderPermissionPresets | undefined,
+  groups: AvailableOptionGroup[] | undefined,
+): ProviderPermissionPresets {
+  return {
+    smart: permissionPresetAvailable(presets?.smart, groups) ? presets?.smart : undefined,
+    bypass: permissionPresetAvailable(presets?.bypass, groups) ? presets?.bypass : undefined,
+  }
 }

--- a/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
@@ -1,7 +1,11 @@
-import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { createControlAnswerState } from '../../controls/types'
 import { ACPControlActions, sendACPPermissionResponse } from './ACPControlRequest'
+
+function decodeOptionId(content: Uint8Array): string {
+  return JSON.parse(new TextDecoder().decode(content)).result.outcome.optionId
+}
 
 describe('sendACPPermissionResponse', () => {
   it('sends an ACP permission response with the selected option', async () => {
@@ -23,11 +27,13 @@ describe('sendACPPermissionResponse', () => {
       },
     })
   })
+})
 
-  it('bypass button sends the allow option and flips permission mode', async () => {
+describe('acpControlActions', () => {
+  /** Goose's wire shape: four kind-named options, emitted allow-first. */
+  function renderGooseActions() {
     const onRespond = vi.fn().mockResolvedValue(undefined)
-    const applyBypass = vi.fn()
-
+    const apply = vi.fn()
     render(() => ACPControlActions({
       request: {
         agentId: 'agent1',
@@ -35,8 +41,10 @@ describe('sendACPPermissionResponse', () => {
         payload: {
           params: {
             options: [
-              { optionId: 'proceed_once', name: 'Allow once', kind: 'allow_once' },
-              { optionId: 'cancel', name: 'Deny', kind: 'reject_once' },
+              { optionId: 'allow_always', kind: 'allow_always', name: 'allow_always' },
+              { optionId: 'allow_once', kind: 'allow_once', name: 'allow_once' },
+              { optionId: 'reject_once', kind: 'reject_once', name: 'reject_once' },
+              { optionId: 'reject_always', kind: 'reject_always', name: 'reject_always' },
             ],
           },
         },
@@ -45,15 +53,172 @@ describe('sendACPPermissionResponse', () => {
       answerState: createControlAnswerState(),
       hasEditorContent: false,
       onTriggerSend: vi.fn(),
-      bypass: { settings: { sets: { permissionMode: 'yolo' } }, apply: applyBypass },
+      presets: {
+        smart: { sets: { permissionMode: 'smart_approve' } },
+        bypass: { sets: { permissionMode: 'auto' } },
+        apply,
+      },
+    }))
+    return { onRespond, apply }
+  }
+
+  /** OpenCode's wire shape: an allow_always with no reject_always. */
+  function renderOpenCodeShapeActions() {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    render(() => ACPControlActions({
+      request: {
+        agentId: 'agent1',
+        requestId: '8',
+        payload: {
+          params: {
+            options: [
+              { optionId: 'once', kind: 'allow_once', name: 'Allow once' },
+              { optionId: 'always', kind: 'allow_always', name: 'Always allow' },
+              { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
+            ],
+          },
+        },
+      },
+      onRespond,
+      answerState: createControlAnswerState(),
+      hasEditorContent: false,
+      onTriggerSend: vi.fn(),
+    }))
+    return { onRespond }
+  }
+
+  it('renders Deny before Allow with Once / Always scope pills and the permission pills, never the raw always buttons', () => {
+    renderGooseActions()
+
+    // Negative before positive; the polarity labels are ours, and the duration
+    // lives in the scope pills rather than the button text.
+    const deny = screen.getByTestId('control-deny-btn')
+    const allow = screen.getByTestId('control-allow-btn')
+    expect(deny.textContent).toBe('Deny')
+    expect(allow.textContent).toBe('Allow')
+    expect(deny.compareDocumentPosition(allow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    const scope = within(screen.getByRole('radiogroup', { name: 'Allow scope' }))
+    expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
+    expect(scope.getByRole('radio', { name: 'Always' })).not.toBeChecked()
+    const pill = within(screen.getByRole('radiogroup', { name: 'Permissions' }))
+    expect(pill.getByRole('radio', { name: 'Default' })).toBeChecked()
+    // The always options live in the scope group, not as their own buttons.
+    expect(screen.queryByTestId('control-decision-allow_always')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('control-decision-reject_always')).not.toBeInTheDocument()
+  })
+
+  it('sends the once options while Once is selected', async () => {
+    const { onRespond } = renderGooseActions()
+
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('allow_once')
+
+    await fireEvent.click(screen.getByTestId('control-deny-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[1][0])).toBe('reject_once')
+  })
+
+  it('sends the always options once a scope beyond Once is selected', async () => {
+    const { onRespond } = renderGooseActions()
+
+    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Allow scope' })).getByRole('radio', { name: 'Always' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('allow_always')
+
+    // A remembering scope also upgrades Deny for the one agent offering reject_always.
+    await fireEvent.click(screen.getByTestId('control-deny-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[1][0])).toBe('reject_always')
+  })
+
+  it('keeps the reject-once option under a remembering scope when the agent offers no reject_always', async () => {
+    const { onRespond } = renderOpenCodeShapeActions()
+
+    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Allow scope' })).getByRole('radio', { name: 'Always' }))
+    await fireEvent.click(screen.getByTestId('control-deny-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('reject')
+
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[1][0])).toBe('always')
+  })
+
+  it('draws no scope group when the agent offers no always option', () => {
+    render(() => ACPControlActions({
+      request: {
+        agentId: 'agent1',
+        requestId: '9',
+        payload: {
+          params: {
+            options: [
+              { optionId: 'once', kind: 'allow_once', name: 'Allow' },
+              { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
+            ],
+          },
+        },
+      },
+      onRespond: vi.fn().mockResolvedValue(undefined),
+      answerState: createControlAnswerState(),
+      hasEditorContent: false,
+      onTriggerSend: vi.fn(),
     }))
 
-    await fireEvent.click(screen.getByTestId('control-bypass-btn'))
+    expect(screen.queryByRole('radiogroup', { name: 'Allow scope' })).not.toBeInTheDocument()
+  })
 
+  it('applies the chosen permission preset after an allow and never after a reject', async () => {
+    const { onRespond, apply } = renderGooseActions()
+
+    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass permissions' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
     expect(onRespond).toHaveBeenCalledTimes(1)
-    const [content] = onRespond.mock.calls[0]
-    const parsed = JSON.parse(new TextDecoder().decode(content))
-    expect(parsed.result.outcome.optionId).toBe('proceed_once')
-    expect(applyBypass).toHaveBeenCalledWith({ sets: { permissionMode: 'yolo' } })
+    expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'auto' } })
+
+    await fireEvent.click(screen.getByTestId('control-deny-btn'))
+    expect(onRespond).toHaveBeenCalledTimes(2)
+    expect(apply).toHaveBeenCalledTimes(1)
+  })
+
+  it('draws a Once / Session / Project pill group for Reasonix\'s two always scopes, replacing the Remember switch', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    render(() => ACPControlActions({
+      request: {
+        agentId: 'agent1',
+        requestId: '13',
+        payload: {
+          params: {
+            options: [
+              { optionId: 'reasonix_write_once', kind: 'allow_once', name: 'Allow once' },
+              { optionId: 'reasonix_write_session', kind: 'allow_always', name: 'Allow these directories for this session' },
+              { optionId: 'reasonix_write_project', kind: 'allow_always', name: 'Add to project allow_write' },
+              { optionId: 'reasonix_write_deny', kind: 'reject_once', name: 'Reject' },
+            ],
+          },
+        },
+      },
+      onRespond,
+      answerState: createControlAnswerState(),
+      hasEditorContent: false,
+      onTriggerSend: vi.fn(),
+    }))
+
+    // The scope group replaces both the Remember switch and the extra button
+    // the project option used to be.
+    const scope = within(screen.getByRole('radiogroup', { name: 'Allow scope' }))
+    expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
+    expect(scope.getByRole('radio', { name: 'Session' })).toBeInTheDocument()
+    expect(scope.getByRole('radio', { name: 'Project' })).toBeInTheDocument()
+    expect(screen.queryByTestId('control-remember-checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('control-decision-reasonix_write_project')).not.toBeInTheDocument()
+    expect(screen.getByTestId('control-allow-btn').textContent).toBe('Allow')
+
+    // Allow sends the selected scope's option, Once first, Project after a pick.
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('reasonix_write_once')
+
+    fireEvent.click(scope.getByRole('radio', { name: 'Project' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[1][0])).toBe('reasonix_write_project')
+
+    await fireEvent.click(screen.getByTestId('control-deny-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[2][0])).toBe('reasonix_write_deny')
   })
 })

--- a/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
@@ -1,5 +1,7 @@
-import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import type { PermissionPresetController } from '../../providerSettings'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
+import { allowScopePillGroup, permissionPillGroup } from '~/test-support/controlRequests'
 import { createControlAnswerState } from '../../controls/types'
 import { ACPControlActions, sendACPPermissionResponse } from './ACPControlRequest'
 
@@ -62,6 +64,23 @@ describe('acpControlActions', () => {
     return { onRespond, apply }
   }
 
+  function renderActions(options: Array<Record<string, string>>, presets?: PermissionPresetController) {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    render(() => ACPControlActions({
+      request: {
+        agentId: 'agent1',
+        requestId: '14',
+        payload: { params: { options } },
+      },
+      onRespond,
+      answerState: createControlAnswerState(),
+      hasEditorContent: false,
+      onTriggerSend: vi.fn(),
+      presets,
+    }))
+    return { onRespond }
+  }
+
   /** OpenCode's wire shape: an allow_always with no reject_always. */
   function renderOpenCodeShapeActions() {
     const onRespond = vi.fn().mockResolvedValue(undefined)
@@ -98,10 +117,10 @@ describe('acpControlActions', () => {
     expect(allow.textContent).toBe('Allow')
     expect(deny.compareDocumentPosition(allow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
-    const scope = within(screen.getByRole('radiogroup', { name: 'Allow scope' }))
+    const scope = allowScopePillGroup()
     expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
     expect(scope.getByRole('radio', { name: 'Always' })).not.toBeChecked()
-    const pill = within(screen.getByRole('radiogroup', { name: 'Permissions' }))
+    const pill = permissionPillGroup()
     expect(pill.getByRole('radio', { name: 'Default' })).toBeChecked()
     // The always options live in the scope group, not as their own buttons.
     expect(screen.queryByTestId('control-decision-allow_always')).not.toBeInTheDocument()
@@ -121,7 +140,7 @@ describe('acpControlActions', () => {
   it('sends the always options once a scope beyond Once is selected', async () => {
     const { onRespond } = renderGooseActions()
 
-    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Allow scope' })).getByRole('radio', { name: 'Always' }))
+    fireEvent.click(allowScopePillGroup().getByRole('radio', { name: 'Always' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
     expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('allow_always')
 
@@ -133,7 +152,7 @@ describe('acpControlActions', () => {
   it('keeps the reject-once option under a remembering scope when the agent offers no reject_always', async () => {
     const { onRespond } = renderOpenCodeShapeActions()
 
-    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Allow scope' })).getByRole('radio', { name: 'Always' }))
+    fireEvent.click(allowScopePillGroup().getByRole('radio', { name: 'Always' }))
     await fireEvent.click(screen.getByTestId('control-deny-btn'))
     expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('reject')
 
@@ -142,32 +161,44 @@ describe('acpControlActions', () => {
   })
 
   it('draws no scope group when the agent offers no always option', () => {
-    render(() => ACPControlActions({
-      request: {
-        agentId: 'agent1',
-        requestId: '9',
-        payload: {
-          params: {
-            options: [
-              { optionId: 'once', kind: 'allow_once', name: 'Allow' },
-              { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
-            ],
-          },
-        },
-      },
-      onRespond: vi.fn().mockResolvedValue(undefined),
-      answerState: createControlAnswerState(),
-      hasEditorContent: false,
-      onTriggerSend: vi.fn(),
-    }))
+    renderActions([
+      { optionId: 'once', kind: 'allow_once', name: 'Allow' },
+      { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
+    ])
 
     expect(screen.queryByRole('radiogroup', { name: 'Allow scope' })).not.toBeInTheDocument()
+  })
+
+  it('draws no permission pills when no allow option can apply them', () => {
+    // A reject-only payload has no positive action, so no selection the group
+    // offers could ever act; drawing it would be a control that silently does
+    // nothing.
+    renderActions([
+      { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
+    ], { smart: { sets: { permissionMode: 'smart_approve' } }, bypass: { sets: { permissionMode: 'auto' } }, apply: vi.fn() })
+
+    expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument()
+    expect(screen.getByTestId('control-deny-btn')).toBeInTheDocument()
+    expect(screen.queryByTestId('control-allow-btn')).not.toBeInTheDocument()
+  })
+
+  it('states the duration on the Allow button when the agent offers no once option', async () => {
+    const { onRespond } = renderActions([
+      { optionId: 'always', kind: 'allow_always', name: 'Always allow' },
+      { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
+    ])
+
+    expect(screen.getByTestId('control-allow-btn').textContent).toBe('Always allow')
+    expect(screen.queryByRole('radiogroup', { name: 'Allow scope' })).not.toBeInTheDocument()
+
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('always')
   })
 
   it('applies the chosen permission preset after an allow and never after a reject', async () => {
     const { onRespond, apply } = renderGooseActions()
 
-    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
     expect(onRespond).toHaveBeenCalledTimes(1)
     expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'auto' } })
@@ -177,7 +208,42 @@ describe('acpControlActions', () => {
     expect(apply).toHaveBeenCalledTimes(1)
   })
 
-  it('draws a Once / Session / Project pill group for Reasonix\'s two always scopes, replacing the Remember switch', async () => {
+  it('applies no preset when an extra option outside the allow family is clicked', async () => {
+    // The pill's contract is "applies when the request's positive action is
+    // taken": an extra button carrying an invented kind (a future agent's
+    // answer variant) is not that action, so it must not switch the mode.
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const apply = vi.fn()
+    render(() => ACPControlActions({
+      request: {
+        agentId: 'agent1',
+        requestId: '15',
+        payload: {
+          params: {
+            options: [
+              { optionId: 'once', kind: 'allow_once', name: 'Allow' },
+              { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
+              { optionId: 'ask', kind: 'ask_user', name: 'Ask the user' },
+            ],
+          },
+        },
+      },
+      onRespond,
+      answerState: createControlAnswerState(),
+      hasEditorContent: false,
+      onTriggerSend: vi.fn(),
+      presets: { bypass: { sets: { permissionMode: 'yolo' } }, apply },
+    }))
+
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    await fireEvent.click(screen.getByTestId('control-decision-ask'))
+
+    expect(onRespond).toHaveBeenCalledOnce()
+    expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('ask')
+    expect(apply).not.toHaveBeenCalled()
+  })
+
+  it('draws a Once / Session / Project pill group for Reasonix\'s two always scopes', async () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     render(() => ACPControlActions({
       request: {
@@ -200,13 +266,11 @@ describe('acpControlActions', () => {
       onTriggerSend: vi.fn(),
     }))
 
-    // The scope group replaces both the Remember switch and the extra button
-    // the project option used to be.
-    const scope = within(screen.getByRole('radiogroup', { name: 'Allow scope' }))
+    // The scope group replaces the extra button the project option used to be.
+    const scope = allowScopePillGroup()
     expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
     expect(scope.getByRole('radio', { name: 'Session' })).toBeInTheDocument()
     expect(scope.getByRole('radio', { name: 'Project' })).toBeInTheDocument()
-    expect(screen.queryByTestId('control-remember-checkbox')).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-reasonix_write_project')).not.toBeInTheDocument()
     expect(screen.getByTestId('control-allow-btn').textContent).toBe('Allow')
 

--- a/frontend/src/components/chat/providers/acp/ACPControlRequest.tsx
+++ b/frontend/src/components/chat/providers/acp/ACPControlRequest.tsx
@@ -2,22 +2,10 @@ import type { Component } from 'solid-js'
 import type { WirePermissionOption } from '../../controls/permissionOptions'
 import type { ActionsProps, ContentProps } from '../../controls/types'
 
-import { createMemo, For, Show } from 'solid-js'
-import { ButtonGroup } from '~/components/common/ButtonGroup'
+import { Show } from 'solid-js'
 import * as styles from '../../ControlRequestBanner.css'
-import { ControlActionRow } from '../../controls/ControlActionRow'
-import { ControlAllowScopePillGroup, ControlPermissionPillGroup } from '../../controls/ControlDecisionFooter'
-import {
-  ALLOW_SCOPE_CHOICE_ID,
-  allowScopePillOptions,
-  isRejectPermissionKind,
-  layoutPermissionOptions,
-  permissionOptionLabel,
-  resolvePermissionOption,
-  scopeRemembers,
-} from '../../controls/permissionOptions'
-import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from '../../controls/permissionPresets'
-import { createControlChoice, sendResponse, toRpcId } from '../../controls/types'
+import { PermissionDecisionActions } from '../../controls/PermissionDecisionActions'
+import { sendSelectedOptionResponse } from '../../controls/types'
 
 function getACPParams(payload: Record<string, unknown>): Record<string, unknown> | undefined {
   return payload.params as Record<string, unknown> | undefined
@@ -36,11 +24,7 @@ export function sendACPPermissionResponse(
   requestId: string,
   optionId: string,
 ): Promise<void> {
-  return sendResponse(onRespond, {
-    jsonrpc: '2.0',
-    id: toRpcId(requestId),
-    result: { outcome: { outcome: 'selected', optionId } },
-  })
+  return sendSelectedOptionResponse(onRespond, requestId, optionId)
 }
 
 export const ACPControlContent: Component<ContentProps> = (props) => {
@@ -58,96 +42,6 @@ export const ACPControlContent: Component<ContentProps> = (props) => {
   )
 }
 
-export const ACPControlActions: Component<ActionsProps> = (props) => {
-  const layout = createMemo(() => layoutPermissionOptions(getOptions(props.request.payload)))
-  const permissionChoice = createPermissionPresetChoice(props)
-  const scopeChoice = createControlChoice(() => props.answerState, ALLOW_SCOPE_CHOICE_ID, '')
-
-  // The scope pills a payload with always options draws (Once / Always, or
-  // Once / Session / Project). The stored selection is clamped to the offered
-  // options: a payload swap must not leave the group reporting an option the
-  // agent no longer offers.
-  const scopeOptions = createMemo(() => {
-    const scope = layout().allowScope
-    return scope ? allowScopePillOptions(scope) : undefined
-  })
-  const selectedScope = () => {
-    const scope = layout().allowScope
-    if (!scope)
-      return undefined
-    return scope.some(option => option.optionId === scopeChoice.choice())
-      ? scopeChoice.choice()
-      : scope[0].optionId
-  }
-
-  // The option's response is AWAITED before a permission preset is applied: the
-  // worker dispatches the two concurrently, and a mode change the provider cannot
-  // take live relaunches the agent, which kills the session before an un-awaited
-  // answer reaches it. A reject-kind option decides nothing about future
-  // permissions, so it applies no preset.
-  const handleOption = async (option: WirePermissionOption | undefined) => {
-    if (!option)
-      return
-    await sendACPPermissionResponse(props.onRespond, props.request.requestId, option.optionId)
-    if (!isRejectPermissionKind(option.kind))
-      await applyPermissionPreset(props.presets, permissionChoice.choice())
-  }
-
-  const handleDecision = (polarity: 'allow' | 'reject') =>
-    handleOption(resolvePermissionOption(layout(), polarity, scopeRemembers(layout(), selectedScope()), selectedScope()))
-
-  return (
-    <ControlActionRow
-      primary={(
-        <>
-          <Show when={scopeOptions() || buildPermissionPill(props.presets, permissionChoice)}>
-            <div class={styles.controlRequestSwitches}>
-              <Show when={scopeOptions()}>
-                {options => (
-                  <ControlAllowScopePillGroup
-                    options={options()}
-                    selected={selectedScope()!}
-                    onSelect={scopeChoice.setChoice}
-                  />
-                )}
-              </Show>
-              <Show when={buildPermissionPill(props.presets, permissionChoice)}>
-                {pill => <ControlPermissionPillGroup pill={pill()} />}
-              </Show>
-            </div>
-          </Show>
-          <ButtonGroup>
-            <Show when={layout().negative}>
-              <button
-                class="outline"
-                onClick={() => handleDecision('reject')}
-                data-testid="control-deny-btn"
-              >
-                Deny
-              </button>
-            </Show>
-            <Show when={layout().positive || scopeOptions()}>
-              <button
-                onClick={() => handleDecision('allow')}
-                data-testid="control-allow-btn"
-              >
-                Allow
-              </button>
-            </Show>
-            <For each={layout().additional}>
-              {option => (
-                <button
-                  class={isRejectPermissionKind(option.kind) ? 'outline' : undefined}
-                  onClick={() => handleOption(option)}
-                  data-testid={`control-decision-${option.optionId}`}
-                >
-                  {permissionOptionLabel(option)}
-                </button>
-              )}
-            </For>
-          </ButtonGroup>
-        </>
-      )}
-    />
-  )
-}
+export const ACPControlActions: Component<ActionsProps> = props => (
+  <PermissionDecisionActions {...props} options={getOptions} send={sendACPPermissionResponse} />
+)

--- a/frontend/src/components/chat/providers/acp/ACPControlRequest.tsx
+++ b/frontend/src/components/chat/providers/acp/ACPControlRequest.tsx
@@ -1,18 +1,23 @@
 import type { Component } from 'solid-js'
+import type { WirePermissionOption } from '../../controls/permissionOptions'
 import type { ActionsProps, ContentProps } from '../../controls/types'
 
-import { For, Show } from 'solid-js'
+import { createMemo, For, Show } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
-import { Tooltip } from '~/components/common/Tooltip'
 import * as styles from '../../ControlRequestBanner.css'
 import { ControlActionRow } from '../../controls/ControlActionRow'
-import { sendResponse, toRpcId } from '../../controls/types'
-
-interface ACPPermissionOption {
-  optionId: string
-  kind: string
-  name: string
-}
+import { ControlAllowScopePillGroup, ControlPermissionPillGroup } from '../../controls/ControlDecisionFooter'
+import {
+  ALLOW_SCOPE_CHOICE_ID,
+  allowScopePillOptions,
+  isRejectPermissionKind,
+  layoutPermissionOptions,
+  permissionOptionLabel,
+  resolvePermissionOption,
+  scopeRemembers,
+} from '../../controls/permissionOptions'
+import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from '../../controls/permissionPresets'
+import { createControlChoice, sendResponse, toRpcId } from '../../controls/types'
 
 function getACPParams(payload: Record<string, unknown>): Record<string, unknown> | undefined {
   return payload.params as Record<string, unknown> | undefined
@@ -22,14 +27,8 @@ function getToolCall(payload: Record<string, unknown>): Record<string, unknown> 
   return getACPParams(payload)?.toolCall as Record<string, unknown> | undefined
 }
 
-function getOptions(payload: Record<string, unknown>): ACPPermissionOption[] {
-  return (getACPParams(payload)?.options as ACPPermissionOption[] | undefined) ?? []
-}
-
-function defaultAllowOptionId(payload: Record<string, unknown>): string | undefined {
-  const options = getOptions(payload)
-  return options.find(option => option.kind === 'allow_once')?.optionId
-    ?? options.find(option => option.kind !== 'reject_once')?.optionId
+function getOptions(payload: Record<string, unknown>): WirePermissionOption[] {
+  return (getACPParams(payload)?.options as WirePermissionOption[] | undefined) ?? []
 }
 
 export function sendACPPermissionResponse(
@@ -60,51 +59,94 @@ export const ACPControlContent: Component<ContentProps> = (props) => {
 }
 
 export const ACPControlActions: Component<ActionsProps> = (props) => {
-  const options = () => getOptions(props.request.payload)
+  const layout = createMemo(() => layoutPermissionOptions(getOptions(props.request.payload)))
+  const permissionChoice = createPermissionPresetChoice(props)
+  const scopeChoice = createControlChoice(() => props.answerState, ALLOW_SCOPE_CHOICE_ID, '')
 
-  const handleOption = (optionId: string) => {
-    sendACPPermissionResponse(props.onRespond, props.request.requestId, optionId)
+  // The scope pills a payload with always options draws (Once / Always, or
+  // Once / Session / Project). The stored selection is clamped to the offered
+  // options: a payload swap must not leave the group reporting an option the
+  // agent no longer offers.
+  const scopeOptions = createMemo(() => {
+    const scope = layout().allowScope
+    return scope ? allowScopePillOptions(scope) : undefined
+  })
+  const selectedScope = () => {
+    const scope = layout().allowScope
+    if (!scope)
+      return undefined
+    return scope.some(option => option.optionId === scopeChoice.choice())
+      ? scopeChoice.choice()
+      : scope[0].optionId
   }
 
-  // Await the allow BEFORE switching the mode: the worker dispatches the two
-  // concurrently, and a mode change the provider cannot take live relaunches the
-  // agent, which kills the session before an un-awaited allow reaches it.
-  const handleBypassPermissions = async () => {
-    const allowOptionId = defaultAllowOptionId(props.request.payload)
-    if (!allowOptionId)
+  // The option's response is AWAITED before a permission preset is applied: the
+  // worker dispatches the two concurrently, and a mode change the provider cannot
+  // take live relaunches the agent, which kills the session before an un-awaited
+  // answer reaches it. A reject-kind option decides nothing about future
+  // permissions, so it applies no preset.
+  const handleOption = async (option: WirePermissionOption | undefined) => {
+    if (!option)
       return
-    await sendACPPermissionResponse(props.onRespond, props.request.requestId, allowOptionId)
-    if (props.bypass)
-      await props.bypass.apply(props.bypass.settings)
+    await sendACPPermissionResponse(props.onRespond, props.request.requestId, option.optionId)
+    if (!isRejectPermissionKind(option.kind))
+      await applyPermissionPreset(props.presets, permissionChoice.choice())
   }
+
+  const handleDecision = (polarity: 'allow' | 'reject') =>
+    handleOption(resolvePermissionOption(layout(), polarity, scopeRemembers(layout(), selectedScope()), selectedScope()))
 
   return (
     <ControlActionRow
       primary={(
-        <ButtonGroup>
-          <For each={options()}>
-            {option => (
-              <button
-                class={option.kind === 'reject_once' ? 'outline' : undefined}
-                onClick={() => handleOption(option.optionId)}
-                data-testid={`control-decision-${option.optionId}`}
-              >
-                {option.name}
-              </button>
-            )}
-          </For>
-          <Show when={props.bypass && defaultAllowOptionId(props.request.payload)}>
-            <Tooltip text="Allow this request and stop asking for permissions">
-              <button
-                data-variant="secondary"
-                onClick={handleBypassPermissions}
-                data-testid="control-bypass-btn"
-              >
-                & Bypass Permissions
-              </button>
-            </Tooltip>
+        <>
+          <Show when={scopeOptions() || buildPermissionPill(props.presets, permissionChoice)}>
+            <div class={styles.controlRequestSwitches}>
+              <Show when={scopeOptions()}>
+                {options => (
+                  <ControlAllowScopePillGroup
+                    options={options()}
+                    selected={selectedScope()!}
+                    onSelect={scopeChoice.setChoice}
+                  />
+                )}
+              </Show>
+              <Show when={buildPermissionPill(props.presets, permissionChoice)}>
+                {pill => <ControlPermissionPillGroup pill={pill()} />}
+              </Show>
+            </div>
           </Show>
-        </ButtonGroup>
+          <ButtonGroup>
+            <Show when={layout().negative}>
+              <button
+                class="outline"
+                onClick={() => handleDecision('reject')}
+                data-testid="control-deny-btn"
+              >
+                Deny
+              </button>
+            </Show>
+            <Show when={layout().positive || scopeOptions()}>
+              <button
+                onClick={() => handleDecision('allow')}
+                data-testid="control-allow-btn"
+              >
+                Allow
+              </button>
+            </Show>
+            <For each={layout().additional}>
+              {option => (
+                <button
+                  class={isRejectPermissionKind(option.kind) ? 'outline' : undefined}
+                  onClick={() => handleOption(option)}
+                  data-testid={`control-decision-${option.optionId}`}
+                >
+                  {permissionOptionLabel(option)}
+                </button>
+              )}
+            </For>
+          </ButtonGroup>
+        </>
       )}
     />
   )

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
@@ -1,5 +1,5 @@
 import type { ControlRequest } from '~/stores/control.store'
-import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { CODEX_BYPASS_SETTINGS } from '~/generated/contracts/codex-bypass'
 import { createControlAnswerState } from '../../controls/types'
@@ -31,20 +31,25 @@ function renderActions(request: ControlRequest, hasEditorContent = false) {
       onRespond={onRespond}
       hasEditorContent={hasEditorContent}
       onTriggerSend={vi.fn()}
-      bypass={{ settings: CODEX_BYPASS_SETTINGS, apply: onSettingChange }}
+      presets={{ bypass: CODEX_BYPASS_SETTINGS, apply: onSettingChange }}
     />
   ))
   return { onRespond, onSettingChange }
 }
 
+function permissionPill() {
+  return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
+}
+
 describe('codex control request actions', () => {
-  it('renders Deny and Allow with Remember and Bypass Permissions switches', () => {
+  it('renders Deny and Allow with the Remember switch and the permission pills', () => {
     renderActions(makeRequest({ availableDecisions: ['accept', 'decline', { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } }] }))
 
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Reject')
     expect(screen.getByTestId('control-allow-btn')).toHaveTextContent('Allow')
     expect(screen.getByTestId('control-remember-checkbox')).toHaveTextContent('Remember')
-    expect(screen.getByTestId('control-bypass-permissions-checkbox')).toHaveTextContent('Bypass Permissions')
+    expect(permissionPill().getByRole('radio', { name: 'Default' })).toBeChecked()
+    expect(permissionPill().getByRole('radio', { name: 'Bypass permissions' })).toBeInTheDocument()
   })
 
   it('uses the remembered Codex decision only when Remember is checked', async () => {
@@ -160,7 +165,7 @@ describe('codex control request actions', () => {
       finishResponse = resolve
     }))
 
-    fireEvent.click(screen.getByTestId('control-bypass-permissions-checkbox').querySelector('input')!)
+    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
     fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     expect(onRespond).toHaveBeenCalledOnce()
@@ -178,7 +183,7 @@ describe('codex control request actions', () => {
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Send feedback')
     expect(screen.queryByTestId('control-allow-btn')).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-remember-checkbox')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('control-bypass-permissions-checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-cancel')).not.toBeInTheDocument()
   })
 
@@ -194,6 +199,20 @@ describe('codex control request actions', () => {
     expect(JSON.parse(new TextDecoder().decode(bytes))).toMatchObject({
       codexPlanModePrompt: true,
       clearContext: true,
+      response: { request_id: 'plan-1', response: { behavior: 'allow' } },
+    })
+  })
+
+  it('embeds the bypass mode in a plan approval when Bypass permissions is selected', async () => {
+    const { onRespond } = renderActions(makePlanRequest())
+
+    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes))).toMatchObject({
+      codexPlanModePrompt: true,
+      permissionMode: 'never',
       response: { request_id: 'plan-1', response: { behavior: 'allow' } },
     })
   })

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
@@ -1,7 +1,8 @@
 import type { ControlRequest } from '~/stores/control.store'
-import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { CODEX_BYPASS_SETTINGS } from '~/generated/contracts/codex-bypass'
+import { permissionPillGroup } from '~/test-support/controlRequests'
 import { createControlAnswerState } from '../../controls/types'
 import { CodexControlActions } from './CodexControlRequest'
 
@@ -37,10 +38,6 @@ function renderActions(request: ControlRequest, hasEditorContent = false) {
   return { onRespond, onSettingChange }
 }
 
-function permissionPill() {
-  return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
-}
-
 describe('codex control request actions', () => {
   it('renders Deny and Allow with the Remember switch and the permission pills', () => {
     renderActions(makeRequest({ availableDecisions: ['accept', 'decline', { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } }] }))
@@ -48,8 +45,8 @@ describe('codex control request actions', () => {
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Reject')
     expect(screen.getByTestId('control-allow-btn')).toHaveTextContent('Allow')
     expect(screen.getByTestId('control-remember-checkbox')).toHaveTextContent('Remember')
-    expect(permissionPill().getByRole('radio', { name: 'Default' })).toBeChecked()
-    expect(permissionPill().getByRole('radio', { name: 'Bypass permissions' })).toBeInTheDocument()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Default' })).toBeChecked()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' })).toBeInTheDocument()
   })
 
   it('uses the remembered Codex decision only when Remember is checked', async () => {
@@ -165,7 +162,7 @@ describe('codex control request actions', () => {
       finishResponse = resolve
     }))
 
-    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
     fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     expect(onRespond).toHaveBeenCalledOnce()
@@ -204,9 +201,9 @@ describe('codex control request actions', () => {
   })
 
   it('embeds the bypass mode in a plan approval when Bypass permissions is selected', async () => {
-    const { onRespond } = renderActions(makePlanRequest())
+    const { onRespond, onSettingChange } = renderActions(makePlanRequest())
 
-    fireEvent.click(permissionPill().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     const [bytes] = onRespond.mock.calls[0]
@@ -215,5 +212,8 @@ describe('codex control request actions', () => {
       permissionMode: 'never',
       response: { request_id: 'plan-1', response: { behavior: 'allow' } },
     })
+    // The mode travels INSIDE the response; a second settings change would race
+    // the restart a context-clearing approval triggers, so the handler never fires.
+    expect(onSettingChange).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
@@ -8,6 +8,7 @@ import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from
 import * as styles from '../../ControlRequestBanner.css'
 import { CollapsibleText } from '../../controls/CollapsibleText'
 import { ControlDecisionFooter } from '../../controls/ControlDecisionFooter'
+import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from '../../controls/permissionPresets'
 import { createPlanApprovalState, planApprovalSwitches } from '../../controls/planApproval'
 import { createControlSwitch, sendJsonRpcResult, sendResponse } from '../../controls/types'
 import { codexDecisionKey, codexDecisionLabel, parseCodexDecision } from './controlResponse'
@@ -204,7 +205,7 @@ export const CodexControlContent: Component<ContentProps> = (props) => {
 
 const CodexPermissionsActions: Component<ActionsProps> = (props) => {
   const rememberSwitch = createControlSwitch(() => props.answerState, 'control-remember-checkbox')
-  const bypassSwitch = createControlSwitch(() => props.answerState, 'control-bypass-permissions-checkbox')
+  const permissionChoice = createPermissionPresetChoice(props)
   const handleAllow = async () => {
     await sendCodexPermissionsResponse(
       props.onRespond,
@@ -212,8 +213,7 @@ const CodexPermissionsActions: Component<ActionsProps> = (props) => {
       codexRequestedPermissions(props.request.payload),
       rememberSwitch.checked() ? 'session' : 'turn',
     )
-    if (bypassSwitch.checked() && props.bypass)
-      await props.bypass.apply(props.bypass.settings)
+    await applyPermissionPreset(props.presets, permissionChoice.choice())
   }
   return (
     <ControlDecisionFooter
@@ -227,15 +227,13 @@ const CodexPermissionsActions: Component<ActionsProps> = (props) => {
       positiveAction={{ label: 'Allow', testId: 'control-allow-btn', onSelect: handleAllow }}
       switches={() => [
         { id: 'control-remember-checkbox', label: 'Remember', checked: rememberSwitch.checked(), onChange: rememberSwitch.set },
-        ...(props.bypass
-          ? [{ id: 'control-bypass-permissions-checkbox', label: 'Bypass Permissions', checked: bypassSwitch.checked(), onChange: bypassSwitch.set }]
-          : []),
       ]}
+      permissionPill={() => buildPermissionPill(props.presets, permissionChoice)}
     />
   )
 }
 
-/** Codex plan-mode prompt actions with clear-context and bypass switches. */
+/** Codex plan-mode prompt actions with clear-context and permission pills. */
 const CodexPlanModePromptActions: Component<ActionsProps> = (props) => {
   const planApproval = createPlanApprovalState(props)
 
@@ -258,6 +256,7 @@ const CodexPlanModePromptActions: Component<ActionsProps> = (props) => {
       }}
       positiveAction={{ label: 'Approve', testId: 'control-allow-btn', onSelect: handleApprove }}
       switches={() => planApprovalSwitches(planApproval)}
+      permissionPill={planApproval.permissionPill}
     />
   )
 }
@@ -269,7 +268,7 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
   const params = () => getCodexParams(props.request.payload)
   const decisions = createMemo(() => resolveCodexDecisions(params()?.availableDecisions))
   const rememberSwitch = createControlSwitch(() => props.answerState, 'control-remember-checkbox')
-  const bypassSwitch = createControlSwitch(() => props.answerState, 'control-bypass-permissions-checkbox')
+  const permissionChoice = createPermissionPresetChoice(props)
 
   const handleDecision = (decision: CodexDecision) => sendCodexDecision(
     props.onRespond,
@@ -279,8 +278,7 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
 
   const handleAllow = async () => {
     await handleDecision(rememberSwitch.checked() ? (decisions().remembered ?? decisions().positive) : decisions().positive)
-    if (bypassSwitch.checked() && props.bypass)
-      await props.bypass.apply(props.bypass.settings)
+    await applyPermissionPreset(props.presets, permissionChoice.choice())
   }
 
   return (
@@ -300,15 +298,8 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
                   onChange: rememberSwitch.set,
                 }]
               : []),
-            ...(props.bypass
-              ? [{
-                  id: 'control-bypass-permissions-checkbox',
-                  label: 'Bypass Permissions',
-                  checked: bypassSwitch.checked(),
-                  onChange: bypassSwitch.set,
-                }]
-              : []),
           ]}
+          permissionPill={() => buildPermissionPill(props.presets, permissionChoice)}
           additionalActions={() => decisions().additional.map(decision => ({
             label: codexDecisionLabel(decision),
             testId: `control-decision-${codexDecisionKey(decision)}`,

--- a/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
@@ -1,5 +1,6 @@
-import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
+import { allowScopePillGroup, permissionPillGroup } from '~/test-support/controlRequests'
 import { createControlAnswerState } from '../../controls/types'
 import { OpenCodeControlActions } from './OpenCodeControlRequest'
 
@@ -44,7 +45,7 @@ describe('openCodeControlActions', () => {
     expect(allow.textContent).toBe('Allow')
     expect(deny.compareDocumentPosition(allow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
-    const scope = within(screen.getByRole('radiogroup', { name: 'Allow scope' }))
+    const scope = allowScopePillGroup()
     expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
     expect(scope.getByRole('radio', { name: 'Always' })).toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-always')).not.toBeInTheDocument()
@@ -58,9 +59,9 @@ describe('openCodeControlActions', () => {
     expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('once')
     expect(apply).not.toHaveBeenCalled()
 
-    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
 
-    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Allow scope' })).getByRole('radio', { name: 'Always' }))
+    fireEvent.click(allowScopePillGroup().getByRole('radio', { name: 'Always' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
     expect(decodeOptionId(onRespond.mock.calls[1][0])).toBe('always')
     expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'yolo' } })

--- a/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { createControlAnswerState } from '../../controls/types'
+import { OpenCodeControlActions } from './OpenCodeControlRequest'
+
+function decodeOptionId(content: Uint8Array): string {
+  return JSON.parse(new TextDecoder().decode(content)).result.outcome.optionId
+}
+
+describe('openCodeControlActions', () => {
+  /** OpenCode's wire shape: once / always / reject, emitted allow-first. */
+  function renderOptionsActions() {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const apply = vi.fn()
+    render(() => OpenCodeControlActions({
+      request: {
+        agentId: 'agent1',
+        requestId: '11',
+        payload: {
+          params: {
+            options: [
+              { optionId: 'once', kind: 'allow_once', name: 'Allow once' },
+              { optionId: 'always', kind: 'allow_always', name: 'Always allow' },
+              { optionId: 'reject', kind: 'reject_once', name: 'Reject' },
+            ],
+          },
+        },
+      },
+      onRespond,
+      answerState: createControlAnswerState(),
+      hasEditorContent: false,
+      onTriggerSend: vi.fn(),
+      presets: { bypass: { sets: { permissionMode: 'yolo' } }, apply },
+    }))
+    return { onRespond, apply }
+  }
+
+  it('renders Deny first and moves Always allow into the Once / Always scope group', () => {
+    renderOptionsActions()
+
+    const deny = screen.getByTestId('control-deny-btn')
+    const allow = screen.getByTestId('control-allow-btn')
+    expect(deny.textContent).toBe('Deny')
+    expect(allow.textContent).toBe('Allow')
+    expect(deny.compareDocumentPosition(allow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    const scope = within(screen.getByRole('radiogroup', { name: 'Allow scope' }))
+    expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
+    expect(scope.getByRole('radio', { name: 'Always' })).toBeInTheDocument()
+    expect(screen.queryByTestId('control-decision-always')).not.toBeInTheDocument()
+  })
+
+  it('sends once while Once is selected and always beyond it, applying the preset after each allow', async () => {
+    const { onRespond, apply } = renderOptionsActions()
+
+    // A preset applies only when the pill selects one; Default applies nothing.
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('once')
+    expect(apply).not.toHaveBeenCalled()
+
+    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass permissions' }))
+
+    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Allow scope' })).getByRole('radio', { name: 'Always' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[1][0])).toBe('always')
+    expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'yolo' } })
+
+    // No reject_always is offered, so Deny keeps its once option -- and never
+    // applies a preset.
+    await fireEvent.click(screen.getByTestId('control-deny-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[2][0])).toBe('reject')
+    expect(apply).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to Deny / Allow for a payload without options', async () => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    render(() => OpenCodeControlActions({
+      request: {
+        agentId: 'agent1',
+        requestId: '12',
+        payload: { params: {} },
+      },
+      onRespond,
+      answerState: createControlAnswerState(),
+      hasEditorContent: false,
+      onTriggerSend: vi.fn(),
+    }))
+
+    expect(screen.getByTestId('control-deny-btn').textContent).toBe('Deny')
+    expect(screen.getByTestId('control-allow-btn').textContent).toBe('Allow')
+    expect(screen.queryByRole('radiogroup', { name: 'Allow scope' })).not.toBeInTheDocument()
+
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+    expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('once')
+  })
+})

--- a/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.tsx
+++ b/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.tsx
@@ -1,12 +1,23 @@
 import type { Component } from 'solid-js'
+import type { WirePermissionOption } from '../../controls/permissionOptions'
 import type { ActionsProps, ContentProps, ControlAnswerState, Question } from '../../controls/types'
 
-import { For, Show } from 'solid-js'
+import { createMemo, For, Show } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
-import { Tooltip } from '~/components/common/Tooltip'
 import * as styles from '../../ControlRequestBanner.css'
 import { ControlActionRow } from '../../controls/ControlActionRow'
-import { sendResponse, toRpcId } from '../../controls/types'
+import { ControlAllowScopePillGroup, ControlPermissionPillGroup } from '../../controls/ControlDecisionFooter'
+import {
+  ALLOW_SCOPE_CHOICE_ID,
+  allowScopePillOptions,
+  isRejectPermissionKind,
+  layoutPermissionOptions,
+  permissionOptionLabel,
+  resolvePermissionOption,
+  scopeRemembers,
+} from '../../controls/permissionOptions'
+import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from '../../controls/permissionPresets'
+import { createControlChoice, sendResponse, toRpcId } from '../../controls/types'
 
 /** Extract OpenCode requestPermission params from the control request payload. */
 function getOpenCodeParams(payload: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -20,9 +31,9 @@ function getToolCall(payload: Record<string, unknown>): Record<string, unknown> 
 }
 
 /** Extract permission options from a requestPermission payload. */
-function getOptions(payload: Record<string, unknown>): Array<{ optionId: string, kind: string, name: string }> {
+function getOptions(payload: Record<string, unknown>): WirePermissionOption[] {
   const params = getOpenCodeParams(payload)
-  return (params?.options as Array<{ optionId: string, kind: string, name: string }>) ?? []
+  return (params?.options as WirePermissionOption[] | undefined) ?? []
 }
 
 function getQuestionProperties(payload: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -114,62 +125,104 @@ export const OpenCodeControlContent: Component<ContentProps> = (props) => {
 
 /** OpenCode-specific control request action buttons. */
 export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
-  const options = () => getOptions(props.request.payload)
+  const layout = createMemo(() => layoutPermissionOptions(getOptions(props.request.payload)))
+  const permissionChoice = createPermissionPresetChoice(props)
+  const scopeChoice = createControlChoice(() => props.answerState, ALLOW_SCOPE_CHOICE_ID, '')
 
-  const handleOption = (optionId: string) => {
-    sendOpenCodePermissionResponse(props.onRespond, props.request.requestId, optionId)
+  // The scope pills a payload with always options draws (Once / Always, or
+  // Once / Session / Project). The stored selection is clamped to the offered
+  // options: a payload swap must not leave the group reporting an option the
+  // agent no longer offers.
+  const scopeOptions = createMemo(() => {
+    const scope = layout().allowScope
+    return scope ? allowScopePillOptions(scope) : undefined
+  })
+  const selectedScope = () => {
+    const scope = layout().allowScope
+    if (!scope)
+      return undefined
+    return scope.some(option => option.optionId === scopeChoice.choice())
+      ? scopeChoice.choice()
+      : scope[0].optionId
   }
 
-  // Allow once, then switch to bypass mode. The allow is AWAITED first: the
-  // worker dispatches the two concurrently, and a mode change the provider
-  // cannot take live relaunches the agent, killing the session before an
-  // un-awaited allow reaches it.
-  const handleBypassPermissions = async () => {
-    await sendOpenCodePermissionResponse(props.onRespond, props.request.requestId, 'once')
-    if (props.bypass)
-      await props.bypass.apply(props.bypass.settings)
+  // The option's response is AWAITED before a permission preset is applied: the
+  // worker dispatches the two concurrently, and a mode change the provider cannot
+  // take live relaunches the agent, killing the session before an un-awaited
+  // answer reaches it. A reject-kind option decides nothing about future
+  // permissions, so it applies no preset.
+  const handleOption = async (option: WirePermissionOption | undefined) => {
+    if (!option)
+      return
+    await sendOpenCodePermissionResponse(props.onRespond, props.request.requestId, option.optionId)
+    if (!isRejectPermissionKind(option.kind))
+      await applyPermissionPreset(props.presets, permissionChoice.choice())
   }
+
+  const handleDecision = (polarity: 'allow' | 'reject') =>
+    handleOption(resolvePermissionOption(layout(), polarity, scopeRemembers(layout(), selectedScope()), selectedScope()))
 
   return (
     <ControlActionRow
       primary={(
-        <Show
-          when={options().length > 0}
-          fallback={(
-            <ButtonGroup>
-              <button class="outline" onClick={() => handleOption('reject')} data-testid="control-deny-btn">Reject</button>
-              <button onClick={() => handleOption('once')} data-testid="control-allow-btn">Allow once</button>
-              <Show when={props.bypass}>
-                <Tooltip text="Allow this request and stop asking for permissions">
-                  <button data-variant="secondary" onClick={handleBypassPermissions} data-testid="control-bypass-btn">
-                    & Bypass Permissions
-                  </button>
-                </Tooltip>
+        <>
+          <Show when={scopeOptions() || buildPermissionPill(props.presets, permissionChoice)}>
+            <div class={styles.controlRequestSwitches}>
+              <Show when={scopeOptions()}>
+                {options => (
+                  <ControlAllowScopePillGroup
+                    options={options()}
+                    selected={selectedScope()!}
+                    onSelect={scopeChoice.setChoice}
+                  />
+                )}
               </Show>
-            </ButtonGroup>
-          )}
-        >
-          <ButtonGroup>
-            <For each={options()}>
-              {option => (
+              <Show when={buildPermissionPill(props.presets, permissionChoice)}>
+                {pill => <ControlPermissionPillGroup pill={pill()} />}
+              </Show>
+            </div>
+          </Show>
+          <Show
+            when={layout().positive || layout().negative}
+            fallback={(
+              <ButtonGroup>
+                <button class="outline" onClick={() => handleOption({ optionId: 'reject', kind: 'reject_once', name: 'Deny' })} data-testid="control-deny-btn">Deny</button>
+                <button onClick={() => handleOption({ optionId: 'once', kind: 'allow_once', name: 'Allow' })} data-testid="control-allow-btn">Allow</button>
+              </ButtonGroup>
+            )}
+          >
+            <ButtonGroup>
+              <Show when={layout().negative}>
                 <button
-                  class={option.kind === 'reject_once' ? 'outline' : undefined}
-                  onClick={() => handleOption(option.optionId)}
-                  data-testid={`control-decision-${option.optionId}`}
+                  class="outline"
+                  onClick={() => handleDecision('reject')}
+                  data-testid="control-deny-btn"
                 >
-                  {option.name}
+                  Deny
                 </button>
-              )}
-            </For>
-            <Show when={props.bypass}>
-              <Tooltip text="Allow this request and stop asking for permissions">
-                <button data-variant="secondary" onClick={handleBypassPermissions} data-testid="control-bypass-btn">
-                  & Bypass Permissions
+              </Show>
+              <Show when={layout().positive || scopeOptions()}>
+                <button
+                  onClick={() => handleDecision('allow')}
+                  data-testid="control-allow-btn"
+                >
+                  Allow
                 </button>
-              </Tooltip>
-            </Show>
-          </ButtonGroup>
-        </Show>
+              </Show>
+              <For each={layout().additional}>
+                {option => (
+                  <button
+                    class={isRejectPermissionKind(option.kind) ? 'outline' : undefined}
+                    onClick={() => handleOption(option)}
+                    data-testid={`control-decision-${option.optionId}`}
+                  >
+                    {permissionOptionLabel(option)}
+                  </button>
+                )}
+              </For>
+            </ButtonGroup>
+          </Show>
+        </>
       )}
     />
   )

--- a/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.tsx
+++ b/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.tsx
@@ -2,22 +2,10 @@ import type { Component } from 'solid-js'
 import type { WirePermissionOption } from '../../controls/permissionOptions'
 import type { ActionsProps, ContentProps, ControlAnswerState, Question } from '../../controls/types'
 
-import { createMemo, For, Show } from 'solid-js'
-import { ButtonGroup } from '~/components/common/ButtonGroup'
+import { Show } from 'solid-js'
 import * as styles from '../../ControlRequestBanner.css'
-import { ControlActionRow } from '../../controls/ControlActionRow'
-import { ControlAllowScopePillGroup, ControlPermissionPillGroup } from '../../controls/ControlDecisionFooter'
-import {
-  ALLOW_SCOPE_CHOICE_ID,
-  allowScopePillOptions,
-  isRejectPermissionKind,
-  layoutPermissionOptions,
-  permissionOptionLabel,
-  resolvePermissionOption,
-  scopeRemembers,
-} from '../../controls/permissionOptions'
-import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from '../../controls/permissionPresets'
-import { createControlChoice, sendResponse, toRpcId } from '../../controls/types'
+import { PermissionDecisionActions } from '../../controls/PermissionDecisionActions'
+import { sendResponse, sendSelectedOptionResponse, toRpcId } from '../../controls/types'
 
 /** Extract OpenCode requestPermission params from the control request payload. */
 function getOpenCodeParams(payload: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -30,10 +18,21 @@ function getToolCall(payload: Record<string, unknown>): Record<string, unknown> 
   return params?.toolCall as Record<string, unknown> | undefined
 }
 
+/**
+ * The pair OpenCode itself answers with, for a payload that carries no options.
+ * These are the daemon's real option ids — it maps an unknown id to reject, so a
+ * synthesized pair with invented ids would turn every Allow into a reject.
+ */
+const DEFAULT_OPTIONS: readonly WirePermissionOption[] = [
+  { optionId: 'once', kind: 'allow_once', name: 'Allow' },
+  { optionId: 'reject', kind: 'reject_once', name: 'Deny' },
+]
+
 /** Extract permission options from a requestPermission payload. */
 function getOptions(payload: Record<string, unknown>): WirePermissionOption[] {
   const params = getOpenCodeParams(payload)
-  return (params?.options as WirePermissionOption[] | undefined) ?? []
+  const options = params?.options as WirePermissionOption[] | undefined
+  return options && options.length > 0 ? options : [...DEFAULT_OPTIONS]
 }
 
 function getQuestionProperties(payload: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -67,11 +66,7 @@ export function sendOpenCodePermissionResponse(
   requestId: string,
   optionId: string,
 ): Promise<void> {
-  return sendResponse(onRespond, {
-    jsonrpc: '2.0',
-    id: toRpcId(requestId),
-    result: { outcome: { outcome: 'selected', optionId } },
-  })
+  return sendSelectedOptionResponse(onRespond, requestId, optionId)
 }
 
 export function sendOpenCodeQuestionResponse(
@@ -124,106 +119,6 @@ export const OpenCodeControlContent: Component<ContentProps> = (props) => {
 }
 
 /** OpenCode-specific control request action buttons. */
-export const OpenCodeControlActions: Component<ActionsProps> = (props) => {
-  const layout = createMemo(() => layoutPermissionOptions(getOptions(props.request.payload)))
-  const permissionChoice = createPermissionPresetChoice(props)
-  const scopeChoice = createControlChoice(() => props.answerState, ALLOW_SCOPE_CHOICE_ID, '')
-
-  // The scope pills a payload with always options draws (Once / Always, or
-  // Once / Session / Project). The stored selection is clamped to the offered
-  // options: a payload swap must not leave the group reporting an option the
-  // agent no longer offers.
-  const scopeOptions = createMemo(() => {
-    const scope = layout().allowScope
-    return scope ? allowScopePillOptions(scope) : undefined
-  })
-  const selectedScope = () => {
-    const scope = layout().allowScope
-    if (!scope)
-      return undefined
-    return scope.some(option => option.optionId === scopeChoice.choice())
-      ? scopeChoice.choice()
-      : scope[0].optionId
-  }
-
-  // The option's response is AWAITED before a permission preset is applied: the
-  // worker dispatches the two concurrently, and a mode change the provider cannot
-  // take live relaunches the agent, killing the session before an un-awaited
-  // answer reaches it. A reject-kind option decides nothing about future
-  // permissions, so it applies no preset.
-  const handleOption = async (option: WirePermissionOption | undefined) => {
-    if (!option)
-      return
-    await sendOpenCodePermissionResponse(props.onRespond, props.request.requestId, option.optionId)
-    if (!isRejectPermissionKind(option.kind))
-      await applyPermissionPreset(props.presets, permissionChoice.choice())
-  }
-
-  const handleDecision = (polarity: 'allow' | 'reject') =>
-    handleOption(resolvePermissionOption(layout(), polarity, scopeRemembers(layout(), selectedScope()), selectedScope()))
-
-  return (
-    <ControlActionRow
-      primary={(
-        <>
-          <Show when={scopeOptions() || buildPermissionPill(props.presets, permissionChoice)}>
-            <div class={styles.controlRequestSwitches}>
-              <Show when={scopeOptions()}>
-                {options => (
-                  <ControlAllowScopePillGroup
-                    options={options()}
-                    selected={selectedScope()!}
-                    onSelect={scopeChoice.setChoice}
-                  />
-                )}
-              </Show>
-              <Show when={buildPermissionPill(props.presets, permissionChoice)}>
-                {pill => <ControlPermissionPillGroup pill={pill()} />}
-              </Show>
-            </div>
-          </Show>
-          <Show
-            when={layout().positive || layout().negative}
-            fallback={(
-              <ButtonGroup>
-                <button class="outline" onClick={() => handleOption({ optionId: 'reject', kind: 'reject_once', name: 'Deny' })} data-testid="control-deny-btn">Deny</button>
-                <button onClick={() => handleOption({ optionId: 'once', kind: 'allow_once', name: 'Allow' })} data-testid="control-allow-btn">Allow</button>
-              </ButtonGroup>
-            )}
-          >
-            <ButtonGroup>
-              <Show when={layout().negative}>
-                <button
-                  class="outline"
-                  onClick={() => handleDecision('reject')}
-                  data-testid="control-deny-btn"
-                >
-                  Deny
-                </button>
-              </Show>
-              <Show when={layout().positive || scopeOptions()}>
-                <button
-                  onClick={() => handleDecision('allow')}
-                  data-testid="control-allow-btn"
-                >
-                  Allow
-                </button>
-              </Show>
-              <For each={layout().additional}>
-                {option => (
-                  <button
-                    class={isRejectPermissionKind(option.kind) ? 'outline' : undefined}
-                    onClick={() => handleOption(option)}
-                    data-testid={`control-decision-${option.optionId}`}
-                  >
-                    {permissionOptionLabel(option)}
-                  </button>
-                )}
-              </For>
-            </ButtonGroup>
-          </Show>
-        </>
-      )}
-    />
-  )
-}
+export const OpenCodeControlActions: Component<ActionsProps> = props => (
+  <PermissionDecisionActions {...props} options={getOptions} send={sendOpenCodePermissionResponse} />
+)

--- a/frontend/src/components/chat/providers/zcode/controls.test.tsx
+++ b/frontend/src/components/chat/providers/zcode/controls.test.tsx
@@ -1,5 +1,5 @@
 import type { ControlRequest } from '~/stores/control.store'
-import { fireEvent, render } from '@solidjs/testing-library'
+import { fireEvent, render, screen, within } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { ZCODE_MODE, ZCODE_TOOL } from '~/generated/contracts/zcode-protocol'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
@@ -203,8 +203,8 @@ describe('zcode permission control', () => {
     })
   })
 
-  // ZCode declares `yolo` as its bypass mode, so the banner offers a bypass switch.
-  // It must allow FIRST and switch the mode after: applying a mode the
+  // ZCode declares `yolo` as its bypass mode, so the banner offers the permission
+  // pill group. It must allow FIRST and switch the mode after: applying a mode the
   // provider cannot take live relaunches the agent, and a relaunch that won the race
   // would kill the session before the allow arrived.
   it('allows and then switches to the bypass mode', async () => {
@@ -220,15 +220,15 @@ describe('zcode permission control', () => {
         onRespond={onRespond}
         hasEditorContent={false}
         onTriggerSend={vi.fn()}
-        bypass={{
-          settings: { sets: { permissionMode: ZCODE_MODE.Yolo } },
+        presets={{
+          bypass: { sets: { permissionMode: ZCODE_MODE.Yolo } },
           apply: (change) => {
             order.push(`mode:${change.sets.permissionMode}`)
           },
         }}
       />
     ))
-    fireEvent.click(getByTestId('control-bypass-permissions-checkbox').querySelector('input')!)
+    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass permissions' }))
     fireEvent.click(getByTestId('control-allow-btn'))
     await vi.waitFor(() => expect(order).toEqual(['allow', `mode:${ZCODE_MODE.Yolo}`]))
   })

--- a/frontend/src/components/chat/providers/zcode/controls.test.tsx
+++ b/frontend/src/components/chat/providers/zcode/controls.test.tsx
@@ -1,8 +1,9 @@
 import type { ControlRequest } from '~/stores/control.store'
-import { fireEvent, render, screen, within } from '@solidjs/testing-library'
+import { fireEvent, render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { ZCODE_MODE, ZCODE_TOOL } from '~/generated/contracts/zcode-protocol'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
+import { permissionPillGroup } from '~/test-support/controlRequests'
 import { ControlRequestActions, ControlRequestContent } from '../../ControlRequestBanner'
 import { createControlAnswerState } from '../../controls/types'
 import { ZCodeControlActions, ZCodeControlContent } from './controls'
@@ -228,7 +229,7 @@ describe('zcode permission control', () => {
         }}
       />
     ))
-    fireEvent.click(within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
     fireEvent.click(getByTestId('control-allow-btn'))
     await vi.waitFor(() => expect(order).toEqual(['allow', `mode:${ZCODE_MODE.Yolo}`]))
   })

--- a/frontend/src/components/common/PillGroup.tsx
+++ b/frontend/src/components/common/PillGroup.tsx
@@ -24,6 +24,16 @@ export type PillOptions<K>
 
 export const PILL_OPTION_LIMIT = 4
 
+/**
+ * Whether a list of option specs is a drawable {@link PillOptions} — one through
+ * `PILL_OPTION_LIMIT` entries. The one source of the "what counts as a drawable
+ * pill set" rule, so callers that must degrade on a longer list (a menu instead)
+ * all apply the same cutoff.
+ */
+export function isPillOptions<K extends string>(options: readonly PillOptionSpec<K>[]): options is PillOptions<K> {
+  return options.length > 0 && options.length <= PILL_OPTION_LIMIT
+}
+
 type PillOptionState
   = | { kind: 'enabled' }
     | { kind: 'option-refused', reason: string }

--- a/frontend/src/components/settings/controls/EnumControl.tsx
+++ b/frontend/src/components/settings/controls/EnumControl.tsx
@@ -1,8 +1,8 @@
 import type { Component } from 'solid-js'
-import type { PillOptions, PillOptionSpec } from '~/components/common/PillGroup'
+import type { PillOptions } from '~/components/common/PillGroup'
 import { Show } from 'solid-js'
 import { LoadingMenu } from '~/components/common/LoadingMenu'
-import { PILL_OPTION_LIMIT, PillGroup } from '~/components/common/PillGroup'
+import { isPillOptions, PillGroup } from '~/components/common/PillGroup'
 import * as styles from '../SettingRow.css'
 
 export interface EnumOption {
@@ -18,10 +18,6 @@ export interface EnumControlProps {
   options: EnumOption[]
   /** Commit the chosen value. */
   onChange: (value: string) => void | Promise<boolean | void>
-}
-
-function isPillOptions(options: readonly PillOptionSpec<string>[]): options is PillOptions<string> {
-  return options.length > 0 && options.length <= PILL_OPTION_LIMIT
 }
 
 function fixedPillOptions(options: readonly EnumOption[]): PillOptions<string> | undefined {

--- a/frontend/src/test-support/controlRequests.ts
+++ b/frontend/src/test-support/controlRequests.ts
@@ -1,0 +1,21 @@
+import { screen, within } from '@solidjs/testing-library'
+
+/**
+ * Reading a control-request banner's pill groups, for the suites that drive a
+ * permission or plan-approval banner.
+ *
+ * Both groups are written by
+ * `~/components/chat/controls/ControlPillGroups`, which owns their accessible
+ * names ("Permissions", "Allow scope"). The locator is spelled once here, so a
+ * rename cannot be applied to some suites and missed in others.
+ */
+
+/** The permission preset group (Default / Smart permissions / Bypass permissions). */
+export function permissionPillGroup() {
+  return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
+}
+
+/** The allow-scope group (Once / Always, or Once / Session / Project). */
+export function allowScopePillGroup() {
+  return within(screen.getByRole('radiogroup', { name: 'Allow scope' }))
+}

--- a/frontend/tests/e2e/051-plan-mode-bypass.spec.ts
+++ b/frontend/tests/e2e/051-plan-mode-bypass.spec.ts
@@ -20,18 +20,21 @@ test.describe('Plan Mode - Bypass Permissions', () => {
     const banner = await waitForControlBanner(page)
     await expect(banner.getByText('Plan Ready for Review')).toBeVisible()
 
-    // Verify both switches are visible and unchecked.
+    // Verify the switch and the permission pills are visible, Default selected.
     const clearContextSwitch = page.locator('[data-testid="plan-clear-context-checkbox"] input[type="checkbox"]')
     await expect(clearContextSwitch).toBeVisible()
     await expect(clearContextSwitch).not.toBeChecked()
 
-    const bypassSwitch = page.locator('[data-testid="plan-bypass-permissions-checkbox"] input[type="checkbox"]')
-    await expect(bypassSwitch).toBeVisible()
-    await expect(bypassSwitch).not.toBeChecked()
+    const permissionPill = page.getByRole('radiogroup', { name: 'Permissions' })
+    const bypassRadio = permissionPill.getByRole('radio', { name: 'Bypass permissions' })
+    await expect(permissionPill.getByRole('radio', { name: 'Default' })).toBeVisible()
+    await expect(permissionPill.getByRole('radio', { name: 'Default' })).toBeChecked()
+    await expect(bypassRadio).toBeVisible()
+    await expect(bypassRadio).not.toBeChecked()
 
-    // Enable bypass permissions, then approve.
-    await bypassSwitch.check()
-    await expect(bypassSwitch).toBeChecked()
+    // Select bypass permissions, then approve.
+    await bypassRadio.click()
+    await expect(bypassRadio).toBeChecked()
 
     const approveBtn = page.locator('[data-testid="plan-approve-btn"]')
     await expect(approveBtn).toBeEnabled()
@@ -50,11 +53,11 @@ test.describe('Plan Mode - Bypass Permissions', () => {
     const banner = await enterAndExitPlanMode(page)
     await expect(banner.getByText('Plan Ready for Review')).toBeVisible()
 
-    // The empty editor shows Reject, Approve, and both switches.
+    // The empty editor shows Reject, Approve, the Clear Context switch, and the permission pills.
     await expect(page.locator('[data-testid="plan-reject-btn"]')).toBeVisible()
     await expect(page.locator('[data-testid="plan-approve-btn"]')).toBeVisible()
     await expect(page.locator('[data-testid="plan-clear-context-checkbox"]')).toBeVisible()
-    await expect(page.locator('[data-testid="plan-bypass-permissions-checkbox"]')).toBeVisible()
+    await expect(page.locator('[data-testid="control-permissions-pill-group"]')).toBeVisible()
 
     // Type rejection text in the editor
     const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
@@ -64,6 +67,8 @@ test.describe('Plan Mode - Bypass Permissions', () => {
     // With editor content: Send feedback is visible and Approve is hidden.
     await expect(page.locator('[data-testid="plan-reject-btn"]')).toHaveText('Send feedback')
     await expect(page.locator('[data-testid="plan-approve-btn"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="plan-clear-context-checkbox"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="control-permissions-pill-group"]')).not.toBeVisible()
 
     // Clear the editor
     await page.keyboard.press('Meta+a')

--- a/frontend/tests/e2e/102-codex-plan-mode.spec.ts
+++ b/frontend/tests/e2e/102-codex-plan-mode.spec.ts
@@ -39,7 +39,7 @@ codexTest.describe('Codex Plan Mode Prompt', () => {
     await expect(page.getByTestId('control-deny-btn')).toHaveText('Reject')
     await expect(page.getByTestId('control-allow-btn')).toHaveText('Approve')
     await expect(page.getByTestId('plan-clear-context-checkbox')).toBeVisible()
-    await expect(page.getByTestId('plan-bypass-permissions-checkbox')).toBeVisible()
+    await expect(page.getByTestId('control-permissions-pill-group')).toBeVisible()
 
     const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
@@ -48,7 +48,7 @@ codexTest.describe('Codex Plan Mode Prompt', () => {
     await expect(page.locator('[data-testid="control-deny-btn"]')).toHaveText('Send feedback')
     await expect(page.locator('[data-testid="control-allow-btn"]')).not.toBeVisible()
     await expect(page.locator('[data-testid="plan-clear-context-checkbox"]')).not.toBeVisible()
-    await expect(page.locator('[data-testid="plan-bypass-permissions-checkbox"]')).not.toBeVisible()
+    await expect(page.locator('[data-testid="control-permissions-pill-group"]')).not.toBeVisible()
     await page.locator('[data-testid="control-deny-btn"]').click()
 
     await waitForAgentIdle(page)

--- a/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
+++ b/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
@@ -52,6 +52,26 @@ zcodeTest.describe('ZCode Permission Prompt', () => {
     await deny.click()
     await expect(page.locator('[data-testid="control-banner"]')).not.toBeVisible()
   })
+
+  // The banner's permission pills are the same settings change the composer
+  // menu's bypass shortcut makes, applied when the request is allowed.
+  zcodeTest('the permission banner applies the selected bypass pill on allow', async ({ authenticatedZCodeWorkspace, page }) => {
+    void authenticatedZCodeWorkspace
+    await sendMessage(page, 'Run this exact bash command and do not skip the confirmation: rm -rf /tmp/zcode-e2e-must-not-exist')
+
+    const banner = await waitForControlBanner(page)
+    await expect(banner).toContainText('Bash')
+    const pills = page.getByRole('radiogroup', { name: 'Permissions' })
+    await expect(pills.getByRole('radio', { name: 'Default' })).toBeChecked()
+    const bypass = pills.getByRole('radio', { name: 'Bypass permissions' })
+    await bypass.click()
+    await expect(bypass).toBeChecked()
+
+    await page.getByTestId('control-allow-btn').click()
+    await expect(page.locator('[data-testid="control-banner"]')).not.toBeVisible()
+    // The same chip the composer menu's bypass shortcut lands on.
+    await expectSettingsChip(page, 'Yolo')
+  })
 })
 
 zcodeTest.describe('ZCode Mode Switch', () => {


### PR DESCRIPTION
## Motivation

Answering a permission request from an agent banner was inconsistent and error-prone. ACP and OpenCode banners rendered raw per-option buttons (two near-identical ~90-line action rows), the Bypass Permissions control was a checkbox that could be drawn but do nothing for presets without a permission mode, and a mode change could fire before the permission answer was delivered — potentially relaunching the agent and killing the session before the answer landed. Stored selections could also silently come back unchecked. This change replaces all of that with a single, uniform pill-group UI for permission choices.

## Modifications

- Add `controls/permissionOptions.ts`: classifies wire options by kind (allow_once / allow_always / reject_once / reject_always) into decision buttons, an allow-scope pill group, and extra buttons; maps a decision plus selected scope onto an optionId. Every offered option stays answerable: pill-limit and ambiguous-once payloads degrade to extra buttons, duplicate ids are deduped, and missing names are tolerated; colliding scope labels fall back to the agent's own option names.
- Add `controls/PermissionDecisionActions.tsx`: shared Deny/Allow decision row (scope pills + permission pills + extra buttons) for wire-options permission requests. The ACP and OpenCode action components become one-line delegates, and the ACP-family JSON-RPC envelope lives in one `sendSelectedOptionResponse`; OpenCode's no-options fallback synthesizes the daemon's real `once`/`reject` ids (unknown id maps to reject).
- Add `controls/ControlPillGroups.tsx`: `ControlPermissionPillGroup` (with a tooltip explaining the preset applies on allow) and `ControlAllowScopePillGroup`.
- Add `controls/permissionPresets.ts`: the Default/Smart/Bypass pill group. The choice is bound to the persisted answer record, clamped to the presets actually offered, and applied only AFTER the awaited answer and only on allow-kind answers. The plan-approval view filters to mode-carrying presets and carries no apply handler — a type-level guarantee the plan path never fires a settings change.
- Generalize `BypassController` to `PermissionPresetController` in `providerSettings.ts` (smart + bypass, one apply handler); `usablePresets()` and `PERMISSION_PRESET_LABELS` are the single availability/label rules, shared with the composer `[+]` menu so the banner pills and menu cannot offer different sets or drift on a rename.
- Replace the bypass switch with the pill in `planApproval.ts` and embed the permission mode atomically inside the approval response; `ControlDecisionFooter`, `GenericToolControl`, and the Codex components render the pill group, preserving awaited-answer-before-apply ordering.
- Persist and restore the new `choices` map with the in-progress answer (`controlResponseHandling.ts`, `types.ts`); export the `isPillOptions` guard from `PillGroup.tsx` as the single source of the 1–4 drawable-pill rule (EnumControl drops its private copy).
- Tests (+1211/−82 across 15 files): new `permissionOptions.test.ts` (real agent wire shapes — goose kind-named options, OpenCode/Reasonix scope vocabularies — plus degradation, duplicates, and never inventing options), new `permissionPresets.test.ts`, choice persistence/restore coverage, shared `permissionPillGroup()`/`allowScopePillGroup()` locators in `src/test-support`, a new zcode e2e that selects the Bypass pill and allows, and updated plan-mode e2e specs.
- Breaking changes (internal frontend APIs only — no wire/protocol change): `BypassController` removed; `ActionsProps.bypass` → `presets`; `PlanApprovalState` reshaped; testids `control-bypass-permissions-checkbox`, `plan-bypass-permissions-checkbox`, and `control-bypass-btn` removed (tests updated).

## Result

Permission banners now present clear Deny/Allow buttons alongside two pill groups: a permission preset pill (Default / Smart / Bypass — Smart is now offered on banners) and, on ACP and OpenCode banners, allow-scope pills (Once / Always / Session / Project) that replace the raw per-option buttons and the "& Bypass Permissions" button. Selecting Bypass on a banner lands the same setting as the composer shortcut (the "Yolo" chip), and the banner pills always match what the composer `[+]` menu offers. Chosen pills survive a reload or remount, only presets actually offered come back checked, and the permission mode changes only after the answer has been delivered — so allowing a request can no longer relaunch the agent mid-answer. Plan-approval banners show the preset pill for the approval response but can never silently change permission settings.
