### PR TITLE
feat(goal): Render the goal as markdown and redesign its card

### DIFF
--- a/frontend/src/components/backgroundtasks/AgentWorkPanel.css.ts
+++ b/frontend/src/components/backgroundtasks/AgentWorkPanel.css.ts
@@ -61,3 +61,31 @@ export const rows = style({
   overflowX: 'hidden',
   minHeight: 0,
 })
+
+/**
+ * The rule between the session goal and the task rows.
+ *
+ * The PANEL owns it, not the card, because a separator states that something
+ * FOLLOWS and only the panel knows whether anything does. The card shows on two
+ * tabs: above the rows on All, where the rule separates them, and alone on
+ * Goal, where it is the last thing in the box and a rule underlines nothing.
+ *
+ * A real `<hr>` between the two, rather than a border on the card. A border
+ * belongs to the box that draws it, so the card would have to take a class to
+ * say what sits under it, and the space below the rule would have to be a
+ * margin -- padding sits INSIDE the border box and only pushes the line further
+ * from the card's own content. An element takes the gap on both sides by
+ * itself.
+ */
+export const goalSeparator = style({
+  // Oat's base `hr` already draws the line (`border: none` plus
+  // `border-top: 1px solid var(--border)`); only its `var(--space-8)` margin is
+  // wrong at this size.
+  //
+  // The rule owns the whole gap on BOTH sides, so the two are one value and
+  // cannot drift apart. That is why `GoalCard` spends no padding at its bottom
+  // edge: two contributors to one gap is what forced this margin to be stated
+  // asymmetrically before, and it made the answer depend on which of the two
+  // you edited. `rows` adds its own 2px gap to each side alike.
+  margin: 'var(--space-3) 0',
+})

--- a/frontend/src/components/backgroundtasks/AgentWorkPanel.test.tsx
+++ b/frontend/src/components/backgroundtasks/AgentWorkPanel.test.tsx
@@ -1,6 +1,7 @@
 import type { BackgroundTaskItem } from '~/stores/chatBackgroundTasks'
-import type { GoalAction, SessionGoal } from '~/stores/chatGoal'
+import type { GoalAction, GoalSurface, SessionGoal } from '~/stores/chatGoal'
 import { fireEvent, render } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
 import { describe, expect, it } from 'vitest'
 import { AgentWorkPanel } from './AgentWorkPanel'
 
@@ -92,28 +93,59 @@ describe('agentWorkPanel', () => {
       tasks: [row({ rowKey: 'a' })],
       goal: goal(),
     })
-    // Between the two, so the rule separates what it stands between.
-    const panel = getByTestId('goal-separator').parentElement!
+    // Between the two, so the rule separates what it stands between. Asserted
+    // as an exact prefix, never as `indexOf(a) < indexOf(b)`: a missing card
+    // gives `indexOf` a `-1`, which is less than every real index, so that
+    // comparison passes for the one regression this case exists to catch.
+    const panel = getByTestId('goal-card-separator').parentElement!
     const order = [...panel.children].map(el => el.getAttribute('data-testid'))
-    expect(order.indexOf('goal-card')).toBeLessThan(order.indexOf('goal-separator'))
+    expect(order.slice(0, 2)).toEqual(['goal-card', 'goal-card-separator'])
 
     fireEvent.click(tab(container, 'goal'))
     expect(getByTestId('goal-card')).not.toBeNull()
-    expect(queryByTestId('goal-separator')).toBeNull()
+    expect(queryByTestId('goal-card-separator')).toBeNull()
   })
 
   // The EMPTY card is still a card, and rows still follow it.
   it('rules off an empty goal card from the rows too', () => {
     const { getByTestId } = renderPanel({ tasks: [row({ rowKey: 'a' })] })
     expect(getByTestId('goal-card-empty')).not.toBeNull()
-    expect(getByTestId('goal-separator')).not.toBeNull()
+    expect(getByTestId('goal-card-separator')).not.toBeNull()
   })
 
   // No card, no rule: the rows would otherwise open with a line above them.
   it('draws no rule for an agent with no goal surface', () => {
     const { queryByTestId } = renderPanel({ tasks: [row({ rowKey: 'a' })], goalActions: [] })
     expect(queryByTestId('goal-card')).toBeNull()
-    expect(queryByTestId('goal-separator')).toBeNull()
+    expect(queryByTestId('goal-card-separator')).toBeNull()
+  })
+
+  /**
+   * The tab buttons SURVIVE a goal broadcast.
+   *
+   * `FilterTabBar` renders them through `<For>`, which reconciles by
+   * reference, so a tab list rebuilt inside the memo replaced every button on
+   * every recompute -- and the memo recomputes whenever the goal surface does,
+   * which for a Codex agent is after each tool call. A keyboard user's focus
+   * left the tablist for `<body>` every couple of seconds while the agent
+   * worked.
+   */
+  it('keeps the same tab elements when the goal surface is replaced', () => {
+    const [surface, setSurface] = createSignal<GoalSurface>({
+      current: goal(),
+      progress: {},
+      actions: ['set'],
+    })
+    const { container } = render(() => (
+      <AgentWorkPanel variant="sidebar" tasks={[]} goal={surface()} />
+    ))
+    const before = container.querySelector('[data-testid="bg-task-filter-all"]')
+
+    // A fresh object with the same content, which is exactly what a progress
+    // broadcast produces upstream.
+    setSurface({ current: goal(), progress: { tokensUsed: 10 }, actions: ['set'] })
+
+    expect(container.querySelector('[data-testid="bg-task-filter-all"]')).toBe(before)
   })
 
   it('hides the goal card on the kind tabs', () => {

--- a/frontend/src/components/backgroundtasks/AgentWorkPanel.test.tsx
+++ b/frontend/src/components/backgroundtasks/AgentWorkPanel.test.tsx
@@ -82,6 +82,40 @@ describe('agentWorkPanel', () => {
     expect(queryByTestId('bg-task-row')).toBeNull()
   })
 
+  /**
+   * The rule under the goal separates it from the rows, so it belongs to the
+   * one tab that has rows. On the Goal tab the card is the last thing in the
+   * box, and a rule there underlines nothing.
+   */
+  it('rules off the goal from the rows on the All tab, and nowhere else', () => {
+    const { container, getByTestId, queryByTestId } = renderPanel({
+      tasks: [row({ rowKey: 'a' })],
+      goal: goal(),
+    })
+    // Between the two, so the rule separates what it stands between.
+    const panel = getByTestId('goal-separator').parentElement!
+    const order = [...panel.children].map(el => el.getAttribute('data-testid'))
+    expect(order.indexOf('goal-card')).toBeLessThan(order.indexOf('goal-separator'))
+
+    fireEvent.click(tab(container, 'goal'))
+    expect(getByTestId('goal-card')).not.toBeNull()
+    expect(queryByTestId('goal-separator')).toBeNull()
+  })
+
+  // The EMPTY card is still a card, and rows still follow it.
+  it('rules off an empty goal card from the rows too', () => {
+    const { getByTestId } = renderPanel({ tasks: [row({ rowKey: 'a' })] })
+    expect(getByTestId('goal-card-empty')).not.toBeNull()
+    expect(getByTestId('goal-separator')).not.toBeNull()
+  })
+
+  // No card, no rule: the rows would otherwise open with a line above them.
+  it('draws no rule for an agent with no goal surface', () => {
+    const { queryByTestId } = renderPanel({ tasks: [row({ rowKey: 'a' })], goalActions: [] })
+    expect(queryByTestId('goal-card')).toBeNull()
+    expect(queryByTestId('goal-separator')).toBeNull()
+  })
+
   it('hides the goal card on the kind tabs', () => {
     const { container, queryByTestId } = renderPanel({
       tasks: [row({ rowKey: 'a' })],

--- a/frontend/src/components/backgroundtasks/AgentWorkPanel.tsx
+++ b/frontend/src/components/backgroundtasks/AgentWorkPanel.tsx
@@ -60,6 +60,19 @@ function listTabFor(tab: AgentWorkTabKey): BackgroundTaskKindFilter | undefined 
   return tab === GOAL_TAB.key ? undefined : tab
 }
 
+/**
+ * The two tab lists, built ONCE at module scope.
+ *
+ * `FilterTabBar` renders them through `<For>`, which reconciles by reference, so
+ * a list rebuilt per render replaces every tab button and drops the focus that
+ * was inside the tablist. Two frozen arrays make that impossible; the panel
+ * selects between them.
+ */
+const LIST_TABS: readonly FilterTab<AgentWorkTabKey>[] = (
+  Object.keys(LIST_TABS_META) as BackgroundTaskKindFilter[]
+).map(key => ({ key, label: LIST_TABS_META[key].label }))
+const TABS_WITH_GOAL: readonly FilterTab<AgentWorkTabKey>[] = [...LIST_TABS, GOAL_TAB]
+
 export interface AgentWorkPanelProps {
   tasks: BackgroundTaskItem[]
   /** The goal, its counters, the live actions and their handler. */
@@ -119,18 +132,23 @@ export const AgentWorkPanel: Component<AgentWorkPanelProps> = (props) => {
   // at all, through the same helper, so the two answers cannot disagree.
   const hasGoal = () => hasGoalSurface(props.goal)
 
-  const tabs = createMemo<readonly FilterTab<AgentWorkTabKey>[]>(() => {
-    const listTabs = (Object.keys(LIST_TABS_META) as BackgroundTaskKindFilter[])
-      .map(key => ({ key, label: LIST_TABS_META[key].label }))
-    return hasGoal() ? [...listTabs, GOAL_TAB] : listTabs
-  })
+  // SELECT between two stable arrays; never build them here. `FilterTabBar`
+  // renders `<For each={props.tabs}>`, which reconciles by REFERENCE, so a
+  // `.map` inside this memo minted a fresh object per tab on every recompute
+  // and tore down and rebuilt every tab button. The memo recomputes on each
+  // goal broadcast -- a Codex agent reports after every tool call -- so a
+  // keyboard user's focus left the tablist for `<body>` every couple of
+  // seconds, exactly while the agent worked. `GoalActionsMenu` records the same
+  // rule for the same reason.
+  const tabs = createMemo<readonly FilterTab<AgentWorkTabKey>[]>(() =>
+    hasGoal() ? TABS_WITH_GOAL : LIST_TABS)
 
   // The ACTIVE tab is derived, never stored, so a selection the tab list no
   // longer offers is unrepresentable rather than repaired afterwards.
   //
   // The Goal tab can disappear -- an agent's process exits and its capability
   // list empties. A `createEffect` that wrote 'all' back would leave one
-  // committed render where `tab()` names a key `tabs()` does not contain, and
+  // committed render where `tab()` holds a key `tabs()` does not contain, and
   // FilterTabBar gives every tab `tabIndex={-1}` and `aria-selected={false}` in
   // that state: a tablist with no selected tab. Deriving skips that state.
   //
@@ -142,7 +160,13 @@ export const AgentWorkPanel: Component<AgentWorkPanelProps> = (props) => {
 
   // The rule under the goal, on the one tab where something follows it. The
   // card draws no separator of its own, because it cannot see what is below.
-  const showsGoalSeparator = () => showsGoal() && activeTab() === 'all'
+  //
+  // It asks the SAME question the list region below asks -- `listTabFor` -- so
+  // the rule and the thing it separates the goal from cannot disagree. Naming
+  // the tab instead put the answer in two places, and the next tab that shows
+  // the goal would repeat the bug this rule exists to avoid: a line that
+  // underlines nothing.
+  const showsGoalSeparator = () => showsGoal() && listTabFor(activeTab()) !== undefined
 
   return (
     <div
@@ -176,7 +200,7 @@ export const AgentWorkPanel: Component<AgentWorkPanelProps> = (props) => {
           />
         </Show>
         <Show when={showsGoalSeparator()}>
-          <hr class={styles.goalSeparator} data-testid="goal-separator" />
+          <hr class={styles.goalSeparator} data-testid="goal-card-separator" />
         </Show>
         <Show when={listTabFor(activeTab())}>
           {kind => (

--- a/frontend/src/components/backgroundtasks/AgentWorkPanel.tsx
+++ b/frontend/src/components/backgroundtasks/AgentWorkPanel.tsx
@@ -140,6 +140,10 @@ export const AgentWorkPanel: Component<AgentWorkPanelProps> = (props) => {
 
   const showsGoal = () => hasGoal() && (activeTab() === GOAL_TAB.key || activeTab() === 'all')
 
+  // The rule under the goal, on the one tab where something follows it. The
+  // card draws no separator of its own, because it cannot see what is below.
+  const showsGoalSeparator = () => showsGoal() && activeTab() === 'all'
+
   return (
     <div
       class={styles.root}
@@ -170,6 +174,9 @@ export const AgentWorkPanel: Component<AgentWorkPanelProps> = (props) => {
             goal={props.goal}
             announce={props.announceGoal}
           />
+        </Show>
+        <Show when={showsGoalSeparator()}>
+          <hr class={styles.goalSeparator} data-testid="goal-separator" />
         </Show>
         <Show when={listTabFor(activeTab())}>
           {kind => (

--- a/frontend/src/components/backgroundtasks/GoalActionsMenu.test.tsx
+++ b/frontend/src/components/backgroundtasks/GoalActionsMenu.test.tsx
@@ -10,23 +10,31 @@ function goal(over: Partial<SessionGoal> = {}): SessionGoal {
 
 const ALL: GoalAction[] = ['set', 'clear', 'pause', 'resume']
 
+/**
+ * A live surface: the goal, its verbs AND its handler, which travel together.
+ *
+ * `onAction` is part of `GoalSurface`, so a case that wants to observe the
+ * handler overrides it here rather than passing a second prop. The menu takes
+ * no separate handler, which is what makes a surface whose verbs and handler
+ * come from different agents unrepresentable.
+ */
 function surface(over: Partial<GoalSurface> = {}): GoalSurface {
-  return { current: goal(), progress: {}, actions: ALL, ...over }
+  return { current: goal(), progress: {}, actions: ALL, onAction: vi.fn(), ...over }
 }
 
 describe('goalActionsMenu', () => {
   it('offers the verbs in the order they read', () => {
     const { getAllByRole } = render(() => (
-      <GoalActionsMenu goal={surface()} onAction={vi.fn()} />
+      <GoalActionsMenu goal={surface()} />
     ))
     expect(getAllByRole('menuitem', { hidden: true }).map(i => i.textContent))
       .toEqual(['Pause', 'Resume', 'Replace goal…', 'Clear goal'])
   })
 
-  it('runs the action a menu item names', () => {
+  it('runs the action its menu item states', () => {
     const onAction = vi.fn()
     const { getByTestId } = render(() => (
-      <GoalActionsMenu goal={surface()} onAction={onAction} />
+      <GoalActionsMenu goal={surface({ onAction })} />
     ))
     fireEvent.click(getByTestId('goal-action-clear'))
     expect(onAction).toHaveBeenCalledWith('clear')
@@ -39,7 +47,7 @@ describe('goalActionsMenu', () => {
    */
   it('omits an action the provider does not support at all', () => {
     const { queryByTestId, getByTestId } = render(() => (
-      <GoalActionsMenu goal={surface({ actions: ['set', 'clear'] })} onAction={vi.fn()} />
+      <GoalActionsMenu goal={surface({ actions: ['set', 'clear'] })} />
     ))
     expect(queryByTestId('goal-action-pause')).toBeNull()
     expect(queryByTestId('goal-action-resume')).toBeNull()
@@ -53,7 +61,7 @@ describe('goalActionsMenu', () => {
    */
   it('keeps a supported action the goal state refuses, disabled with its reason', () => {
     const { getByTestId } = render(() => (
-      <GoalActionsMenu goal={surface({ current: goal({ status: 'paused' }) })} onAction={vi.fn()} />
+      <GoalActionsMenu goal={surface({ current: goal({ status: 'paused' }) })} />
     ))
     const pause = getByTestId('goal-action-pause') as HTMLButtonElement
     expect(pause.disabled).toBe(true)
@@ -68,7 +76,7 @@ describe('goalActionsMenu', () => {
   // rather than going silent.
   it('disables pause and resume for a dormant goal, and keeps clear', () => {
     const { getByTestId } = render(() => (
-      <GoalActionsMenu goal={surface({ current: goal({ status: 'dormant' }) })} onAction={vi.fn()} />
+      <GoalActionsMenu goal={surface({ current: goal({ status: 'dormant' }) })} />
     ))
     expect((getByTestId('goal-action-pause') as HTMLButtonElement).disabled).toBe(true)
     expect((getByTestId('goal-action-resume') as HTMLButtonElement).disabled).toBe(true)
@@ -79,7 +87,7 @@ describe('goalActionsMenu', () => {
   // and a rule keeps it away from the verb above it.
   it('marks Clear goal as destructive and separates it', () => {
     const { getByTestId, container } = render(() => (
-      <GoalActionsMenu goal={surface()} onAction={vi.fn()} />
+      <GoalActionsMenu goal={surface()} />
     ))
     expect(getByTestId('goal-action-clear').classList.contains(dangerMenuItem)).toBe(true)
     expect(container.querySelectorAll('hr')).toHaveLength(1)
@@ -89,7 +97,7 @@ describe('goalActionsMenu', () => {
   // Nothing to separate when Clear is the only verb the provider offers.
   it('draws no rule when the destructive verb stands alone', () => {
     const { container } = render(() => (
-      <GoalActionsMenu goal={surface({ actions: ['clear'] })} onAction={vi.fn()} />
+      <GoalActionsMenu goal={surface({ actions: ['clear'] })} />
     ))
     expect(container.querySelectorAll('hr')).toHaveLength(0)
   })
@@ -100,18 +108,33 @@ describe('goalActionsMenu', () => {
    */
   it('renders nothing when the agent supports no action', () => {
     const { queryByTestId } = render(() => (
-      <GoalActionsMenu goal={surface({ actions: [] })} onAction={vi.fn()} />
+      <GoalActionsMenu goal={surface({ actions: [] })} />
     ))
     expect(queryByTestId('goal-actions-trigger')).toBeNull()
     for (const action of ALL)
       expect(queryByTestId(`goal-action-${action}`)).toBeNull()
   })
 
+  /**
+   * The menu owns the WHOLE "can act" decision, not half of it.
+   *
+   * A host with no handler gets no trigger, for the same reason a provider with
+   * no verbs does: a `...` that opens a card of controls which cannot run is
+   * worse than no `...`. The card used to make this half of the decision
+   * itself, from the same surface, which is one question asked twice.
+   */
+  it('renders nothing when the surface carries no handler', () => {
+    const { queryByTestId } = render(() => (
+      <GoalActionsMenu goal={surface({ onAction: undefined })} />
+    ))
+    expect(queryByTestId('goal-actions-trigger')).toBeNull()
+  })
+
   // The trigger is an icon with no visible text, so its tooltip is also its
   // accessible name.
-  it('names its trigger', () => {
+  it('gives its trigger an accessible name', () => {
     const { getByRole } = render(() => (
-      <GoalActionsMenu goal={surface()} onAction={vi.fn()} />
+      <GoalActionsMenu goal={surface()} />
     ))
     expect(getByRole('button', { name: 'Goal actions' })).not.toBeNull()
   })

--- a/frontend/src/components/backgroundtasks/GoalActionsMenu.test.tsx
+++ b/frontend/src/components/backgroundtasks/GoalActionsMenu.test.tsx
@@ -1,0 +1,118 @@
+import type { GoalAction, GoalSurface, SessionGoal } from '~/stores/chatGoal'
+import { fireEvent, render } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { dangerMenuItem } from '~/styles/shared.css'
+import { GoalActionsMenu } from './GoalActionsMenu'
+
+function goal(over: Partial<SessionGoal> = {}): SessionGoal {
+  return { objective: 'every test passes', status: 'active', ...over }
+}
+
+const ALL: GoalAction[] = ['set', 'clear', 'pause', 'resume']
+
+function surface(over: Partial<GoalSurface> = {}): GoalSurface {
+  return { current: goal(), progress: {}, actions: ALL, ...over }
+}
+
+describe('goalActionsMenu', () => {
+  it('offers the verbs in the order they read', () => {
+    const { getAllByRole } = render(() => (
+      <GoalActionsMenu goal={surface()} onAction={vi.fn()} />
+    ))
+    expect(getAllByRole('menuitem', { hidden: true }).map(i => i.textContent))
+      .toEqual(['Pause', 'Resume', 'Replace goal…', 'Clear goal'])
+  })
+
+  it('runs the action a menu item names', () => {
+    const onAction = vi.fn()
+    const { getByTestId } = render(() => (
+      <GoalActionsMenu goal={surface()} onAction={onAction} />
+    ))
+    fireEvent.click(getByTestId('goal-action-clear'))
+    expect(onAction).toHaveBeenCalledWith('clear')
+  })
+
+  /**
+   * Claude Code's gap, and the one a user meets most: it has no pause and no
+   * resume at all. That gap is PERMANENT, so the items are absent -- an item
+   * that can never light up says less than no item.
+   */
+  it('omits an action the provider does not support at all', () => {
+    const { queryByTestId, getByTestId } = render(() => (
+      <GoalActionsMenu goal={surface({ actions: ['set', 'clear'] })} onAction={vi.fn()} />
+    ))
+    expect(queryByTestId('goal-action-pause')).toBeNull()
+    expect(queryByTestId('goal-action-resume')).toBeNull()
+    expect(getByTestId('goal-action-clear')).not.toBeNull()
+  })
+
+  /**
+   * The other half of the same rule. A SUPPORTED action that the current goal
+   * state refuses keeps its place, disabled with the reason, because it comes
+   * back the moment the state changes.
+   */
+  it('keeps a supported action the goal state refuses, disabled with its reason', () => {
+    const { getByTestId } = render(() => (
+      <GoalActionsMenu goal={surface({ current: goal({ status: 'paused' }) })} onAction={vi.fn()} />
+    ))
+    const pause = getByTestId('goal-action-pause') as HTMLButtonElement
+    expect(pause.disabled).toBe(true)
+    // The accessible name stays the verb. An ariaLabel carrying the reason
+    // would announce a sentence where "Pause" belongs and break every
+    // by-role lookup.
+    expect(pause.textContent).toBe('Pause')
+    expect((getByTestId('goal-action-resume') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  // Neither verb applies to a dormant goal, and each says which state it needs
+  // rather than going silent.
+  it('disables pause and resume for a dormant goal, and keeps clear', () => {
+    const { getByTestId } = render(() => (
+      <GoalActionsMenu goal={surface({ current: goal({ status: 'dormant' }) })} onAction={vi.fn()} />
+    ))
+    expect((getByTestId('goal-action-pause') as HTMLButtonElement).disabled).toBe(true)
+    expect((getByTestId('goal-action-resume') as HTMLButtonElement).disabled).toBe(true)
+    expect((getByTestId('goal-action-clear') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  // Clearing destroys the goal. It is the one item that reads as destructive,
+  // and a rule keeps it away from the verb above it.
+  it('marks Clear goal as destructive and separates it', () => {
+    const { getByTestId, container } = render(() => (
+      <GoalActionsMenu goal={surface()} onAction={vi.fn()} />
+    ))
+    expect(getByTestId('goal-action-clear').classList.contains(dangerMenuItem)).toBe(true)
+    expect(container.querySelectorAll('hr')).toHaveLength(1)
+    expect(getByTestId('goal-action-set').classList.contains(dangerMenuItem)).toBe(false)
+  })
+
+  // Nothing to separate when Clear is the only verb the provider offers.
+  it('draws no rule when the destructive verb stands alone', () => {
+    const { container } = render(() => (
+      <GoalActionsMenu goal={surface({ actions: ['clear'] })} onAction={vi.fn()} />
+    ))
+    expect(container.querySelectorAll('hr')).toHaveLength(0)
+  })
+
+  /**
+   * A read-only provider -- Reasonix reports a goal but can change none --
+   * gets no trigger at all, rather than a `...` that opens an empty card.
+   */
+  it('renders nothing when the agent supports no action', () => {
+    const { queryByTestId } = render(() => (
+      <GoalActionsMenu goal={surface({ actions: [] })} onAction={vi.fn()} />
+    ))
+    expect(queryByTestId('goal-actions-trigger')).toBeNull()
+    for (const action of ALL)
+      expect(queryByTestId(`goal-action-${action}`)).toBeNull()
+  })
+
+  // The trigger is an icon with no visible text, so its tooltip is also its
+  // accessible name.
+  it('names its trigger', () => {
+    const { getByRole } = render(() => (
+      <GoalActionsMenu goal={surface()} onAction={vi.fn()} />
+    ))
+    expect(getByRole('button', { name: 'Goal actions' })).not.toBeNull()
+  })
+})

--- a/frontend/src/components/backgroundtasks/GoalActionsMenu.tsx
+++ b/frontend/src/components/backgroundtasks/GoalActionsMenu.tsx
@@ -1,0 +1,101 @@
+import type { Component } from 'solid-js'
+import type { GoalAction, GoalSurface } from '~/stores/chatGoal'
+import { createMemo, For, Show } from 'solid-js'
+import { DisabledReasonMenuItem } from '~/components/common/DisabledReasonMenuItem'
+import { DropdownMenu } from '~/components/common/DropdownMenu'
+import { moreHorizontalTrigger } from '~/components/common/moreHorizontalTrigger'
+import { goalActionState } from '~/stores/chatGoal'
+import { dangerMenuItem } from '~/styles/shared.css'
+
+export interface GoalActionsMenuProps {
+  /** The goal and what the running agent can do with it. */
+  goal: GoalSurface
+  /** Perform one action. */
+  onAction: (action: GoalAction) => void
+}
+
+/**
+ * The verbs, in the order they read.
+ *
+ * `danger` marks the one that destroys the goal, which the menu draws in the
+ * danger colour and separates from the rest.
+ */
+const ACTIONS: { action: GoalAction, label: string, danger?: boolean }[] = [
+  { action: 'pause', label: 'Pause' },
+  { action: 'resume', label: 'Resume' },
+  { action: 'set', label: 'Replace goal…' },
+  { action: 'clear', label: 'Clear goal', danger: true },
+]
+
+/**
+ * The session goal's verbs, behind the card's `...` trigger.
+ *
+ * A menu rather than a row of buttons. Pause and Resume are opposites, so at
+ * most one of them applies at any moment, and neither applies to a goal that is
+ * achieved, blocked or dormant -- a row therefore showed one live control
+ * beside two or three dead ones, and it wrapped inside the 360px popover the
+ * same panel renders in. A menu costs no width, holds each refused verb with
+ * its reason, and lets Clear read as the destructive action it is.
+ *
+ * Clearing asks for no confirmation. It destroys no artifact, and reopening
+ * Replace prefilled with the objective is a better undo than a confirm step.
+ */
+export const GoalActionsMenu: Component<GoalActionsMenuProps> = (props) => {
+  // FILTER, never map. `<For>` reconciles rows by REFERENCE, so returning fresh
+  // objects would tear down and rebuild every item whenever the goal's status
+  // moved -- losing the tooltip under the pointer and the focus a screen-reader
+  // user had on a disabled item, at the exact moment the goal changed. The
+  // module-level ACTIONS entries are stable, so an item survives while it stays
+  // offered.
+  //
+  // A gap in the PROVIDER is permanent -- Claude Code has no pause or resume,
+  // Reasonix can report a goal but never change one -- so its item is absent
+  // rather than dead. A verb the current goal state refuses comes back, so it
+  // holds its place and says why.
+  const offered = createMemo(() =>
+    ACTIONS.filter(({ action }) =>
+      goalActionState(props.goal.current, props.goal.actions, action).kind !== 'hidden'),
+  )
+
+  return (
+    <Show when={offered().length > 0}>
+      <DropdownMenu
+        trigger={moreHorizontalTrigger({
+          'title': 'Goal actions',
+          'data-testid': 'goal-actions-trigger',
+        })}
+        aria-label="Goal actions"
+        data-testid="goal-actions-menu"
+      >
+        <For each={offered()}>
+          {(item, index) => {
+            // Re-asked per render, so a capability that changes when the
+            // process restarts updates the item and its reason together -- one
+            // question, so the two can never disagree.
+            const reason = () => {
+              const state = goalActionState(props.goal.current, props.goal.actions, item.action)
+              return state.kind === 'disabled' ? state.reason : undefined
+            }
+            return (
+              <>
+                {/* A rule above the destructive verb, and only when something
+                    stands above it. */}
+                <Show when={item.danger && index() > 0}>
+                  <hr />
+                </Show>
+                <DisabledReasonMenuItem
+                  reason={reason()}
+                  class={item.danger ? dangerMenuItem : undefined}
+                  data-testid={`goal-action-${item.action}`}
+                  onClick={() => props.onAction(item.action)}
+                >
+                  {item.label}
+                </DisabledReasonMenuItem>
+              </>
+            )
+          }}
+        </For>
+      </DropdownMenu>
+    </Show>
+  )
+}

--- a/frontend/src/components/backgroundtasks/GoalActionsMenu.tsx
+++ b/frontend/src/components/backgroundtasks/GoalActionsMenu.tsx
@@ -8,10 +8,15 @@ import { goalActionState } from '~/stores/chatGoal'
 import { dangerMenuItem } from '~/styles/shared.css'
 
 export interface GoalActionsMenuProps {
-  /** The goal and what the running agent can do with it. */
+  /**
+   * The goal, what the running agent can do with it, AND the handler.
+   *
+   * One object, and no separate `onAction` beside it. `GoalSurface` carries the
+   * handler already, so a second prop lets a caller pair one surface's verbs
+   * with another surface's handler -- the exact split the parameter object
+   * exists to prevent.
+   */
   goal: GoalSurface
-  /** Perform one action. */
-  onAction: (action: GoalAction) => void
 }
 
 /**
@@ -54,11 +59,13 @@ export const GoalActionsMenu: Component<GoalActionsMenuProps> = (props) => {
   // holds its place and says why.
   const offered = createMemo(() =>
     ACTIONS.filter(({ action }) =>
-      goalActionState(props.goal.current, props.goal.actions, action).kind !== 'hidden'),
+      goalActionState(props.goal, action).kind !== 'hidden'),
   )
 
+  // The menu owns the WHOLE "can act" decision: an agent with no handler gets
+  // no trigger, and neither does one whose every verb is hidden.
   return (
-    <Show when={offered().length > 0}>
+    <Show when={props.goal.onAction && offered().length > 0}>
       <DropdownMenu
         trigger={moreHorizontalTrigger({
           'title': 'Goal actions',
@@ -73,7 +80,7 @@ export const GoalActionsMenu: Component<GoalActionsMenuProps> = (props) => {
             // process restarts updates the item and its reason together -- one
             // question, so the two can never disagree.
             const reason = () => {
-              const state = goalActionState(props.goal.current, props.goal.actions, item.action)
+              const state = goalActionState(props.goal, item.action)
               return state.kind === 'disabled' ? state.reason : undefined
             }
             return (
@@ -87,7 +94,7 @@ export const GoalActionsMenu: Component<GoalActionsMenuProps> = (props) => {
                   reason={reason()}
                   class={item.danger ? dangerMenuItem : undefined}
                   data-testid={`goal-action-${item.action}`}
-                  onClick={() => props.onAction(item.action)}
+                  onClick={() => props.goal.onAction?.(item.action)}
                 >
                   {item.label}
                 </DisabledReasonMenuItem>

--- a/frontend/src/components/backgroundtasks/GoalCard.css.ts
+++ b/frontend/src/components/backgroundtasks/GoalCard.css.ts
@@ -1,12 +1,34 @@
 import { style } from '@vanilla-extract/css'
 
-/** The goal card: a heading, the objective, its status, and the verb buttons. */
+/**
+ * The goal card: a header, the objective, its status, and its counters.
+ *
+ * No rule of its own. A separator states that something FOLLOWS, and only the
+ * host knows whether anything does -- see `goalSeparator` in
+ * `./AgentWorkPanel.css.ts`.
+ */
 export const card = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 'var(--space-1)',
-  padding: 'var(--space-2)',
-  borderBottom: '1px solid var(--border-color)',
+  // No padding at the BOTTOM. What sits under the card is the separator, and
+  // the separator owns the space on both of its sides -- see `goalSeparator`.
+  // Padding here would be a second contributor to one gap, which is what forced
+  // the rule's own margin to be stated asymmetrically to compensate.
+  padding: 'var(--space-2) var(--space-2) 0',
+})
+
+/**
+ * The card's own header: what this card is, and its `...` menu at the far end.
+ *
+ * The heading takes the squeeze and the trigger keeps its size, which is what
+ * the sidebar's own section header does with its actions.
+ */
+export const headerRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--space-1)',
+  minWidth: 0,
 })
 
 /**
@@ -16,21 +38,13 @@ export const card = style({
  * say anything at all -- the card cannot borrow it to say what it is.
  */
 export const heading = style({
+  flex: 1,
+  minWidth: 0,
   fontSize: 'var(--text-8)',
-  fontWeight: 600,
+  fontWeight: 'var(--font-bold)',
   color: 'var(--muted-foreground)',
   textTransform: 'uppercase',
   letterSpacing: '0.04em',
-})
-
-export const objective = style({
-  fontSize: 'var(--text-7)',
-  color: 'var(--foreground)',
-  // The objective is prose and may be a paragraph. It wraps rather than
-  // clipping, because a goal the reader cannot read is the one thing this card
-  // exists to show.
-  whiteSpace: 'pre-wrap',
-  overflowWrap: 'anywhere',
 })
 
 export const statusRow = style({
@@ -50,34 +64,25 @@ export const meta = style({
   color: 'var(--faint-foreground)',
 })
 
-export const actions = style({
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: 'var(--space-1)',
-  marginTop: 'var(--space-1)',
-})
-
-export const action = style({
-  fontSize: 'var(--text-8)',
-  padding: 'var(--space-1) var(--space-2)',
-  borderRadius: '4px',
-  border: '1px solid var(--border-color)',
-  background: 'transparent',
-  color: 'var(--foreground)',
-  cursor: 'pointer',
-  selectors: {
-    '&:hover:not(:disabled)': { background: 'var(--subtle-background)' },
-    '&:disabled': { opacity: 0.5, cursor: 'default' },
-  },
-})
-
-/** The empty state on the Goals tab, where a goal can still be set. */
+/**
+ * The empty state on the Goal tab, where a goal can still be set.
+ *
+ * Laid out to match the populated card exactly, because the two swap in the
+ * same slot and a reader watching a goal arrive should see the rows change and
+ * nothing move. So: no padding of its own -- the card supplies every edge --
+ * the same `space-1` between rows that the card puts between the objective,
+ * the status and the counters, and the same `text-7` on its first line as the
+ * objective it stands in for.
+ *
+ * `align-items` is the one genuine difference. The card lets its rows stretch,
+ * which is right for a line of text and wrong for a button: stretched, the call
+ * to action would span the whole sidebar.
+ */
 export const empty = style({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
-  gap: 'var(--space-2)',
-  padding: 'var(--space-4) var(--space-2)',
+  gap: 'var(--space-1)',
   color: 'var(--faint-foreground)',
   fontSize: 'var(--text-7)',
 })

--- a/frontend/src/components/backgroundtasks/GoalCard.test.tsx
+++ b/frontend/src/components/backgroundtasks/GoalCard.test.tsx
@@ -78,45 +78,26 @@ describe('goalCard', () => {
     }
   })
 
-  it('runs the action a verb button names', () => {
-    const onAction = vi.fn()
+  /**
+   * The card offers the verbs behind one `...` trigger, so a menu is what a
+   * goal with a handler shows. Which verbs it holds, and which of them are
+   * refused, is `GoalActionsMenu`'s decision and is tested there.
+   */
+  it('offers the actions menu for a goal it can act on', () => {
     const { getByTestId } = render(() => (
-      <GoalCard goal={{ current: goal(), progress: {}, actions: ALL, onAction }} />
+      <GoalCard goal={{ current: goal(), progress: {}, actions: ALL, onAction: vi.fn() }} />
     ))
-    fireEvent.click(getByTestId('goal-action-clear'))
-    expect(onAction).toHaveBeenCalledWith('clear')
+    expect(getByTestId('goal-actions-trigger')).not.toBeNull()
   })
 
-  /**
-   * Claude Code's gap, and the one a user meets most: it has no pause and no
-   * resume at all. That gap is PERMANENT, so the buttons are absent -- a control
-   * that can never light up says less than no control.
-   */
-  it('omits an action the provider does not support at all', () => {
+  // A read-only surface: the panel renders the goal, and nothing can change it.
+  it('offers no actions menu when the surface has no handler', () => {
     const { queryByTestId, getByTestId } = render(() => (
-      <GoalCard goal={{ current: goal(), progress: {}, actions: ['set', 'clear'], onAction: vi.fn() }} />
+      <GoalCard goal={{ current: goal(), progress: {}, actions: ALL }} />
     ))
-    expect(queryByTestId('goal-action-pause')).toBeNull()
-    expect(queryByTestId('goal-action-resume')).toBeNull()
-    expect(getByTestId('goal-action-clear')).not.toBeNull()
-  })
-
-  /**
-   * The other half of the same rule. A SUPPORTED action that the current goal
-   * state refuses keeps its place, disabled with the reason, because it comes
-   * back the moment the state changes.
-   */
-  it('keeps a supported action the goal state refuses, disabled with its reason', () => {
-    const { getByTestId } = render(() => (
-      <GoalCard goal={{ current: goal({ status: 'paused' }), progress: {}, actions: ALL, onAction: vi.fn() }} />
-    ))
-    const pause = getByTestId('goal-action-pause') as HTMLButtonElement
-    expect(pause.disabled).toBe(true)
-    // The accessible name stays the verb. An ariaLabel carrying the reason
-    // would announce a sentence where "Pause" belongs and break every
-    // by-role lookup.
-    expect(pause.textContent).toBe('Pause')
-    expect((getByTestId('goal-action-resume') as HTMLButtonElement).disabled).toBe(false)
+    expect(queryByTestId('goal-actions-trigger')).toBeNull()
+    // The goal itself is still on screen; only the verbs are absent.
+    expect(getByTestId('goal-objective').textContent).toContain('every test passes')
   })
 
   // A read-only provider (Reasonix reports a goal but can change none) shows the
@@ -125,8 +106,21 @@ describe('goalCard', () => {
     const { queryByTestId } = render(() => (
       <GoalCard goal={{ current: goal(), progress: {}, actions: [], onAction: vi.fn() }} />
     ))
+    expect(queryByTestId('goal-actions-trigger')).toBeNull()
     for (const action of ALL)
       expect(queryByTestId(`goal-action-${action}`)).toBeNull()
+  })
+
+  /**
+   * No menu in the empty state. `set` is the only verb that applies with no
+   * goal, and the empty state offers it as its own call to action -- a first
+   * goal must not be one click deeper than the concept it introduces.
+   */
+  it('offers no actions menu in the empty state', () => {
+    const { queryByTestId } = render(() => (
+      <GoalCard goal={{ progress: {}, actions: ['set'], onAction: vi.fn() }} />
+    ))
+    expect(queryByTestId('goal-actions-trigger')).toBeNull()
   })
 
   // Setting is how the FIRST goal arrives, so the empty state has to offer it --
@@ -140,6 +134,18 @@ describe('goalCard', () => {
     expect(button.disabled).toBe(false)
     fireEvent.click(button)
     expect(onAction).toHaveBeenCalledWith('set')
+  })
+
+  /**
+   * A separator states that something FOLLOWS, and the card cannot see what is
+   * below it. `AgentWorkPanel` renders the rule between the two, on the one tab
+   * that has rows.
+   */
+  it('draws no separator of its own', () => {
+    const { container } = render(() => (
+      <GoalCard goal={{ current: goal(), progress: {}, actions: ALL }} />
+    ))
+    expect(container.querySelectorAll('hr')).toHaveLength(0)
   })
 
   it('omits Set a goal for an agent that cannot set one', () => {
@@ -191,16 +197,5 @@ describe('goalCard', () => {
     expect(getByTestId('goal-status-dot').getAttribute('data-status')).toBe('dormant')
     expect(getByTestId('goal-card').textContent).toContain('Not running')
     expect(getByTestId('goal-card').textContent).not.toContain('Needs attention')
-  })
-
-  // Neither verb applies to a dormant goal, and each says which state it needs
-  // rather than going silent.
-  it('disables pause and resume for a dormant goal, and keeps clear', () => {
-    const { getByTestId } = render(() => (
-      <GoalCard goal={{ current: goal({ status: 'dormant' }), progress: {}, actions: ALL, onAction: () => {} }} />
-    ))
-    expect(getByTestId('goal-action-pause').hasAttribute('disabled')).toBe(true)
-    expect(getByTestId('goal-action-resume').hasAttribute('disabled')).toBe(true)
-    expect(getByTestId('goal-action-clear').hasAttribute('disabled')).toBe(false)
   })
 })

--- a/frontend/src/components/backgroundtasks/GoalCard.test.tsx
+++ b/frontend/src/components/backgroundtasks/GoalCard.test.tsx
@@ -90,6 +90,27 @@ describe('goalCard', () => {
     expect(getByTestId('goal-actions-trigger')).not.toBeNull()
   })
 
+  /**
+   * The card hands the menu the WHOLE surface, so the verb a reader picks
+   * reaches the handler that surface carries.
+   *
+   * Tested here rather than only in `./GoalActionsMenu.test.tsx`, because that
+   * suite renders the menu alone: it cannot see the card dropping the handler
+   * or forwarding the wrong action, and the only other coverage of this path
+   * sits in another component's test file.
+   */
+  it('runs a menu verb against the handler its surface carries', () => {
+    const onAction = vi.fn()
+    const { getByTestId } = render(() => (
+      <GoalCard goal={{ current: goal(), progress: {}, actions: ALL, onAction }} />
+    ))
+
+    fireEvent.click(getByTestId('goal-actions-trigger'))
+    fireEvent.click(getByTestId('goal-action-pause'))
+
+    expect(onAction).toHaveBeenCalledWith('pause')
+  })
+
   // A read-only surface: the panel renders the goal, and nothing can change it.
   it('offers no actions menu when the surface has no handler', () => {
     const { queryByTestId, getByTestId } = render(() => (
@@ -167,6 +188,30 @@ describe('goalCard', () => {
     expect(live.length).toBe(1)
     expect(live[0].textContent).toContain('every test passes')
     expect(live[0].textContent).toContain('notSatisfied')
+  })
+
+  /**
+   * The objective is markdown SOURCE, and the card renders it. A screen reader
+   * handed the source reads the syntax -- "ship the asterisk asterisk auth
+   * refactor asterisk asterisk" -- so the live region announces the words the
+   * card actually shows. `GoalObjective` refuses to hand the source to
+   * `Tooltip`'s `text` for the same reason.
+   */
+  it('announces the objective as words, not as markdown syntax', () => {
+    const { container } = render(() => (
+      <GoalCard
+        goal={{
+          current: goal({ objective: 'ship the **auth refactor**, see `task test`' }),
+          progress: {},
+          actions: [],
+        }}
+        announce
+      />
+    ))
+    const live = container.querySelector('[role="status"][aria-live="polite"]')!
+    expect(live.textContent).toContain('ship the auth refactor, see task test')
+    expect(live.textContent).not.toContain('**')
+    expect(live.textContent).not.toContain('`')
   })
 
   /**

--- a/frontend/src/components/backgroundtasks/GoalCard.tsx
+++ b/frontend/src/components/backgroundtasks/GoalCard.tsx
@@ -1,13 +1,14 @@
 import type { Component } from 'solid-js'
-import type { GoalAction, GoalSurface, SessionGoal } from '~/stores/chatGoal'
-import { createMemo, For, Show } from 'solid-js'
+import type { GoalSurface, SessionGoal } from '~/stores/chatGoal'
+import { createMemo, Show } from 'solid-js'
 import { formatSecondsParts } from '~/components/chat/rendererUtils'
 import { StatusDot } from '~/components/common/StatusDot'
-import { Tooltip } from '~/components/common/Tooltip'
 import { goalActionState, goalStatusLabel } from '~/stores/chatGoal'
 import { srOnly } from '~/styles/shared.css'
 import * as taskStyles from './BackgroundTaskList.css'
+import { GoalActionsMenu } from './GoalActionsMenu'
 import * as styles from './GoalCard.css'
+import { GoalObjective } from './GoalObjective'
 
 export interface GoalCardProps {
   /** The goal, its counters, the live actions and their handler. */
@@ -21,14 +22,6 @@ export interface GoalCardProps {
    */
   announce?: boolean
 }
-
-/** The verb buttons, in the order they read. */
-const ACTIONS: { action: GoalAction, label: string }[] = [
-  { action: 'pause', label: 'Pause' },
-  { action: 'resume', label: 'Resume' },
-  { action: 'set', label: 'Replace' },
-  { action: 'clear', label: 'Clear' },
-]
 
 function statusDotClass(goal: SessionGoal): string {
   switch (goal.status) {
@@ -62,6 +55,11 @@ function statusDotClass(goal: SessionGoal): string {
  * `timeUsedSeconds` is BUDGET CONSUMED rather than wall clock -- so ticking it
  * would assert the agent is spending while it waits on an approval, and the
  * number would jump backwards when the real value lands.
+ *
+ * The objective and the verbs each live in their own component --
+ * `./GoalObjective` and `./GoalActionsMenu` -- because each owns a rule this
+ * card must not restate: the clamp and its two routes back, and the three-way
+ * hidden / enabled / refused state of every verb.
  */
 export const GoalCard: Component<GoalCardProps> = (props) => {
   // One string, rebuilt only when a field it reads changes, so the live region
@@ -93,26 +91,29 @@ export const GoalCard: Component<GoalCardProps> = (props) => {
     return parts
   })
 
-  // Only the actions this agent offers at all. A gap in the PROVIDER is
-  // permanent -- Claude Code has no pause or resume, Reasonix can report a goal
-  // but never change one -- so its button would never light up, and a row of
-  // dead controls says less than no row. A supported action that the current
-  // goal state refuses still renders, disabled with its reason, because that one
-  // comes back.
-  // FILTER, never map. `<For>` reconciles rows by REFERENCE, so returning fresh
-  // objects would tear down and rebuild every button whenever the goal's status
-  // moved -- losing the tooltip under the pointer and the focus a screen-reader
-  // user had on a disabled control, at the exact moment the goal changed. The
-  // module-level ACTIONS entries are stable, so a row survives while it stays
-  // offered.
-  const offeredActions = createMemo(() =>
-    ACTIONS.filter(({ action }) =>
-      goalActionState(props.goal.current, props.goal.actions, action).kind !== 'hidden'),
-  )
+  /** Whether the empty state may offer its call to action. */
+  const canSetFirstGoal = () =>
+    props.goal.onAction !== undefined
+    && goalActionState(props.goal.current, props.goal.actions, 'set').kind === 'enabled'
 
   return (
     <div class={styles.card} data-testid="goal-card">
-      <div class={styles.heading}>Session goal</div>
+      <div class={styles.headerRow}>
+        {/* The section header above this card is the user-renameable
+            `section.name`, so it may say anything at all -- the card cannot
+            borrow it to say what it is. */}
+        <div class={styles.heading}>Session goal</div>
+        {/* No menu in the empty state. `set` is the only verb that applies with
+            no goal, and the empty state offers it as its own call to action --
+            a first goal must not be one click deeper than the concept it
+            introduces. */}
+        <Show when={props.goal.current && props.goal.onAction}>
+          <GoalActionsMenu
+            goal={props.goal}
+            onAction={action => props.goal.onAction?.(action)}
+          />
+        </Show>
+      </div>
       {/* Offscreen rather than hidden: `display: none` and `visibility: hidden`
           both take a live region out of the accessibility tree, so nothing is
           announced. `srOnly` is the shared spelling of that.
@@ -131,11 +132,11 @@ export const GoalCard: Component<GoalCardProps> = (props) => {
         when={props.goal.current}
         fallback={(
           <div class={styles.empty} data-testid="goal-card-empty">
-            <span>No session goal</span>
-            <Show when={props.goal.onAction && goalActionState(props.goal.current, props.goal.actions, 'set').kind === 'enabled'}>
+            <span>No session goal.</span>
+            <Show when={canSetFirstGoal()}>
               <button
                 type="button"
-                class={styles.action}
+                class="small outline"
                 data-testid="goal-action-set"
                 onClick={() => props.goal.onAction?.('set')}
               >
@@ -147,7 +148,7 @@ export const GoalCard: Component<GoalCardProps> = (props) => {
       >
         {goal => (
           <>
-            <div class={styles.objective} data-testid="goal-objective">{goal().objective}</div>
+            <GoalObjective objective={goal().objective} />
             <div class={styles.statusRow}>
               <StatusDot
                 class={statusDotClass(goal())}
@@ -169,58 +170,6 @@ export const GoalCard: Component<GoalCardProps> = (props) => {
             </div>
             <Show when={metaParts().length > 0}>
               <div class={styles.meta} data-testid="goal-progress">{metaParts().join(' · ')}</div>
-            </Show>
-            <Show when={props.goal.onAction && offeredActions().length > 0}>
-              <div class={styles.actions}>
-                <For each={offeredActions()}>
-                  {({ action, label }) => {
-                    // Re-asked per render, so a capability that changes when the
-                    // process restarts updates the control and its tooltip
-                    // together -- one question, so the two can never disagree.
-                    const reason = () => {
-                      const state = goalActionState(props.goal.current, props.goal.actions, action)
-                      return state.kind === 'disabled' ? state.reason : undefined
-                    }
-                    return (
-                      <Show
-                        when={reason()}
-                        fallback={(
-                          <button
-                            type="button"
-                            class={styles.action}
-                            data-testid={`goal-action-${action}`}
-                            onClick={() => props.goal.onAction?.(action)}
-                          >
-                            {label}
-                          </button>
-                        )}
-                      >
-                        {why => (
-                          // A real `disabled`, wrapped in Tooltip so the reason
-                          // is reachable: a disabled control takes no focus, so
-                          // the offscreen description Tooltip leaves behind is
-                          // the only route to it for a screen-reader user.
-                          //
-                          // No `ariaLabel`: the button has visible text, and
-                          // ariaLabel would REPLACE "Pause" with the reason
-                          // sentence -- which breaks every by-role lookup and
-                          // announces a sentence where a verb belongs.
-                          <Tooltip text={why()}>
-                            <button
-                              type="button"
-                              class={styles.action}
-                              data-testid={`goal-action-${action}`}
-                              disabled
-                            >
-                              {label}
-                            </button>
-                          </Tooltip>
-                        )}
-                      </Show>
-                    )
-                  }}
-                </For>
-              </div>
             </Show>
           </>
         )}

--- a/frontend/src/components/backgroundtasks/GoalCard.tsx
+++ b/frontend/src/components/backgroundtasks/GoalCard.tsx
@@ -3,6 +3,7 @@ import type { GoalSurface, SessionGoal } from '~/stores/chatGoal'
 import { createMemo, Show } from 'solid-js'
 import { formatSecondsParts } from '~/components/chat/rendererUtils'
 import { StatusDot } from '~/components/common/StatusDot'
+import { markdownToPlainText } from '~/lib/markdownPlainText'
 import { goalActionState, goalStatusLabel } from '~/stores/chatGoal'
 import { srOnly } from '~/styles/shared.css'
 import * as taskStyles from './BackgroundTaskList.css'
@@ -70,7 +71,12 @@ export const GoalCard: Component<GoalCardProps> = (props) => {
     if (!goal)
       return 'No session goal'
     const detail = goal.statusDetail ? `, ${goal.statusDetail}` : ''
-    return `Session goal ${goalStatusLabel(goal.status).toLowerCase()}${detail}: ${goal.objective}`
+    // The objective is markdown SOURCE, and `./GoalObjective` renders it. A
+    // screen reader given the source reads the syntax -- "ship the asterisk
+    // asterisk auth refactor asterisk asterisk" -- so strip the marks to the
+    // words the card actually shows. `GoalObjective` refuses to hand the source
+    // to `Tooltip`'s `text` for the same reason.
+    return `Session goal ${goalStatusLabel(goal.status).toLowerCase()}${detail}: ${markdownToPlainText(goal.objective)}`
   })
 
   // Only the counters the provider actually reported. An absent counter is left
@@ -94,7 +100,7 @@ export const GoalCard: Component<GoalCardProps> = (props) => {
   /** Whether the empty state may offer its call to action. */
   const canSetFirstGoal = () =>
     props.goal.onAction !== undefined
-    && goalActionState(props.goal.current, props.goal.actions, 'set').kind === 'enabled'
+    && goalActionState(props.goal, 'set').kind === 'enabled'
 
   return (
     <div class={styles.card} data-testid="goal-card">
@@ -106,12 +112,11 @@ export const GoalCard: Component<GoalCardProps> = (props) => {
         {/* No menu in the empty state. `set` is the only verb that applies with
             no goal, and the empty state offers it as its own call to action --
             a first goal must not be one click deeper than the concept it
-            introduces. */}
-        <Show when={props.goal.current && props.goal.onAction}>
-          <GoalActionsMenu
-            goal={props.goal}
-            onAction={action => props.goal.onAction?.(action)}
-          />
+            introduces.
+            That state is the only half the CARD owns. Whether any verb can run
+            is the menu's own decision, which it makes from the same surface. */}
+        <Show when={props.goal.current}>
+          <GoalActionsMenu goal={props.goal} />
         </Show>
       </div>
       {/* Offscreen rather than hidden: `display: none` and `visibility: hidden`

--- a/frontend/src/components/backgroundtasks/GoalObjective.css.ts
+++ b/frontend/src/components/backgroundtasks/GoalObjective.css.ts
@@ -1,0 +1,89 @@
+import { globalStyle, style } from '@vanilla-extract/css'
+
+/**
+ * How many lines of the objective the card shows before it clamps.
+ *
+ * Four, because that is what a one-sentence goal and a short list both fit in,
+ * and the sidebar still has room for the status and the counters below.
+ */
+const CLAMPED_LINES = 4
+
+/** The line box the clamp counts in. Also what the fade's height is measured in. */
+const LINE_HEIGHT = 1.5
+
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 'var(--space-1)',
+  minWidth: 0,
+})
+
+export const body = style({
+  fontSize: 'var(--text-7)',
+  color: 'var(--foreground)',
+  lineHeight: LINE_HEIGHT,
+  // The objective is model-written or user-written prose, so it may hold a URL
+  // or an identifier longer than the sidebar is wide.
+  overflowWrap: 'anywhere',
+})
+
+/**
+ * The collapsed box: at most four lines, with the rest clipped.
+ *
+ * A visual clamp, never a slice of the markdown SOURCE. A slice cuts a block in
+ * half -- a fenced code block loses its closing fence, a list loses its last
+ * item -- which is the rule `~/components/chat/results/CollapsibleContent.tsx`
+ * records for every markdown body in the app.
+ */
+export const bodyClamped = style({
+  maxHeight: `calc(${LINE_HEIGHT}em * ${CLAMPED_LINES})`,
+  overflow: 'hidden',
+})
+
+/**
+ * The fade over the last line of a clamped box.
+ *
+ * Apart from the clamp, and applied only once the box actually hides something.
+ * A goal that is exactly four lines long carries the clamp and hides nothing,
+ * and a fade there would dim a line that is completely visible.
+ */
+export const bodyFaded = style({
+  WebkitMaskImage: `linear-gradient(to bottom, black calc(100% - ${LINE_HEIGHT}em), transparent)`,
+  maskImage: `linear-gradient(to bottom, black calc(100% - ${LINE_HEIGHT}em), transparent)`,
+})
+
+/** The disclosure sits at the right end, under the fade it removes. */
+export const toggleRow = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+})
+
+/**
+ * The objective inside the hover tooltip.
+ *
+ * A height cap and nothing else. The tooltip sets `pointer-events: none`, so it
+ * cannot scroll, and a very long objective therefore stops at the cap -- the
+ * `Show more` disclosure in the card is the complete read, and this is the
+ * peek. No fade here: the tooltip is as tall as its content until it reaches
+ * the cap, so a fade would dim the last line of every objective that fits.
+ */
+export const tooltipBody = style({
+  maxHeight: '50vh',
+  overflow: 'hidden',
+})
+
+// The markdown renderer emits block elements with their own vertical margins.
+// Strip the outer ones so the objective sits flush against the card's padding.
+// Two levels of `> *`: this element holds the measured content wrapper, which
+// holds MarkdownText's own container.
+globalStyle(`${body} > * > * > :first-child`, { marginTop: 0 })
+globalStyle(`${body} > * > * > :last-child`, { marginBottom: 0 })
+globalStyle(`${tooltipBody} > * > :first-child`, { marginTop: 0 })
+globalStyle(`${tooltipBody} > * > :last-child`, { marginBottom: 0 })
+
+// A heading in a 300px sidebar column renders at the transcript's size and
+// swamps the card. The weight still marks it as a heading; only the size is
+// capped. `toolResultCollapsed` caps the same way for the same reason.
+const HEADINGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+globalStyle(HEADINGS.map(h => `${body} ${h}`).join(', '), { fontSize: 'inherit' })
+globalStyle(HEADINGS.map(h => `${tooltipBody} ${h}`).join(', '), { fontSize: 'inherit' })

--- a/frontend/src/components/backgroundtasks/GoalObjective.css.ts
+++ b/frontend/src/components/backgroundtasks/GoalObjective.css.ts
@@ -1,4 +1,6 @@
 import { globalStyle, style } from '@vanilla-extract/css'
+import { markdownContent } from '~/components/chat/markdownEditor/markdownContent.css'
+import { fadeMaskBottom } from '~/styles/fadeMask'
 
 /**
  * How many lines of the objective the card shows before it clamps.
@@ -47,10 +49,7 @@ export const bodyClamped = style({
  * A goal that is exactly four lines long carries the clamp and hides nothing,
  * and a fade there would dim a line that is completely visible.
  */
-export const bodyFaded = style({
-  WebkitMaskImage: `linear-gradient(to bottom, black calc(100% - ${LINE_HEIGHT}em), transparent)`,
-  maskImage: `linear-gradient(to bottom, black calc(100% - ${LINE_HEIGHT}em), transparent)`,
-})
+export const bodyFaded = style(fadeMaskBottom(LINE_HEIGHT))
 
 /** The disclosure sits at the right end, under the fade it removes. */
 export const toggleRow = style({
@@ -72,18 +71,30 @@ export const tooltipBody = style({
   overflow: 'hidden',
 })
 
-// The markdown renderer emits block elements with their own vertical margins.
-// Strip the outer ones so the objective sits flush against the card's padding.
-// Two levels of `> *`: this element holds the measured content wrapper, which
-// holds MarkdownText's own container.
-globalStyle(`${body} > * > * > :first-child`, { marginTop: 0 })
-globalStyle(`${body} > * > * > :last-child`, { marginBottom: 0 })
-globalStyle(`${tooltipBody} > * > :first-child`, { marginTop: 0 })
-globalStyle(`${tooltipBody} > * > :last-child`, { marginBottom: 0 })
+/**
+ * Strip the markdown renderer's outer vertical margins, so the objective sits
+ * flush against the card's padding.
+ *
+ * Anchored on `MarkdownText`'s own container class, NOT on a count of `> *`
+ * hops. The two boxes nest differently -- `body` holds the measured wrapper and
+ * `tooltipBody` does not -- so a depth-counted selector needed one spelling
+ * each, and both stopped matching, silently, the moment either box gained or
+ * lost a wrapper. The class is where the margins actually come from.
+ */
+function stripOuterMargins(scope: string): void {
+  globalStyle(`${scope} .${markdownContent} > :first-child`, { marginTop: 0 })
+  globalStyle(`${scope} .${markdownContent} > :last-child`, { marginBottom: 0 })
+}
+
+stripOuterMargins(body)
+stripOuterMargins(tooltipBody)
 
 // A heading in a 300px sidebar column renders at the transcript's size and
 // swamps the card. The weight still marks it as a heading; only the size is
-// capped. `toolResultCollapsed` caps the same way for the same reason.
+// capped. `toolResultCollapsed` in `~/components/chat/toolStyles.css.ts` caps
+// the same way for the same reason.
 const HEADINGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
-globalStyle(HEADINGS.map(h => `${body} ${h}`).join(', '), { fontSize: 'inherit' })
-globalStyle(HEADINGS.map(h => `${tooltipBody} ${h}`).join(', '), { fontSize: 'inherit' })
+globalStyle(
+  HEADINGS.flatMap(h => [`${body} ${h}`, `${tooltipBody} ${h}`]).join(', '),
+  { fontSize: 'inherit' },
+)

--- a/frontend/src/components/backgroundtasks/GoalObjective.test.tsx
+++ b/frontend/src/components/backgroundtasks/GoalObjective.test.tsx
@@ -15,19 +15,6 @@ function statesLayout(box: HTMLElement, contentPx: number, boxPx: number) {
   Object.defineProperty(box, 'clientHeight', { value: boxPx, configurable: true })
 }
 
-/**
- * The clamp is a vanilla-extract class, and vitest injects no stylesheet, so
- * `getComputedStyle` reports `overflow: visible` for the clamped box and
- * `Tooltip`'s clip test would refuse every tooltip. The inline longhands are
- * what the class supplies in the browser. jsdom does not expand the `overflow`
- * shorthand, which is why both axes are set by hand -- `Tooltip.test.tsx`
- * records the same limitation.
- */
-function statesClipping(box: HTMLElement) {
-  box.style.overflowX = 'hidden'
-  box.style.overflowY = 'hidden'
-}
-
 const HOVER_DELAY_MS = 700
 
 describe('goalObjective', () => {
@@ -51,7 +38,7 @@ describe('goalObjective', () => {
 
   /**
    * A goal that fits gets no disclosure and no fade. The clamp is still on --
-   * it is what keeps a later, longer goal in bounds -- but nothing is hidden,
+   * it is what caps a later, longer goal -- but nothing is hidden,
    * so a fade there would dim a line the reader can see in full.
    */
   it('offers no disclosure and no fade while the objective fits', () => {
@@ -70,6 +57,29 @@ describe('goalObjective', () => {
     triggerResizeObserversSync()
     expect(getByTestId('goal-objective-toggle').textContent).toBe('Show more')
     expect(box.classList.contains(styles.bodyFaded)).toBe(true)
+  })
+
+  /**
+   * A disclosure states whether it is open, and what it opens.
+   *
+   * Without them a screen reader announces "Show more, button" with no state,
+   * and activating it announces nothing at all -- the changed label is the only
+   * signal, and a virtual-cursor reader who moved on never receives it.
+   */
+  it('states its open state and the block it controls', () => {
+    const { getByTestId } = render(() => <GoalObjective objective="a long goal" />)
+    const box = getByTestId('goal-objective')
+    statesLayout(box, 200, 84)
+    triggerResizeObserversSync()
+
+    const toggle = getByTestId('goal-objective-toggle')
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(toggle.getAttribute('aria-controls')).toBe(box.id)
+    expect(box.id).not.toBe('')
+
+    fireEvent.click(toggle)
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
   })
 
   /**
@@ -115,7 +125,11 @@ describe('goalObjective', () => {
   describe('the hover tooltip', () => {
     beforeEach(() => {
       vi.useFakeTimers()
-      HTMLElement.prototype.showPopover = vi.fn()
+      // A SPY, not an assignment. `~/vitest.setup.ts` installs a working
+      // `showPopover` that sets `data-popover-open`, and a bare assignment
+      // replaces it with a no-op that `vi.restoreAllMocks()` cannot undo -- so
+      // every later case in this file would find `:popover-open` false forever.
+      vi.spyOn(HTMLElement.prototype, 'showPopover').mockImplementation(() => {})
     })
     afterEach(() => {
       vi.useRealTimers()
@@ -126,7 +140,6 @@ describe('goalObjective', () => {
       const { getByTestId } = render(() => <GoalObjective objective="a long **goal**" />)
       const box = getByTestId('goal-objective')
       statesLayout(box, 200, 84)
-      statesClipping(box)
       triggerResizeObserversSync()
 
       fireEvent.mouseEnter(box)
@@ -145,7 +158,6 @@ describe('goalObjective', () => {
       const { getByTestId } = render(() => <GoalObjective objective="a short goal" />)
       const box = getByTestId('goal-objective')
       statesLayout(box, 40, 40)
-      statesClipping(box)
       triggerResizeObserversSync()
 
       fireEvent.mouseEnter(box)
@@ -160,7 +172,6 @@ describe('goalObjective', () => {
       const { getByTestId } = render(() => <GoalObjective objective="a long goal" />)
       const box = getByTestId('goal-objective')
       statesLayout(box, 200, 84)
-      statesClipping(box)
       triggerResizeObserversSync()
       fireEvent.click(getByTestId('goal-objective-toggle'))
 

--- a/frontend/src/components/backgroundtasks/GoalObjective.test.tsx
+++ b/frontend/src/components/backgroundtasks/GoalObjective.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installControllableResizeObserver, triggerResizeObserversSync } from '~/test-support/resizeObserverStub'
+import { GoalObjective } from './GoalObjective'
+import * as styles from './GoalObjective.css'
+
+/**
+ * jsdom lays nothing out, so `scrollHeight` and `clientHeight` are both zero and
+ * the box can never report that it hides anything. This states the layout the
+ * component reads, which is the only input its decision has.
+ */
+function statesLayout(box: HTMLElement, contentPx: number, boxPx: number) {
+  Object.defineProperty(box, 'scrollHeight', { value: contentPx, configurable: true })
+  Object.defineProperty(box, 'clientHeight', { value: boxPx, configurable: true })
+}
+
+/**
+ * The clamp is a vanilla-extract class, and vitest injects no stylesheet, so
+ * `getComputedStyle` reports `overflow: visible` for the clamped box and
+ * `Tooltip`'s clip test would refuse every tooltip. The inline longhands are
+ * what the class supplies in the browser. jsdom does not expand the `overflow`
+ * shorthand, which is why both axes are set by hand -- `Tooltip.test.tsx`
+ * records the same limitation.
+ */
+function statesClipping(box: HTMLElement) {
+  box.style.overflowX = 'hidden'
+  box.style.overflowY = 'hidden'
+}
+
+const HOVER_DELAY_MS = 700
+
+describe('goalObjective', () => {
+  beforeEach(() => {
+    installControllableResizeObserver()
+  })
+
+  // The whole point of the change: a goal is markdown, so the card shows what
+  // the markup MEANS rather than its asterisks.
+  it('renders the objective as markdown', () => {
+    const { getByTestId } = render(() => <GoalObjective objective="ship the **auth refactor**" />)
+    const box = getByTestId('goal-objective')
+    expect(box.querySelector('strong')?.textContent).toBe('auth refactor')
+    expect(box.textContent).not.toContain('**')
+  })
+
+  it('clamps the objective until the reader opens it', () => {
+    const { getByTestId } = render(() => <GoalObjective objective="a goal" />)
+    expect(getByTestId('goal-objective').classList.contains(styles.bodyClamped)).toBe(true)
+  })
+
+  /**
+   * A goal that fits gets no disclosure and no fade. The clamp is still on --
+   * it is what keeps a later, longer goal in bounds -- but nothing is hidden,
+   * so a fade there would dim a line the reader can see in full.
+   */
+  it('offers no disclosure and no fade while the objective fits', () => {
+    const { getByTestId, queryByTestId } = render(() => <GoalObjective objective="a short goal" />)
+    const box = getByTestId('goal-objective')
+    statesLayout(box, 40, 40)
+    triggerResizeObserversSync()
+    expect(queryByTestId('goal-objective-toggle')).toBeNull()
+    expect(box.classList.contains(styles.bodyFaded)).toBe(false)
+  })
+
+  it('offers the disclosure and fades the last line once the box hides something', () => {
+    const { getByTestId } = render(() => <GoalObjective objective="a long goal" />)
+    const box = getByTestId('goal-objective')
+    statesLayout(box, 200, 84)
+    triggerResizeObserversSync()
+    expect(getByTestId('goal-objective-toggle').textContent).toBe('Show more')
+    expect(box.classList.contains(styles.bodyFaded)).toBe(true)
+  })
+
+  /**
+   * The measurement runs only while the box is clamped, and its answer has to
+   * survive the expansion. An expanded box hides nothing, so a live measurement
+   * would answer "no" and take away the only control that clamps it again.
+   */
+  it('keeps the disclosure after expanding, so the box can be clamped again', () => {
+    const { getByTestId } = render(() => <GoalObjective objective="a long goal" />)
+    const box = getByTestId('goal-objective')
+    statesLayout(box, 200, 84)
+    triggerResizeObserversSync()
+
+    fireEvent.click(getByTestId('goal-objective-toggle'))
+    // The expanded box now reports its full height, as a real one would.
+    statesLayout(box, 200, 200)
+    triggerResizeObserversSync()
+
+    expect(box.classList.contains(styles.bodyClamped)).toBe(false)
+    expect(box.classList.contains(styles.bodyFaded)).toBe(false)
+    const toggle = getByTestId('goal-objective-toggle')
+    expect(toggle.textContent).toBe('Show less')
+
+    fireEvent.click(toggle)
+    expect(box.classList.contains(styles.bodyClamped)).toBe(true)
+  })
+
+  // An expansion belongs to the text the reader opened, not to the one that
+  // replaced it.
+  it('collapses again when the objective changes', () => {
+    const [objective, setObjective] = createSignal('a long goal')
+    const { getByTestId } = render(() => <GoalObjective objective={objective()} />)
+    const box = getByTestId('goal-objective')
+    statesLayout(box, 200, 84)
+    triggerResizeObserversSync()
+    fireEvent.click(getByTestId('goal-objective-toggle'))
+    expect(box.classList.contains(styles.bodyClamped)).toBe(false)
+
+    setObjective('a different long goal')
+    expect(box.classList.contains(styles.bodyClamped)).toBe(true)
+  })
+
+  describe('the hover tooltip', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      HTMLElement.prototype.showPopover = vi.fn()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+    })
+
+    it('shows the whole objective as markdown once the box hides something', () => {
+      const { getByTestId } = render(() => <GoalObjective objective="a long **goal**" />)
+      const box = getByTestId('goal-objective')
+      statesLayout(box, 200, 84)
+      statesClipping(box)
+      triggerResizeObserversSync()
+
+      fireEvent.mouseEnter(box)
+      vi.advanceTimersByTime(HOVER_DELAY_MS)
+
+      const tip = screen.getByRole('tooltip', { hidden: true })
+      expect(tip.querySelector('strong')?.textContent).toBe('goal')
+    })
+
+    /**
+     * `Tooltip` resolves `content` eagerly, in a memo, so the objective's
+     * markdown must not be built for a card that hides nothing -- and two cards
+     * can be on screen at once.
+     */
+    it('stays silent while the objective fits', () => {
+      const { getByTestId } = render(() => <GoalObjective objective="a short goal" />)
+      const box = getByTestId('goal-objective')
+      statesLayout(box, 40, 40)
+      statesClipping(box)
+      triggerResizeObserversSync()
+
+      fireEvent.mouseEnter(box)
+      vi.advanceTimersByTime(HOVER_DELAY_MS)
+
+      expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull()
+    })
+
+    // Expanded, the card already shows every line. A tooltip repeating them
+    // would cover the text the reader just opened.
+    it('stays silent once the reader expands the objective', () => {
+      const { getByTestId } = render(() => <GoalObjective objective="a long goal" />)
+      const box = getByTestId('goal-objective')
+      statesLayout(box, 200, 84)
+      statesClipping(box)
+      triggerResizeObserversSync()
+      fireEvent.click(getByTestId('goal-objective-toggle'))
+
+      fireEvent.mouseEnter(box)
+      vi.advanceTimersByTime(HOVER_DELAY_MS)
+
+      expect(screen.queryByRole('tooltip', { hidden: true })).toBeNull()
+    })
+  })
+})

--- a/frontend/src/components/backgroundtasks/GoalObjective.tsx
+++ b/frontend/src/components/backgroundtasks/GoalObjective.tsx
@@ -1,0 +1,136 @@
+import type { Component } from 'solid-js'
+import { createEffect, createSignal, on, onCleanup, onMount, Show } from 'solid-js'
+import { MarkdownText } from '~/components/chat/messageRenderers'
+import { Tooltip } from '~/components/common/Tooltip'
+import { collapsibleToggle } from '~/styles/shared.css'
+import * as styles from './GoalObjective.css'
+
+export interface GoalObjectiveProps {
+  /** The objective, as the provider stored it: markdown source. */
+  objective: string
+}
+
+/**
+ * A sub-pixel difference is not overflow. A box whose content rounds to one
+ * pixel taller than its clamp hides nothing a reader can see, and offering a
+ * `Show more` for it is noise. `Tooltip` uses the same tolerance for the same
+ * measurement.
+ */
+const OVERFLOW_TOLERANCE_PX = 1
+
+/**
+ * The session goal's objective: rendered markdown, clamped to four lines, with
+ * both routes back to the rest of it.
+ *
+ * One component rather than a style plus a caller, because a clamp HIDES text
+ * and the routes back are what make that acceptable. `ClippedText` owns the
+ * same pairing for a one-line label; this is its multi-line sibling.
+ *
+ * Two routes, for two different jobs. The hover tooltip is a peek that costs no
+ * click and no layout. The disclosure is the complete read: it expands inside
+ * the panel, which scrolls, so an objective of any length is reachable there --
+ * and the tooltip, which takes no pointer events, could never scroll to it.
+ *
+ * A SINGLE newline in the objective is a space, not a line break. The card used
+ * to set the objective `white-space: pre-wrap`, where it was a break. This is
+ * CommonMark, and it is what every other rendered surface in the app does with
+ * the same input, because `createMarkdownParser` uses `remarkParse` and
+ * `remarkGfm` and no `remark-breaks`. A goal written in the dialog is
+ * unaffected: the editor ends a paragraph with a blank line.
+ */
+export const GoalObjective: Component<GoalObjectiveProps> = (props) => {
+  const [expanded, setExpanded] = createSignal(false)
+  const [overflows, setOverflows] = createSignal(false)
+  let boxEl: HTMLDivElement | undefined
+  let contentEl: HTMLDivElement | undefined
+
+  /**
+   * Whether the clamped box hides anything.
+   *
+   * Measured ONLY while collapsed, and the answer persists while expanded. An
+   * expanded box is as tall as its content and overflows by definition nothing,
+   * so a live measurement there would answer "no" and take away the `Show less`
+   * control that is the only way back to the clamped state.
+   */
+  const measure = () => {
+    if (!boxEl || expanded())
+      return
+    setOverflows(boxEl.scrollHeight - boxEl.clientHeight > OVERFLOW_TOLERANCE_PX)
+  }
+
+  onMount(() => {
+    if (!contentEl)
+      return
+    // The CONTENT, not the box. The box's height is pinned by the clamp, so it
+    // never resizes when a longer objective arrives or when the asynchronous
+    // markdown highlight lands and reflows it. The content element grows with
+    // both, and it also tracks the box's width -- so a narrower sidebar, which
+    // re-wraps the same text onto more lines, re-measures through the same
+    // observer.
+    const observer = new ResizeObserver(measure)
+    observer.observe(contentEl)
+    onCleanup(() => observer.disconnect())
+  })
+
+  // Re-measure whenever the clamp goes back on, because `measure` declines to
+  // run while the box is open. Not deferred: the first run is the initial
+  // measurement, for the frame the card mounts in.
+  createEffect(on(expanded, measure))
+
+  // A new objective starts collapsed. An expansion belongs to the text the
+  // reader opened, not to the one that replaced it. The observer re-measures
+  // for the new text; a replacement of the same height keeps the same answer.
+  createEffect(on(() => props.objective, () => setExpanded(false), { defer: true }))
+
+  return (
+    <div class={styles.root}>
+      <Tooltip
+        // Built ONLY while the box hides something. `Tooltip` resolves
+        // `content` in a memo, which is eager, so an unconditional element
+        // would render the objective's markdown a second time for every card
+        // that shows one -- and two cards can be on screen at once.
+        //
+        // No `text` beside it. `text` becomes an offscreen description, and the
+        // objective is markdown SOURCE: a screen reader would read the asterisks
+        // of every bold run. The rendered objective is already on screen, and
+        // the disclosure below reaches the rest of it.
+        content={overflows() && !expanded()
+          ? (
+              <div class={styles.tooltipBody}>
+                <MarkdownText text={props.objective} />
+              </div>
+            )
+          : undefined}
+        showWhen="clipped"
+      >
+        <div
+          ref={boxEl}
+          class={styles.body}
+          classList={{
+            [styles.bodyClamped]: !expanded(),
+            [styles.bodyFaded]: !expanded() && overflows(),
+          }}
+          data-testid="goal-objective"
+        >
+          {/* The measured element. It exists so the ResizeObserver has
+              something that actually changes size -- see `onMount`. */}
+          <div ref={contentEl}>
+            <MarkdownText text={props.objective} />
+          </div>
+        </div>
+      </Tooltip>
+      <Show when={overflows()}>
+        <div class={styles.toggleRow}>
+          <button
+            type="button"
+            class={collapsibleToggle}
+            data-testid="goal-objective-toggle"
+            onClick={() => setExpanded(prev => !prev)}
+          >
+            {expanded() ? 'Show less' : 'Show more'}
+          </button>
+        </div>
+      </Show>
+    </div>
+  )
+}

--- a/frontend/src/components/backgroundtasks/GoalObjective.tsx
+++ b/frontend/src/components/backgroundtasks/GoalObjective.tsx
@@ -1,8 +1,8 @@
 import type { Component } from 'solid-js'
-import { createEffect, createSignal, on, onCleanup, onMount, Show } from 'solid-js'
+import { createEffect, createSignal, createUniqueId, on, onCleanup, onMount, Show } from 'solid-js'
 import { MarkdownText } from '~/components/chat/messageRenderers'
+import { CollapsibleToggle } from '~/components/common/CollapsibleToggle'
 import { Tooltip } from '~/components/common/Tooltip'
-import { collapsibleToggle } from '~/styles/shared.css'
 import * as styles from './GoalObjective.css'
 
 export interface GoalObjectiveProps {
@@ -13,8 +13,7 @@ export interface GoalObjectiveProps {
 /**
  * A sub-pixel difference is not overflow. A box whose content rounds to one
  * pixel taller than its clamp hides nothing a reader can see, and offering a
- * `Show more` for it is noise. `Tooltip` uses the same tolerance for the same
- * measurement.
+ * `Show more` for it is noise.
  */
 const OVERFLOW_TOLERANCE_PX = 1
 
@@ -37,9 +36,18 @@ const OVERFLOW_TOLERANCE_PX = 1
  * the same input, because `createMarkdownParser` uses `remarkParse` and
  * `remarkGfm` and no `remark-breaks`. A goal written in the dialog is
  * unaffected: the editor ends a paragraph with a blank line.
+ *
+ * A PROVIDER can still send soft-wrapped plain text, and it reads as one
+ * paragraph here. Claude folds an objective to a single line before it stores
+ * one, but Codex, ZCode and Reasonix copy the raw string through. The case is
+ * known and accepted: one card cannot answer this input differently from every
+ * other markdown surface without splitting the app's single parser config, and
+ * `remark-breaks` is an app-wide decision rather than a goal-card one.
  */
 export const GoalObjective: Component<GoalObjectiveProps> = (props) => {
   const [expanded, setExpanded] = createSignal(false)
+  // The clamped box, so the disclosure can point at what it opens.
+  const bodyId = createUniqueId()
   const [overflows, setOverflows] = createSignal(false)
   let boxEl: HTMLDivElement | undefined
   let contentEl: HTMLDivElement | undefined
@@ -94,6 +102,13 @@ export const GoalObjective: Component<GoalObjectiveProps> = (props) => {
         // objective is markdown SOURCE: a screen reader would read the asterisks
         // of every bold run. The rendered objective is already on screen, and
         // the disclosure below reaches the rest of it.
+        // No `showWhen="clipped"`. This component ALREADY knows whether the box
+        // hides anything -- it measures that itself, and `content` below is
+        // gated on the answer -- so asking `Tooltip` to measure the same box
+        // again gives one fact two detectors, with two tolerances and two
+        // algorithms. They agree by construction today, and the second one
+        // reads live layout, so the two disagree in the window where this
+        // component's own answer is still stale.
         content={overflows() && !expanded()
           ? (
               <div class={styles.tooltipBody}>
@@ -101,7 +116,6 @@ export const GoalObjective: Component<GoalObjectiveProps> = (props) => {
               </div>
             )
           : undefined}
-        showWhen="clipped"
       >
         <div
           ref={boxEl}
@@ -111,6 +125,7 @@ export const GoalObjective: Component<GoalObjectiveProps> = (props) => {
             [styles.bodyFaded]: !expanded() && overflows(),
           }}
           data-testid="goal-objective"
+          id={bodyId}
         >
           {/* The measured element. It exists so the ResizeObserver has
               something that actually changes size -- see `onMount`. */}
@@ -121,14 +136,13 @@ export const GoalObjective: Component<GoalObjectiveProps> = (props) => {
       </Tooltip>
       <Show when={overflows()}>
         <div class={styles.toggleRow}>
-          <button
-            type="button"
-            class={collapsibleToggle}
+          <CollapsibleToggle
+            expanded={expanded()}
+            onToggle={() => setExpanded(prev => !prev)}
+            controls={bodyId}
+            moreLabel="Show more"
             data-testid="goal-objective-toggle"
-            onClick={() => setExpanded(prev => !prev)}
-          >
-            {expanded() ? 'Show less' : 'Show more'}
-          </button>
+          />
         </div>
       </Show>
     </div>

--- a/frontend/src/components/backgroundtasks/SetGoalDialog.css.ts
+++ b/frontend/src/components/backgroundtasks/SetGoalDialog.css.ts
@@ -4,11 +4,16 @@ export const form = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 'var(--space-2)',
-  minWidth: '320px',
+  // Wide enough to write a paragraph in, and never wider than the viewport.
+  // `Dialog` drops to `width: 100%` below the `sm` breakpoint, so a bare 420px
+  // would push the panel off a phone screen. The subtraction matches Oat's own
+  // dialog inset, `min(100% - 2rem, 32rem)`.
+  minWidth: 'min(420px, calc(100vw - var(--space-8)))',
 })
 
 // The field column. Dialog's own stylesheet gives `> .body > form > section`
-// its scroller, so the label and the textarea sit in one and stack here.
+// its scroller, so the hint, the editor and the byte notice sit in one and
+// stack here.
 export const field = style({
   display: 'flex',
   flexDirection: 'column',
@@ -20,15 +25,9 @@ export const label = style({
   color: 'var(--muted-foreground)',
 })
 
-export const input = style({
-  width: '100%',
-  fontFamily: 'inherit',
-  fontSize: 'var(--text-7)',
-  resize: 'vertical',
-})
-
-// No `actions` and no `button` here on purpose. The footer row is the shared
+// No `input`, no `actions` and no `button` here on purpose. The field is
+// `MarkdownEditor`, which owns its own box; the footer row is the shared
 // `actionsFooter` from `~/components/common/actionsFooter.css`, which 30 other
-// dialogs use, and the buttons are Oat's plain `<button>` and
-// `<button class="outline">`, the pair ConfirmDialog uses. Hand-rolling either
-// one approximated the shared rule and stopped following it when it changed.
+// dialogs use; and the buttons are Oat's plain `<button>` and
+// `<button class="outline">`, the pair ConfirmDialog uses. Hand-rolling any of
+// them approximated the shared rule and stopped following it when it changed.

--- a/frontend/src/components/backgroundtasks/SetGoalDialog.css.ts
+++ b/frontend/src/components/backgroundtasks/SetGoalDialog.css.ts
@@ -1,23 +1,22 @@
 import { style } from '@vanilla-extract/css'
 
-export const form = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 'var(--space-2)',
-  // Wide enough to write a paragraph in, and never wider than the viewport.
-  // `Dialog` drops to `width: 100%` below the `sm` breakpoint, so a bare 420px
-  // would push the panel off a phone screen. The subtraction matches Oat's own
-  // dialog inset, `min(100% - 2rem, 32rem)`.
-  minWidth: 'min(420px, calc(100vw - var(--space-8)))',
-})
-
-// The field column. Dialog's own stylesheet gives `> .body > form > section`
-// its scroller, so the hint, the editor and the byte notice sit in one and
-// stack here.
+/**
+ * The field column, and the dialog's width.
+ *
+ * `Dialog`'s own stylesheet gives `> .body > section` the scroller and the
+ * edge-to-edge bleed, so the hint, the editor and the byte notice sit in one
+ * and stack here. There is no wrapper element above it -- see `SetGoalDialog`.
+ *
+ * The width lives here for that reason. Wide enough to write a paragraph in,
+ * and never wider than the viewport: `Dialog` drops to `width: 100%` below the
+ * `sm` breakpoint, so a bare 420px would push the panel off a phone screen. The
+ * subtraction matches Oat's own dialog inset, `min(100% - 2rem, 32rem)`.
+ */
 export const field = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 'var(--space-2)',
+  minWidth: 'min(420px, calc(100vw - var(--space-8)))',
 })
 
 export const label = style({

--- a/frontend/src/components/backgroundtasks/SetGoalDialog.test.tsx
+++ b/frontend/src/components/backgroundtasks/SetGoalDialog.test.tsx
@@ -1,52 +1,135 @@
-import { fireEvent, render } from '@solidjs/testing-library'
+import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
+import { PreferencesProvider } from '~/context/PreferencesContext'
+import { GOAL_OBJECTIVE_BYTE_LIMIT } from '~/generated/contracts/validate'
+import { useTestStorage } from '~/test-support/persistentStorage'
 import { SetGoalDialog } from './SetGoalDialog'
+
+useTestStorage()
+
+function mount(props: { initialObjective?: string, onSubmit?: () => void, onClose?: () => void } = {}) {
+  const onSubmit = vi.fn(props.onSubmit)
+  const onClose = vi.fn(props.onClose)
+  const result = render(() => (
+    <PreferencesProvider>
+      <SetGoalDialog
+        initialObjective={props.initialObjective}
+        onSubmit={onSubmit}
+        onClose={onClose}
+      />
+    </PreferencesProvider>
+  ))
+  return { ...result, onSubmit, onClose }
+}
+
+/** The editor is built asynchronously, so every case waits for its document. */
+async function editorReady(): Promise<HTMLElement> {
+  let el: HTMLElement | null = null
+  await waitFor(() => {
+    el = document.querySelector('[data-testid="goal-editor"] .ProseMirror')
+    expect(el).not.toBeNull()
+  })
+  return el as unknown as HTMLElement
+}
 
 describe('setGoalDialog', () => {
   // Replacing prefills the current objective, so the reader EDITS what is there
   // instead of retyping it. It is also what makes Clear safe without a
   // confirmation: the editor reopens holding the objective that was cleared.
-  it('starts from the objective it was given', () => {
-    const { getByTestId } = render(() => (
-      <SetGoalDialog initialObjective="every test passes" onSubmit={vi.fn()} onClose={vi.fn()} />
-    ))
-    expect((getByTestId('set-goal-input') as HTMLTextAreaElement).value).toBe('every test passes')
+  it('starts from the objective it was given', async () => {
+    mount({ initialObjective: 'every test passes' })
+    const editor = await editorReady()
+    await waitFor(() => expect(editor.textContent).toContain('every test passes'))
   })
 
-  it('submits the trimmed objective and closes', () => {
-    const onSubmit = vi.fn()
-    const onClose = vi.fn()
-    const { getByTestId } = render(() => (
-      <SetGoalDialog onSubmit={onSubmit} onClose={onClose} />
-    ))
-    const input = getByTestId('set-goal-input') as HTMLTextAreaElement
-    fireEvent.input(input, { target: { value: '  ship it  ' } })
+  it('submits the trimmed objective and closes', async () => {
+    const { getByTestId, onSubmit, onClose } = mount({ initialObjective: 'ship it' })
+    await editorReady()
+    await waitFor(() => expect((getByTestId('set-goal-submit') as HTMLButtonElement).disabled).toBe(false))
+
     fireEvent.click(getByTestId('set-goal-submit'))
-    expect(onSubmit).toHaveBeenCalledWith('ship it')
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('ship it'))
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('refuses an objective that is only whitespace', () => {
-    const onSubmit = vi.fn()
-    const { getByTestId } = render(() => (
-      <SetGoalDialog onSubmit={onSubmit} onClose={vi.fn()} />
-    ))
-    fireEvent.input(getByTestId('set-goal-input'), { target: { value: '   ' } })
+  // The editor is the field for markdown, so what the user wrote as markdown is
+  // what the worker stores -- the card renders it back the same way.
+  it('submits the objective as markdown source', async () => {
+    const { getByTestId, onSubmit } = mount({ initialObjective: 'ship the **auth refactor**' })
+    await editorReady()
+    await waitFor(() => expect((getByTestId('set-goal-submit') as HTMLButtonElement).disabled).toBe(false))
+
+    fireEvent.click(getByTestId('set-goal-submit'))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('ship the **auth refactor**'))
+  })
+
+  it('refuses an empty objective', async () => {
+    const { getByTestId, onSubmit } = mount()
+    await editorReady()
     const submit = getByTestId('set-goal-submit') as HTMLButtonElement
     expect(submit.disabled).toBe(true)
     fireEvent.click(submit)
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
-  it('writes nothing when cancelled', () => {
-    const onSubmit = vi.fn()
-    const onClose = vi.fn()
-    const { getByText, getByTestId } = render(() => (
-      <SetGoalDialog onSubmit={onSubmit} onClose={onClose} />
-    ))
-    fireEvent.input(getByTestId('set-goal-input'), { target: { value: 'abandoned' } })
+  /**
+   * The worker REFUSES an objective over the cap rather than truncating it, so
+   * the dialog refuses it too -- otherwise the user meets an error whose cause
+   * is invisible. The cap counts UTF-8 BYTES, which is why the dialog measures
+   * them rather than characters.
+   */
+  it('refuses an objective over the byte cap and says by how much', async () => {
+    const over = 'a'.repeat(GOAL_OBJECTIVE_BYTE_LIMIT + 12)
+    const { getByTestId, onSubmit } = mount({ initialObjective: over })
+    await editorReady()
+
+    await waitFor(() => expect(getByTestId('set-goal-too-long').textContent).toContain('Too long by 12 bytes'))
+    const submit = getByTestId('set-goal-submit') as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+    fireEvent.click(submit)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  // A counter over a two-line objective states a number nobody is close to
+  // spending. It appears where the refusal becomes a real prospect.
+  it('states the remaining budget only near the cap', async () => {
+    const { queryByTestId } = mount({ initialObjective: 'a short goal' })
+    await editorReady()
+    expect(queryByTestId('set-goal-budget')).toBeNull()
+    expect(queryByTestId('set-goal-too-long')).toBeNull()
+  })
+
+  it('states the remaining budget once the objective approaches the cap', async () => {
+    const near = 'a'.repeat(Math.ceil(GOAL_OBJECTIVE_BYTE_LIMIT * 0.95))
+    const { getByTestId } = mount({ initialObjective: near })
+    await editorReady()
+    await waitFor(() => {
+      expect(getByTestId('set-goal-budget').textContent)
+        .toBe(`${(GOAL_OBJECTIVE_BYTE_LIMIT - near.length).toLocaleString()} bytes left`)
+    })
+  })
+
+  it('writes nothing when cancelled', async () => {
+    const { getByText, onSubmit, onClose } = mount({ initialObjective: 'abandoned' })
+    await editorReady()
     fireEvent.click(getByText('Cancel'))
     expect(onSubmit).not.toHaveBeenCalled()
     expect(onClose).toHaveBeenCalled()
+  })
+
+  /**
+   * The goal editor is not the message composer. `useShortcuts` reads
+   * `data-chat-input` for the `chatInputFocused` context, and `$mod+j` sends the
+   * chat message there -- so the marker here would send a message from inside
+   * this dialog. The test id matters for the same kind of reason: about twenty
+   * E2E specs address `chat-editor` with an unscoped locator.
+   */
+  it('is not the chat composer', async () => {
+    mount({ initialObjective: 'every test passes' })
+    await editorReady()
+    expect(document.querySelector('[data-chat-input]')).toBeNull()
+    expect(document.querySelector('[data-testid="chat-editor"]')).toBeNull()
   })
 })

--- a/frontend/src/components/backgroundtasks/SetGoalDialog.test.tsx
+++ b/frontend/src/components/backgroundtasks/SetGoalDialog.test.tsx
@@ -22,12 +22,27 @@ function mount(props: { initialObjective?: string, onSubmit?: () => void, onClos
   return { ...result, onSubmit, onClose }
 }
 
-/** The editor is built asynchronously, so every case waits for its document. */
-async function editorReady(): Promise<HTMLElement> {
+/**
+ * The editor is built asynchronously, so every case waits for its document.
+ *
+ * `seeded` waits for the SEED to land as well. `onReady` fires after the build
+ * and replaces the document then, so a case that clicks the moment `.ProseMirror`
+ * exists can act on an empty editor and prove nothing about the text it meant to
+ * submit.
+ */
+async function editorReady(seeded?: string): Promise<HTMLElement> {
   let el: HTMLElement | null = null
   await waitFor(() => {
     el = document.querySelector('[data-testid="goal-editor"] .ProseMirror')
     expect(el).not.toBeNull()
+    // The button is disabled until the editor installs its imperative send, so
+    // this is the dialog's own readiness signal. `.ProseMirror` appearing is
+    // not enough: the refs install after it, and a click before then reaches an
+    // `undefined` send.
+    const submit = document.querySelector('[data-testid="set-goal-submit"]') as HTMLButtonElement | null
+    expect(submit?.disabled).toBe(false)
+    if (seeded !== undefined)
+      expect(el!.textContent).toContain(seeded)
   })
   return el as unknown as HTMLElement
 }
@@ -44,8 +59,7 @@ describe('setGoalDialog', () => {
 
   it('submits the trimmed objective and closes', async () => {
     const { getByTestId, onSubmit, onClose } = mount({ initialObjective: 'ship it' })
-    await editorReady()
-    await waitFor(() => expect((getByTestId('set-goal-submit') as HTMLButtonElement).disabled).toBe(false))
+    await editorReady('ship it')
 
     fireEvent.click(getByTestId('set-goal-submit'))
 
@@ -57,21 +71,49 @@ describe('setGoalDialog', () => {
   // what the worker stores -- the card renders it back the same way.
   it('submits the objective as markdown source', async () => {
     const { getByTestId, onSubmit } = mount({ initialObjective: 'ship the **auth refactor**' })
-    await editorReady()
-    await waitFor(() => expect((getByTestId('set-goal-submit') as HTMLButtonElement).disabled).toBe(false))
+    await editorReady('ship the auth refactor')
 
     fireEvent.click(getByTestId('set-goal-submit'))
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('ship the **auth refactor**'))
   })
 
-  it('refuses an empty objective', async () => {
-    const { getByTestId, onSubmit } = mount()
+  /**
+   * The button is deliberately never `disabled`.
+   *
+   * Its state would have to come from the mirrored text, which lags the
+   * document by the editor's 200ms listener debounce -- so a click inside that
+   * window met a disabled button and did NOTHING, with no message. It always
+   * clicks; the refusal reads the live document and says why.
+   */
+  it('refuses an empty objective and says so', async () => {
+    const { getByTestId, onSubmit, onClose } = mount()
     await editorReady()
-    const submit = getByTestId('set-goal-submit') as HTMLButtonElement
-    expect(submit.disabled).toBe(true)
-    fireEvent.click(submit)
+
+    fireEvent.click(getByTestId('set-goal-submit'))
+
+    await waitFor(() => expect(getByTestId('set-goal-too-long').textContent)
+      .toContain('Write the condition the agent works toward.'))
     expect(onSubmit).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Whitespace is empty. The editor trims before it hands the text over, so a
+   * document of spaces reaches `submit` as `''` and is refused there -- and the
+   * dialog must not hand the worker a blank standing goal the agent can never
+   * satisfy.
+   */
+  it('refuses an objective that is only whitespace', async () => {
+    const { getByTestId, onSubmit, onClose } = mount({ initialObjective: '   ' })
+    await editorReady()
+
+    fireEvent.click(getByTestId('set-goal-submit'))
+
+    await waitFor(() => expect(getByTestId('set-goal-too-long').textContent)
+      .toContain('Write the condition the agent works toward.'))
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
   })
 
   /**
@@ -86,9 +128,9 @@ describe('setGoalDialog', () => {
     await editorReady()
 
     await waitFor(() => expect(getByTestId('set-goal-too-long').textContent).toContain('Too long by 12 bytes'))
-    const submit = getByTestId('set-goal-submit') as HTMLButtonElement
-    expect(submit.disabled).toBe(true)
-    fireEvent.click(submit)
+
+    fireEvent.click(getByTestId('set-goal-submit'))
+
     expect(onSubmit).not.toHaveBeenCalled()
   })
 
@@ -106,9 +148,34 @@ describe('setGoalDialog', () => {
     const { getByTestId } = mount({ initialObjective: near })
     await editorReady()
     await waitFor(() => {
+      // The expected number is spelled with an explicit `en-US`, not with the
+      // same `toLocaleString()` the component calls: asserting a value against
+      // the call that produced it passes in every locale, including the ones
+      // where the rendered string is wrong.
       expect(getByTestId('set-goal-budget').textContent)
-        .toBe(`${(GOAL_OBJECTIVE_BYTE_LIMIT - near.length).toLocaleString()} bytes left`)
+        .toBe(`${(GOAL_OBJECTIVE_BYTE_LIMIT - near.length).toLocaleString('en-US')} bytes left`)
     })
+  })
+
+  /**
+   * No `<form>`, and the two children Dialog's stylesheet expects.
+   *
+   * A form with no `onSubmit` NAVIGATES the page on implicit submission, so the
+   * first `<input>` a later change adds to this dialog would reload the app.
+   * The shape assertion goes with it: `Dialog.css.ts` gives the scroller to
+   * `> .body > section` and the spacing to `> .body > footer`, so a wrapper
+   * reappearing would take both away silently.
+   */
+  it('renders no form, and puts the section and footer where Dialog styles them', async () => {
+    const { getByTestId } = mount({ initialObjective: 'ship it' })
+    await editorReady('ship it')
+
+    const body = getByTestId('set-goal-dialog').querySelector('[class*="body"]')!
+    // Scoped to the direct children: the editor's own LinkPopover renders a
+    // real `<form>` deeper in the tree, which is the nesting this removal also
+    // undoes.
+    expect(body.querySelector(':scope > form')).toBeNull()
+    expect([...body.children].map(el => el.tagName)).toEqual(['SECTION', 'FOOTER'])
   })
 
   it('writes nothing when cancelled', async () => {
@@ -124,12 +191,12 @@ describe('setGoalDialog', () => {
    * `data-chat-input` for the `chatInputFocused` context, and `$mod+j` sends the
    * chat message there -- so the marker here would send a message from inside
    * this dialog. The test id matters for the same kind of reason: about twenty
-   * E2E specs address `chat-editor` with an unscoped locator.
+   * E2E specs address `composer-editor` with an unscoped locator.
    */
   it('is not the chat composer', async () => {
     mount({ initialObjective: 'every test passes' })
     await editorReady()
     expect(document.querySelector('[data-chat-input]')).toBeNull()
-    expect(document.querySelector('[data-testid="chat-editor"]')).toBeNull()
+    expect(document.querySelector('[data-testid="composer-editor"]')).toBeNull()
   })
 })

--- a/frontend/src/components/backgroundtasks/SetGoalDialog.tsx
+++ b/frontend/src/components/backgroundtasks/SetGoalDialog.tsx
@@ -1,6 +1,7 @@
 import type { Component } from 'solid-js'
-import { createSignal, Show } from 'solid-js'
+import { createSignal, createUniqueId, Show } from 'solid-js'
 import { MarkdownEditor } from '~/components/chat/markdownEditor/MarkdownEditor'
+import { formatNumber } from '~/components/chat/rendererUtils'
 import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { Dialog } from '~/components/common/Dialog'
 import { GOAL_OBJECTIVE_BYTE_LIMIT } from '~/generated/contracts/validate'
@@ -27,7 +28,14 @@ export interface SetGoalDialogProps {
  */
 const BUDGET_NOTICE_RATIO = 0.9
 
-/** The editor's opening height and its ceiling, in pixels. */
+/**
+ * The editor's opening height and its ceiling, in pixels.
+ *
+ * A floor and a ceiling, so the box opens big enough to write a paragraph in
+ * and then grows with the objective until it scrolls. `minHeight` rather than
+ * `pinnedHeight`: a pinned height stops being a floor the moment the content
+ * passes it, which would hold the box at 120px and leave the ceiling unused.
+ */
 const EDITOR_MIN_HEIGHT_PX = 120
 const EDITOR_MAX_HEIGHT_PX = 320
 
@@ -49,22 +57,36 @@ export const SetGoalDialog: Component<SetGoalDialogProps> = (props) => {
   /**
    * The editor's text, as the EDITOR reports it. Never seeded from the prop.
    *
-   * The editor is built asynchronously, so its document is empty for the first
-   * frames even when this dialog opens to replace an objective. Seeding this
-   * signal from the prop armed the Set goal button during that window, and a
-   * click there ran a send against an empty document and did nothing at all.
-   * Reading the editor makes the button live at exactly the moment a click
-   * works, because the send reads the same document.
-   *
-   * The seed itself arrives here synchronously: a programmatic `set` reports
-   * its text as it applies it. Typing arrives through Milkdown's
-   * `markdownUpdated` listener, which is debounced 200ms -- the same lag the
-   * composer's own Send button lives with, from the same listener. Enter waits
-   * for neither: the editor's send reads the ProseMirror document directly.
+   * A MIRROR, and only ever read for the byte NOTICE. It lags the document by
+   * the 200ms debounce on Milkdown's `markdownUpdated` listener, so nothing
+   * that decides an action may read it -- an advisory counter that is a fifth
+   * of a second late is fine, and a button that refuses a click for a fifth of
+   * a second is not. The seed arrives without that lag, because a programmatic
+   * `set` reports the document as it applies it.
    */
   const [objective, setObjective] = createSignal('')
+  /**
+   * Why the last send was refused, or `undefined` when none was.
+   *
+   * The mirrored `objective` lags the document by the listener's debounce, so
+   * it can never decide an ACTION -- only the send reads the live text. The
+   * button therefore always clicks, and a refusal states its reason here rather
+   * than being swallowed.
+   */
+  const [refusal, setRefusal] = createSignal<string | undefined>()
+  /**
+   * Whether the editor finished building and installed its imperative send.
+   *
+   * The ONE thing that legitimately disables the button. A click before this is
+   * true reaches an `undefined` send and does nothing at all -- the same silent
+   * no-op the debounced text used to cause, from the other end of the build. It
+   * is a fact about the EDITOR, not about the text, so it cannot lag the
+   * document.
+   */
+  const [ready, setReady] = createSignal(false)
+  // The caption that names the editor -- see the `aria-labelledby` below.
+  const hintId = createUniqueId()
   let triggerSend: (() => void | Promise<void>) | undefined
-  let setEditorContent: ((text: string) => void) | undefined
 
   const trimmed = () => objective().trim()
   // Measured in UTF-8 bytes, the unit the worker's cap counts in. The worker
@@ -72,9 +94,35 @@ export const SetGoalDialog: Component<SetGoalDialogProps> = (props) => {
   // dialog has to refuse it too or the user meets an error they cannot see the
   // cause of.
   const usedBytes = () => utf8ByteLength(trimmed())
-  const overLimit = () => usedBytes() > GOAL_OBJECTIVE_BYTE_LIMIT
   const showsBudget = () => usedBytes() >= GOAL_OBJECTIVE_BYTE_LIMIT * BUDGET_NOTICE_RATIO
-  const canSubmit = () => trimmed() !== '' && !overLimit()
+
+  /**
+   * The ONE statement of the byte cap, for the notice AND for the refusal.
+   *
+   * Written once so a change to the cap cannot leave a warning that disagrees
+   * with what the send accepts.
+   */
+  const overLimitMessage = (text: string): string | undefined => {
+    const used = utf8ByteLength(text)
+    if (used <= GOAL_OBJECTIVE_BYTE_LIMIT)
+      return undefined
+    return `Too long by ${formatNumber(used - GOAL_OBJECTIVE_BYTE_LIMIT)} bytes. `
+      + `The limit is ${formatNumber(GOAL_OBJECTIVE_BYTE_LIMIT)}.`
+  }
+
+  /** Why the dialog refuses `text`, or `undefined` when it accepts it. */
+  const refusalFor = (text: string): string | undefined =>
+    text === '' ? 'Write the condition the agent works toward.' : overLimitMessage(text)
+
+  /**
+   * What the notice under the editor says.
+   *
+   * The over-limit half is proactive, from the mirrored text, so the warning
+   * arrives while the user types rather than only when they click. The empty
+   * half is not: an empty editor the user has not typed in yet owes no
+   * complaint, so `refusal()` supplies that one, and only after a click.
+   */
+  const notice = () => refusal() ?? overLimitMessage(trimmed())
 
   /**
    * The ONE submit path.
@@ -87,82 +135,115 @@ export const SetGoalDialog: Component<SetGoalDialogProps> = (props) => {
    * editor, and the user's own `enterKeyMode` preference governs it exactly as
    * it governs the composer.
    *
+   * It decides on the text the EDITOR hands it, which is the live document.
+   * Deciding on the mirrored signal instead left a window -- one debounce wide
+   * -- where the button disagreed with the document, and a click inside it did
+   * nothing at all, with no message.
+   *
    * Returns `false` when it refuses, which is how the editor knows to keep what
    * the user wrote.
    */
   const submit = (markdown: string): boolean | void => {
     const text = markdown.trim()
-    if (text === '' || utf8ByteLength(text) > GOAL_OBJECTIVE_BYTE_LIMIT)
+    const why = refusalFor(text)
+    if (why !== undefined) {
+      setRefusal(why)
       return false
+    }
     props.onSubmit(text)
     props.onClose()
   }
 
   return (
     <Dialog title="Session goal" onClose={props.onClose} data-testid="set-goal-dialog">
-      {/* `<section>` and `<footer>`, because Dialog's own stylesheet targets
-          `> .body > form > section` and `> .body > form > footer`. A form with
-          neither loses the footer's spacing and the section's scroller.
+      {/* `<section>` and `<footer>` as DIRECT children of Dialog's `.body`. The
+          stylesheet carries that bare shape: `> .body > section` gives the
+          scroller and the edge bleed, `> .body > footer` the spacing.
 
-          No `onSubmit`: nothing in this form submits it -- see `submit`. */}
-      <form class={styles.form}>
-        <section class={styles.field}>
-          {/* A plain `<div>`, not a `<label>`. The editor is a contenteditable
-              region rather than a form control, so a `for` would name nothing
-              and a click on the label would focus nothing. */}
-          <div class={styles.label}>
-            The agent keeps working until this condition holds.
-          </div>
-          <MarkdownEditor
-            surface="goal"
-            // No `draftKey`. A persisted draft would resurrect prose the user
-            // abandoned the next time they open Replace, in place of the
-            // objective the worker actually holds -- and the objective, not the
-            // draft, is what Replace exists to edit.
-            onSend={submit}
-            onMarkdownChange={setObjective}
-            requestedHeight={EDITOR_MIN_HEIGHT_PX}
-            maxHeight={EDITOR_MAX_HEIGHT_PX}
-            placeholder="Describe the condition the agent works toward..."
-            imperative={{
-              sendRef: (send) => { triggerSend = send },
-              contentRef: (_get, set) => { setEditorContent = set },
-              // Seeded on ready rather than through a draft key. The editor is
-              // built asynchronously, and `onReady` is the moment it holds a
-              // document to replace.
-              onReady: () => {
-                if (props.initialObjective)
-                  setEditorContent?.(props.initialObjective)
-              },
-            }}
-          />
-          <Show
-            when={overLimit()}
-            fallback={(
-              <Show when={showsBudget()}>
-                <span class={styles.label} data-testid="set-goal-budget">
-                  {`${(GOAL_OBJECTIVE_BYTE_LIMIT - usedBytes()).toLocaleString()} bytes left`}
-                </span>
-              </Show>
-            )}
-          >
-            <span class={errorText} data-testid="set-goal-too-long">
-              {`Too long by ${(usedBytes() - GOAL_OBJECTIVE_BYTE_LIMIT).toLocaleString()} bytes. The limit is ${GOAL_OBJECTIVE_BYTE_LIMIT.toLocaleString()}.`}
+          No `<form>` around them, because nothing here submits one -- see
+          `submit`. An empty form is not inert: a form with no `onSubmit`
+          NAVIGATES the page on implicit submission, so the first `<input>` a
+          later change adds would reload the app. It would also nest inside the
+          editor's own LinkPopover form, which is mounted whether that popover
+          is open or not. */}
+      <section class={styles.field}>
+        {/* A plain `<div>`, not a `<label>`. The editor is a contenteditable
+              region rather than a form control, so a `for` would point at no
+              control and a click on the label would focus nothing.
+              `aria-labelledby` carries the connection instead: the one
+              instruction this dialog exists to give has to reach a screen
+              reader, and without it the caret lands in an unnamed region. */}
+        <div class={styles.label} id={hintId}>
+          The agent keeps working until this condition holds.
+        </div>
+        <MarkdownEditor
+          surface="goal"
+          ariaLabelledBy={hintId}
+          // The objective as DATA, seeded at BUILD time, so the editor never
+          // holds an empty document that a later replace overwrites.
+          //
+          // And no `draftKey`: a persisted draft would resurrect prose the user
+          // abandoned the next time they open Replace, in place of the
+          // objective the worker actually holds -- and the objective, not the
+          // draft, is what Replace exists to edit.
+          initialMarkdown={props.initialObjective}
+          onSend={submit}
+          // The send must REACH `submit` even for an empty document, or an
+          // empty send is a second silent no-op beside the one the button
+          // used to be. `submit` is what states the reason.
+          allowEmptySend
+          onMarkdownChange={(markdown) => {
+            setObjective(markdown)
+            // The reader answered the complaint; take it down.
+            setRefusal(undefined)
+          }}
+          minHeight={EDITOR_MIN_HEIGHT_PX}
+          maxHeight={EDITOR_MAX_HEIGHT_PX}
+          placeholder="Describe the condition the agent works toward..."
+          imperative={{
+            sendRef: (send) => { triggerSend = send },
+            // The build is asynchronous, and this is the moment the editor
+            // holds both a document and its imperative send. The button waits
+            // for it, because a click before then reaches nothing.
+            onReady: () => setReady(true),
+          }}
+        />
+        <Show
+          when={notice()}
+          fallback={(
+            <Show when={showsBudget()}>
+              <span class={styles.label} data-testid="set-goal-budget">
+                {`${formatNumber(GOAL_OBJECTIVE_BYTE_LIMIT - usedBytes())} bytes left`}
+              </span>
+            </Show>
+          )}
+        >
+          {/* `role="alert"`, because a refusal that only a sighted reader
+                notices is the silent no-op with extra steps. */}
+          {why => (
+            <span class={errorText} role="alert" data-testid="set-goal-too-long">
+              {why()}
             </span>
-          </Show>
-        </section>
-        <footer class={actionsFooter}>
-          <button type="button" class="outline" onClick={() => props.onClose()}>Cancel</button>
-          <button
-            type="button"
-            data-testid="set-goal-submit"
-            disabled={!canSubmit()}
-            onClick={() => void triggerSend?.()}
-          >
-            Set goal
-          </button>
-        </footer>
-      </form>
+          )}
+        </Show>
+      </section>
+      <footer class={actionsFooter}>
+        <button type="button" class="outline" onClick={() => props.onClose()}>Cancel</button>
+        {/* Disabled ONLY while the editor is still building, which is the one
+              state where a click genuinely cannot work. Never from the text:
+              that reading is the debounced mirror, and a button disabled from
+              it refuses a click the document would have accepted -- silently.
+              Once the editor is up the button always clicks, and `submit`
+              states why when it declines. */}
+        <button
+          type="button"
+          data-testid="set-goal-submit"
+          disabled={!ready()}
+          onClick={() => void triggerSend?.()}
+        >
+          Set goal
+        </button>
+      </footer>
     </Dialog>
   )
 }

--- a/frontend/src/components/backgroundtasks/SetGoalDialog.tsx
+++ b/frontend/src/components/backgroundtasks/SetGoalDialog.tsx
@@ -1,9 +1,11 @@
 import type { Component } from 'solid-js'
 import { createSignal, Show } from 'solid-js'
+import { MarkdownEditor } from '~/components/chat/markdownEditor/MarkdownEditor'
 import { actionsFooter } from '~/components/common/actionsFooter.css'
 import { Dialog } from '~/components/common/Dialog'
 import { GOAL_OBJECTIVE_BYTE_LIMIT } from '~/generated/contracts/validate'
 import { utf8ByteLength } from '~/lib/validate'
+import { errorText } from '~/styles/shared.css'
 import * as styles from './SetGoalDialog.css'
 
 export interface SetGoalDialogProps {
@@ -17,6 +19,19 @@ export interface SetGoalDialogProps {
 }
 
 /**
+ * The share of the byte cap at which the remaining budget appears.
+ *
+ * A counter over a two-line objective states a number nobody is close to
+ * spending; a counter over a page of prose is the warning that the refusal is
+ * near. 90% is where the second becomes true.
+ */
+const BUDGET_NOTICE_RATIO = 0.9
+
+/** The editor's opening height and its ceiling, in pixels. */
+const EDITOR_MIN_HEIGHT_PX = 120
+const EDITOR_MAX_HEIGHT_PX = 320
+
+/**
  * The editor for a session goal's objective.
  *
  * A dialog rather than an input inside the work panel, for two reasons. An
@@ -25,21 +40,61 @@ export interface SetGoalDialogProps {
  * paragraph in. And the panel is a `DropdownMenu as="card"`, whose whole point
  * is that a click inside it does not dismiss it; a form that must close on
  * submit fights that.
+ *
+ * The field is the app's own markdown editor, so a goal is written with the
+ * lists, links and code spans the card renders -- and with the keys the user
+ * already learned in the composer.
  */
 export const SetGoalDialog: Component<SetGoalDialogProps> = (props) => {
-  const [objective, setObjective] = createSignal(props.initialObjective ?? '')
+  /**
+   * The editor's text, as the EDITOR reports it. Never seeded from the prop.
+   *
+   * The editor is built asynchronously, so its document is empty for the first
+   * frames even when this dialog opens to replace an objective. Seeding this
+   * signal from the prop armed the Set goal button during that window, and a
+   * click there ran a send against an empty document and did nothing at all.
+   * Reading the editor makes the button live at exactly the moment a click
+   * works, because the send reads the same document.
+   *
+   * The seed itself arrives here synchronously: a programmatic `set` reports
+   * its text as it applies it. Typing arrives through Milkdown's
+   * `markdownUpdated` listener, which is debounced 200ms -- the same lag the
+   * composer's own Send button lives with, from the same listener. Enter waits
+   * for neither: the editor's send reads the ProseMirror document directly.
+   */
+  const [objective, setObjective] = createSignal('')
+  let triggerSend: (() => void | Promise<void>) | undefined
+  let setEditorContent: ((text: string) => void) | undefined
+
   const trimmed = () => objective().trim()
   // Measured in UTF-8 bytes, the unit the worker's cap counts in. The worker
   // REFUSES an objective over the limit rather than truncating it, so the
   // dialog has to refuse it too or the user meets an error they cannot see the
   // cause of.
-  const overLimit = () => utf8ByteLength(trimmed()) > GOAL_OBJECTIVE_BYTE_LIMIT
+  const usedBytes = () => utf8ByteLength(trimmed())
+  const overLimit = () => usedBytes() > GOAL_OBJECTIVE_BYTE_LIMIT
+  const showsBudget = () => usedBytes() >= GOAL_OBJECTIVE_BYTE_LIMIT * BUDGET_NOTICE_RATIO
+  const canSubmit = () => trimmed() !== '' && !overLimit()
 
-  const submit = (e: Event) => {
-    e.preventDefault()
-    if (trimmed() === '' || overLimit())
-      return
-    props.onSubmit(trimmed())
+  /**
+   * The ONE submit path.
+   *
+   * The editor's own send is what commits, whether the user pressed the key or
+   * the footer button, which calls the same send. There is deliberately no
+   * `type="submit"` button in this dialog: `Dialog` answers a bare Enter by
+   * clicking the first one it finds, and that plus the editor's own Enter
+   * handling would be two routes to one action. With none, Enter belongs to the
+   * editor, and the user's own `enterKeyMode` preference governs it exactly as
+   * it governs the composer.
+   *
+   * Returns `false` when it refuses, which is how the editor knows to keep what
+   * the user wrote.
+   */
+  const submit = (markdown: string): boolean | void => {
+    const text = markdown.trim()
+    if (text === '' || utf8ByteLength(text) > GOAL_OBJECTIVE_BYTE_LIMIT)
+      return false
+    props.onSubmit(text)
     props.onClose()
   }
 
@@ -47,42 +102,62 @@ export const SetGoalDialog: Component<SetGoalDialogProps> = (props) => {
     <Dialog title="Session goal" onClose={props.onClose} data-testid="set-goal-dialog">
       {/* `<section>` and `<footer>`, because Dialog's own stylesheet targets
           `> .body > form > section` and `> .body > form > footer`. A form with
-          neither loses the footer's spacing and the section's scroller. */}
-      <form class={styles.form} onSubmit={submit}>
+          neither loses the footer's spacing and the section's scroller.
+
+          No `onSubmit`: nothing in this form submits it -- see `submit`. */}
+      <form class={styles.form}>
         <section class={styles.field}>
-          <label class={styles.label} for="goal-objective-input">
+          {/* A plain `<div>`, not a `<label>`. The editor is a contenteditable
+              region rather than a form control, so a `for` would name nothing
+              and a click on the label would focus nothing. */}
+          <div class={styles.label}>
             The agent keeps working until this condition holds.
-          </label>
-          <Show when={overLimit()}>
-            <span class={styles.label} data-testid="set-goal-too-long">
-              {`Too long by ${utf8ByteLength(trimmed()) - GOAL_OBJECTIVE_BYTE_LIMIT} bytes. The limit is ${GOAL_OBJECTIVE_BYTE_LIMIT}.`}
+          </div>
+          <MarkdownEditor
+            surface="goal"
+            // No `draftKey`. A persisted draft would resurrect prose the user
+            // abandoned the next time they open Replace, in place of the
+            // objective the worker actually holds -- and the objective, not the
+            // draft, is what Replace exists to edit.
+            onSend={submit}
+            onMarkdownChange={setObjective}
+            requestedHeight={EDITOR_MIN_HEIGHT_PX}
+            maxHeight={EDITOR_MAX_HEIGHT_PX}
+            placeholder="Describe the condition the agent works toward..."
+            imperative={{
+              sendRef: (send) => { triggerSend = send },
+              contentRef: (_get, set) => { setEditorContent = set },
+              // Seeded on ready rather than through a draft key. The editor is
+              // built asynchronously, and `onReady` is the moment it holds a
+              // document to replace.
+              onReady: () => {
+                if (props.initialObjective)
+                  setEditorContent?.(props.initialObjective)
+              },
+            }}
+          />
+          <Show
+            when={overLimit()}
+            fallback={(
+              <Show when={showsBudget()}>
+                <span class={styles.label} data-testid="set-goal-budget">
+                  {`${(GOAL_OBJECTIVE_BYTE_LIMIT - usedBytes()).toLocaleString()} bytes left`}
+                </span>
+              </Show>
+            )}
+          >
+            <span class={errorText} data-testid="set-goal-too-long">
+              {`Too long by ${(usedBytes() - GOAL_OBJECTIVE_BYTE_LIMIT).toLocaleString()} bytes. The limit is ${GOAL_OBJECTIVE_BYTE_LIMIT.toLocaleString()}.`}
             </span>
           </Show>
-          <textarea
-            id="goal-objective-input"
-            class={styles.input}
-            data-testid="set-goal-input"
-            value={objective()}
-            onInput={e => setObjective(e.currentTarget.value)}
-            rows={4}
-            // No `maxlength`. It counts UTF-16 code units and the worker's cap
-            // counts UTF-8 BYTES, so it would let 2000 CJK characters through
-            // (about 6000 bytes) and the worker would refuse them -- a limit
-            // that reads as satisfied while the submit button says otherwise.
-            // The byte count below is the one the worker enforces.
-            // Autofocus is safe HERE and not in the panel: a dialog already took
-            // focus from the page, so claiming it inside costs nothing -- whereas
-            // the panel's popover opens beside a composer the user may be typing
-            // in.
-            autofocus
-          />
         </section>
         <footer class={actionsFooter}>
           <button type="button" class="outline" onClick={() => props.onClose()}>Cancel</button>
           <button
-            type="submit"
+            type="button"
             data-testid="set-goal-submit"
-            disabled={trimmed() === '' || overLimit()}
+            disabled={!canSubmit()}
+            onClick={() => void triggerSend?.()}
           >
             Set goal
           </button>

--- a/frontend/src/components/chat/AgentEditorPanel.test.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.test.tsx
@@ -808,7 +808,7 @@ describe('agent editor panel', () => {
     expect(onSendMessage).toHaveBeenCalledWith('draft a', [attachmentA])
 
     setAgentId('a2')
-    await waitFor(() => expect(document.querySelector('[data-testid="chat-editor"] .ProseMirror')).toHaveTextContent('draft b'))
+    await waitFor(() => expect(document.querySelector('[data-testid="composer-editor"] .ProseMirror')).toHaveTextContent('draft b'))
     finishEnqueue?.()
     // Wait on the draft that the send clears, not on the composer re-opening:
     // the attachment paths open one microtask before the editor clears its
@@ -816,7 +816,7 @@ describe('agent editor panel', () => {
     await waitFor(async () => expect((await loadDraft('a1')).content).toBe(''))
 
     expect(screen.getByTestId('file-input')).not.toBeDisabled()
-    expect(document.querySelector('[data-testid="chat-editor"] .ProseMirror')).toHaveTextContent('draft b')
+    expect(document.querySelector('[data-testid="composer-editor"] .ProseMirror')).toHaveTextContent('draft b')
     expect((await loadDraft('a2')).content).toBe('draft b')
     expect(getAttachments('a1')).toEqual([])
     expect(getAttachments('a2')).toEqual([attachmentB])
@@ -863,17 +863,17 @@ describe('agent editor panel', () => {
         />
       </PreferencesProvider>
     ))
-    await waitFor(() => expect(document.querySelector('[data-testid="chat-editor"] .ProseMirror')).toHaveTextContent('saved a1 edit'))
+    await waitFor(() => expect(document.querySelector('[data-testid="composer-editor"] .ProseMirror')).toHaveTextContent('saved a1 edit'))
     send?.()
     expect(onUpdateQueueItem).toHaveBeenCalledWith(expect.objectContaining({ agentId: 'a1' }), 'saved a1 edit', [])
 
     setAgentId('a2')
-    await waitFor(() => expect(document.querySelector('[data-testid="chat-editor"] .ProseMirror')).toHaveTextContent('full a2'))
+    await waitFor(() => expect(document.querySelector('[data-testid="composer-editor"] .ProseMirror')).toHaveTextContent('full a2'))
     finishSave?.()
     await waitFor(() => expect(screen.getByTestId('file-input')).not.toBeDisabled())
 
     expect(onBeginQueueEdit.mock.calls.filter(([item]) => item.agentId === 'a2')).toHaveLength(1)
-    expect(document.querySelector('[data-testid="chat-editor"] .ProseMirror')).toHaveTextContent('full a2')
+    expect(document.querySelector('[data-testid="composer-editor"] .ProseMirror')).toHaveTextContent('full a2')
     expect(screen.getByRole('button', { name: 'Cancel Edit' })).toBeInTheDocument()
   })
 

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -625,7 +625,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
           disabled={disabled()}
           disabledPlaceholder={props.disabledReason}
           onTogglePlanMode={ctrl.togglePlanMode}
-          requestedHeight={editorMinHeightSignal()}
+          pinnedHeight={editorMinHeightSignal()}
           maxHeight={editorHeight.maxEditorHeight()}
           onContentHeightChange={setEditorContentHeight}
           onContentChange={(has) => {

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -608,6 +608,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
           data-testid="file-input"
         />
         <MarkdownEditor
+          surface="chat"
           suppressAutoFocus={props.suppressAutoFocus}
           draftKey={{
             agentId: props.agentId,

--- a/frontend/src/components/chat/ControlRequestBanner.css.ts
+++ b/frontend/src/components/chat/ControlRequestBanner.css.ts
@@ -214,20 +214,6 @@ export const controlRequestPill = style({
   flexShrink: 1,
 })
 
-export const collapsibleToggle = style({
-  'all': 'unset',
-  'display': 'inline',
-  'fontSize': 'var(--text-8)',
-  'color': 'var(--muted-foreground)',
-  'cursor': 'pointer',
-  'textDecoration': 'underline',
-  'textDecorationStyle': 'dotted',
-  'textUnderlineOffset': '2px',
-  ':hover': {
-    color: 'var(--foreground)',
-  },
-})
-
 export const bannerReason = style({
   fontSize: 'var(--text-7)',
   color: 'var(--foreground)',

--- a/frontend/src/components/chat/composer/composer.css.ts
+++ b/frontend/src/components/chat/composer/composer.css.ts
@@ -124,10 +124,10 @@ export const plusButton = style({
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
-  // Sized to match the single-line text area height (--composer-btn-h, defined
+  // Sized to match the single-line text area height (--editor-btn-h, defined
   // on the MarkdownEditor container), kept square.
-  width: 'var(--composer-btn-h)',
-  height: 'var(--composer-btn-h)',
+  width: 'var(--editor-btn-h)',
+  height: 'var(--editor-btn-h)',
   borderRadius: 'var(--radius-small)',
   color: 'var(--muted-foreground)',
   backgroundColor: 'var(--muted)',

--- a/frontend/src/components/chat/controls/CollapsibleList.tsx
+++ b/frontend/src/components/chat/controls/CollapsibleList.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'solid-js'
 import { createSignal, For, Show } from 'solid-js'
-import { collapsibleToggle } from '~/styles/shared.css'
+import { CollapsibleToggle } from '~/components/common/CollapsibleToggle'
 
 interface CollapsibleListProps<T> {
   items: T[]
@@ -27,16 +27,16 @@ export function CollapsibleList<T>(props: CollapsibleListProps<T>): JSX.Element 
       <For each={visibleItems()}>
         {item => props.renderItem(item)}
       </For>
+      {/* No `controls`: the items are siblings with no wrapper to point at.
+          `aria-expanded` still states the open state, which is the half that
+          matters most here. */}
       <Show when={shouldCollapse()}>
-        <button
-          type="button"
-          class={collapsibleToggle}
-          onClick={() => setExpanded(prev => !prev)}
-        >
-          {expanded()
-            ? (props.lessLabel ?? 'Show less')
-            : (props.moreLabel?.(hiddenCount()) ?? `Show ${hiddenCount()} more\u2026`)}
-        </button>
+        <CollapsibleToggle
+          expanded={expanded()}
+          onToggle={() => setExpanded(prev => !prev)}
+          moreLabel={props.moreLabel?.(hiddenCount()) ?? `Show ${hiddenCount()} more\u2026`}
+          lessLabel={props.lessLabel}
+        />
       </Show>
     </>
   )

--- a/frontend/src/components/chat/controls/CollapsibleList.tsx
+++ b/frontend/src/components/chat/controls/CollapsibleList.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'solid-js'
 import { createSignal, For, Show } from 'solid-js'
-import * as styles from '../ControlRequestBanner.css'
+import { collapsibleToggle } from '~/styles/shared.css'
 
 interface CollapsibleListProps<T> {
   items: T[]
@@ -29,7 +29,8 @@ export function CollapsibleList<T>(props: CollapsibleListProps<T>): JSX.Element 
       </For>
       <Show when={shouldCollapse()}>
         <button
-          class={styles.collapsibleToggle}
+          type="button"
+          class={collapsibleToggle}
           onClick={() => setExpanded(prev => !prev)}
         >
           {expanded()

--- a/frontend/src/components/chat/controls/CollapsibleText.test.tsx
+++ b/frontend/src/components/chat/controls/CollapsibleText.test.tsx
@@ -43,6 +43,28 @@ describe('collapsibleText', () => {
     expect(screen.getByRole('button')).toHaveTextContent('Show less')
   })
 
+  /**
+   * The disclosure states whether it is open, and which block it opens.
+   *
+   * Without them a screen reader announces the label and no state, and
+   * activating the control announces nothing at all. `CollapsibleToggle` owns
+   * both attributes for all three disclosures in the app, so this pins the
+   * contract at one of its call sites.
+   */
+  it('states its open state and the block it controls', () => {
+    render(() => <CollapsibleText text={'line 1\nline 2\nline 3'} maxLines={2} />)
+
+    const toggle = screen.getByRole('button')
+    const body = document.querySelector('pre')!
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(toggle.getAttribute('aria-controls')).toBe(body.id)
+    expect(body.id).not.toBe('')
+
+    fireEvent.click(toggle)
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+  })
+
   it('collapses back when toggle is clicked twice', () => {
     render(() => <CollapsibleText text={'line 1\nline 2\nline 3\nline 4\nline 5'} maxLines={2} />)
 

--- a/frontend/src/components/chat/controls/CollapsibleText.tsx
+++ b/frontend/src/components/chat/controls/CollapsibleText.tsx
@@ -2,7 +2,7 @@ import type { JSX } from 'solid-js'
 import { createSignal, Show } from 'solid-js'
 import { Dynamic } from 'solid-js/web'
 import { pluralize } from '~/lib/plural'
-import * as styles from '../ControlRequestBanner.css'
+import { collapsibleToggle } from '~/styles/shared.css'
 
 interface CollapsibleTextProps {
   text: string
@@ -29,7 +29,8 @@ export function CollapsibleText(props: CollapsibleTextProps): JSX.Element {
       <Dynamic component={props.tag ?? 'pre'} class={props.class}>{visibleText()}</Dynamic>
       <Show when={shouldCollapse()}>
         <button
-          class={styles.collapsibleToggle}
+          type="button"
+          class={collapsibleToggle}
           onClick={() => setExpanded(prev => !prev)}
         >
           {expanded()

--- a/frontend/src/components/chat/controls/CollapsibleText.tsx
+++ b/frontend/src/components/chat/controls/CollapsibleText.tsx
@@ -1,8 +1,8 @@
 import type { JSX } from 'solid-js'
-import { createSignal, Show } from 'solid-js'
+import { createSignal, createUniqueId, Show } from 'solid-js'
 import { Dynamic } from 'solid-js/web'
+import { CollapsibleToggle } from '~/components/common/CollapsibleToggle'
 import { pluralize } from '~/lib/plural'
-import { collapsibleToggle } from '~/styles/shared.css'
 
 interface CollapsibleTextProps {
   text: string
@@ -15,6 +15,7 @@ interface CollapsibleTextProps {
 
 export function CollapsibleText(props: CollapsibleTextProps): JSX.Element {
   const [expanded, setExpanded] = createSignal(false)
+  const bodyId = createUniqueId()
 
   const lines = () => props.text.split('\n')
   const shouldCollapse = () => lines().length > props.maxLines
@@ -26,17 +27,14 @@ export function CollapsibleText(props: CollapsibleTextProps): JSX.Element {
 
   return (
     <>
-      <Dynamic component={props.tag ?? 'pre'} class={props.class}>{visibleText()}</Dynamic>
+      <Dynamic component={props.tag ?? 'pre'} class={props.class} id={bodyId}>{visibleText()}</Dynamic>
       <Show when={shouldCollapse()}>
-        <button
-          type="button"
-          class={collapsibleToggle}
-          onClick={() => setExpanded(prev => !prev)}
-        >
-          {expanded()
-            ? 'Show less'
-            : `Show ${pluralize(hiddenCount(), 'more line')}\u2026`}
-        </button>
+        <CollapsibleToggle
+          expanded={expanded()}
+          onToggle={() => setExpanded(prev => !prev)}
+          controls={bodyId}
+          moreLabel={`Show ${pluralize(hiddenCount(), 'more line')}\u2026`}
+        />
       </Show>
     </>
   )

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
@@ -33,6 +33,22 @@ export const container = style({
 })
 
 /**
+ * A box with no `[+]` button reserves no column for one.
+ *
+ * The VARIABLE is overridden, not the padding, so every value derived from it
+ * moves together: the ProseMirror's left padding, the action slot's width cap,
+ * the full-width footer's left edge, and the hidden probe in `./composerLayout`
+ * that measures the collapsed left pad through inheritance. A rule that
+ * overrode the padding alone would leave those three measuring a column that no
+ * longer exists.
+ */
+globalStyle(`${container}:not([data-plus])`, {
+  vars: {
+    '--composer-left-pad': 'var(--space-2)',
+  },
+})
+
+/**
  * The editor row holds the editor body and the two overlay slots: the `[+]`
  * button (left) and the action cluster (right). The slots are absolutely
  * positioned so they can hug the top corners when the content is a single

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
@@ -18,12 +18,12 @@ export const container = style({
   // the action buttons, the editor wrapper min-height, the separator position,
   // and the ProseMirror paddings — all derived from this single value.
   vars: {
-    '--composer-btn-h': 'calc(var(--text-7) * var(--leading-normal) + var(--space-1) * 2)',
+    '--editor-btn-h': 'calc(var(--text-7) * var(--leading-normal) + var(--space-1) * 2)',
     // Collapsed-mode left padding of the text area: the `[+]` button's left
     // offset + its width + a gap. Declared here so the stylesheet below and
     // the expand/collapse measurement in MarkdownEditor.tsx read one value
     // instead of each spelling the same calc().
-    '--composer-left-pad': 'calc(var(--space-1) + var(--composer-btn-h) + var(--space-1))',
+    '--editor-left-pad': 'calc(var(--space-1) + var(--editor-btn-h) + var(--space-1))',
   },
   selectors: {
     '&:focus-within': {
@@ -37,14 +37,14 @@ export const container = style({
  *
  * The VARIABLE is overridden, not the padding, so every value derived from it
  * moves together: the ProseMirror's left padding, the action slot's width cap,
- * the full-width footer's left edge, and the hidden probe in `./composerLayout`
+ * the full-width footer's left edge, and the hidden probe in `./editorLayout`
  * that measures the collapsed left pad through inheritance. A rule that
  * overrode the padding alone would leave those three measuring a column that no
  * longer exists.
  */
 globalStyle(`${container}:not([data-plus])`, {
   vars: {
-    '--composer-left-pad': 'var(--space-2)',
+    '--editor-left-pad': 'var(--space-2)',
   },
 })
 
@@ -65,7 +65,7 @@ export const editorRow = style({
   // Min-height fits the button height (text-7 * leading-normal + space-1 * 2)
   // plus a space-1 gap above and below.
   'alignItems': 'center',
-  'minHeight': 'calc(var(--composer-btn-h) + var(--space-1) * 2)',
+  'minHeight': 'calc(var(--editor-btn-h) + var(--space-1) * 2)',
   // The expanded state reserves the button row here (see below). Animating it
   // is what grows and shrinks the box as the layout mode flips.
   '@media': {
@@ -109,7 +109,7 @@ export const footerSlot = style({
   // `~/components/chat/ChatView.css.ts` is this slot's only child, so the
   // `flex-wrap` that moves a button onto a second line belongs there, and the
   // cluster also declares `min-width: 0` so the cap can actually compress it.
-  // `composerLayout` measures the slot's height into `--composer-actions-h`,
+  // `editorLayout` measures the slot's height into `--editor-actions-h`,
   // and the expanded layout reserves it, so a wrapped row pushes the text up
   // instead of covering it.
   //
@@ -126,7 +126,7 @@ export const footerSlot = style({
   pointerEvents: 'none',
   selectors: {
     '&:not([data-full-width])': {
-      maxWidth: 'calc(100% - var(--composer-left-pad) - var(--space-1))',
+      maxWidth: 'calc(100% - var(--editor-left-pad) - var(--space-1))',
     },
   },
 })
@@ -152,7 +152,7 @@ globalStyle(`${footerSlot} > *`, {
 // than the item, so a future non-action control placed there keeps its own
 // size too.
 globalStyle(`${footerSlot} button:not(.${paginationContainer} button)`, {
-  height: 'var(--composer-btn-h)',
+  height: 'var(--editor-btn-h)',
   padding: '0 var(--space-2)',
   fontSize: 'var(--text-8)',
   lineHeight: 1,
@@ -176,14 +176,14 @@ globalStyle(`${container}[data-expanded] ${footerSlot}`, {
 // Control-request footers (full-width two-zone action rows) stretch across the
 // box instead of hugging the right corner.
 //
-// The left edge stops at `--composer-left-pad`, not at `space-1`, because the
+// The left edge stops at `--editor-left-pad`, not at `space-1`, because the
 // `[+]` button sits at `space-1` on this same bottom line and stays rendered
 // during a control request. A row that started at `space-1` covered it
 // outright, which a narrow composer made obvious. This rule sets no
 // `max-width`: the base rule above scopes its cap to
 // `:not([data-full-width])`, so there is nothing here to undo.
 globalStyle(`${container}[data-expanded] ${footerSlot}[data-full-width]`, {
-  left: 'var(--composer-left-pad)',
+  left: 'var(--editor-left-pad)',
   right: 'var(--space-1)',
 })
 
@@ -260,7 +260,7 @@ export const editorWrapper = style({
   // Min-height matches one line of text (font-size * line-height) plus the
   // ProseMirror's top/bottom padding (space-1 * 2), so the editor wrapper is
   // exactly as tall as its content — no extra space to misalign the placeholder.
-  minHeight: 'var(--composer-btn-h)',
+  minHeight: 'var(--editor-btn-h)',
   maxHeight: '50vh',
   overflowY: 'auto',
 })
@@ -279,7 +279,7 @@ export const editorSeparator = style({
   // separator and the row. Row top = bottom(space-1) + the row's measured
   // height; the separator is space-1 above that. The fallback is one button
   // height, which is what the row measures until the ResizeObserver runs.
-  'bottom': 'calc(var(--composer-actions-h, var(--composer-btn-h)) + var(--space-1) * 2)',
+  'bottom': 'calc(var(--editor-actions-h, var(--editor-btn-h)) + var(--space-1) * 2)',
   'height': '1px',
   'backgroundColor': 'transparent',
   'pointerEvents': 'none',
@@ -303,7 +303,7 @@ globalStyle(`${container}[data-expanded] ${editorSeparator}`, {
 // state the `[+]` and actions sit on their own bottom row, so the text area
 // drops to the normal small padding and uses the box's full width.
 globalStyle(`${editorWrapper} .ProseMirror`, {
-  'padding': 'var(--space-1) var(--composer-right-pad, 96px) var(--space-1) var(--composer-left-pad)',
+  'padding': 'var(--space-1) var(--editor-right-pad, 96px) var(--space-1) var(--editor-left-pad)',
   'outline': 'none',
   'minHeight': '20px',
   'whiteSpace': 'pre-wrap',
@@ -334,7 +334,7 @@ globalStyle(`${container}[data-expanded] ${editorWrapper} .ProseMirror`, {
 // The reservation is: gap above separator (space-1) + separator + gap below
 // separator to the row (space-1) + the row's height + bottom offset (space-1).
 //
-// The height is the MEASURED one (--composer-actions-h, written by
+// The height is the MEASURED one (--editor-actions-h, written by
 // MarkdownEditor.tsx from a ResizeObserver), not a fixed button height. The row
 // is an absolutely positioned overlay anchored to the bottom edge, so a
 // reservation shorter than the row does not grow the box -- the row grows
@@ -343,7 +343,7 @@ globalStyle(`${container}[data-expanded] ${editorWrapper} .ProseMirror`, {
 // ExitPlanMode puts a column of approval switches beside Approve) does exactly
 // that. The fallback covers the frames before the first measurement.
 globalStyle(`${container}[data-expanded] ${editorRow}`, {
-  paddingBottom: 'calc(var(--composer-actions-h, var(--composer-btn-h)) + var(--space-1) * 3)',
+  paddingBottom: 'calc(var(--editor-actions-h, var(--editor-btn-h)) + var(--space-1) * 3)',
 })
 
 // Code blocks: move scroll to <code> so the language label stays fixed.

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.test.tsx
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.test.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor } from '@solidjs/testing-library'
-import { createSignal } from 'solid-js'
+import { createSignal, Show } from 'solid-js'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { PreferencesProvider } from '~/context/PreferencesContext'
 import { flushStorageWrites } from '~/lib/browserStorage'
@@ -269,14 +269,14 @@ describe('markdownEditor surface', () => {
     ))
     await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
     expect(container.querySelector('[data-testid="composer-box"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="chat-editor"][data-chat-input]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="composer-editor"][data-chat-input]')).not.toBeNull()
   })
 
   /**
    * `useShortcuts` reads `data-chat-input` for the `chatInputFocused` context,
    * and `$mod+j` maps to `chat.sendMessage` there -- so a goal editor carrying
    * it would send a chat message from inside a dialog. The test ids are the
-   * same fact: about twenty E2E specs address `chat-editor` with an unscoped
+   * same fact: about twenty E2E specs address `composer-editor` with an unscoped
    * locator, which a second element of that name breaks.
    */
   it('leaves every chat marker off another surface', async () => {
@@ -286,14 +286,14 @@ describe('markdownEditor surface', () => {
       </PreferencesProvider>
     ))
     await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
-    expect(container.querySelector('[data-testid="goal-editor-box"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="goal-box"]')).not.toBeNull()
     expect(container.querySelector('[data-testid="goal-editor"]')).not.toBeNull()
     expect(container.querySelector('[data-chat-input]')).toBeNull()
-    // Every id, not only the two that name the editor. The three layout slots
+    // Every id, not only the two that identify the editor. The three layout slots
     // would put the same collision back for anything that addresses one.
-    for (const id of ['chat-editor', 'composer-box', 'composer-plus-slot', 'composer-separator', 'composer-footer-slot'])
+    for (const id of ['composer-editor', 'composer-box', 'composer-plus-slot', 'composer-separator', 'composer-footer-slot'])
       expect(container.querySelector(`[data-testid="${id}"]`), id).toBeNull()
-    expect(container.querySelector('[data-testid="goal-editor-footer-slot"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="goal-footer-slot"]')).not.toBeNull()
   })
 
   // The stylesheet reserves a left column for the `[+]` button. A box with no
@@ -316,13 +316,45 @@ describe('markdownEditor surface', () => {
       </PreferencesProvider>
     ))
     await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
-    expect(container.querySelector('[data-testid="goal-editor-box"]')).not.toHaveAttribute('data-plus')
+    expect(container.querySelector('[data-testid="goal-box"]')).not.toHaveAttribute('data-plus')
+  })
+
+  /**
+   * A slot that RESOLVES to nothing reserves nothing either.
+   *
+   * `children()` gives an ARRAY for a fragment, and `[]` is truthy -- so a bare
+   * truthiness test on the resolved node reads an empty fragment, an empty
+   * `<For>`, or a fragment of falsy entries as "a button is there" and leaves a
+   * ~40px gutter with nothing in it.
+   */
+  it.each([
+    ['an empty fragment', <></>],
+    [
+      'a fragment of falsy entries',
+      <>
+        {false && <button type="button">a</button>}
+        {null}
+      </>,
+    ],
+    ['a bare false', false],
+  ])('reserves no left column for %s', async (_name, plus) => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor surface="chat" onSend={() => {}} plus={plus} />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+    expect(container.querySelector('[data-testid="composer-box"]')).not.toHaveAttribute('data-plus')
   })
 
   /**
    * `onContentChange` answers "is there anything here"; this one carries the
    * text. The goal dialog measures the objective's UTF-8 length against the
    * worker's cap, which the boolean cannot answer.
+   *
+   * The assertion is the WHOLE serialized string, not a substring of the input.
+   * A `toContain` on the text just handed to `set` passes even when the editor
+   * parsed nothing, because `set` used to echo its own argument back.
    */
   it('reports the document text to its host', async () => {
     const seen: string[] = []
@@ -339,6 +371,186 @@ describe('markdownEditor surface', () => {
     ))
     await waitFor(() => expect(setContent).toBeTypeOf('function'))
     setContent?.('ship the **auth refactor**')
-    await waitFor(() => expect(seen.at(-1)).toContain('auth refactor'))
+    await waitFor(() => expect(seen.at(-1)?.trim()).toBe('ship the **auth refactor**'))
+  })
+
+  /**
+   * A caption outside the editor names the contenteditable.
+   *
+   * It has to land on the `.ProseMirror` element, not on the wrapper: the
+   * wrapper is not the editable region, so naming it names nothing and a
+   * screen reader announces an unnamed editable area.
+   */
+  it('names the contenteditable from the caption its host points at', async () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor surface="goal" ariaLabelledBy="the-caption" onSend={() => {}} />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+    expect(container.querySelector('.ProseMirror')?.getAttribute('aria-labelledby')).toBe('the-caption')
+  })
+
+  /**
+   * `minHeight` is a FLOOR, so the ceiling still binds.
+   *
+   * `pinnedHeight` -- the composer's dragged handle -- becomes a fixed height
+   * once the content passes it, which stops `maxHeight` from ever applying. A
+   * host that wants a comfortable opening size and room to grow states
+   * `minHeight`, and both values must reach the box.
+   */
+  it('applies a floor and a ceiling together for a host that states minHeight', async () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor surface="goal" minHeight={120} maxHeight={320} onSend={() => {}} />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+    const wrapper = container.querySelector('[data-testid="goal-editor"]') as HTMLElement
+    expect(wrapper.style.minHeight).toBe('120px')
+    expect(wrapper.style.maxHeight).toBe('320px')
+    // Never a fixed height: that is what would make the ceiling unreachable.
+    expect(wrapper.style.height).toBe('')
+  })
+
+  /**
+   * A seeded document is announced at all, and announced as the DOCUMENT.
+   *
+   * Milkdown's `markdownUpdated` listener never fires for `defaultValueCtx`, so
+   * without this emit a host with `onMarkdownChange` learns nothing until the
+   * reader types. The value is the round trip, not the prop: the goal dialog
+   * measures it against the worker's byte cap, and the escaped form is what a
+   * send would actually submit.
+   */
+  it('reports the serialized document for an initialMarkdown seed', async () => {
+    const seen: string[] = []
+    render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor
+          surface="goal"
+          initialMarkdown="Stop when 2 * 3 = 6"
+          onSend={() => {}}
+          onMarkdownChange={md => seen.push(md)}
+        />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0))
+    expect(seen.at(-1)?.trim()).toBe('Stop when 2 \\* 3 = 6')
+  })
+
+  /**
+   * The seed WINS over a stored draft.
+   *
+   * A host that states the starting text is editing a specific document; the
+   * draft is what it abandoned last time. Showing the draft would silently edit
+   * the wrong thing.
+   */
+  it('prefers an initialMarkdown seed over a stored draft', async () => {
+    const KEY = 'seed-beats-draft'
+    await saveDraft(KEY, 'the abandoned draft', -1)
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor
+          surface="goal"
+          draftKey={{ key: KEY }}
+          initialMarkdown="the real objective"
+          onSend={() => {}}
+        />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).toHaveTextContent('the real objective'))
+    expect(container.querySelector('.ProseMirror')).not.toHaveTextContent('abandoned')
+  })
+
+  /**
+   * A loaded DRAFT is reported the same way: from the document, not from the
+   * stored string.
+   *
+   * Milkdown's `markdownUpdated` listener never fires for a document seeded
+   * through `defaultValueCtx`, so this one emit is everything a host with
+   * `onMarkdownChange` learns about a restored draft — and it has to be the
+   * text a send would submit.
+   */
+  it('reports the serialized document for a loaded draft, not the stored string', async () => {
+    const KEY = 'draft-round-trip'
+    await saveDraft(KEY, 'Stop when 2 * 3 = 6', -1)
+    const seen: string[] = []
+    render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor
+          surface="chat"
+          draftKey={{ key: KEY }}
+          onSend={() => {}}
+          onMarkdownChange={md => seen.push(md)}
+        />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0))
+    expect(seen.at(-1)?.trim()).toBe('Stop when 2 \\* 3 = 6')
+  })
+
+  /**
+   * A programmatic `set` reports what the DOCUMENT holds, not the string it was
+   * handed.
+   *
+   * The round trip through ProseMirror is not the identity: it escapes a bare
+   * `*` so the text cannot be re-read as emphasis. A host that mirrors this
+   * report -- the goal dialog measures it against the worker's byte cap --
+   * otherwise holds a string that differs from the one a send would submit, and
+   * corrects itself a debounce later with no keystroke.
+   */
+  it('reports the serialized document after a programmatic set, not the raw seed', async () => {
+    const seen: string[] = []
+    let setContent: ((text: string) => void) | undefined
+    render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor
+          surface="goal"
+          onSend={() => {}}
+          onMarkdownChange={md => seen.push(md)}
+          imperative={{ contentRef: (_get, set) => { setContent = set } }}
+        />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(setContent).toBeTypeOf('function'))
+    setContent?.('Stop when 2 * 3 = 6')
+    await waitFor(() => expect(seen.at(-1)?.trim()).toBe('Stop when 2 \\* 3 = 6'))
+  })
+
+  /**
+   * A host that unmounts the editor from inside its own `onSend` -- which
+   * `SetGoalDialog` does, by closing on a successful submit -- leaves the send's
+   * continuation running against a destroyed editor. It must not rebuild the
+   * document there, and it must still clear the draft, or `onCleanup` leaves the
+   * SENT text behind as a draft that reappears on the next open.
+   */
+  it('does not touch a disposed editor after a send that unmounted it', async () => {
+    const KEY = 'disposed-after-send'
+    await saveDraft(KEY, 'the sent message', -1)
+    const seen: string[] = []
+    let send: (() => void | Promise<void>) | undefined
+    const [open, setOpen] = createSignal(true)
+    render(() => (
+      <PreferencesProvider>
+        <Show when={open()} keyed>
+          <MarkdownEditor
+            surface="chat"
+            draftKey={{ key: KEY }}
+            onSend={() => { setOpen(false) }}
+            onMarkdownChange={md => seen.push(md)}
+            imperative={{ sendRef: (fn) => { send = fn } }}
+          />
+        </Show>
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(send).toBeTypeOf('function'))
+    await waitFor(() => expect(seen.at(-1)).toContain('the sent message'))
+    const before = seen.length
+
+    await send?.()
+
+    // No report from the disposed editor: the reset never ran.
+    expect(seen.length).toBe(before)
+    expect(await loadDraft(KEY)).toEqual({ content: '', cursor: -1 })
   })
 })

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.test.tsx
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.test.tsx
@@ -81,6 +81,7 @@ describe('markdownEditor send', () => {
     render(() => (
       <PreferencesProvider>
         <MarkdownEditor
+          surface="chat"
           draftKey={{ key: DRAFT_KEY }}
           onSend={() => {}}
           onAfterSend={() => { throw resetFailure }}
@@ -109,6 +110,7 @@ describe('markdownEditor send', () => {
     render(() => (
       <PreferencesProvider>
         <MarkdownEditor
+          surface="chat"
           draftKey={{ key: DRAFT_KEY }}
           onSend={() => Promise.resolve().then(() => { outside.focus() })}
           imperative={{ sendRef: (fn) => { send = fn } }}
@@ -155,6 +157,7 @@ describe('markdownEditor autofocus', () => {
     render(() => (
       <PreferencesProvider>
         <MarkdownEditor
+          surface="chat"
           draftKey={{ key: FOCUS_KEY }}
           onSend={() => {}}
           suppressAutoFocus={suppressAutoFocus}
@@ -219,6 +222,7 @@ describe('markdownEditor draft key swaps', () => {
     const { container } = render(() => (
       <PreferencesProvider>
         <MarkdownEditor
+          surface="chat"
           draftKey={{ key: key() }}
           onSend={() => {}}
           imperative={{ sendRef: (fn) => { send = fn } }}
@@ -248,5 +252,93 @@ describe('markdownEditor draft key swaps', () => {
     // draft the user never even opened.
     expect((await loadDraft(KEY_B)).content).toBe('the B document')
     expect((await loadDraft(KEY_A)).content).toBe('the A document')
+  })
+})
+
+/**
+ * The composer is one of the editor's hosts, and the session-goal dialog is
+ * another. What separates them is one prop, because the two markers below are
+ * one fact -- see `MarkdownEditorSurface`.
+ */
+describe('markdownEditor surface', () => {
+  it('marks the chat composer as the chat input', async () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor surface="chat" onSend={() => {}} />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+    expect(container.querySelector('[data-testid="composer-box"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="chat-editor"][data-chat-input]')).not.toBeNull()
+  })
+
+  /**
+   * `useShortcuts` reads `data-chat-input` for the `chatInputFocused` context,
+   * and `$mod+j` maps to `chat.sendMessage` there -- so a goal editor carrying
+   * it would send a chat message from inside a dialog. The test ids are the
+   * same fact: about twenty E2E specs address `chat-editor` with an unscoped
+   * locator, which a second element of that name breaks.
+   */
+  it('leaves every chat marker off another surface', async () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor surface="goal" onSend={() => {}} />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+    expect(container.querySelector('[data-testid="goal-editor-box"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="goal-editor"]')).not.toBeNull()
+    expect(container.querySelector('[data-chat-input]')).toBeNull()
+    // Every id, not only the two that name the editor. The three layout slots
+    // would put the same collision back for anything that addresses one.
+    for (const id of ['chat-editor', 'composer-box', 'composer-plus-slot', 'composer-separator', 'composer-footer-slot'])
+      expect(container.querySelector(`[data-testid="${id}"]`), id).toBeNull()
+    expect(container.querySelector('[data-testid="goal-editor-footer-slot"]')).not.toBeNull()
+  })
+
+  // The stylesheet reserves a left column for the `[+]` button. A box with no
+  // `[+]` would otherwise start its text about 40px in, for a control that is
+  // not there.
+  it('reserves the left column only for a box that has a [+] button', async () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor surface="chat" onSend={() => {}} plus={<button type="button">+</button>} />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+    expect(container.querySelector('[data-testid="composer-box"]')).toHaveAttribute('data-plus')
+  })
+
+  it('reserves no left column for a box with no [+] button', async () => {
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor surface="goal" onSend={() => {}} />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(container.querySelector('.ProseMirror')).not.toBeNull())
+    expect(container.querySelector('[data-testid="goal-editor-box"]')).not.toHaveAttribute('data-plus')
+  })
+
+  /**
+   * `onContentChange` answers "is there anything here"; this one carries the
+   * text. The goal dialog measures the objective's UTF-8 length against the
+   * worker's cap, which the boolean cannot answer.
+   */
+  it('reports the document text to its host', async () => {
+    const seen: string[] = []
+    let setContent: ((text: string) => void) | undefined
+    render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor
+          surface="goal"
+          onSend={() => {}}
+          onMarkdownChange={md => seen.push(md)}
+          imperative={{ contentRef: (_get, set) => { setContent = set } }}
+        />
+      </PreferencesProvider>
+    ))
+    await waitFor(() => expect(setContent).toBeTypeOf('function'))
+    setContent?.('ship the **auth refactor**')
+    await waitFor(() => expect(seen.at(-1)).toContain('auth refactor'))
   })
 })

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.tsx
@@ -7,17 +7,18 @@ import type { TrailingDebounced } from '~/lib/debounce'
 import type { LinkRange } from '~/lib/editor/linkPlugin'
 import { editorViewCtx, serializerCtx } from '@milkdown/core'
 import { replaceAll } from '@milkdown/utils'
-import { children, createEffect, createSignal, getOwner, on, onCleanup, onMount, runWithOwner } from 'solid-js'
+import { children, createEffect, createSignal, getOwner, on, onCleanup, onMount, runWithOwner, Show } from 'solid-js'
 import { isTauriApp, readClipboardImage } from '~/api/platformBridge'
 import { usePreferences } from '~/context/PreferencesContext'
 import { loadDraft } from '~/lib/editor/draftPersistence'
 import { createLogger } from '~/lib/logger'
 import { dismissSoftKeyboard, isSoftKeyboardVisible } from '~/lib/softKeyboard'
 import { syntaxThemeGeneration } from '~/lib/syntaxThemeStore'
+import { errorText } from '~/styles/shared.css'
 import { CodeLanguagePopover } from './CodeLanguagePopover'
-import { createComposerLayout } from './composerLayout'
 import { clearDraft, createDraftSwapper, restoreCursor, saveDraftFromEditor } from './draftManagement'
 import { applyCodeBlockLanguage, applyLinkHref, removeLinkRange } from './editorCommands'
+import { createEditorLayout } from './editorLayout'
 import { setupEditorRefHandlers } from './editorRefHandlers'
 import { buildEditor, computeDocStats, refreshEditorHighlight } from './editorSetup'
 import { LinkPopover } from './LinkPopover'
@@ -46,27 +47,46 @@ export type MarkdownEditorSurface = 'chat' | 'goal'
  * Every surface's markers.
  *
  * A `Record` over the union, so a new surface fails to compile until it states
- * all four. An array of pairs type-checked with any subset, which is how a new
+ * both. An array of pairs type-checked with any subset, which is how a new
  * surface would ship with the composer's own test id.
  *
- * EVERY test id this component writes comes from here. Three of them name
- * layout slots rather than the editor itself, and leaving those shared would
- * put the whole collision back for anything that addresses one: a spec with a
- * goal dialog open resolves two `composer-footer-slot` elements and Playwright's
- * strict mode fails it.
+ * ONE prefix per surface, from which `testIds` derives every id this component
+ * writes. Spelling them out separately let `chat` disagree with itself --
+ * `chat-editor` beside `composer-box` -- and made a third surface four strings
+ * to copy rather than one to choose.
  */
 const SURFACE_MARKERS: Record<MarkdownEditorSurface, {
-  /** `data-testid` for the outer box, whose `data-expanded` states the layout. */
-  boxTestId: string
-  /** `data-testid` for the ProseMirror host. */
-  editorTestId: string
-  /** Leads the `data-testid` of each layout slot inside the box. */
-  slotPrefix: string
+  /** Leads the `data-testid` of the box, the editor and every layout slot. */
+  testIdPrefix: string
   /** Whether `chatInputFocused` treats focus here as the message composer. */
   chatInput: boolean
 }> = {
-  chat: { boxTestId: 'composer-box', editorTestId: 'chat-editor', slotPrefix: 'composer', chatInput: true },
-  goal: { boxTestId: 'goal-editor-box', editorTestId: 'goal-editor', slotPrefix: 'goal-editor', chatInput: false },
+  chat: { testIdPrefix: 'composer', chatInput: true },
+  goal: { testIdPrefix: 'goal', chatInput: false },
+}
+
+/**
+ * The six `data-testid` values of one surface.
+ *
+ * DERIVED, never declared per surface, so a surface cannot carry another one's
+ * id for a single element: a spec with the goal dialog open would otherwise
+ * resolve two `composer-footer-slot` elements and fail Playwright's strict
+ * mode.
+ *
+ * The prefixes must stay distinct from any id the rest of the app writes. The
+ * work panel's rule above its task rows is `goal-card-separator` for exactly
+ * that reason -- it and the goal editor are on screen together while the dialog
+ * is open.
+ */
+function testIds(prefix: string) {
+  return {
+    box: `${prefix}-box`,
+    editor: `${prefix}-editor`,
+    buildFailed: `${prefix}-build-failed`,
+    plusSlot: `${prefix}-plus-slot`,
+    separator: `${prefix}-separator`,
+    footerSlot: `${prefix}-footer-slot`,
+  }
 }
 
 /**
@@ -131,8 +151,46 @@ interface MarkdownEditorProps {
   onAfterSend?: () => void
   onDraftKeyChanged?: (key: string | null) => void
   disabled?: boolean
-  requestedHeight?: number
+  /**
+   * A height the box HOLDS once the content passes it: the composer's
+   * drag-to-resize.
+   *
+   * It is a floor while the content is shorter and a fixed height once the
+   * content is taller, which is what a dragged handle means -- the reader
+   * chose that height, so the box keeps it and scrolls. `maxHeight` cannot
+   * bind alongside it, because the box never grows past this value.
+   */
+  pinnedHeight?: number
+  /**
+   * A height the box OPENS at and then grows past, up to `maxHeight`.
+   *
+   * For a host that wants a comfortable starting size rather than a fixed one.
+   * Use this with `maxHeight` to state a floor and a ceiling; use
+   * `pinnedHeight` only where the reader picked the height.
+   */
+  minHeight?: number
   maxHeight?: number
+  /**
+   * The `id` of the element whose text names this editor.
+   *
+   * A contenteditable takes no `<label for>`, so a host that shows a caption
+   * beside the box states the connection here instead. It lands on the
+   * ProseMirror element, which is the one the caret enters.
+   */
+  ariaLabelledBy?: string
+  /**
+   * The text the editor OPENS with.
+   *
+   * Data rather than an imperative seed: a host that wrote the text through
+   * `contentRef` had to hold a nullable setter and call it from `onReady`, which
+   * depends on the order of two lines inside this component. It also replaced
+   * the document one frame after the build, so the editor briefly held an empty
+   * one.
+   *
+   * It WINS over a stored draft. A host that states the starting text is editing
+   * a specific document, and a draft is the text it abandoned last time.
+   */
+  initialMarkdown?: string
   onContentHeightChange?: (height: number) => void
   onContentChange?: (hasContent: boolean) => void
   /**
@@ -203,6 +261,8 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
    * its ResizeObservers, and its paste/drop listeners.
    */
   let disposed = false
+  /** Set when the asynchronous build failed -- see the `catch` on `onMount`. */
+  const [buildFailed, setBuildFailed] = createSignal(false)
   // Owns the generation token that drops a read a newer swap superseded. See
   // `createDraftSwapper` for why the token lives there and not here. Declared
   // with the other per-editor state, because `onMount` runs its own initial
@@ -212,9 +272,9 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
   /**
    * The box's expand/collapse decision and the three DOM measurements it needs.
    * Every probe, observer, and threshold lives in that one unit — see
-   * `./composerLayout`.
+   * `./editorLayout`.
    */
-  const layout = createComposerLayout({
+  const layout = createEditorLayout({
     editorRoot: () => editorRef,
     row: () => editorRowEl,
     actionSlot: () => footerSlotEl,
@@ -237,15 +297,24 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       : dk.agentId
   }
 
-  // Editor wrapper sizing: the explicit `requestedHeight` becomes a hard cap
-  // when the content already overflows it, otherwise it acts as a min-height
-  // floor so empty/short editors still render at the expected size.
+  /**
+   * Editor wrapper sizing.
+   *
+   * `pinnedHeight` is a floor while the content is shorter and a fixed height
+   * once it is taller, so a dragged handle keeps the height the reader chose.
+   * That fixed height also stops `maxHeight` from ever binding, which is why a
+   * host that wants a floor AND a ceiling states `minHeight` instead: it stays
+   * a floor at every content size, and the box grows to `maxHeight`.
+   */
   const editorWrapperStyle = (): JSX.CSSProperties => {
     const style: JSX.CSSProperties = {}
-    const requested = props.requestedHeight
-    if (requested != null) {
-      const overflowing = contentHeight() > 0 && requested < contentHeight()
-      style[overflowing ? 'height' : 'min-height'] = `${requested}px`
+    const pinned = props.pinnedHeight
+    if (pinned != null) {
+      const overflowing = contentHeight() > 0 && pinned < contentHeight()
+      style[overflowing ? 'height' : 'min-height'] = `${pinned}px`
+    }
+    else if (props.minHeight != null) {
+      style['min-height'] = `${props.minHeight}px`
     }
     if (props.maxHeight)
       style['max-height'] = `${props.maxHeight}px`
@@ -276,13 +345,24 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
   let onMarkdownChangeRef: MarkdownEditorProps['onMarkdownChange']
 
   /**
-   * Reports the document's markdown to the host.
+   * Reports the document to the host: its markdown, and whether it holds
+   * anything.
+   *
+   * ONE function for both callbacks, because `hasContent` is DERIVED from the
+   * markdown and every site that reported one owed the other. Reporting them
+   * separately meant each new document-replacement path had to remember two
+   * calls, and the draft-load path already forgot: it announced `hasContent`
+   * and never announced the text, so a host with `onMarkdownChange` learned
+   * that content existed and never learned what it was until the user typed.
    *
    * Not a signal. This component never reads the text back -- it asks the
    * serializer whenever it needs one -- so storing it would be a second copy
    * that only drifts.
    */
-  const emitMarkdown = (markdown: string) => onMarkdownChangeRef?.(markdown)
+  const emitDocument = (markdown: string) => {
+    onMarkdownChangeRef?.(markdown)
+    onContentChangeRef?.(markdown.trim().length > 0)
+  }
 
   // Repaint the composer's code blocks when the syntax theme changes.
   //
@@ -428,12 +508,24 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
     // soft keyboard outside a user gesture, and the RPC ends the gesture -- but
     // an earlier call repairs nothing, because focus is still on the editor
     // there and `applySendFocus` skips a view that already holds it.
+    // The host may have unmounted this editor from inside its own `onSend`:
+    // `SetGoalDialog` closes on a successful submit, which disposes the whole
+    // subtree synchronously. `onCleanup` then set `disposed` and destroyed the
+    // editor before this continuation resumed, so rebuilding the document below
+    // would dispatch into a detached view. The draft still has to be cleared --
+    // `onCleanup` saved the SENT text as a draft on its way out, and leaving it
+    // there resurrects a sent message in the composer on the next open.
+    if (disposed) {
+      if (initialDraftKey)
+        clearDraft(initialDraftKey)
+      props.onAfterSend?.()
+      return
+    }
     try {
       const clearSubmittedContent = sentContentIsCurrent()
       if (clearSubmittedContent) {
         editorInstance.action(replaceAll(''))
-        emitMarkdown('')
-        onContentChangeRef?.(false)
+        emitDocument('')
       }
       if (initialDraftKey && (!sentDraftIsCurrent() || clearSubmittedContent))
         clearDraft(initialDraftKey)
@@ -525,7 +617,13 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       latestDraftKey = key
   })
 
-  onMount(async () => {
+  /**
+   * Build the editor and attach everything that depends on it.
+   *
+   * A plain function rather than the `onMount` callback itself, so the caller
+   * below can attach a `catch` -- see there.
+   */
+  const attachEditor = async () => {
     if (!editorRef)
       return
 
@@ -541,10 +639,17 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
     // with its content in hand. The draft read is asynchronous now, and this
     // `onMount` already awaits `buildEditor`, so it costs no extra round trip.
     const initialDraft = initialDraftKey ? await loadDraft(initialDraftKey) : { content: '', cursor: -1 }
+    // `initialMarkdown` WINS over a stored draft -- see the prop. A host that
+    // states the starting text is editing a specific document, and a draft is
+    // the text it abandoned last time; showing the draft would silently edit
+    // the wrong thing.
+    const seed = props.initialMarkdown ?? initialDraft.content
+    const seedCursor = props.initialMarkdown != null ? -1 : initialDraft.cursor
 
     const editor = await buildEditor({
       editorRoot: editorRef,
-      initialContent: initialDraft.content,
+      initialContent: seed,
+      ariaLabelledBy: props.ariaLabelledBy,
       pluginRefs: {
         getDisabled: () => disabledRef,
         getEnterMode: () => enterModeRef,
@@ -566,8 +671,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
         getLinkPopoverOpen: linkPopoverOpen,
         getLinkRange: linkRange,
       },
-      onMarkdown: emitMarkdown,
-      onContentChange: hasContent => props.onContentChange?.(hasContent),
+      onDocument: emitDocument,
       onDocTransaction: layout.setDocStats,
       getDraftKey,
       draftSaveDebounce,
@@ -605,8 +709,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
           return
         readyDraft = draft
         editor.action(replaceAll(draft.content))
-        emitMarkdown(draft.content)
-        props.onContentChange?.(draft.content.trim().length > 0)
+        emitDocument(draft.content)
         prevDraftKey = initialReadyDraftKey ?? null
       })
       // Checked AGAIN, for the same reason it is checked after `buildEditor`:
@@ -664,18 +767,42 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
     // Notify parent if we loaded a draft with content, and restore cursor
     // position. `prevDraftKey` is the key whose document the editor now holds,
     // whichever of the two reads above produced it.
-    if (prevDraftKey && readyDraft.content) {
-      props.onContentChange?.(true)
+    // A seeded document is announced HERE or nowhere: Milkdown's
+    // `markdownUpdated` listener never fires for `defaultValueCtx`, so a host
+    // with `onMarkdownChange` would otherwise learn nothing until the reader
+    // typed.
+    if (props.initialMarkdown != null ? seed !== '' : Boolean(prevDraftKey && readyDraft.content)) {
+      // Both halves. Milkdown's `markdownUpdated` listener never fires for a
+      // document seeded this way, so this is the only announcement a host with
+      // `onMarkdownChange` gets for a loaded draft.
+      //
+      // Report what the DOCUMENT holds, not the stored draft string. The round
+      // trip through ProseMirror is not the identity -- it escapes `*`, `_` and
+      // `&`, and refolds a code block -- so echoing the input hands the host a
+      // string that differs from the one a send would submit. `editorRefHandlers`
+      // re-serializes for the same reason; this is the same path for a draft.
       try {
-        restoreCursor(editor, readyDraft.cursor)
+        editor.action((ctx: Ctx) => {
+          emitDocument(ctx.get(serializerCtx)(ctx.get(editorViewCtx).state.doc))
+        })
+      }
+      catch {
+        // The editor is not ready to serialize, so the stored text is the best
+        // answer available. A host that hears nothing at all is worse.
+        emitDocument(readyDraft.content)
+      }
+      try {
+        // `-1` for a seed, which `restoreCursor` reads as the document END --
+        // a reader who opens Replace continues the objective rather than
+        // typing in front of it.
+        restoreCursor(editor, props.initialMarkdown != null ? seedCursor : readyDraft.cursor)
       }
       catch { /* editor may not be ready */ }
     }
 
     setupEditorRefHandlers({
       editor,
-      onMarkdown: emitMarkdown,
-      onContentChange: hasContent => props.onContentChange?.(hasContent),
+      onDocument: emitDocument,
       sendRef: props.imperative?.sendRef,
       focusRef: props.imperative?.focusRef,
       contentRef: props.imperative?.contentRef,
@@ -734,6 +861,23 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       editorRef?.removeEventListener('paste', handlePaste, true)
       editorRef?.removeEventListener('drop', handleDrop, true)
     }))
+  }
+
+  /**
+   * The build is asynchronous and it can fail: a plugin factory that throws, or
+   * `Editor.create()` rejecting.
+   *
+   * Without this `catch` the rejection is unhandled and the box is simply DEAD
+   * -- `onReady` never fires, the imperative refs are never installed, and a
+   * host that drives its own submit button through `sendRef` has no route to
+   * the action at all. That is a grey rectangle with no message. Say so
+   * instead, and log the cause.
+   */
+  onMount(() => {
+    void attachEditor().catch((error) => {
+      logger.error('The editor failed to build:', error)
+      setBuildFailed(true)
+    })
   })
 
   onCleanup(() => {
@@ -794,7 +938,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       // Load the draft for the new key and replace the editor content.
       //
       // `prevDraftKey` MOVES WITH THE DOCUMENT, inside `apply` below, never
-      // here. It names the key whose text the editor is holding, and the read is
+      // here. It identifies the key whose text the editor holds, and the read is
       // asynchronous -- so until it lands the editor still shows the OUTGOING
       // key's prose. Moving the pointer up front made a second swap arriving
       // during this read save that outgoing prose under the incoming key, which
@@ -804,9 +948,15 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       const swapTarget = editorInstance
       // Captured before the await. `props` is reactive, and reading a prop off
       // it inside the callback below would read it outside any tracked scope --
-      // which is what solid/reactivity flags, and it is right: the handlers this
-      // swap belongs to are the ones that were installed when the swap started.
-      const notifyContentChange = props.onContentChange
+      // which is what solid/reactivity flags, and it is right: the handler this
+      // swap belongs to is the one that was installed when the swap started.
+      //
+      // The document report does NOT go through a capture like this one. It
+      // goes through `emitDocument`, which reads the mirrored refs and so
+      // reports the LATEST handlers. That was already true of the markdown half
+      // before the two were folded together, so the pair used to disagree here:
+      // one announcement reached the current host and the other reached the
+      // host that was current when the read began.
       const notifyDraftKeyChanged = props.onDraftKeyChanged
       void swapDraft(newDraftKey, (draft) => {
         // The component unmounted while the read was in flight. `onCleanup`
@@ -819,8 +969,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
         try {
           swapTarget.action(replaceAll(draft.content))
           restoreCursor(swapTarget, draft.cursor)
-          emitMarkdown(draft.content)
-          notifyContentChange?.(draft.content.trim().length > 0)
+          emitDocument(draft.content)
           prevDraftKey = newDraftKey
         }
         catch { /* editor may not be ready */ }
@@ -865,13 +1014,26 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
   }
 
   const markers = () => SURFACE_MARKERS[props.surface]
+  const ids = () => testIds(markers().testIdPrefix)
   // Resolved ONCE. `props.plus` is a prop getter, so reading it twice -- once to
   // insert it and once to ask whether it exists -- builds the menu twice and
   // mounts two copies of it. `children` memoizes the resolved node, which is
-  // what makes the question below safe to ask. Read for TRUTH rather than
-  // against `undefined`, because a caller that writes `plus={cond && <X/>}`
-  // hands this `false`, which reserves a column for nothing.
+  // what makes the question below safe to ask.
   const plusNode = children(() => props.plus)
+
+  /**
+   * Whether the `[+]` slot renders anything at all.
+   *
+   * Through `toArray`, never as a bare truthiness test on `plusNode()`.
+   * `children()` resolves a fragment to an ARRAY, and `[]` is TRUTHY -- so
+   * `plus={<></>}`, a `<For>` over an empty list, or `<>{a && <A/>}{b && <B/>}</>`
+   * (which resolves to `[false, false]`) all read as "a button is there" and
+   * reserve a ~40px left column for nothing. A caller that writes
+   * `plus={cond && <X/>}` hands this a bare `false`, which `toArray` wraps, so
+   * one test covers both shapes.
+   */
+  const hasPlus = () =>
+    plusNode.toArray().some(node => node != null && node !== false && node !== '')
 
   return (
     <div
@@ -879,25 +1041,33 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       // The box whose layout mode `data-expanded` states. A test that asserts
       // the collapsed-versus-expanded decision has to address this element, and
       // the class name is a build-mode-dependent hash.
-      data-testid={markers().boxTestId}
+      data-testid={ids().box}
       data-expanded={isExpanded() ? '' : undefined}
       // Whether a `[+]` button is rendered at all. The stylesheet reserves the
       // left column for it, and a box without one starts its text 40px in for
-      // no reason -- see `--composer-left-pad` in the stylesheet.
-      data-plus={plusNode() ? '' : undefined}
+      // no reason -- see `--editor-left-pad` in the stylesheet.
+      data-plus={hasPlus() ? '' : undefined}
       style={{
-        '--composer-right-pad': `${layout.rightPad()}px`,
+        '--editor-right-pad': `${layout.rightPad()}px`,
         // Omitted until measured, so the stylesheet's own fallback applies.
-        ...(layout.actionsHeight() > 0 ? { '--composer-actions-h': `${layout.actionsHeight()}px` } : {}),
+        ...(layout.actionsHeight() > 0 ? { '--editor-actions-h': `${layout.actionsHeight()}px` } : {}),
       }}
     >
       {props.banner}
+      {/* The box is unusable when the build failed, and it looks identical to
+          an empty one. Say what happened, so the reader knows to reload rather
+          than retyping into a field that will never send. */}
+      <Show when={buildFailed()}>
+        <div class={errorText} role="alert" data-testid={ids().buildFailed}>
+          The editor failed to load. Reload the page to try again.
+        </div>
+      </Show>
       <div class={styles.editorRow} ref={editorRowEl}>
-        <div class={styles.plusSlot} data-testid={`${markers().slotPrefix}-plus-slot`}>{plusNode()}</div>
+        <div class={styles.plusSlot} data-testid={ids().plusSlot}>{plusNode()}</div>
         <div
           class={styles.editorWrapper}
           ref={editorRef}
-          data-testid={markers().editorTestId}
+          data-testid={ids().editor}
           // Only the message composer claims it. `useShortcuts` reads it for the
           // `chatInputFocused` context, and `$mod+j` sends the chat message
           // there -- so a goal editor carrying it would send a message from
@@ -908,12 +1078,12 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
         {/* Separator between text area and button row in expanded mode. Positioned
             at the top of the button reservation (the editor row's padding-bottom
             area) so it sits right between the text and the buttons. */}
-        <div class={styles.editorSeparator} data-testid={`${markers().slotPrefix}-separator`} />
+        <div class={styles.editorSeparator} data-testid={ids().separator} />
         {/* The action cluster: compact Interrupt/Send (actions) when composing,
             or the full-width control-request actions (footer) when a request is
             active. `data-full-width` distinguishes the two so the expanded
             layout can stretch the control-request footer across the box. */}
-        <div class={styles.footerSlot} ref={footerSlotEl} data-testid={`${markers().slotPrefix}-footer-slot`} data-full-width={props.actions?.layout === 'fullWidth' ? '' : undefined}>{props.actions?.node()}</div>
+        <div class={styles.footerSlot} ref={footerSlotEl} data-testid={ids().footerSlot} data-full-width={props.actions?.layout === 'fullWidth' ? '' : undefined}>{props.actions?.node()}</div>
       </div>
       <CodeLanguagePopover
         open={codeLangPopoverOpen}

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.tsx
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.tsx
@@ -7,7 +7,7 @@ import type { TrailingDebounced } from '~/lib/debounce'
 import type { LinkRange } from '~/lib/editor/linkPlugin'
 import { editorViewCtx, serializerCtx } from '@milkdown/core'
 import { replaceAll } from '@milkdown/utils'
-import { createEffect, createSignal, getOwner, on, onCleanup, onMount, runWithOwner } from 'solid-js'
+import { children, createEffect, createSignal, getOwner, on, onCleanup, onMount, runWithOwner } from 'solid-js'
 import { isTauriApp, readClipboardImage } from '~/api/platformBridge'
 import { usePreferences } from '~/context/PreferencesContext'
 import { loadDraft } from '~/lib/editor/draftPersistence'
@@ -28,6 +28,46 @@ import { decideSendFocus } from './sendFocus'
 const logger = createLogger('MarkdownEditor')
 
 export { clearDraft }
+
+/**
+ * What an editor IS. The one thing a host has to say about itself.
+ *
+ * ONE prop rather than a test id plus a flag, because the two facts below are
+ * one fact. `data-chat-input` decides whether the app's chat keybindings treat
+ * focus inside this box as the composer -- `useShortcuts` reads it for the
+ * `chatInputFocused` context, and `$mod+j` maps to `chat.sendMessage` there --
+ * and the test ids decide which box an E2E locator resolves to. A caller given
+ * two props can change the id and forget the marker, and the symptom is Cmd+J
+ * inside a dialog sending a chat message.
+ */
+export type MarkdownEditorSurface = 'chat' | 'goal'
+
+/**
+ * Every surface's markers.
+ *
+ * A `Record` over the union, so a new surface fails to compile until it states
+ * all four. An array of pairs type-checked with any subset, which is how a new
+ * surface would ship with the composer's own test id.
+ *
+ * EVERY test id this component writes comes from here. Three of them name
+ * layout slots rather than the editor itself, and leaving those shared would
+ * put the whole collision back for anything that addresses one: a spec with a
+ * goal dialog open resolves two `composer-footer-slot` elements and Playwright's
+ * strict mode fails it.
+ */
+const SURFACE_MARKERS: Record<MarkdownEditorSurface, {
+  /** `data-testid` for the outer box, whose `data-expanded` states the layout. */
+  boxTestId: string
+  /** `data-testid` for the ProseMirror host. */
+  editorTestId: string
+  /** Leads the `data-testid` of each layout slot inside the box. */
+  slotPrefix: string
+  /** Whether `chatInputFocused` treats focus here as the message composer. */
+  chatInput: boolean
+}> = {
+  chat: { boxTestId: 'composer-box', editorTestId: 'chat-editor', slotPrefix: 'composer', chatInput: true },
+  goal: { boxTestId: 'goal-editor-box', editorTestId: 'goal-editor', slotPrefix: 'goal-editor', chatInput: false },
+}
 
 /**
  * Identifies the stored draft key. Only one of `key` or
@@ -70,6 +110,11 @@ export interface MarkdownEditorImperative {
 
 interface MarkdownEditorProps {
   /**
+   * What this editor IS -- see {@link MarkdownEditorSurface}. Required, because
+   * a default would silently hand a new host the composer's identity.
+   */
+  surface: MarkdownEditorSurface
+  /**
    * Whether the composer must NOT take the keyboard when it finishes building.
    * Absent means "go ahead", for a caller with no competing focus.
    *
@@ -90,6 +135,16 @@ interface MarkdownEditorProps {
   maxHeight?: number
   onContentHeightChange?: (height: number) => void
   onContentChange?: (hasContent: boolean) => void
+  /**
+   * The document's markdown, on every change.
+   *
+   * Beside `onContentChange` rather than folded into it: that one answers
+   * "is there anything here", which a host reads to arm a Send button, and this
+   * one carries the text, which a host reads to measure it. The goal dialog
+   * measures the objective's UTF-8 length against the worker's cap while the
+   * user types.
+   */
+  onMarkdownChange?: (markdown: string) => void
   banner?: JSX.Element
   /**
    * The action row for the box, and the layout it needs.
@@ -137,7 +192,6 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
   let editorInstance: Editor | undefined
   const preferences = usePreferences()
   const enterMode = preferences.enterKeyMode
-  const [_markdown, setMarkdown] = createSignal('')
   const [contentHeight, setContentHeight] = createSignal(0)
   /**
    * Set by this component's own `onCleanup`. `buildEditor` is asynchronous, so
@@ -219,6 +273,16 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
   let onSendRef: MarkdownEditorProps['onSend'] = () => undefined
   let allowEmptySendRef = false
   let onContentChangeRef: MarkdownEditorProps['onContentChange']
+  let onMarkdownChangeRef: MarkdownEditorProps['onMarkdownChange']
+
+  /**
+   * Reports the document's markdown to the host.
+   *
+   * Not a signal. This component never reads the text back -- it asks the
+   * serializer whenever it needs one -- so storing it would be a second copy
+   * that only drifts.
+   */
+  const emitMarkdown = (markdown: string) => onMarkdownChangeRef?.(markdown)
 
   // Repaint the composer's code blocks when the syntax theme changes.
   //
@@ -368,7 +432,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
       const clearSubmittedContent = sentContentIsCurrent()
       if (clearSubmittedContent) {
         editorInstance.action(replaceAll(''))
-        setMarkdown('')
+        emitMarkdown('')
         onContentChangeRef?.(false)
       }
       if (initialDraftKey && (!sentDraftIsCurrent() || clearSubmittedContent))
@@ -397,6 +461,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
     onSendRef = props.onSend
     allowEmptySendRef = props.allowEmptySend ?? false
     onContentChangeRef = props.onContentChange
+    onMarkdownChangeRef = props.onMarkdownChange
   })
 
   // Force ProseMirror to re-render decorations when disabled or placeholder changes.
@@ -501,7 +566,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
         getLinkPopoverOpen: linkPopoverOpen,
         getLinkRange: linkRange,
       },
-      setMarkdown,
+      onMarkdown: emitMarkdown,
       onContentChange: hasContent => props.onContentChange?.(hasContent),
       onDocTransaction: layout.setDocStats,
       getDraftKey,
@@ -540,7 +605,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
           return
         readyDraft = draft
         editor.action(replaceAll(draft.content))
-        setMarkdown(draft.content)
+        emitMarkdown(draft.content)
         props.onContentChange?.(draft.content.trim().length > 0)
         prevDraftKey = initialReadyDraftKey ?? null
       })
@@ -609,7 +674,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
 
     setupEditorRefHandlers({
       editor,
-      setMarkdown,
+      onMarkdown: emitMarkdown,
       onContentChange: hasContent => props.onContentChange?.(hasContent),
       sendRef: props.imperative?.sendRef,
       focusRef: props.imperative?.focusRef,
@@ -754,7 +819,7 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
         try {
           swapTarget.action(replaceAll(draft.content))
           restoreCursor(swapTarget, draft.cursor)
-          setMarkdown(draft.content)
+          emitMarkdown(draft.content)
           notifyContentChange?.(draft.content.trim().length > 0)
           prevDraftKey = newDraftKey
         }
@@ -799,14 +864,27 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
     })
   }
 
+  const markers = () => SURFACE_MARKERS[props.surface]
+  // Resolved ONCE. `props.plus` is a prop getter, so reading it twice -- once to
+  // insert it and once to ask whether it exists -- builds the menu twice and
+  // mounts two copies of it. `children` memoizes the resolved node, which is
+  // what makes the question below safe to ask. Read for TRUTH rather than
+  // against `undefined`, because a caller that writes `plus={cond && <X/>}`
+  // hands this `false`, which reserves a column for nothing.
+  const plusNode = children(() => props.plus)
+
   return (
     <div
       class={styles.container}
       // The box whose layout mode `data-expanded` states. A test that asserts
       // the collapsed-versus-expanded decision has to address this element, and
       // the class name is a build-mode-dependent hash.
-      data-testid="composer-box"
+      data-testid={markers().boxTestId}
       data-expanded={isExpanded() ? '' : undefined}
+      // Whether a `[+]` button is rendered at all. The stylesheet reserves the
+      // left column for it, and a box without one starts its text 40px in for
+      // no reason -- see `--composer-left-pad` in the stylesheet.
+      data-plus={plusNode() ? '' : undefined}
       style={{
         '--composer-right-pad': `${layout.rightPad()}px`,
         // Omitted until measured, so the stylesheet's own fallback applies.
@@ -815,23 +893,27 @@ export const MarkdownEditor: Component<MarkdownEditorProps> = (props) => {
     >
       {props.banner}
       <div class={styles.editorRow} ref={editorRowEl}>
-        <div class={styles.plusSlot} data-testid="composer-plus-slot">{props.plus}</div>
+        <div class={styles.plusSlot} data-testid={`${markers().slotPrefix}-plus-slot`}>{plusNode()}</div>
         <div
           class={styles.editorWrapper}
           ref={editorRef}
-          data-testid="chat-editor"
-          data-chat-input
+          data-testid={markers().editorTestId}
+          // Only the message composer claims it. `useShortcuts` reads it for the
+          // `chatInputFocused` context, and `$mod+j` sends the chat message
+          // there -- so a goal editor carrying it would send a message from
+          // inside a dialog. See `MarkdownEditorSurface`.
+          data-chat-input={markers().chatInput ? '' : undefined}
           style={editorWrapperStyle()}
         />
         {/* Separator between text area and button row in expanded mode. Positioned
             at the top of the button reservation (the editor row's padding-bottom
             area) so it sits right between the text and the buttons. */}
-        <div class={styles.editorSeparator} data-testid="composer-separator" />
+        <div class={styles.editorSeparator} data-testid={`${markers().slotPrefix}-separator`} />
         {/* The action cluster: compact Interrupt/Send (actions) when composing,
             or the full-width control-request actions (footer) when a request is
             active. `data-full-width` distinguishes the two so the expanded
             layout can stretch the control-request footer across the box. */}
-        <div class={styles.footerSlot} ref={footerSlotEl} data-testid="composer-footer-slot" data-full-width={props.actions?.layout === 'fullWidth' ? '' : undefined}>{props.actions?.node()}</div>
+        <div class={styles.footerSlot} ref={footerSlotEl} data-testid={`${markers().slotPrefix}-footer-slot`} data-full-width={props.actions?.layout === 'fullWidth' ? '' : undefined}>{props.actions?.node()}</div>
       </div>
       <CodeLanguagePopover
         open={codeLangPopoverOpen}

--- a/frontend/src/components/chat/markdownEditor/buildFailure.test.tsx
+++ b/frontend/src/components/chat/markdownEditor/buildFailure.test.tsx
@@ -1,0 +1,45 @@
+import { render, waitFor } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import { PreferencesProvider } from '~/context/PreferencesContext'
+
+/**
+ * A rejected `buildEditor` must leave a MESSAGE, not a dead grey box.
+ *
+ * `onMount` builds the editor asynchronously. Without a `catch` the rejection
+ * is unhandled, `onReady` never fires, the imperative refs are never installed,
+ * and a host that drives its own submit button through `sendRef` has no route
+ * to the action at all -- an empty box and a button that does nothing, with no
+ * explanation.
+ *
+ * Its own file, because the mock has to replace `buildEditor` for the whole
+ * module graph and the other cases in `./MarkdownEditor.test.tsx` need the real
+ * one.
+ */
+vi.mock('./editorSetup', async (importActual) => {
+  const actual = await importActual<typeof import('./editorSetup')>()
+  return {
+    ...actual,
+    buildEditor: () => Promise.reject(new Error('a plugin threw')),
+  }
+})
+
+const { MarkdownEditor } = await import('./MarkdownEditor')
+
+describe('markdownEditor build failure', () => {
+  it('says the editor failed to load instead of leaving an empty box', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { container } = render(() => (
+      <PreferencesProvider>
+        <MarkdownEditor surface="goal" onSend={() => {}} />
+      </PreferencesProvider>
+    ))
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="goal-build-failed"]')).not.toBeNull()
+    })
+    expect(container.querySelector('[data-testid="goal-build-failed"]')?.textContent)
+      .toContain('The editor failed to load')
+    // The cause reaches the console, so the failure is diagnosable.
+    expect(error).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/chat/markdownEditor/editorLayout.test.ts
+++ b/frontend/src/components/chat/markdownEditor/editorLayout.test.ts
@@ -1,6 +1,6 @@
 import { createRoot } from 'solid-js'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { createComposerLayout } from './composerLayout'
+import { createEditorLayout } from './editorLayout'
 
 /**
  * jsdom lays nothing out, so every measurement reads 0. These stubs give the
@@ -53,7 +53,7 @@ function stubbedActionSlot(width: number): HTMLElement {
 /** Build a layout over stubbed DOM and run `fn` with it inside a reactive root. */
 function withLayout(
   opts: { rowWidth?: number, actionSlotWidth?: number, observe?: boolean },
-  fn: (layout: ReturnType<typeof createComposerLayout>) => void,
+  fn: (layout: ReturnType<typeof createEditorLayout>) => void,
 ) {
   document.body.replaceChildren()
   const root = stubbedRoot()
@@ -66,7 +66,7 @@ function withLayout(
     document.body.appendChild(actionSlot)
 
   createRoot((dispose) => {
-    const layout = createComposerLayout({
+    const layout = createEditorLayout({
       editorRoot: () => root,
       row: () => row,
       actionSlot: () => actionSlot,
@@ -81,7 +81,7 @@ function withLayout(
   })
 }
 
-describe('createComposerLayout', () => {
+describe('createEditorLayout', () => {
   it('expands for multi-line content whatever its width', () => {
     withLayout({ rowWidth: 1000 }, (layout) => {
       expect(layout.contentExpanded()).toBe(false)
@@ -100,7 +100,7 @@ describe('createComposerLayout', () => {
   })
 
   it('keeps an EMPTY composer collapsed however little width the action row leaves', () => {
-    // `footerSlot` caps its own width at the row minus `--composer-left-pad`
+    // `footerSlot` caps its own width at the row minus `--editor-left-pad`
     // and one `space-1`, and an action row AT that cap drives the available
     // width to zero. The expand test subtracts a 16px margin, so a text width
     // of 0 satisfied `0 > 0 - 16` and the composer opened in the tall layout
@@ -171,7 +171,7 @@ describe('createComposerLayout', () => {
     block.append(document.createTextNode('x'.repeat(100)))
 
     createRoot((dispose) => {
-      const layout = createComposerLayout({
+      const layout = createEditorLayout({
         editorRoot: () => root,
         row: () => row,
         actionSlot: () => undefined,
@@ -201,7 +201,7 @@ describe('createComposerLayout', () => {
     document.body.append(root, row)
 
     const dispose = createRoot((d) => {
-      const layout = createComposerLayout({
+      const layout = createEditorLayout({
         editorRoot: () => root,
         row: () => row,
         actionSlot: () => undefined,

--- a/frontend/src/components/chat/markdownEditor/editorLayout.ts
+++ b/frontend/src/components/chat/markdownEditor/editorLayout.ts
@@ -4,7 +4,7 @@ import { batch, createComputed, createMemo, createSignal, onCleanup } from 'soli
 /**
  * The right padding the collapsed layout falls back to before the action row is
  * measured. The stylesheet declares the same number as the fallback of
- * `--composer-right-pad`, and both exist only for the frames before the first
+ * `--editor-right-pad`, and both exist only for the frames before the first
  * ResizeObserver callback.
  */
 const UNMEASURED_RIGHT_PAD_PX = 96
@@ -19,7 +19,7 @@ const EXPAND_MARGIN_PX = 16
 const COLLAPSE_MARGIN_PX = 32
 
 /** The DOM the layout measures. Each getter is a ref that resolves after mount. */
-export interface ComposerLayoutRefs {
+export interface EditorLayoutRefs {
   /** The editor wrapper. Hosts the width probe, so the probe inherits its font. */
   editorRoot: () => HTMLElement | undefined
   /**
@@ -36,7 +36,7 @@ export interface ComposerLayoutRefs {
   actionSlot: () => HTMLElement | undefined
 }
 
-export interface ComposerLayout {
+export interface EditorLayout {
   /** Whether the content needs the expanded layout. */
   contentExpanded: () => boolean
   /** The collapsed-mode right padding, in pixels. */
@@ -70,7 +70,7 @@ export interface ComposerLayout {
  * down in a different place from the other three, and the decision itself is
  * reachable from a test without mounting Milkdown.
  */
-export function createComposerLayout(refs: ComposerLayoutRefs): ComposerLayout {
+export function createEditorLayout(refs: EditorLayoutRefs): EditorLayout {
   const [docStats, setDocStats] = createSignal<DocStats>({ multiLine: false, text: '' })
   const [rightPad, setRightPad] = createSignal(UNMEASURED_RIGHT_PAD_PX)
   const [actionsHeight, setActionsHeight] = createSignal(0)
@@ -167,7 +167,7 @@ export function createComposerLayout(refs: ComposerLayoutRefs): ComposerLayout {
     // The comparison below subtracts a margin from the available width, so a
     // width of 0 still expands once the available width falls under that
     // margin. The action row reaches that point on its own: `footerSlot` caps
-    // its width at the row minus `--composer-left-pad` and one `space-1`, and a
+    // its width at the row minus `--editor-left-pad` and one `space-1`, and a
     // slot at the cap leaves `collapsedAvailableWidth()` at exactly zero. The
     // composer then opened in the tall layout with nothing typed in it.
     //
@@ -220,7 +220,7 @@ export function createComposerLayout(refs: ComposerLayoutRefs): ComposerLayout {
       // A throwaway probe resolves the CSS custom property to pixels, because an
       // unregistered custom property computes to its token stream, not a length.
       const padProbeEl = document.createElement('div')
-      padProbeEl.style.cssText = 'position:absolute;visibility:hidden;width:100%;padding-left:var(--composer-left-pad);'
+      padProbeEl.style.cssText = 'position:absolute;visibility:hidden;width:100%;padding-left:var(--editor-left-pad);'
       row.appendChild(padProbeEl)
       const measureRow = () => {
         setRowWidth(row.clientWidth)

--- a/frontend/src/components/chat/markdownEditor/editorRefHandlers.ts
+++ b/frontend/src/components/chat/markdownEditor/editorRefHandlers.ts
@@ -1,6 +1,5 @@
 import type { Editor } from '@milkdown/core'
 import type { Ctx } from '@milkdown/ctx'
-import type { Setter } from 'solid-js'
 import { editorViewCtx, serializerCtx } from '@milkdown/core'
 import { TextSelection } from '@milkdown/prose/state'
 import { replaceAll } from '@milkdown/utils'
@@ -8,7 +7,8 @@ import { replaceAll } from '@milkdown/utils'
 /** Options for setting up the ref callbacks exposed to the parent component. */
 export interface EditorRefHandlersOptions {
   editor: Editor
-  setMarkdown: Setter<string>
+  /** Reports the document's markdown after a programmatic `set`. */
+  onMarkdown: (markdown: string) => void
   onContentChange?: (hasContent: boolean) => void
   sendRef?: (send: () => void | Promise<void>) => void
   focusRef?: (focus: () => void) => void
@@ -63,7 +63,7 @@ export function setupEditorRefHandlers(opts: EditorRefHandlersOptions): void {
             }
           }
         })
-        opts.setMarkdown(text)
+        opts.onMarkdown(text)
         opts.onContentChange?.(text.trim().length > 0)
       }
       catch { /* editor may not be ready */ }

--- a/frontend/src/components/chat/markdownEditor/editorRefHandlers.ts
+++ b/frontend/src/components/chat/markdownEditor/editorRefHandlers.ts
@@ -7,9 +7,8 @@ import { replaceAll } from '@milkdown/utils'
 /** Options for setting up the ref callbacks exposed to the parent component. */
 export interface EditorRefHandlersOptions {
   editor: Editor
-  /** Reports the document's markdown after a programmatic `set`. */
-  onMarkdown: (markdown: string) => void
-  onContentChange?: (hasContent: boolean) => void
+  /** Reports the document after a programmatic `set`: see `EditorSetupOptions`. */
+  onDocument: (markdown: string) => void
   sendRef?: (send: () => void | Promise<void>) => void
   focusRef?: (focus: () => void) => void
   contentRef?: (get: () => string, set: (text: string) => void) => void
@@ -63,8 +62,19 @@ export function setupEditorRefHandlers(opts: EditorRefHandlersOptions): void {
             }
           }
         })
-        opts.onMarkdown(text)
-        opts.onContentChange?.(text.trim().length > 0)
+        // Report what the DOCUMENT now holds, not the argument that seeded it.
+        // The two differ: the round trip through ProseMirror escapes `*`, `_`
+        // and `&`, turns an indented code block into a fenced one, and
+        // renumbers an ordered list. Reporting the input made the host's mirror
+        // briefly disagree with the text a send would submit -- the goal dialog
+        // opened a near-cap objective showing one byte count and then changed
+        // it, with no keystroke, when the debounced listener reported the real
+        // one.
+        let applied = text
+        editor.action((ctx: Ctx) => {
+          applied = ctx.get(serializerCtx)(ctx.get(editorViewCtx).state.doc)
+        })
+        opts.onDocument(applied)
       }
       catch { /* editor may not be ready */ }
     },

--- a/frontend/src/components/chat/markdownEditor/editorSetup.ts
+++ b/frontend/src/components/chat/markdownEditor/editorSetup.ts
@@ -1,7 +1,6 @@
 import type { Ctx } from '@milkdown/ctx'
 import type { Node, NodeType, Schema } from '@milkdown/prose/model'
 import type { EditorView } from '@milkdown/prose/view'
-import type { Setter } from 'solid-js'
 import type { TrailingDebounced } from '~/lib/debounce'
 import type { CodeLangHandlers } from '~/lib/editor/codeLangPlugin'
 import type { PluginRefs } from '~/lib/editor/keyboardPlugins'
@@ -138,8 +137,8 @@ export interface EditorSetupOptions {
   codeLangHandlers: CodeLangHandlers
   /** Link-edit popover state setters + getters (getters enable toggle-on-reclick). */
   linkClickHandlers: LinkClickHandlers
-  /** Markdown signal setter (called on every document change). */
-  setMarkdown: Setter<string>
+  /** Reports the document's markdown (called on every document change). */
+  onMarkdown: (markdown: string) => void
   /** Optional callback when content changes (has content / empty). */
   onContentChange?: (hasContent: boolean) => void
   /**
@@ -259,7 +258,7 @@ export function buildEditor(opts: EditorSetupOptions): Promise<Editor> {
       ctx.get(listenerCtx).markdownUpdated((_ctx, md) => {
         if (typeof md !== 'string')
           return
-        opts.setMarkdown(md)
+        opts.onMarkdown(md)
         opts.onContentChange?.(md.trim().length > 0)
         const draftKey = opts.getDraftKey()
         if (draftKey) {

--- a/frontend/src/components/chat/markdownEditor/editorSetup.ts
+++ b/frontend/src/components/chat/markdownEditor/editorSetup.ts
@@ -137,10 +137,21 @@ export interface EditorSetupOptions {
   codeLangHandlers: CodeLangHandlers
   /** Link-edit popover state setters + getters (getters enable toggle-on-reclick). */
   linkClickHandlers: LinkClickHandlers
-  /** Reports the document's markdown (called on every document change). */
-  onMarkdown: (markdown: string) => void
-  /** Optional callback when content changes (has content / empty). */
-  onContentChange?: (hasContent: boolean) => void
+  /**
+   * The `id` of the element whose text names this editor.
+   *
+   * A contenteditable takes no `<label for>`, so a host that shows a caption
+   * beside the box has no other way to connect the two -- without it the caret
+   * lands in an unnamed editable region and the instruction is never read.
+   */
+  ariaLabelledBy?: string
+  /**
+   * Reports the document (called on every document change): its markdown, and
+   * -- through the same call -- whether it holds anything. One callback,
+   * because the second fact is derived from the first and a site that reported
+   * one always owed the other.
+   */
+  onDocument: (markdown: string) => void
   /**
    * Synchronous callback fired on every ProseMirror document-changing
    * transaction (NOT debounced). Used for layout decisions that must land
@@ -241,6 +252,10 @@ export function buildEditor(opts: EditorSetupOptions): Promise<Editor> {
           spellcheck: 'false',
           autocorrect: 'off',
           autocapitalize: 'off',
+          // On the CONTENTEDITABLE, never on the wrapper. The wrapper is not
+          // the editable element, so naming it names nothing: a screen reader
+          // announces the region the caret lands in, which is this one.
+          ...(opts.ariaLabelledBy ? { 'aria-labelledby': opts.ariaLabelledBy } : {}),
         },
       }))
       let pendingMd = ''
@@ -258,8 +273,7 @@ export function buildEditor(opts: EditorSetupOptions): Promise<Editor> {
       ctx.get(listenerCtx).markdownUpdated((_ctx, md) => {
         if (typeof md !== 'string')
           return
-        opts.onMarkdown(md)
-        opts.onContentChange?.(md.trim().length > 0)
+        opts.onDocument(md)
         const draftKey = opts.getDraftKey()
         if (draftKey) {
           pendingMd = md

--- a/frontend/src/components/chat/toolStyles.css.ts
+++ b/frontend/src/components/chat/toolStyles.css.ts
@@ -1,6 +1,7 @@
 import { globalStyle, style } from '@vanilla-extract/css'
 import { todoList } from '~/components/todo/TodoList.css'
 import { codeTypography, codeWrap } from '~/styles/codeBlock'
+import { fadeMaskBottom } from '~/styles/fadeMask'
 import { clippedText, controlReset } from '~/styles/shared.css'
 import { codeSurface } from './shikiTokenColors.css'
 import { LINE_THICKNESS, TOOL_BODY_INDENT } from './widgets/SpanLines.geometry'
@@ -122,8 +123,7 @@ codeSurface(toolResultContentAnsi, 'page', [
 export const toolResultCollapsed = style({
   maxHeight: '3.6rem',
   overflow: 'hidden',
-  WebkitMaskImage: 'linear-gradient(to bottom, black calc(100% - 1.5em), transparent)',
-  maskImage: 'linear-gradient(to bottom, black calc(100% - 1.5em), transparent)',
+  ...fadeMaskBottom(),
 })
 
 // Cap heading font sizes inside collapsed markdown previews
@@ -156,10 +156,7 @@ export const commandInputCollapsed = style({
   overflow: 'hidden',
 })
 
-export const commandInputCollapsedFade = style({
-  WebkitMaskImage: 'linear-gradient(to bottom, black calc(100% - 1.5em), transparent)',
-  maskImage: 'linear-gradient(to bottom, black calc(100% - 1.5em), transparent)',
-})
+export const commandInputCollapsedFade = style(fadeMaskBottom())
 
 // Override Shiki's default <pre> styling inside tool input summary (for Bash highlighting)
 globalStyle(`${toolInputSummary} pre.shiki`, {

--- a/frontend/src/components/chat/useEditorMinHeight.ts
+++ b/frontend/src/components/chat/useEditorMinHeight.ts
@@ -136,7 +136,7 @@ export function useEditorMinHeight(opts: UseEditorMinHeightOptions): UseEditorMi
     // Use the current visual height of the editor wrapper as the drag starting
     // point so the drag feels anchored to the handle's visual position.
     const panel = opts.panelRef()
-    const editorWrapperEl = panel?.querySelector('[data-testid="chat-editor"]') as HTMLElement | null
+    const editorWrapperEl = panel?.querySelector('[data-testid="composer-editor"]') as HTMLElement | null
     const startHeight = editorWrapperEl?.getBoundingClientRect().height
       ?? editorMinHeightSignal()
       ?? EDITOR_MIN_HEIGHT

--- a/frontend/src/components/chat/widgets/ThinkingIndicator.test.tsx
+++ b/frontend/src/components/chat/widgets/ThinkingIndicator.test.tsx
@@ -311,6 +311,11 @@ describe('thinking indicator chips', () => {
     const popover = getByTestId('goal-popover')
     const hide = vi.spyOn(popover, 'hidePopover')
 
+    // Through the `...` menu, which is where every verb of an EXISTING goal
+    // lives. jsdom does not enforce a closed popover's `display: none`, so a
+    // direct click on the item passes here while failing in a real browser --
+    // it would prove nothing about the trigger being wired at all.
+    await fireEvent.click(getByTestId('goal-actions-trigger'))
     await fireEvent.click(getByTestId('goal-action-set'))
 
     expect(hide).toHaveBeenCalled()
@@ -329,6 +334,7 @@ describe('thinking indicator chips', () => {
     const popover = getByTestId('goal-popover')
     const hide = vi.spyOn(popover, 'hidePopover')
 
+    await fireEvent.click(getByTestId('goal-actions-trigger'))
     await fireEvent.click(getByTestId('goal-action-pause'))
 
     expect(hide).not.toHaveBeenCalled()
@@ -349,6 +355,7 @@ describe('thinking indicator chips', () => {
     const card = getByTestId('goal-card')
     expect(card).toHaveTextContent('Keep the suite green')
     expect(card).toHaveTextContent('1,200 tokens')
+    fireEvent.click(getByTestId('goal-actions-trigger'))
     expect(getByTestId('goal-action-pause')).toBeInTheDocument()
   })
 

--- a/frontend/src/components/common/CollapsibleToggle.css.ts
+++ b/frontend/src/components/common/CollapsibleToggle.css.ts
@@ -1,0 +1,29 @@
+import { style } from '@vanilla-extract/css'
+
+/**
+ * The disclosure toggle that opens and closes a clipped block: "Show more" and
+ * "Show less".
+ *
+ * A dotted underline rather than a button box, because it sits at the end of the
+ * content it opens and a solid control there reads as a second action on the
+ * row.
+ *
+ * Beside its component rather than in `~/styles/shared.css.ts`. It was shared
+ * while three surfaces each hand-wrote their own button around it -- a control
+ * request's reason text, a control request's option list, and the session goal's
+ * objective. `./CollapsibleToggle.tsx` now owns all three, so the paint and the
+ * behavior have one home and one owner.
+ */
+export const collapsibleToggle = style({
+  'all': 'unset',
+  'display': 'inline',
+  'fontSize': 'var(--text-8)',
+  'color': 'var(--muted-foreground)',
+  'cursor': 'pointer',
+  'textDecoration': 'underline',
+  'textDecorationStyle': 'dotted',
+  'textUnderlineOffset': '2px',
+  ':hover': {
+    color: 'var(--foreground)',
+  },
+})

--- a/frontend/src/components/common/CollapsibleToggle.tsx
+++ b/frontend/src/components/common/CollapsibleToggle.tsx
@@ -1,0 +1,50 @@
+import type { Component } from 'solid-js'
+import { collapsibleToggle } from './CollapsibleToggle.css'
+
+export interface CollapsibleToggleProps {
+  /** Whether the block this control opens is open now. */
+  'expanded': boolean
+  /** Open it, or close it. */
+  'onToggle': () => void
+  /** What the control says while the block is collapsed. */
+  'moreLabel': string
+  /** What it says while the block is open. Defaults to "Show less". */
+  'lessLabel'?: string
+  /**
+   * The `id` of the block this control opens.
+   *
+   * Optional, because a caller that expands a LIST has no single element to
+   * point at. `aria-expanded` still applies in that case, so the state is
+   * announced either way.
+   */
+  'controls'?: string
+  'data-testid'?: string
+}
+
+/**
+ * The "Show more" / "Show less" control that opens a clipped block.
+ *
+ * One component rather than one shared class, because the paint is the smallest
+ * part of what the three call sites share. They also share the label pairing,
+ * the `type="button"` -- a bare `<button>` inside a form defaults to `submit`,
+ * which reloads the page -- and the two ARIA attributes a disclosure owes a
+ * screen reader. A shared class left every one of those to be remembered per
+ * site, and each site is where it went wrong.
+ *
+ * `aria-expanded` is the whole point of the extraction. Without it a screen
+ * reader announces "Show more, button" with no state, and activating it
+ * announces nothing at all -- the label is the only signal, and a virtual-cursor
+ * user who moved on never receives it.
+ */
+export const CollapsibleToggle: Component<CollapsibleToggleProps> = props => (
+  <button
+    type="button"
+    class={collapsibleToggle}
+    aria-expanded={props.expanded}
+    aria-controls={props.controls}
+    data-testid={props['data-testid']}
+    onClick={() => props.onToggle()}
+  >
+    {props.expanded ? (props.lessLabel ?? 'Show less') : props.moreLabel}
+  </button>
+)

--- a/frontend/src/components/common/Dialog.test.tsx
+++ b/frontend/src/components/common/Dialog.test.tsx
@@ -234,6 +234,43 @@ describe('dialog', () => {
     expect(onClose).not.toHaveBeenCalled()
   })
 
+  /**
+   * A popover mounts its children whether it is open or shut, so a dialog that
+   * hosts one holds that popover's controls in its own subtree the whole time.
+   *
+   * Any dialog with a MarkdownEditor is in this position: the editor's
+   * LinkPopover carries a `type="submit"` Save button. Answering Enter by
+   * clicking the first submit button in the subtree therefore submitted a form
+   * the user could not see, and nothing visible happened.
+   */
+  it('ignores a submit button that lives inside a popover', () => {
+    const onClose = vi.fn()
+    const hidden = vi.fn((e: Event) => e.preventDefault())
+    const real = vi.fn((e: Event) => e.preventDefault())
+
+    const { container } = render(() => (
+      <Dialog title="Test" onClose={onClose}>
+        {/* Ahead of the real form in document order, which is what made it win. */}
+        <div popover="auto">
+          <form onSubmit={hidden}>
+            <button type="submit">Save link</button>
+          </form>
+        </div>
+        <form onSubmit={real}>
+          <input type="text" />
+          <button type="submit">Create</button>
+        </form>
+      </Dialog>
+    ))
+
+    container.querySelector('input')!.focus()
+    container.querySelector('dialog')!
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+
+    expect(hidden).not.toHaveBeenCalled()
+    expect(real).toHaveBeenCalled()
+  })
+
   it('does not trigger submit on Enter when submit button is disabled', () => {
     const onClose = vi.fn()
     const onSubmit = vi.fn((e: Event) => e.preventDefault())

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -97,7 +97,17 @@ export const Dialog: Component<DialogProps> = (props) => {
       const active = document.activeElement
       if (active instanceof HTMLTextAreaElement || active instanceof HTMLButtonElement || active instanceof HTMLAnchorElement)
         return
-      const submitBtn = dialogRef.querySelector('button[type="submit"]') as HTMLButtonElement | null
+      // The first submit button that is NOT inside a popover. A popover mounts
+      // its children whether it is open or shut, so a dialog that hosts one --
+      // any dialog with a MarkdownEditor, whose LinkPopover holds a
+      // `type="submit"` Save button -- otherwise answers a bare Enter by
+      // clicking a form the user cannot see.
+      //
+      // A scan rather than one `:not([popover] *)` selector: `:not()` with a
+      // descendant argument needs Selectors 4 support, which the jsdom matcher
+      // the unit tests run on does not have.
+      const submitBtn = [...dialogRef.querySelectorAll('button[type="submit"]')]
+        .find(el => !el.closest('[popover]')) as HTMLButtonElement | undefined
       if (submitBtn && !submitBtn.disabled) {
         e.preventDefault()
         submitBtn.click()

--- a/frontend/src/lib/markdownPlainText.test.ts
+++ b/frontend/src/lib/markdownPlainText.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { markdownToPlainText } from './markdownPlainText'
+
+describe('markdownToPlainText', () => {
+  it('drops emphasis marks and keeps the words', () => {
+    expect(markdownToPlainText('ship the **auth refactor**')).toBe('ship the auth refactor')
+    expect(markdownToPlainText('_every_ test passes')).toBe('every test passes')
+    expect(markdownToPlainText('~~drop~~ this')).toBe('drop this')
+  })
+
+  it('keeps the text inside a code span and a fence', () => {
+    expect(markdownToPlainText('run `task test` first')).toBe('run task test first')
+    expect(markdownToPlainText('```sh\nbun run lint\n```')).toBe('bun run lint')
+  })
+
+  it('reads a link as its label, not its URL', () => {
+    expect(markdownToPlainText('see [the plan](https://example.com/p)')).toBe('see the plan')
+  })
+
+  it('reads an image as its alt text', () => {
+    expect(markdownToPlainText('![a chart](chart.png)')).toBe('a chart')
+  })
+
+  it('separates list items so they do not run together', () => {
+    expect(markdownToPlainText('- fix the parser\n- rerun CI')).toBe('fix the parser rerun CI')
+  })
+
+  it('separates paragraphs and headings', () => {
+    expect(markdownToPlainText('# Goal\n\nShip it.\n\nThen rest.')).toBe('Goal Ship it. Then rest.')
+  })
+
+  it('collapses every block boundary to one line', () => {
+    expect(markdownToPlainText('a\n\n\nb')).toBe('a b')
+    expect(markdownToPlainText('> quoted\n\nafter')).toBe('quoted after')
+  })
+
+  /**
+   * The renderer shows a raw-HTML run as literal text rather than dropping it,
+   * so the spoken reading has to carry the same characters -- see
+   * `remarkHtmlAsText` in `./markdownProcessor.ts`.
+   */
+  it('keeps a bare angle-bracket run, matching what the renderer shows', () => {
+    expect(markdownToPlainText('Replace <old-token> with the new one'))
+      .toBe('Replace <old-token> with the new one')
+  })
+
+  it('returns an empty string for empty and whitespace-only input', () => {
+    expect(markdownToPlainText('')).toBe('')
+    expect(markdownToPlainText('   \n  ')).toBe('')
+  })
+
+  it('leaves plain prose untouched', () => {
+    expect(markdownToPlainText('every test passes')).toBe('every test passes')
+  })
+
+  it('reads a table row by row', () => {
+    expect(markdownToPlainText('| a | b |\n| - | - |\n| 1 | 2 |')).toBe('a b 1 2')
+  })
+})

--- a/frontend/src/lib/markdownPlainText.ts
+++ b/frontend/src/lib/markdownPlainText.ts
@@ -1,0 +1,68 @@
+import type { Nodes } from 'mdast'
+import { createMarkdownParser } from './markdownParse'
+
+/**
+ * The markdown node types whose own `value` IS the text a reader sees.
+ *
+ * `html` is here on purpose, and it matches what the renderer does: the
+ * pipeline shows a raw-HTML run as literal text rather than dropping it (see
+ * `remarkHtmlAsText` in `./markdownProcessor.ts`), so a goal that says
+ * `Replace <old-token>` must announce those characters too.
+ */
+const LITERAL_TYPES = new Set(['text', 'inlineCode', 'code', 'html'])
+
+/**
+ * A block whose end is a pause. Joining its siblings with a space would run two
+ * sentences together, and a list would read as one long line.
+ */
+const BLOCK_TYPES = new Set([
+  'paragraph',
+  'heading',
+  'listItem',
+  'blockquote',
+  'code',
+  'tableRow',
+  // Each cell too, or two adjacent cells read as one word ("a" + "b" = "ab").
+  'tableCell',
+  'thematicBreak',
+])
+
+function collect(node: Nodes, out: string[]): void {
+  if (LITERAL_TYPES.has(node.type)) {
+    out.push((node as { value: string }).value)
+  }
+  else if (node.type === 'image' || node.type === 'imageReference') {
+    // The alt text is what the image contributes to a spoken reading.
+    out.push(node.alt ?? '')
+  }
+  else if ('children' in node) {
+    for (const child of node.children)
+      collect(child as Nodes, out)
+  }
+  if (BLOCK_TYPES.has(node.type))
+    out.push('\n')
+}
+
+/**
+ * Reduce markdown SOURCE to the words a person reads.
+ *
+ * A screen reader given markdown source reads the syntax: "ship the asterisk
+ * asterisk auth refactor asterisk asterisk". Anything that announces
+ * model-written or user-written prose through `aria-live` has to strip the
+ * marks first, because the visible surface renders them and the spoken one
+ * cannot.
+ *
+ * It reuses `createMarkdownParser`, so what counts as a mark here is exactly
+ * what the renderer treats as one -- the two cannot drift on, say, whether a
+ * `~~strikethrough~~` is syntax.
+ *
+ * The result is a single line: every block boundary collapses to one space, so
+ * the caller can put it inside a sentence.
+ */
+export function markdownToPlainText(markdown: string): string {
+  if (markdown.trim() === '')
+    return ''
+  const out: string[] = []
+  collect(createMarkdownParser().parse(markdown) as Nodes, out)
+  return out.join('').replace(/\s+/g, ' ').trim()
+}

--- a/frontend/src/lib/markdownProcessor.test.ts
+++ b/frontend/src/lib/markdownProcessor.test.ts
@@ -317,8 +317,29 @@ describe('remote-image blocking in both processors', () => {
     ]
     for (const [name, render] of await processors()) {
       for (const vector of vectors) {
-        expect(render(vector), `${name}: ${vector}`).not.toContain('evil.example')
+        const html = render(vector)
+        // The URL survives as ESCAPED TEXT -- `remarkHtmlAsText` keeps the
+        // characters the author wrote, so a goal that says `Replace <old-token>`
+        // still reads. What must never appear is an ELEMENT that fetches it, so
+        // assert on the markup rather than on the substring.
+        // No ELEMENT, which is the whole invariant: every one of these tags
+        // fetches a URL, and none of them reaches the `img` branch that
+        // rehypeBlockRemoteImages guards.
+        expect(html, `${name}: ${vector}`).not.toMatch(/<(?:img|video|source|audio|iframe|svg|image|embed|object|input|picture)\b/i)
+        // The author's opening angle bracket is escaped, which is what proves
+        // the run reached the stringifier as text rather than as markup. `src=`
+        // and the host still appear INSIDE that text, and are inert there.
+        expect(html, `${name}: ${vector}`).toContain('&#x3C;')
       }
+    }
+  })
+
+  // The other half of the rule above: dropping the run silently was the bug.
+  it('keeps a bare angle-bracket run as readable text', async () => {
+    for (const [name, render] of await processors()) {
+      expect(render('Replace <old-token> with the new one'), name)
+        .toContain('Replace &#x3C;old-token> with the new one')
+      expect(render('Support a<b and c>d'), name).toContain('Support a&#x3C;b and c>d')
     }
   })
 

--- a/frontend/src/lib/markdownProcessor.ts
+++ b/frontend/src/lib/markdownProcessor.ts
@@ -67,6 +67,34 @@ function remarkLowercaseCodeLang() {
 }
 
 /**
+ * Remark plugin: show a raw-HTML run as the literal text the author wrote.
+ *
+ * `remarkRehype` runs without `allowDangerousHtml`, which DROPS every `html`
+ * node. That is correct for safety and wrong for the reader: a goal, a message
+ * or a tool result that says `Replace <old-token> with the new one` renders as
+ * `Replace  with the new one`, and `Support a<b and c>d` loses the words
+ * between the angle brackets too. CommonMark reads `<old-token>` as inline
+ * HTML, so the text disappears with no sign that anything was there.
+ *
+ * Retyping the node to `text` BEFORE remark-rehype keeps the security property
+ * exactly as it was -- rehype-stringify escapes the value, so `<` becomes
+ * `&#x3C;` and no element is ever created -- while the reader gets the
+ * characters back. The alternative, `allowDangerousHtml`, would build real
+ * elements and reopen the exfiltration vector that `rehypeBlockRemoteImages`
+ * closes for `<img>` alone; see the invariant test in
+ * `./markdownProcessor.test.ts`.
+ */
+function remarkHtmlAsText() {
+  return (tree: MdastRoot) => {
+    visit(tree, 'html', (node) => {
+      // `html` and `text` are both literal nodes, so the value carries over and
+      // only the type changes.
+      ;(node as unknown as { type: string }).type = 'text'
+    })
+  }
+}
+
+/**
  * Rehype plugin that secures links: adds target/rel to http(s) links, unwraps non-http(s)
  * links. Also the single source of the link-hardening rule for the placeholder anchors
  * rehypeBlockRemoteImages emits, which is why it runs AFTER that plugin.
@@ -133,6 +161,7 @@ function withHardeningTail<P extends Processor<any, any, Root, any, any>>(pipeli
 export function createMarkdownProcessor(highlighter: HighlighterCore, pair: SyntaxThemePair) {
   const base = createMarkdownParser()
     .use(remarkLowercaseCodeLang)
+    .use(remarkHtmlAsText)
     .use(remarkRehype)
     .use(rehypeShikiFromHighlighter, highlighter as Parameters<typeof rehypeShikiFromHighlighter>[0], {
       ...dualThemeTokenOptions(pair),
@@ -168,6 +197,7 @@ export function createMarkdownProcessor(highlighter: HighlighterCore, pair: Synt
  */
 export const plainMarkdownProcessor = withHardeningTail(
   createMarkdownParser()
+    .use(remarkHtmlAsText)
     .use(remarkRehype),
 )
 

--- a/frontend/src/stores/chatGoal.test.ts
+++ b/frontend/src/stores/chatGoal.test.ts
@@ -1,3 +1,4 @@
+import type { GoalSurface } from './chatGoal'
 import type { AgentGoal as ProtoAgentGoal } from '~/generated/proto/leapmux/v1/agent_pb'
 import { describe, expect, it } from 'vitest'
 import { AgentGoalAction, AgentGoalStatus } from '~/generated/proto/leapmux/v1/agent_pb'
@@ -82,27 +83,27 @@ describe('goalActionState', () => {
   // A provider's gap is PERMANENT -- Claude Code has no pause -- so its button
   // would never light up and is better absent than dead.
   it('hides an action the agent does not support', () => {
-    expect(goalActionState(active, ['set', 'clear'], 'pause')).toEqual({ kind: 'hidden' })
-    expect(goalActionState(undefined, [], 'set')).toEqual({ kind: 'hidden' })
+    expect(goalActionState({ current: active, actions: ['set', 'clear'] }, 'pause')).toEqual({ kind: 'hidden' })
+    expect(goalActionState({ current: undefined, actions: [] }, 'set')).toEqual({ kind: 'hidden' })
   })
 
   // Pause and resume are opposites: offering both would leave one that does
   // nothing on a goal already in that state. The refused one stays RENDERED,
   // because it comes back.
   it('enables pause only for an active goal, and resume only for a paused one', () => {
-    expect(goalActionState(active, [...all], 'pause')).toEqual({ kind: 'enabled' })
-    expect(goalActionState(active, [...all], 'resume'))
+    expect(goalActionState({ current: active, actions: [...all] }, 'pause')).toEqual({ kind: 'enabled' })
+    expect(goalActionState({ current: active, actions: [...all] }, 'resume'))
       .toEqual({ kind: 'disabled', reason: 'Only a paused goal can be resumed' })
-    expect(goalActionState(paused, [...all], 'resume')).toEqual({ kind: 'enabled' })
-    expect(goalActionState(paused, [...all], 'pause'))
+    expect(goalActionState({ current: paused, actions: [...all] }, 'resume')).toEqual({ kind: 'enabled' })
+    expect(goalActionState({ current: paused, actions: [...all] }, 'pause'))
       .toEqual({ kind: 'disabled', reason: 'Only an active goal can be paused' })
   })
 
   // The one action that does not need a goal to exist -- it is how the first one
   // arrives, and the empty state's button depends on exactly this.
   it('enables set when there is no goal at all', () => {
-    expect(goalActionState(undefined, ['set'], 'set')).toEqual({ kind: 'enabled' })
-    expect(goalActionState(undefined, ['set', 'clear'], 'clear'))
+    expect(goalActionState({ current: undefined, actions: ['set'] }, 'set')).toEqual({ kind: 'enabled' })
+    expect(goalActionState({ current: undefined, actions: ['set', 'clear'] }, 'clear'))
       .toEqual({ kind: 'disabled', reason: 'This session has no goal' })
   })
 
@@ -110,11 +111,23 @@ describe('goalActionState', () => {
   // applies -- and each says which state it needs rather than going silent.
   it('refuses both pause and resume for a dormant goal, with a reason', () => {
     const dormant = protoGoalToStore(protoGoal({ status: AgentGoalStatus.DORMANT }))
-    expect(goalActionState(dormant, [...all], 'pause'))
+    expect(goalActionState({ current: dormant, actions: [...all] }, 'pause'))
       .toEqual({ kind: 'disabled', reason: 'Only an active goal can be paused' })
-    expect(goalActionState(dormant, [...all], 'resume'))
+    expect(goalActionState({ current: dormant, actions: [...all] }, 'resume'))
       .toEqual({ kind: 'disabled', reason: 'Only a paused goal can be resumed' })
-    expect(goalActionState(dormant, [...all], 'clear')).toEqual({ kind: 'enabled' })
+    expect(goalActionState({ current: dormant, actions: [...all] }, 'clear')).toEqual({ kind: 'enabled' })
+  })
+
+  /**
+   * Both fields come from ONE surface, which is what the signature is for. A
+   * caller cannot pair one agent's goal with another agent's verb list, because
+   * there is no second argument to pair it with.
+   */
+  it('reads the goal and the verb list from the same surface', () => {
+    const surface: GoalSurface = { current: paused, progress: {}, actions: [...all] }
+    expect(goalActionState(surface, 'resume')).toEqual({ kind: 'enabled' })
+    // Narrow that ONE surface's verbs, and the same goal now hides the verb.
+    expect(goalActionState({ ...surface, actions: ['set'] }, 'resume')).toEqual({ kind: 'hidden' })
   })
 })
 

--- a/frontend/src/stores/chatGoal.ts
+++ b/frontend/src/stores/chatGoal.ts
@@ -240,12 +240,23 @@ export type GoalActionState
     | { kind: 'enabled' }
     | { kind: 'disabled', reason: string }
 
+/**
+ * Whether one verb is hidden, live, or refused for a goal surface.
+ *
+ * It takes the SURFACE, not a goal and an action list side by side. The two
+ * fields travel together for a reason -- they describe one agent -- and two
+ * parameters let a caller pair one agent's goal with another agent's verbs,
+ * which is exactly the split `GoalSurface` exists to remove. `Pick` rather than
+ * the whole surface, because the answer never depends on the counters or the
+ * handler, and a test that had to build a `progress` field this never reads
+ * would say otherwise.
+ */
 export function goalActionState(
-  goal: SessionGoal | undefined,
-  supportedActions: GoalAction[],
+  surface: Pick<GoalSurface, 'current' | 'actions'>,
   action: GoalAction,
 ): GoalActionState {
-  if (!supportedActions.includes(action))
+  const goal = surface.current
+  if (!surface.actions.includes(action))
     return { kind: 'hidden' }
   // Setting a goal is the one action that does not need one to exist -- it is
   // how the first one arrives.

--- a/frontend/src/styles/fadeMask.ts
+++ b/frontend/src/styles/fadeMask.ts
@@ -1,0 +1,27 @@
+import type { StyleRule } from '@vanilla-extract/css'
+
+/**
+ * The fade over the last line of a box that clips its content.
+ *
+ * A plain `.ts` module rather than a `.css.ts` one, because vanilla-extract
+ * lets a `.css.ts` file export only plain data -- a function export fails the
+ * whole module at build time with `Invalid exports`. `~/styles/codeBlock.ts`
+ * holds the shared code-surface rules for the same reason.
+ *
+ * Both spellings, always. The unprefixed `mask-image` and the `-webkit-` one
+ * are a PAIR: WebKit needs the prefixed property, and a site that edits one line
+ * and not the other loses the fade in exactly one engine, which no test catches.
+ * Returning the two together makes that impossible.
+ *
+ * `fadeEm` is how tall the fade is, in the box's own line-height units, so a
+ * caller states it as the number of lines to dim.
+ *
+ * Usage in a `.css.ts` file:
+ * ```ts
+ * export const collapsed = style({ maxHeight: '3.6rem', overflow: 'hidden', ...fadeMaskBottom() })
+ * ```
+ */
+export function fadeMaskBottom(fadeEm = 1.5): StyleRule {
+  const mask = `linear-gradient(to bottom, black calc(100% - ${fadeEm}em), transparent)`
+  return { WebkitMaskImage: mask, maskImage: mask }
+}

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -49,30 +49,6 @@ export const chipBase = style([controlReset, {
   },
 }])
 
-/**
- * The disclosure toggle that expands and collapses a clipped block: "Show more"
- * and "Show less".
- *
- * A dotted underline rather than a button box, because it sits at the end of
- * the content it opens and a solid control there reads as a second action on
- * the row. Three unrelated surfaces share it -- a control request's reason
- * text, a control request's option list, and the session goal's objective --
- * so it lives here rather than in any one of their stylesheets.
- */
-export const collapsibleToggle = style({
-  'all': 'unset',
-  'display': 'inline',
-  'fontSize': 'var(--text-8)',
-  'color': 'var(--muted-foreground)',
-  'cursor': 'pointer',
-  'textDecoration': 'underline',
-  'textDecorationStyle': 'dotted',
-  'textUnderlineOffset': '2px',
-  ':hover': {
-    color: 'var(--foreground)',
-  },
-})
-
 export const errorText = style({
   color: 'var(--danger)',
   fontSize: 'var(--text-7)',

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -49,6 +49,30 @@ export const chipBase = style([controlReset, {
   },
 }])
 
+/**
+ * The disclosure toggle that expands and collapses a clipped block: "Show more"
+ * and "Show less".
+ *
+ * A dotted underline rather than a button box, because it sits at the end of
+ * the content it opens and a solid control there reads as a second action on
+ * the row. Three unrelated surfaces share it -- a control request's reason
+ * text, a control request's option list, and the session goal's objective --
+ * so it lives here rather than in any one of their stylesheets.
+ */
+export const collapsibleToggle = style({
+  'all': 'unset',
+  'display': 'inline',
+  'fontSize': 'var(--text-8)',
+  'color': 'var(--muted-foreground)',
+  'cursor': 'pointer',
+  'textDecoration': 'underline',
+  'textDecorationStyle': 'dotted',
+  'textUnderlineOffset': '2px',
+  ':hover': {
+    color: 'var(--foreground)',
+  },
+})
+
 export const errorText = style({
   color: 'var(--danger)',
   fontSize: 'var(--text-7)',

--- a/frontend/tests/e2e/010-workspace-chat.spec.ts
+++ b/frontend/tests/e2e/010-workspace-chat.spec.ts
@@ -25,7 +25,7 @@ test.describe('Workspace Chat', () => {
   test('should create workspace, open agent, and receive response from Claude', async ({ page, authenticatedWorkspace }) => {
     // An agent tab is auto-created when a workspace is created.
     // Wait for the Milkdown editor to be ready.
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // OpenAgent now returns immediately (status=STARTING); wait for the

--- a/frontend/tests/e2e/014-workspace-archive.spec.ts
+++ b/frontend/tests/e2e/014-workspace-archive.spec.ts
@@ -177,7 +177,7 @@ test.describe('workspace archive', () => {
       const agents = await listAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId)
       return agents.find(agent => agent.id === agentId)?.status
     }).toBe(AgentStatus.ACTIVE)
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editor.click()
     await page.keyboard.type(ARITHMETIC_PROMPT)
     await page.keyboard.press('Meta+Enter')
@@ -399,7 +399,7 @@ processTest.describe('workspace archive reconciliation', () => {
         const agents = await listAgentsViaAPI(hubUrl, adminToken, workerId, workspaceId)
         return agents.find(agent => agent.id === agentId)?.status
       }).toBe(AgentStatus.ACTIVE)
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await editor.click()
       await page.keyboard.type(ARITHMETIC_PROMPT)
       await page.keyboard.press('Meta+Enter')

--- a/frontend/tests/e2e/022-worker-restart-thinking-indicator.spec.ts
+++ b/frontend/tests/e2e/022-worker-restart-thinking-indicator.spec.ts
@@ -13,7 +13,7 @@ test.describe('Worker Restart Thinking Indicator', () => {
       await openWorkspace(page, workspaceId)
 
       // Wait for agent tab and editor
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Send a message to start an agent turn
@@ -53,7 +53,7 @@ test.describe('Worker Restart Thinking Indicator', () => {
       await loginViaToken(page, adminToken)
       await openWorkspace(page, workspaceId)
 
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Send a message and wait for a response

--- a/frontend/tests/e2e/023-full-restart.spec.ts
+++ b/frontend/tests/e2e/023-full-restart.spec.ts
@@ -15,7 +15,7 @@ test.describe('Full Hub+Worker Restart', () => {
       await openWorkspace(page, workspaceId)
 
       // Wait for agent tab and editor
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Step 1: Send a message and wait for a response
@@ -238,7 +238,7 @@ test.describe('Full Hub+Worker Restart', () => {
       await loginViaToken(page, adminToken)
       await openWorkspace(page, workspaceId)
 
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Send a long message to start an agent turn

--- a/frontend/tests/e2e/024-message-delivery-error.spec.ts
+++ b/frontend/tests/e2e/024-message-delivery-error.spec.ts
@@ -11,7 +11,7 @@ test.describe('Failed agent input enqueue', () => {
     try {
       await loginViaToken(page, adminToken)
       await openWorkspace(page, workspaceId)
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       await editor.fill('What is 1234 + 5678? Reply with only the number.')
@@ -48,7 +48,7 @@ test.describe('Failed agent input enqueue', () => {
     try {
       await loginViaToken(page, adminToken)
       await openWorkspace(page, workspaceId)
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       await stopWorker()
@@ -62,7 +62,7 @@ test.describe('Failed agent input enqueue', () => {
       await page.reload()
       await appMenuTrigger(page).waitFor({ state: 'visible' })
       await page.getByText('Retained Draft Test').click()
-      await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toHaveText('Draft survives reload')
+      await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toHaveText('Draft survives reload')
     }
     finally {
       await deleteWorkspaceViaAPI(hubUrl, adminToken, workspaceId).catch(() => {})

--- a/frontend/tests/e2e/025-no-worker-settings.spec.ts
+++ b/frontend/tests/e2e/025-no-worker-settings.spec.ts
@@ -14,7 +14,7 @@ test.describe('Settings and /clear after Worker restart', () => {
       await openWorkspace(page, workspaceId)
 
       // Wait for agent tab and editor
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Step 1: Send a message and wait for a response (agent starts)

--- a/frontend/tests/e2e/026-agent-resume.spec.ts
+++ b/frontend/tests/e2e/026-agent-resume.spec.ts
@@ -15,7 +15,7 @@ test.describe('Agent Session Resume', () => {
       await openWorkspace(page, workspaceId)
 
       // Wait for agent tab and editor
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Send a message and wait for response
@@ -63,7 +63,7 @@ test.describe('Agent Session Resume', () => {
       await loginViaToken(page, adminToken)
       await openWorkspace(page, workspaceId)
 
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // One exchange is what gets the CLI to report a session id, which is the
@@ -105,7 +105,7 @@ test.describe('Agent Session Resume', () => {
       await openWorkspace(page, workspaceId)
 
       // Wait for agent tab and editor
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Send a message and wait for response (establishes session)
@@ -145,7 +145,7 @@ test.describe('Agent Session Resume', () => {
       await openWorkspace(page, workspaceId)
 
       // Wait for agent tab and editor
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Send a message and wait for response (establishes session)

--- a/frontend/tests/e2e/030-markdown-editor-input.spec.ts
+++ b/frontend/tests/e2e/030-markdown-editor-input.spec.ts
@@ -15,7 +15,7 @@ import { expect, test } from './fixtures'
  */
 test.describe('Markdown editor input — smoke', () => {
   test('the bullet-list input rule + Tab produces a nested list in the live editor', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     await editor.click()

--- a/frontend/tests/e2e/031-markdown-editor-draft.spec.ts
+++ b/frontend/tests/e2e/031-markdown-editor-draft.spec.ts
@@ -9,7 +9,7 @@ import { expect, test } from './fixtures'
  */
 test.describe('Draft Persistence', () => {
   test('draft survives page reload', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     await editor.click()
@@ -19,7 +19,7 @@ test.describe('Draft Persistence', () => {
     await page.waitForTimeout(700)
 
     await page.reload()
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toContainText('draft text to preserve')
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toContainText('draft text to preserve')
   })
 })

--- a/frontend/tests/e2e/032-markdown-editor-paste.spec.ts
+++ b/frontend/tests/e2e/032-markdown-editor-paste.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from './fixtures'
 
 test.describe('Markdown Paste', () => {
   test('pasting markdown list text creates a bullet list', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -26,7 +26,7 @@ test.describe('Markdown Paste', () => {
 
 test.describe('Clipboard Copy/Paste', () => {
   test('copy and paste preserves markdown structure', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -80,7 +80,7 @@ test.describe('Clipboard Copy/Paste', () => {
 
 test.describe('Paste Into Code Context', () => {
   test('paste fenced code block into code_block strips delimiters', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -109,7 +109,7 @@ test.describe('Paste Into Code Context', () => {
   })
 
   test('paste inline code into code_block strips backticks', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -136,7 +136,7 @@ test.describe('Paste Into Code Context', () => {
   })
 
   test('paste plain text into code_block is unchanged', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 

--- a/frontend/tests/e2e/033-markdown-editor-code.spec.ts
+++ b/frontend/tests/e2e/033-markdown-editor-code.spec.ts
@@ -8,7 +8,7 @@ const MONOSPACE_FONT_RE = /HackNerdFont|Menlo|Monaco|Courier New|monospace/
 
 test.describe('Markdown Editor', () => {
   test('should grow editor beyond old 120px limit', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Default mode is Cmd+Enter-to-send, so Enter creates newlines
@@ -21,13 +21,13 @@ test.describe('Markdown Editor', () => {
     }
 
     // The editor wrapper should have grown (capped at 75% of container)
-    const wrapper = page.locator('[data-testid="chat-editor"]')
+    const wrapper = page.locator('[data-testid="composer-editor"]')
     const height = await wrapper.evaluate(el => el.getBoundingClientRect().height)
     expect(height).toBeGreaterThan(60)
   })
 
   test('should use --mono-font-family CSS variable for code elements', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     await editor.click()
@@ -74,7 +74,7 @@ test.describe('Code block field', () => {
 
   test('paints the composer code block a field that composites on its host, in both polarities', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -108,7 +108,7 @@ test.describe('Code block field', () => {
 
   test('paints a sent code block the same field as the one in the composer', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
     await page.keyboard.type('```')
@@ -160,7 +160,7 @@ test.describe('Code block field', () => {
 
   test('shows the block through, rather than tinting it twice, for a child that fills the background', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
     await page.keyboard.type('```')
@@ -193,7 +193,7 @@ test.describe('Code block field', () => {
 
   test('gives inline code and a <kbd> the same step as a fenced block', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -232,7 +232,7 @@ test.describe('Code block field', () => {
 
 test.describe('Code Language Label', () => {
   test('clicking language label opens popover and selecting language updates it', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -281,7 +281,7 @@ test.describe('Code Language Label', () => {
   })
 
   test('re-clicking the language label closes the popover instead of reopening it', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
     await page.keyboard.type('```')
@@ -314,7 +314,7 @@ test.describe('send feedback button labels', () => {
     await expect(rejectBtn).toHaveText('Reject')
 
     // Type feedback into the editor. The button must switch to "Send feedback".
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editor.click()
     await page.keyboard.type('Please reconsider this approach')
     await expect(rejectBtn).toHaveText('Send feedback')
@@ -324,7 +324,7 @@ test.describe('send feedback button labels', () => {
 test.describe('Markdown Editor links', () => {
   test('a link URL can be corrected after it is created', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -355,7 +355,7 @@ test.describe('Markdown Editor links', () => {
 
   test('Enter in the URL field applies and dismisses the popover', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -374,7 +374,7 @@ test.describe('Markdown Editor links', () => {
 
   test('mod+K links the selected text', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -404,7 +404,7 @@ test.describe('Markdown Editor links', () => {
 
   test('mod+K on a caret in a link edits that link, and over it overrides it', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -438,7 +438,7 @@ test.describe('Markdown Editor links', () => {
 
   test('a link can be unmade, keeping its text', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -455,7 +455,7 @@ test.describe('Markdown Editor links', () => {
 
   test('saving dismisses the popover, and it reopens cleanly afterwards', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
     await page.keyboard.type('[docs](https://old.test)')
@@ -484,7 +484,7 @@ test.describe('Markdown Editor links', () => {
 
   test('the link popover fits its own box, with no horizontal overflow', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
     await page.keyboard.type('[docs](https://a-fairly-long-example-url.test/some/path)')

--- a/frontend/tests/e2e/035-tabbar-improvements.spec.ts
+++ b/frontend/tests/e2e/035-tabbar-improvements.spec.ts
@@ -15,7 +15,7 @@ test.describe('TabBar Improvements', () => {
   test('new agent tab focuses editor and surfaces session ID after first turn', async ({ page, authenticatedWorkspace }) => {
     await openAgentViaUI(page)
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await expect(editor).toBeFocused()
 

--- a/frontend/tests/e2e/036-dropdown-popover.spec.ts
+++ b/frontend/tests/e2e/036-dropdown-popover.spec.ts
@@ -103,7 +103,7 @@ test.describe('DropdownMenu Popover – Focus and Positioning', () => {
     // Ensure an agent tab is open
     await openAgentViaUI(page)
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Send a message so the agent session starts and context info appears
@@ -167,7 +167,7 @@ test.describe('DropdownMenu Popover – Focus and Positioning', () => {
 
     // The editor should retain focus after the popover closes.
     const editorHasFocus = await page.evaluate(() => {
-      const proseMirror = document.querySelector('[data-testid="chat-editor"] .ProseMirror')
+      const proseMirror = document.querySelector('[data-testid="composer-editor"] .ProseMirror')
       if (!proseMirror)
         return false
       return proseMirror.contains(document.activeElement) || proseMirror === document.activeElement
@@ -187,7 +187,7 @@ test.describe('DropdownMenu Popover – Focus and Positioning', () => {
     // Ensure an agent tab is open
     await openAgentViaUI(page)
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Send a message so the agent session starts and context info appears

--- a/frontend/tests/e2e/037-quote-and-mention.spec.ts
+++ b/frontend/tests/e2e/037-quote-and-mention.spec.ts
@@ -8,7 +8,7 @@ const frontendDir = path.resolve(import.meta.dirname, '../..')
 test.describe('Quote and Mention', () => {
   test('reply button on assistant message inserts quoted text into editor', async ({ page, authenticatedWorkspace }) => {
     // Wait for the editor to be ready
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Send a message and wait for the assistant to reply
@@ -35,7 +35,7 @@ test.describe('Quote and Mention', () => {
   })
 
   test('cursor lands outside blockquote after quoting', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Send a message and wait for the assistant to reply
@@ -66,7 +66,7 @@ test.describe('Quote and Mention', () => {
   test('text selection copy button copies to clipboard', async ({ page, context, authenticatedWorkspace }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write'])
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Send a message and wait for the assistant to reply
@@ -103,7 +103,7 @@ test.describe('Quote and Mention', () => {
   test('text selection copy button copies with no Clipboard API', async ({ page, context, authenticatedWorkspace }) => {
     await context.grantPermissions(['clipboard-read', 'clipboard-write'])
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     await sendMessage(page, 'Say exactly: The quick brown fox jumps over the lazy dog')
@@ -141,7 +141,7 @@ test.describe('Quote and Mention', () => {
   // app uses to say "copied", so a failed write must do neither -- and must say
   // why, because a Copy button that silently does nothing reads as a dead button.
   test('text selection copy button keeps the selection and says why when nothing can copy', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     await sendMessage(page, 'Say exactly: The quick brown fox jumps over the lazy dog')
@@ -170,7 +170,7 @@ test.describe('Quote and Mention', () => {
   })
 
   test('text selection in chat message shows quote popover', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Send a message and wait for the assistant to reply
@@ -206,7 +206,7 @@ test.describe('Quote and Mention', () => {
       await openWorkspace(page, workspaceId)
 
       // Ensure an agent tab exists and the editor is ready
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Wait for the file tree to load — package.json should be visible
@@ -239,7 +239,7 @@ test.describe('Quote and Mention', () => {
       await expect(agentTab).toBeVisible()
       await agentTab.click()
 
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Wait for the file tree to load
@@ -291,7 +291,7 @@ test.describe('Quote and Mention', () => {
       await expect(agentTab).toBeVisible()
       await agentTab.click()
 
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Type some draft text into the editor
@@ -337,7 +337,7 @@ test.describe('Quote and Mention', () => {
       await openWorkspace(page, workspaceId)
 
       // Ensure an agent tab exists and the editor is ready
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Wait for the file tree to load — package.json should be visible
@@ -375,7 +375,7 @@ test.describe('Quote and Mention', () => {
       await expect(agentTab).toBeVisible()
       await agentTab.click()
 
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       // Wait for the file tree to load

--- a/frontend/tests/e2e/038-attachment-support.spec.ts
+++ b/frontend/tests/e2e/038-attachment-support.spec.ts
@@ -26,7 +26,7 @@ function createTestBinary(name = 'test.bin'): string {
 
 test.describe('Attachment Support', () => {
   test('attach item opens file dialog and attachment appears in strip', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Attach moved from the deleted formatting toolbar into the `[+]` menu.
@@ -58,7 +58,7 @@ test.describe('Attachment Support', () => {
   })
 
   test('remove attachment via X button', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Upload a file.
@@ -75,7 +75,7 @@ test.describe('Attachment Support', () => {
   })
 
   test('attachments survive tab switch', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Upload a file.
@@ -101,7 +101,7 @@ test.describe('Attachment Support', () => {
   })
 
   test('attachments cleared after send', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Upload a file.
@@ -119,7 +119,7 @@ test.describe('Attachment Support', () => {
   })
 
   test('paste image adds attachment', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -130,7 +130,7 @@ test.describe('Attachment Support', () => {
       const dt = new DataTransfer()
       dt.items.add(file)
       const event = new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true })
-      document.querySelector('[data-testid="chat-editor"]')!.dispatchEvent(event)
+      document.querySelector('[data-testid="composer-editor"]')!.dispatchEvent(event)
     })
 
     // An attachment pill should appear.
@@ -138,7 +138,7 @@ test.describe('Attachment Support', () => {
   })
 
   test('paste image adds attachment when clipboardData.files is empty (Linux/WebKitGTK shape)', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
 
@@ -158,7 +158,7 @@ test.describe('Attachment Support', () => {
       }
       const event = new Event('paste', { bubbles: true, cancelable: true })
       Object.defineProperty(event, 'clipboardData', { value: fakeClipboardData })
-      document.querySelector('[data-testid="chat-editor"]')!.dispatchEvent(event)
+      document.querySelector('[data-testid="composer-editor"]')!.dispatchEvent(event)
     })
 
     // An attachment pill should appear.
@@ -173,7 +173,7 @@ test.describe('Attachment Support', () => {
   // test; manual paste in the desktop build is the only true end-to-end.
 
   test('unsupported file type rejected with toast', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Upload a binary file (unsupported type for the default provider).
@@ -189,7 +189,7 @@ test.describe('Attachment Support', () => {
   })
 
   test('attachment-only message (no text) can be sent', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Upload a file without typing any text.
@@ -209,7 +209,7 @@ test.describe('Attachment Support', () => {
   })
 
   test('drag and drop adds attachment', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Simulate drag and drop via the file input (Playwright doesn't natively
@@ -222,7 +222,7 @@ test.describe('Attachment Support', () => {
   })
 
   test('chat history shows attachment list in user message', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Upload a file and send with text.

--- a/frontend/tests/e2e/039-composer-send-focus.spec.ts
+++ b/frontend/tests/e2e/039-composer-send-focus.spec.ts
@@ -13,7 +13,7 @@ import { CHAT_SCROLL_CONTAINER } from './helpers/ui'
  * the transcript the user just uncovered.
  */
 test.describe('composer send focus', () => {
-  const EDITOR = '[data-testid="chat-editor"] .ProseMirror'
+  const EDITOR = '[data-testid="composer-editor"] .ProseMirror'
 
   test('a press on Send keeps the caret in the editor', async ({ page, authenticatedWorkspace }) => {
     const editor = page.locator(EDITOR)

--- a/frontend/tests/e2e/043-control-request-draft.spec.ts
+++ b/frontend/tests/e2e/043-control-request-draft.spec.ts
@@ -9,7 +9,7 @@ test.describe('Control Request Draft Persistence', () => {
     await expect(banner.getByText('Plan Ready for Review')).toBeVisible()
 
     // Type a rejection reason in the editor.
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editor.click()
     await page.keyboard.type('draft rejection reason', { delay: 100 })
 
@@ -24,7 +24,7 @@ test.describe('Control Request Draft Persistence', () => {
     await expect(bannerAfterReload).toBeVisible()
 
     // Verify the editor still contains the rejection reason.
-    const restoredEditor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const restoredEditor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(restoredEditor).toContainText('draft rejection reason')
   })
 
@@ -39,7 +39,7 @@ test.describe('Control Request Draft Persistence', () => {
     await waitForControlBanner(page)
 
     // Type custom text in the editor.
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editor.click()
     await page.keyboard.type('my custom color answer', { delay: 100 })
 
@@ -54,13 +54,13 @@ test.describe('Control Request Draft Persistence', () => {
     await expect(bannerAfterReload).toBeVisible()
 
     // Verify the editor still contains the custom text.
-    const restoredEditor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const restoredEditor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(restoredEditor).toContainText('my custom color answer')
   })
 
   test('control request draft is isolated from conversation draft', async ({ page, authenticatedWorkspace, leapmuxServer }) => {
     // Type a conversation draft first.
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
     await page.keyboard.type('conversation draft text', { delay: 100 })
@@ -81,10 +81,10 @@ test.describe('Control Request Draft Persistence', () => {
 
     // Editor should be empty (control request has its own draft key). The
     // web-first assertion retries, so it needs no settling sleep.
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toHaveText('')
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toHaveText('')
 
     // Type control request draft text.
-    const editorForCtrl = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editorForCtrl = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editorForCtrl.click()
     await page.keyboard.type('control request draft text', { delay: 100 })
 
@@ -99,7 +99,7 @@ test.describe('Control Request Draft Persistence', () => {
     await expect(bannerAfterReload).toBeVisible()
 
     // Verify editor contains the control request draft (not the conversation draft).
-    const restoredEditor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const restoredEditor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(restoredEditor).toContainText('control request draft text')
     await expect(restoredEditor).not.toContainText('conversation draft text')
   })

--- a/frontend/tests/e2e/044-agent-settings.spec.ts
+++ b/frontend/tests/e2e/044-agent-settings.spec.ts
@@ -113,7 +113,7 @@ test.describe('Agent Settings', () => {
       await waitForSettingsIdle(page)
 
       // Verify agent restarted successfully by sending a message
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
       await editor.click()
       await page.keyboard.type('What is 3+4? Reply with just the number, nothing else.')
@@ -227,7 +227,7 @@ test.describe('Agent Settings', () => {
     await chooseSettingsOption(page, 'effort-ultracode')
     await waitForSettingsIdle(page)
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
     // Use a distinctive sentinel word as the answer, not a number. A numeric
@@ -314,7 +314,7 @@ test.describe('Agent Settings', () => {
 
   test('permission mode persistence across refresh', async ({ authenticatedWorkspace, page }) => {
     // Wait for the editor to be ready (agent is started)
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     const trigger = settingsBar(page)
@@ -358,7 +358,7 @@ test.describe('Agent Settings', () => {
 
   test('focus returns to editor after mode change', async ({ authenticatedWorkspace, page }) => {
     // Wait for the editor to be ready (agent is started)
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     const trigger = settingsBar(page)
@@ -387,7 +387,7 @@ test.describe('Agent Settings', () => {
     test.describe.configure({ retries: MODEL_NONDETERMINISM_RETRIES })
 
     test('settings restored after worker restart', async ({ authenticatedWorkspace, separateHubWorker, page }) => {
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await expect(editor).toBeVisible()
 
       const trigger = settingsBar(page)
@@ -434,7 +434,7 @@ test.describe('Agent Settings', () => {
   })
 
   test('interrupt via control request', async ({ authenticatedWorkspace, page }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // Send a quick message to ensure the agent is fully started
@@ -538,7 +538,7 @@ test.describe('Agent Settings', () => {
   })
 
   test('no thinking indicator when switching settings', async ({ authenticatedWorkspace, page }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     const trigger = settingsBar(page)

--- a/frontend/tests/e2e/045-1m-context-model.spec.ts
+++ b/frontend/tests/e2e/045-1m-context-model.spec.ts
@@ -30,7 +30,7 @@ test.describe('1m-context model', () => {
     await waitForSettingsIdle(page)
 
     // Send a message and verify the agent responds
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
     await page.keyboard.type('What is 5+3? Reply with just the number, nothing else.')

--- a/frontend/tests/e2e/047-chat-scroll-rail.spec.ts
+++ b/frontend/tests/e2e/047-chat-scroll-rail.spec.ts
@@ -36,7 +36,7 @@ test.describe('chat scroll rail', () => {
     // A short viewport so a couple of tall user bubbles overflow and the rail appears.
     await page.setViewportSize({ width: 720, height: 380 })
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     // Let the agent finish starting so the send takes the fast path (see 010).
     await expect(page.getByText(/^Starting /)).not.toBeVisible()

--- a/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
+++ b/frontend/tests/e2e/047b-chat-scroll-rail-autohide.spec.ts
@@ -43,7 +43,7 @@ const SCROLLER = '[data-chat-scroll-container="true"]'
  * than on "the viewport was too tall for one message".
  */
 async function seedOverflowingConversation(page: import('@playwright/test').Page) {
-  const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+  const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
   await expect(editor).toBeVisible()
   // Let the agent finish starting so the send takes the fast path (see 010).
   await expect(page.getByText(/^Starting /)).not.toBeVisible()

--- a/frontend/tests/e2e/047c-chat-scroll-rail-scrub.spec.ts
+++ b/frontend/tests/e2e/047c-chat-scroll-rail-scrub.spec.ts
@@ -30,7 +30,7 @@ const SCROLLER = '[data-chat-scroll-container="true"]'
 
 /** Send one tall message so the conversation overflows and the rail takes over scrolling. */
 async function seedOverflowingConversation(page: Page) {
-  const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+  const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
   await expect(editor).toBeVisible()
   // Let the agent finish starting so the send takes the fast path (see 010).
   await expect(page.getByText(/^Starting /)).not.toBeVisible()

--- a/frontend/tests/e2e/050-plan-mode.spec.ts
+++ b/frontend/tests/e2e/050-plan-mode.spec.ts
@@ -33,7 +33,7 @@ test.describe('Plan Mode', () => {
     await expect(exitBanner1.getByText('Plan Ready for Review')).toBeVisible()
 
     // ── Step 3: Reject the plan with a comment ──
-    const editorForReject = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editorForReject = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editorForReject.click()
     await page.keyboard.type('not ready yet', { delay: 100 })
     const rejectBtn = page.locator('[data-testid="plan-reject-btn"]')

--- a/frontend/tests/e2e/051-plan-mode-bypass.spec.ts
+++ b/frontend/tests/e2e/051-plan-mode-bypass.spec.ts
@@ -60,7 +60,7 @@ test.describe('Plan Mode - Bypass Permissions', () => {
     await expect(page.locator('[data-testid="control-permissions-pill-group"]')).toBeVisible()
 
     // Type rejection text in the editor
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editor.click()
     await page.keyboard.type('needs changes', { delay: 100 })
 

--- a/frontend/tests/e2e/090-claude-agent-open-timing.spec.ts
+++ b/frontend/tests/e2e/090-claude-agent-open-timing.spec.ts
@@ -82,7 +82,7 @@ test.describe('Claude Code agent open timing', () => {
     await loginViaToken(page, srv.adminToken)
     await openWorkspace(page, workspaceId)
     await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(1)
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
 
     await installRpcListeners(page)
 
@@ -109,7 +109,7 @@ test.describe('Claude Code agent open timing', () => {
         w.__editorAppearedAt = null
         w.__startupOverlayGoneAt = null
         w.__tabBaseline = document.querySelectorAll('[data-testid="tab"][data-tab-type="agent"]').length
-        const priorEditor = document.querySelector('[data-testid="chat-editor"] .ProseMirror')
+        const priorEditor = document.querySelector('[data-testid="composer-editor"] .ProseMirror')
         w.__tabObserver?.disconnect()
         w.__tabObserver = new MutationObserver(() => {
           if (w.__tabAppearedAt == null) {
@@ -118,7 +118,7 @@ test.describe('Claude Code agent open timing', () => {
               w.__tabAppearedAt = performance.now()
           }
           if (w.__editorAppearedAt == null) {
-            const ed = document.querySelector('[data-testid="chat-editor"] .ProseMirror')
+            const ed = document.querySelector('[data-testid="composer-editor"] .ProseMirror')
             // A fresh .ProseMirror for the new tab (DOM node differs from
             // the pre-click instance).
             if (ed && ed !== priorEditor)
@@ -145,7 +145,7 @@ test.describe('Claude Code agent open timing', () => {
       await page.locator('[data-testid^="new-agent-button"]').first().click()
 
       await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(tabsBefore + 1)
-      await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+      await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
       // Since OpenAgent now returns immediately (status=STARTING), we
       // need to actively wait for this specific iteration's subprocess
       // startup to finish. Identify the new agent_id from the first

--- a/frontend/tests/e2e/091-claude-agent-startup-queue.spec.ts
+++ b/frontend/tests/e2e/091-claude-agent-startup-queue.spec.ts
@@ -8,7 +8,7 @@ test.describe('Claude Code agent startup queue', () => {
   test('queues a typed-during-startup message and delivers it on ACTIVE', async ({ page, authenticatedWorkspace }) => {
     // Editor is reachable while the agent is still STARTING — the new
     // OpenAgent flow returns immediately and renders the loader overlay.
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
 
     // The startup overlay must be visible at the start (or transition

--- a/frontend/tests/e2e/092-claude-agent-startup-error.spec.ts
+++ b/frontend/tests/e2e/092-claude-agent-startup-error.spec.ts
@@ -63,7 +63,7 @@ test.describe('Claude Code agent startup error', () => {
     await expect(errorPanel.locator('pre code')).toBeVisible()
 
     // The Worker retains the input as a failed queue item.
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editor.click()
     await page.keyboard.type('hello')
     await page.keyboard.press('Meta+Enter')

--- a/frontend/tests/e2e/099-selection-stability.spec.ts
+++ b/frontend/tests/e2e/099-selection-stability.spec.ts
@@ -33,7 +33,7 @@ test.describe('chat text selection stability', () => {
     page.evaluate(() => (window.getSelection()?.toString() ?? '').trim().length)
 
   test('a drag-selection survives the mouse release', async ({ page, authenticatedWorkspace }) => {
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
     await sendMessage(page, 'Say exactly: The quick brown fox jumps over the lazy dog')
     await waitForAgentIdle(page)
 
@@ -58,7 +58,7 @@ test.describe('chat text selection stability', () => {
   })
 
   test('selecting text while scrolled up does not move the viewport', async ({ page, authenticatedWorkspace }) => {
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
     // Enough turns to make the transcript scrollable, so "scrolled up" is a real state.
     for (const n of [1, 2, 3, 4]) {
       await sendMessage(page, `Say exactly: line ${n} -- the quick brown fox jumps over the lazy dog`)

--- a/frontend/tests/e2e/102-codex-plan-mode.spec.ts
+++ b/frontend/tests/e2e/102-codex-plan-mode.spec.ts
@@ -41,7 +41,7 @@ codexTest.describe('Codex Plan Mode Prompt', () => {
     await expect(page.getByTestId('plan-clear-context-checkbox')).toBeVisible()
     await expect(page.getByTestId('control-permissions-pill-group')).toBeVisible()
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await editor.click()
     await page.keyboard.type(REVISE_PLAN_PROMPT, { delay: 50 })

--- a/frontend/tests/e2e/106-codex-turn-end-sound.spec.ts
+++ b/frontend/tests/e2e/106-codex-turn-end-sound.spec.ts
@@ -17,7 +17,7 @@ codexTest.describe('Codex Turn End Sound', () => {
 
     // Reload so the init scripts take effect
     await page.reload()
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
 
     // Send a message that triggers tool use (command execution) so num_tool_uses > 0
     await sendMessage(page, 'Run the command `pwd` and tell me the result.')
@@ -46,7 +46,7 @@ codexTest.describe('Codex Turn End Sound', () => {
 
     // Reload so the init scripts take effect
     await page.reload()
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
 
     // Send a simple question that completes without tool use (num_tool_uses = 0)
     await sendMessage(page, 'What is 1234 + 5678? Reply with just the number, nothing else.')

--- a/frontend/tests/e2e/107-codex-request-user-input.spec.ts
+++ b/frontend/tests/e2e/107-codex-request-user-input.spec.ts
@@ -13,7 +13,7 @@ codexTest.describe('Codex requestUserInput', () => {
     await waitForSettingsIdle(page)
 
     // Close the menu by clicking elsewhere.
-    await page.locator('[data-testid="chat-editor"] .ProseMirror').click()
+    await page.locator('[data-testid="composer-editor"] .ProseMirror').click()
 
     // Send a command that will trigger an approval request.
     // Use rm which should always require approval in on-request mode.

--- a/frontend/tests/e2e/108-agent-input-queue.spec.ts
+++ b/frontend/tests/e2e/108-agent-input-queue.spec.ts
@@ -18,7 +18,7 @@ import { ensureWorkerOnline, expect, restartWorker, processTest as test } from '
  * matches more than the row.
  */
 async function seedTwoQueuedRows(page: Page) {
-  await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+  await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
   await page.getByTestId('queue-pause-button').click()
   await sendMessage(page, 'first queued')
   await sendMessage(page, 'second queued')
@@ -35,7 +35,7 @@ async function seedTwoQueuedRows(page: Page) {
 
 test.describe('agent input queue', () => {
   test('persists paused input across clients, a reload, and a Worker restart, then supports queue changes', async ({ page, browser, authenticatedWorkspace, separateHubWorker }) => {
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
     await page.getByTestId('queue-pause-button').click()
     await expect(page.getByTestId('queue-pause-button')).toHaveText('Resume Queue')
 
@@ -43,7 +43,7 @@ test.describe('agent input queue', () => {
     const secondPage = await secondContext.newPage()
     await loginViaToken(secondPage, separateHubWorker.adminToken)
     await openWorkspace(secondPage, authenticatedWorkspace.workspaceId)
-    await expect(secondPage.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(secondPage.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
 
     try {
       await expect(secondPage.getByTestId('queue-pause-button')).toHaveText('Resume Queue')
@@ -71,7 +71,7 @@ test.describe('agent input queue', () => {
       await expect(page.getByTestId('agent-input-queue')).toContainText(queuedFirstPreview)
       await expect(page.getByTestId('agent-input-queue')).toContainText('queued second')
 
-      const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+      const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
       await editor.fill('normal draft')
       await page.getByTestId('file-input').setInputFiles({
         name: 'normal-draft.txt',
@@ -113,7 +113,7 @@ test.describe('agent input queue', () => {
       await edited.getByRole('button', { name: 'Edit', exact: true }).click()
       const secondClientItem = secondPage.getByTestId(/queued-input-/).filter({ hasText: 'edited first' })
       await secondClientItem.getByRole('button', { name: 'Take Over' }).click()
-      await expect(secondPage.locator('[data-testid="chat-editor"] .ProseMirror')).toHaveText('edited first')
+      await expect(secondPage.locator('[data-testid="composer-editor"] .ProseMirror')).toHaveText('edited first')
       await expect(editor).toHaveText('normal draft')
       await secondClientItem.getByRole('button', { name: 'Cancel Edit' }).click()
 
@@ -205,7 +205,7 @@ test.describe('agent input queue', () => {
 
   test('spaces the pause banner, the queue, the attachments and the composer alike', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
     await page.getByTestId('queue-pause-button').click()
     await sendMessage(page, 'a queued input')
     await expect(page.getByTestId('agent-input-queue')).toContainText('a queued input')
@@ -268,7 +268,7 @@ test.describe('agent input queue', () => {
     // Narrower than any phone this app targets, so the action row has the
     // least space it will ever have.
     await page.setViewportSize({ width: 320, height: 720 })
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
 
     const plus = page.getByTestId('composer-plus-trigger')
     const footer = page.getByTestId('composer-footer-slot')
@@ -295,7 +295,7 @@ test.describe('agent input queue', () => {
     // pane or a floating window puts a ~260px composer on a 1200px display, and
     // a VIEWPORT media query calls that composer wide.
     await page.setViewportSize({ width: 1200, height: 800 })
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
     await page.addStyleTag({ content: '[data-testid="agent-editor-panel"] { max-width: 260px; }' })
 
     const plus = page.getByTestId('composer-plus-trigger')

--- a/frontend/tests/e2e/118-opencode-agent-lifecycle.spec.ts
+++ b/frontend/tests/e2e/118-opencode-agent-lifecycle.spec.ts
@@ -7,7 +7,7 @@ opencodeTest.describe('OpenCode Agent Lifecycle', () => {
   opencodeTest('agent starts and shows ready state', async ({ authenticatedOpencodeWorkspace, page }) => {
     void authenticatedOpencodeWorkspace // fixture trigger
 
-    // The editor renders regardless of agent state — a chat-editor visibility
+    // The editor renders regardless of agent state — a composer-editor visibility
     // check alone passes even when the agent backend is broken. Send a
     // trivial prompt and assert a response comes back so the test catches
     // a regression where the agent fails to start.

--- a/frontend/tests/e2e/179-mobile-tabs-touch.spec.ts
+++ b/frontend/tests/e2e/179-mobile-tabs-touch.spec.ts
@@ -261,7 +261,7 @@ test.describe('soft-keyboard viewport contract (phone)', () => {
     const bar = page.getByTestId('tab-bar')
     await expect(bar).toBeVisible()
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editor.click()
     await expect(editor).toBeFocused()
 
@@ -292,7 +292,7 @@ test.describe('soft-keyboard viewport contract (phone)', () => {
   // the first half is the phone-with-a-hardware-keyboard case, where dropping
   // the caret would reclaim nothing.
   test('a send releases focus only while the keyboard takes screen space', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     const size = page.viewportSize()!
 
     await editor.click()
@@ -327,7 +327,7 @@ test.describe('soft-keyboard viewport contract (phone)', () => {
   // composer that overlays its centre. Hit-testing is the browser's job; what
   // is ours is what the handler makes of the gesture.
   test('a tap on the transcript releases the composer only while the keyboard takes screen space', async ({ page, authenticatedWorkspace }) => {
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     const transcript = page.locator('[data-chat-scroll-container="true"]')
     const size = page.viewportSize()!
 

--- a/frontend/tests/e2e/180-codex-session-goal.spec.ts
+++ b/frontend/tests/e2e/180-codex-session-goal.spec.ts
@@ -153,8 +153,8 @@ codexTest.describe('Codex session goal', () => {
   }) => {
     void authenticatedCodexWorkspace
 
-    // The chip needs a goal to name and a busy agent to sit beside, so the goal
-    // is set first from the sidebar, while the agent is idle.
+    // The chip needs a goal to report and a busy agent to sit beside, so the
+    // goal is set first from the sidebar, while the agent is idle.
     await sendMessage(page, 'Reply with the single word: ready')
     await waitForAgentIdle(page)
     await expandBackgroundTasksSection(page)
@@ -174,10 +174,11 @@ codexTest.describe('Codex session goal', () => {
     const popover = page.locator('[data-testid="goal-popover"]')
     await expect(popover).toBeVisible()
 
-    // Scoped to the popover throughout: the sidebar card is on screen too, so
-    // every one of these test ids matches twice while this popover is open.
-    await popover.locator('[data-testid="goal-actions-trigger"]').click()
-    await expect(popover.locator('[data-testid="goal-action-clear"]')).toBeVisible()
+    // Rooted at the popover, through the same helpers the sidebar cases use:
+    // the sidebar card is on screen too, so every one of these test ids matches
+    // twice while this popover is open, and only the root separates them.
+    await openGoalMenu(popover)
+    await expect(goalAction(popover, 'clear')).toBeVisible()
     // The card survived its own menu opening. That is the assertion.
     await expect(popover).toBeVisible()
 

--- a/frontend/tests/e2e/180-codex-session-goal.spec.ts
+++ b/frontend/tests/e2e/180-codex-session-goal.spec.ts
@@ -19,6 +19,7 @@ import {
   goalAction,
   goalCard,
   listAgents,
+  openGoalMenu,
   workPanelTab,
 } from './helpers/subagentRegistry'
 import { sendMessage, waitForAgentIdle } from './helpers/ui'
@@ -53,9 +54,10 @@ codexTest.describe('Codex session goal', () => {
     await workPanelTab(page, 'goal').click()
     await expect(page.locator('[data-testid="goal-card-empty"]:visible')).toBeVisible()
 
-    // 4. Set one through the dialog.
+    // 4. Set one through the dialog. The field is the app's markdown editor, so
+    //    the target is its contenteditable body rather than a textarea.
     await goalAction(page, 'set').click()
-    const input = page.locator('[data-testid="set-goal-input"]:visible')
+    const input = page.locator('[data-testid="goal-editor"]:visible .ProseMirror')
     await input.fill('Reply with the single word DONE and then stop.')
     await page.locator('[data-testid="set-goal-submit"]:visible').click()
 
@@ -66,18 +68,50 @@ codexTest.describe('Codex session goal', () => {
     ).toContain('Reply with the single word DONE')
     await expectGoalStatus(page, 'active')
 
-    // 6. Pause, then resume. Codex carries both on thread/goal/set, and each
+    // 6. Replace it through the card's `...` menu, with an objective too long
+    //    for the card. The clamp and its disclosure are real LAYOUT -- only a
+    //    browser can say whether the box actually hides anything -- so this is
+    //    the one place that decision is exercised for real.
+    //
+    //    Prose, with no markdown marks. `fill` writes into the editor's
+    //    contenteditable body without running ProseMirror's input rules, so
+    //    typed asterisks would reach the serializer as literal text and come
+    //    back escaped. What the card does with real marks is a unit case.
+    const longObjective = `Keep going until every check passes on both runners. ${'Then confirm the result and report it back before stopping. '.repeat(8)}`
+    await openGoalMenu(page)
+    await goalAction(page, 'set').click()
+    await page.locator('[data-testid="goal-editor"]:visible .ProseMirror').fill(longObjective)
+    await page.locator('[data-testid="set-goal-submit"]:visible').click()
+
+    const objective = page.locator('[data-testid="goal-objective"]:visible')
+    await expect.poll(async () => await objective.textContent())
+      .toContain('Keep going until every check passes')
+
+    const toggle = page.locator('[data-testid="goal-objective-toggle"]:visible')
+    await expect(toggle).toHaveText('Show more')
+    const clampedHeight = (await objective.boundingBox())?.height ?? 0
+    expect(clampedHeight).toBeGreaterThan(0)
+    await toggle.click()
+    await expect(toggle).toHaveText('Show less')
+    expect((await objective.boundingBox())?.height ?? 0).toBeGreaterThan(clampedHeight)
+
+    // 7. Pause, then resume. Codex carries both on thread/goal/set, and each
     //    round trip is confirmed by the status the worker broadcasts back.
+    //    Each verb lives in the card's `...` menu, which closes behind the
+    //    click that runs one.
+    await openGoalMenu(page)
     await goalAction(page, 'pause').click()
     await expectGoalStatus(page, 'paused')
+    await openGoalMenu(page)
     await goalAction(page, 'resume').click()
     await expectGoalStatus(page, 'active')
 
-    // 7. Clear. The card returns to the empty state that can set another.
+    // 8. Clear. The card returns to the empty state that can set another.
+    await openGoalMenu(page)
     await goalAction(page, 'clear').click()
     await expect(page.locator('[data-testid="goal-card-empty"]:visible')).toBeVisible()
 
-    // 8. The transcript records the TRANSITIONS and not the progress reports.
+    // 9. The transcript records the TRANSITIONS and not the progress reports.
     //    This is the assertion the whole change exists for: Codex sends a full
     //    goal report after every completed tool call, and each one used to
     //    become its own raw-JSON row.
@@ -94,11 +128,61 @@ codexTest.describe('Codex session goal', () => {
     const agentId = agents?.[0]?.id ?? ''
     expect(agentId).not.toBe('')
     const transitions = async () => await countGoalTransitions(hubUrl, adminToken, workerId, agentId)
-    // Four actions were performed above.
+    // Five actions were performed above.
     await expect.poll(transitions).toBeGreaterThan(0)
     // A generous ceiling that still fails loudly if a progress report ever
     // reaches the transcript again -- that would put one row per completed tool
     // call here, which is the bug this whole change removes.
     await expect.poll(transitions).toBeLessThan(10)
+  })
+
+  /**
+   * The card is rendered by TWO hosts, and this is the second one: the
+   * ThinkingIndicator's goal popover renders the same panel inside a
+   * `DropdownMenu as="card"`.
+   *
+   * The card's `...` menu is therefore a `popover=auto` nested inside another
+   * one. A browser that did not treat the inner popover as a descendant of the
+   * outer would light-dismiss the card the moment the menu opened, and every
+   * verb would be unreachable from this host. Only a real browser can answer
+   * that, so it is answered here.
+   */
+  codexTest('opens the goal actions from the thinking indicator popover', async ({
+    authenticatedCodexWorkspace,
+    page,
+  }) => {
+    void authenticatedCodexWorkspace
+
+    // The chip needs a goal to name and a busy agent to sit beside, so the goal
+    // is set first from the sidebar, while the agent is idle.
+    await sendMessage(page, 'Reply with the single word: ready')
+    await waitForAgentIdle(page)
+    await expandBackgroundTasksSection(page)
+    await workPanelTab(page, 'goal').click()
+    await goalAction(page, 'set').click()
+    await page.locator('[data-testid="goal-editor"]:visible .ProseMirror').fill('Keep the build green.')
+    await page.locator('[data-testid="set-goal-submit"]:visible').click()
+    await expectGoalStatus(page, 'active')
+
+    // A prompt long enough to hold the indicator on screen -- the same device
+    // the interrupt spec uses for the same window.
+    await sendMessage(page, 'Write a very detailed essay about the history of computing, at least 5000 words across multiple chapters with subheadings.')
+
+    const chip = page.locator('[data-testid="thinking-goal-chip"]:visible')
+    await expect(chip).toBeVisible()
+    await chip.click()
+    const popover = page.locator('[data-testid="goal-popover"]')
+    await expect(popover).toBeVisible()
+
+    // Scoped to the popover throughout: the sidebar card is on screen too, so
+    // every one of these test ids matches twice while this popover is open.
+    await popover.locator('[data-testid="goal-actions-trigger"]').click()
+    await expect(popover.locator('[data-testid="goal-action-clear"]')).toBeVisible()
+    // The card survived its own menu opening. That is the assertion.
+    await expect(popover).toBeVisible()
+
+    // End the turn, so teardown is not racing a running generation.
+    await page.keyboard.press('Escape')
+    await page.locator('[data-testid="interrupt-button"]').click()
   })
 })

--- a/frontend/tests/e2e/183-mobile-swipe-drawers.spec.ts
+++ b/frontend/tests/e2e/183-mobile-swipe-drawers.spec.ts
@@ -38,7 +38,7 @@ function drawers(page: Page): Drawers {
  * Both halves matter, and the first is the subtle one. The drawer test ids
  * exist ONLY in the mobile layout, so resolving them is what waits for that
  * layout to mount -- and the shell picks its layout from a media query, so the
- * desktop one can paint first and be swapped out. `tab-bar` and `chat-editor`
+ * desktop one can paint first and be swapped out. `tab-bar` and `composer-editor`
  * are in BOTH layouts, so a spec that measures against them and then swipes
  * reads as ready while nothing has armed the gesture yet, and the swipe is lost.
  */
@@ -59,7 +59,7 @@ async function expectMobileShellIdle(page: Page) {
  */
 async function transcriptY(page: Page): Promise<number> {
   const bar = (await page.getByTestId('tab-bar').boundingBox())!
-  const editor = (await page.getByTestId('chat-editor').boundingBox())!
+  const editor = (await page.getByTestId('composer-editor').boundingBox())!
   return (bar.y + bar.height + editor.y) / 2
 }
 
@@ -109,7 +109,7 @@ async function swipeBand(page: Page, direction: 'left' | 'right') {
   // that rather than as "the drawer never opened".
   const landing = await elementUnder(page, fromX, y)
   const where = `the swipe start at (${Math.round(fromX)}, ${Math.round(y)})`
-  expect(landing, where).not.toMatch(/chat-editor|tab-bar|nothing/)
+  expect(landing, where).not.toMatch(/composer-editor|tab-bar|nothing/)
   await touchSwipe(page, { from: { x: fromX, y }, to: { x: fromX + travel, y } })
 }
 
@@ -180,7 +180,7 @@ test.describe('mobile drawer swipes (phone)', () => {
   // A finger sweeping the composer is placing a caret or extending a selection.
   // The recognizer declines every press inside an editing host for that reason.
   test('a swipe across the composer opens no drawer', async ({ page, authenticatedWorkspace }) => {
-    const editorBox = (await page.locator('[data-testid="chat-editor"] .ProseMirror').boundingBox())!
+    const editorBox = (await page.locator('[data-testid="composer-editor"] .ProseMirror').boundingBox())!
     const y = editorBox.y + editorBox.height / 2
     await touchSwipe(page, {
       from: { x: editorBox.x + editorBox.width * 0.25, y },

--- a/frontend/tests/e2e/192-session-picker.spec.ts
+++ b/frontend/tests/e2e/192-session-picker.spec.ts
@@ -63,7 +63,7 @@ test.describe('Session picker in the New Agent dialog', () => {
       .filter({ hasText: 'Subject' })
       .first()
       .click()
-    await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
 
     // A turn, so the worker records a resume handle: an agent that never spoke
     // has no session to offer.

--- a/frontend/tests/e2e/193-tool-running-badge.spec.ts
+++ b/frontend/tests/e2e/193-tool-running-badge.spec.ts
@@ -34,7 +34,7 @@ test.describe('Tool Running Badge', () => {
     const dir = await mkdtemp(join(tmpdir(), 'leapmux-badge-'))
     const flag = join(dir, 'release')
 
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await expect(editor).toBeVisible()
     await expect(page.getByText(/^Starting /)).not.toBeVisible()
 

--- a/frontend/tests/e2e/helpers/subagentRegistry.ts
+++ b/frontend/tests/e2e/helpers/subagentRegistry.ts
@@ -1,5 +1,6 @@
 /**
- * Shared helpers for the subagent / background-task E2E specs (170-177).
+ * Shared helpers for the E2E specs that drive an agent's work panel: the
+ * subagent and background-task registry, and the session goal.
  *
  * These wrap the common registry assertions so each per-provider spec stays
  * small. A locator that must MATCH an element is `:visible`-scoped, because the
@@ -41,7 +42,7 @@ export async function expandBackgroundTasksSection(page: Page): Promise<void> {
  * `:visible`-scoped for the reason every locator in this file is: the sidebar is
  * mounted twice, so the bare test id matches two elements.
  */
-export function goalCard(page: Page): Locator {
+export function goalCard(page: Page | Locator): Locator {
   return page.locator('[data-testid="goal-card"]:visible')
 }
 
@@ -55,8 +56,14 @@ export function workPanelTab(page: Page, key: string): Locator {
  *
  * Every verb but the empty state's own `set` lives inside the card's `...`
  * menu, so a caller opens that menu first -- see `openGoalMenu`.
+ *
+ * `page` takes a `Locator` as well, and a caller that can see TWO goal cards
+ * must pass one. The sidebar card and the ThinkingIndicator popover's card are
+ * both on screen while that popover is open, so `:visible` alone resolves two
+ * elements and Playwright's strict mode fails the call. Rooting the search at
+ * the popover is the only thing that separates them.
  */
-export function goalAction(page: Page, action: string): Locator {
+export function goalAction(page: Page | Locator, action: string): Locator {
   return page.locator(`[data-testid="goal-action-${action}"]:visible`)
 }
 
@@ -66,8 +73,10 @@ export function goalAction(page: Page, action: string): Locator {
  *
  * The empty state is the exception: `set` is the only verb that applies with no
  * goal, and the card offers it there as its own button.
+ *
+ * Takes the same root as `goalAction`, and for the same reason.
  */
-export async function openGoalMenu(page: Page): Promise<void> {
+export async function openGoalMenu(page: Page | Locator): Promise<void> {
   await page.locator('[data-testid="goal-actions-trigger"]:visible').click()
 }
 

--- a/frontend/tests/e2e/helpers/subagentRegistry.ts
+++ b/frontend/tests/e2e/helpers/subagentRegistry.ts
@@ -50,9 +50,25 @@ export function workPanelTab(page: Page, key: string): Locator {
   return page.locator(`[data-testid="bg-task-filter-${key}"]:visible`)
 }
 
-/** A verb button on the goal card, by action (`set`, `clear`, `pause`, `resume`). */
+/**
+ * A verb on the goal card, by action (`set`, `clear`, `pause`, `resume`).
+ *
+ * Every verb but the empty state's own `set` lives inside the card's `...`
+ * menu, so a caller opens that menu first -- see `openGoalMenu`.
+ */
 export function goalAction(page: Page, action: string): Locator {
   return page.locator(`[data-testid="goal-action-${action}"]:visible`)
+}
+
+/**
+ * Open the goal card's `...` menu, which holds every verb for a goal that
+ * already exists.
+ *
+ * The empty state is the exception: `set` is the only verb that applies with no
+ * goal, and the card offers it there as its own button.
+ */
+export async function openGoalMenu(page: Page): Promise<void> {
+  await page.locator('[data-testid="goal-actions-trigger"]:visible').click()
 }
 
 /**

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -116,7 +116,7 @@ export async function expectClipsLongText(label: Locator) {
  * mention/slash triggers) keep their local, deliberately paced typing.
  */
 export async function sendMessage(page: Page, text: string) {
-  const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+  const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
   await expect(editor).toBeVisible()
   await editor.click()
   await page.keyboard.type(text)
@@ -776,7 +776,7 @@ export async function openAgentViaUI(page: Page) {
   await expect(page.locator('[data-testid="tab"][data-tab-type="agent"]')).toHaveCount(tabsBefore + 1)
   // Wait for the new tab to become selected and its editor to be ready
   await expect(page.locator('[data-testid="tab"][data-tab-type="agent"][aria-selected="true"]')).toBeVisible()
-  await expect(page.locator('[data-testid="chat-editor"] .ProseMirror')).toBeVisible()
+  await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
 }
 
 /**


### PR DESCRIPTION
## Motivation
The session goal rendered as plain text and shared no editing affordances with
the rest of the app. The Set Goal dialog used a bare `<textarea>`, while chat
messages already had a full markdown composer. The goal card's four verb
buttons (Pause/Resume/Replace/Clear) were always visible although only one
made sense at a time, and the row wrapped inside the 360px sidebar popover.

Two correctness bugs compounded the UX problem. The Set Goal dialog armed its
submit button from a 200ms-debounced text mirror rather than the live editor
document, so a click inside that window met a disabled button and did nothing
at all, with no message. Separately, the work panel's tab-bar memo rebuilt a
fresh array on every recompute, which tore down and rebuilt every tab button
whenever the goal surface changed — for an active Codex agent, that meant
keyboard focus jumped to `<body>` every few seconds.

Generalizing the chat `MarkdownEditor` for reuse in the goal dialog also
surfaced several of its own latent bugs: draft-restore echoed the raw input
string instead of what ProseMirror actually serializes, `buildEditor()` had
no error handling, and a host that unmounts the editor from its own `onSend`
handler could resume an async continuation against a destroyed editor.

## Modifications
- Moved the goal card's verb buttons into a new `GoalActionsMenu` dropdown
  behind a `...` trigger; `Clear goal` is marked destructive and separated by
  a rule. The card's bottom border moved to a `goalSeparator` `<hr>` owned by
  `AgentWorkPanel`, which alone knows whether a row list follows the card.
- Fixed the tab-bar focus-stability bug with two module-level frozen arrays,
  so the tab buttons keep referential identity across recomputes.
- Added `GoalObjective`: renders the objective as CommonMark, clamps to 4
  lines with a fade mask, and offers a hover tooltip peek and a
  `CollapsibleToggle` disclosure past the clamp. The screen-reader live
  region now announces `markdownToPlainText(objective)` instead of raw
  markdown source.
- `SetGoalDialog` now embeds the app's own `MarkdownEditor` (`surface="goal"`)
  instead of a `<textarea>`. Every accept-or-refuse decision reads the
  editor's live document instead of the debounced mirror, closing the silent
  no-op window. Dropped the `<form>` wrapper, which submitted nothing and
  risked an implicit-submit page navigation. Added a byte-budget warning and
  an explicit `role="alert"` refusal for empty or over-limit objectives, both
  driven by one shared predicate so the warning and the refusal cannot
  disagree.
- **Notable behavior change:** the Set Goal submit button is now always
  clickable once the editor has built — previously
  `disabled={trimmed() === '' || overLimit()}` — and invalid input is refused
  with the new alert message instead of the button going inert.
- `MarkdownEditor` gained a required `surface: 'chat' | 'goal'` prop that
  drives `data-testid` and whether the `$mod+j` chat-send shortcut context
  applies, plus `initialMarkdown`, `onMarkdownChange`, and `ariaLabelledBy`.
  All `--composer-*` CSS variables and `composerLayout` renamed to
  `--editor-*` / `editorLayout` to match the widened scope, and
  `requestedHeight` split into `pinnedHeight` (fixed once overflowing) and
  `minHeight` (a floor that lets `maxHeight` bind). Fixed the draft-restore
  serialization mismatch, added error handling around `buildEditor()`
  (rendered as a `role="alert"` message on failure), and guarded the
  unmount-during-`onSend` race.
- Extracted shared `CollapsibleToggle` (replacing three hand-rolled disclosure
  buttons, now with `type="button"`, `aria-expanded`, `aria-controls`) and
  `fadeMaskBottom()`. Fixed `Dialog`'s Enter-to-submit handler to skip a
  `button[type="submit"]` inside a `[popover]` ancestor, which previously let
  Enter in the `MarkdownEditor`'s `LinkPopover` submit an invisible dialog
  form.
- Fixed a markdown-pipeline bug where raw HTML-looking text (e.g.
  `Replace <old-token> with the new one`) vanished silently; a new
  `remarkHtmlAsText` plugin retypes those nodes to text before
  `remarkRehype` drops them, without reopening the remote-content
  exfiltration vector that `rehypeBlockRemoteImages` closes.
- `goalActionState` now takes one `Pick<GoalSurface, 'current' | 'actions'>`
  argument instead of two positional ones, making it impossible to pair one
  agent's goal with another agent's action list.
- E2E: renamed the `chat-editor` locator to `composer-editor` across ~38
  specs and two shared helpers; `goalAction`/`goalCard` helpers now accept
  `Page | Locator`; added `openGoalMenu`; extended
  `180-codex-session-goal.spec.ts` for the clamp/disclosure and for opening
  the goal menu from the ThinkingIndicator's nested popover.

## Result
The session goal now renders as real markdown, with the same editor,
keybindings, and validation feedback as the chat composer. The goal card's
action menu no longer wraps or shows contradictory buttons, and the tab bar
no longer steals keyboard focus while an agent is active. Overlong goals
clamp cleanly with a tooltip peek or an expand toggle, and raw HTML-looking
text in a goal or message body displays as-is instead of disappearing. The
Set Goal dialog acts on what is on screen rather than on a stale mirror, and
reports empty or over-limit input with a clear inline message instead of a
button that does nothing.
