### PR TITLE
fix(worker): Replace dual turn-active tracking with one signal

### DIFF
--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -84,7 +84,7 @@ type jsonrpcBase struct {
 	// this base for its JSON-RPC plumbing but drives its turn from turnID and
 	// never writes promptActive, so a nil hook is what stops this base from
 	// publishing a flag Codex does not use.
-	publishTurnActive func(active bool)
+	publishTurnActive func(active bool, seq uint64)
 	steerMethod       string
 	steerRunID        string
 }
@@ -1276,14 +1276,21 @@ func (b *jsonrpcBase) readOutputLoop(scanner *bufio.Scanner, handle outputHandle
 	b.readOutput(scanner, b.handleJSONRPCResponse, handle)
 }
 
-// wireTurnActive points the base's turn-state hook at the sink.
+// wireTurnActive points the base's turn-state hook at b.sink.
 //
 // Called once in acpStart, so a new ACP provider cannot forget it: every one of
 // the six reaches that constructor, and none of them wires this itself. The
 // tests that pin the behavior call this too rather than building a hook of
 // their own, so a test cannot pass against wiring the constructor does not do.
-func (b *jsonrpcBase) wireTurnActive(sink OutputSink) {
-	b.publishTurnActive = func(active bool) { publishTurnActiveTo(sink, active) }
+//
+// The hook re-reads b.sink on every call, and takes no sink of its own.
+// startACPHandshake REPLACES that field with a decorator (thinkingResetSink),
+// and a hook that captured the raw sink would keep publishing past the
+// decorator for the life of the process. That flag is the input queue's only
+// dispatch guard, so a decorator that ever overrides SetTurnActive would then
+// hold every later message of every ACP provider, silently.
+func (b *acpBase) wireTurnActive() {
+	b.publishTurnActive = func(active bool, seq uint64) { publishTurnActiveTo(b.sink, active, seq) }
 }
 
 // notePromptActive republishes the turn state from promptActive, the single
@@ -1299,8 +1306,9 @@ func (b *jsonrpcBase) notePromptActive() {
 	}
 	b.mu.Lock()
 	active := b.promptActive
+	seq := b.nextTurnSeq()
 	b.mu.Unlock()
-	b.publishTurnActive(active)
+	b.publishTurnActive(active, seq)
 }
 
 // SendInput starts one prompt. The Worker queue holds later input until this
@@ -1317,10 +1325,6 @@ func (b *acpBase) SendInput(content string, attachments []*leapmuxv1.Attachment)
 	}
 	if b.promptActive {
 		b.mu.Unlock()
-		// The refusal is proof that this prompt is in flight, and the Worker
-		// dispatched into it, so its view of the turn was wrong. See
-		// CodexAgent.SendInput for why the publish belongs here.
-		b.notePromptActive()
 		return ErrAgentBusy
 	}
 	b.promptActive = true
@@ -2313,7 +2317,7 @@ func acpStart[T any](ctx context.Context, opts Options, sink OutputSink, spec ac
 	// so assigning it to the embedded processBase doesn't copy a held lock.
 	b.processBase = newProcessBase(opts, spec.providerName, cmd, stdin, ctx, cancel, preambleDelimiter, metaPrefix)
 	b.sink = sink
-	b.wireTurnActive(sink)
+	b.wireTurnActive()
 	b.model = opts.Model()
 	// Default settings-lifecycle hooks shared by every mode-bearing ACP provider:
 	// reapply on relaunch/ClearContext and refresh from a session response both derive
@@ -3654,3 +3658,8 @@ func (b *acpBase) handleACPOutput(line *parsedLine, extraSessionUpdate acpSessio
 		}
 	}
 }
+
+// PublishTurnActive satisfies Agent for every ACP provider. The base already
+// republishes promptActive from one place, so this only gives that place the
+// interface's name.
+func (b *acpBase) PublishTurnActive() { b.notePromptActive() }

--- a/backend/internal/worker/agent/acp_common.go
+++ b/backend/internal/worker/agent/acp_common.go
@@ -1317,6 +1317,10 @@ func (b *acpBase) SendInput(content string, attachments []*leapmuxv1.Attachment)
 	}
 	if b.promptActive {
 		b.mu.Unlock()
+		// The refusal is proof that this prompt is in flight, and the Worker
+		// dispatched into it, so its view of the turn was wrong. See
+		// CodexAgent.SendInput for why the publish belongs here.
+		b.notePromptActive()
 		return ErrAgentBusy
 	}
 	b.promptActive = true
@@ -1336,7 +1340,6 @@ func (b *acpBase) SendInput(content string, attachments []*leapmuxv1.Attachment)
 		b.steerRunID = ""
 		b.mu.Unlock()
 		b.notePromptActive()
-		notifyInputReady(b.sink)
 	})
 	if err != nil {
 		b.mu.Lock()

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -276,11 +276,17 @@ type OutputSink interface {
 	// ACP prompt response, Pi agent_end) routes here so that turn-end-
 	// specific side effects are explicit at the call site.
 	PersistTurnEnd(content []byte, span SpanInfo) error
-	// SetTurnActive publishes whether a turn is in flight, so the Worker can
-	// answer "is this agent busy" without a client re-deriving it from the
-	// transcript. Providers already keep this flag for their own control flow;
-	// call this from the SAME site that mutates it, so the published state
-	// cannot drift from the private one.
+	// SetTurnActive publishes whether a turn is in flight. It is the ONE signal
+	// for that fact, and the Worker derives two answers from it: "is this agent
+	// busy", which a client renders without re-deriving it from the transcript,
+	// and the input queue's dispatch guard, which holds a message until the
+	// running turn ends. Providers already keep this flag for their own control
+	// flow -- SendInput refuses input from the same value -- so call this from
+	// the SAME site that mutates it, and the three cannot drift.
+	//
+	// A publish that repeats the current state costs nothing: the Worker
+	// deduplicates it, and the queue reconciles idempotently. A MISSING publish
+	// is the only failure, and it hands the queue a turn it cannot see.
 	//
 	// Report the turn as active for as long as the agent owes the user a reply,
 	// which is not always the same as "between one envelope and the next": a
@@ -679,26 +685,6 @@ type InputSteerer interface {
 	// interface, not to an optional one, so a new provider cannot forget it and
 	// claim a capability that it does not have.
 	SupportsSteering() bool
-}
-
-type inputReadySink interface {
-	InputReady()
-}
-
-type inputStartedSink interface {
-	InputStarted()
-}
-
-func notifyInputStarted(sink OutputSink) {
-	if started, ok := sink.(inputStartedSink); ok {
-		started.InputStarted()
-	}
-}
-
-func notifyInputReady(sink OutputSink) {
-	if ready, ok := sink.(inputReadySink); ok {
-		ready.InputReady()
-	}
 }
 
 var (

--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -252,11 +252,11 @@ func scheduleOrCancelAPIErrorAutoContinue(sink OutputSink, retry bool, payload [
 // The jsonrpcBase hook takes the same stance for the same reason: nobody is
 // listening, so there is nothing to say. Every agent the Worker builds has a
 // sink, so this is never nil in production.
-func publishTurnActiveTo(sink OutputSink, active bool) {
+func publishTurnActiveTo(sink OutputSink, active bool, seq uint64) {
 	if sink == nil {
 		return
 	}
-	sink.SetTurnActive(active)
+	sink.SetTurnActive(active, seq)
 }
 
 // OutputSink provides generic primitives for persisting and broadcasting
@@ -276,23 +276,34 @@ type OutputSink interface {
 	// ACP prompt response, Pi agent_end) routes here so that turn-end-
 	// specific side effects are explicit at the call site.
 	PersistTurnEnd(content []byte, span SpanInfo) error
-	// SetTurnActive publishes whether a turn is in flight. It is the ONE signal
-	// for that fact, and the Worker derives two answers from it: "is this agent
-	// busy", which a client renders without re-deriving it from the transcript,
-	// and the input queue's dispatch guard, which holds a message until the
-	// running turn ends. Providers already keep this flag for their own control
-	// flow -- SendInput refuses input from the same value -- so call this from
-	// the SAME site that mutates it, and the three cannot drift.
+	// SetTurnActive publishes whether a turn is in flight, and it is the ONE
+	// signal for that fact. The Worker derives two answers from it. The first is
+	// "is this agent busy", which a client renders without re-deriving it from
+	// the transcript. The second is the input queue's dispatch guard, which
+	// holds a message until the running turn ends. Providers already keep this
+	// flag for their own control flow, and SendInput refuses input from the same
+	// value. Call this from the SAME site that mutates the flag, and the three
+	// cannot drift.
 	//
-	// A publish that repeats the current state costs nothing: the Worker
-	// deduplicates it, and the queue reconciles idempotently. A MISSING publish
-	// is the only failure, and it hands the queue a turn it cannot see.
+	// A publish that repeats the current state is SAFE, and every caller may
+	// repeat it freely: the Worker deduplicates it, and the queue reconciles
+	// idempotently and moves no revision. It is not free -- the queue answers
+	// from one small write transaction -- so publish on a turn boundary or a
+	// refusal, not once per streamed message block. A MISSING publish is the
+	// only failure, and it hands the queue a turn it cannot see.
+	//
+	// seq ORDERS the publishes. A provider reads its flag under a lock and then
+	// calls this without one, because the sink broadcasts and a broadcast can
+	// block -- so two goroutines can reach the Worker with the older value
+	// second. Take seq from the SAME critical section that reads the flag, and
+	// the Worker drops what it overtook. Every provider gets it from
+	// nextTurnSeq, so no call site chooses the number.
 	//
 	// Report the turn as active for as long as the agent owes the user a reply,
 	// which is not always the same as "between one envelope and the next": a
 	// provider that retries a failed attempt itself stays active across the
 	// backoff, where nothing streams and no envelope arrives.
-	SetTurnActive(active bool)
+	SetTurnActive(active bool, seq uint64)
 	OpenSpan(spanID string, parentSpanID string)
 	// CloseSpan frees a span's column. The recorded span type SURVIVES it (only
 	// ResetSpans clears types), because a provider's closing message reads that
@@ -636,6 +647,17 @@ type Agent interface {
 	// A turn-level failure is reported afterwards, out of band, through the
 	// provider's own error notification -- not by holding this call open.
 	SendInput(content string, attachments []*leapmuxv1.Attachment) error
+	// PublishTurnActive republishes this provider's turn flag through its sink.
+	// It re-reads the flag, so a caller states nothing: it only asks the
+	// provider to say again what it already holds.
+	//
+	// Manager.SendInput calls it on ErrAgentBusy. That refusal is PROOF that the
+	// Worker's view of the turn was wrong -- the Worker dispatched into a turn
+	// the provider was already running -- and the one moment both the activity
+	// state and the input queue's dispatch guard are known to need repair. It
+	// lives on the interface rather than in each provider's SendInput so a new
+	// provider cannot leave it out.
+	PublishTurnActive()
 	SendRawInput(data []byte) error
 	Stop()
 	IsStopped() bool
@@ -742,3 +764,22 @@ var ErrChildSteeringUnsupported = errors.New("agent provider does not support st
 // (SendChildInput) passes it to classifyQueueDeliveryError, which decides how
 // the queue records the failed delivery.
 var ErrChildNotSteerableYet = errors.New("subagent not yet steerable in the running owner process; retry")
+
+// turnSeqSource issues the ordering token that goes with a provider's turn
+// flag. Read the token in the SAME critical section that reads the flag: the
+// pair is what lets the Worker tell a publish it overtook from a current one,
+// and a token taken outside that section orders nothing.
+//
+// It is a plain counter under the provider's own lock rather than an atomic,
+// because the lock is what makes the pair atomic. An atomic would let the two
+// reads separate again, which is the defect this exists to close.
+type turnSeqSource struct {
+	seq uint64
+}
+
+// nextTurnSeq issues the next token. The caller must hold the lock that guards
+// the provider's turn flag.
+func (t *turnSeqSource) nextTurnSeq() uint64 {
+	t.seq++
+	return t.seq
+}

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -645,19 +645,24 @@ func (a *ClaudeCodeAgent) SendInput(content string, attachments []*leapmuxv1.Att
 	return a.sendInput(content, attachments, "")
 }
 
-// publishTurnActive republishes the Worker-visible turn state from turnActive,
+// PublishTurnActive republishes the Worker-visible turn state from turnActive,
 // the single source. Call it after EVERY critical section that writes that
 // field.
 //
 // It re-reads rather than taking a value, so a caller cannot publish something
 // the field does not say, and a missing call is the only way the two can drift.
 // Never called with a.mu held: the sink broadcasts, and a broadcast can block on
-// a slow transport.
-func (a *ClaudeCodeAgent) publishTurnActive() {
+// a slow transport.//
+// seq comes from the SAME critical section that reads the flag. Two goroutines
+// reach the sink unordered -- the reader that ends a turn, and the drain that a
+// refusal answers -- so without it the older value can land second and latch a
+// turn that is over.
+func (a *ClaudeCodeAgent) PublishTurnActive() {
 	a.mu.Lock()
 	active := a.turnActive
+	seq := a.nextTurnSeq()
 	a.mu.Unlock()
-	publishTurnActiveTo(a.sink, active)
+	publishTurnActiveTo(a.sink, active, seq)
 }
 
 // armTurn records a turn that the CLI runs and this Worker did not start. The
@@ -674,7 +679,22 @@ func (a *ClaudeCodeAgent) armTurn() {
 	if already {
 		return
 	}
-	a.publishTurnActive()
+	a.PublishTurnActive()
+}
+
+// disarmTurn records the end of the turn and publishes it, the way armTurn
+// records the start. OutputSink.SetTurnActive requires the mutation and the
+// publish at ONE site, and the falling edge kept them twenty lines apart in the
+// middle of the output handler.
+//
+// The caller decides WHEN. The publish releases the Worker's input queue, so
+// the next message dispatches on it and must find the finished turn's spans
+// already reset.
+func (a *ClaudeCodeAgent) disarmTurn() {
+	a.mu.Lock()
+	a.turnActive = false
+	a.mu.Unlock()
+	a.PublishTurnActive()
 }
 
 // SupportsSteering always reports true. The Claude Code stream-json protocol
@@ -699,7 +719,7 @@ func (a *ClaudeCodeAgent) sendInput(content string, attachments []*leapmuxv1.Att
 	// steer, which opens no turn -- publish the unchanged value, and the Worker
 	// reconciles rather than moves. That covers the busy refusal for this
 	// provider, which the other four publish explicitly.
-	defer a.publishTurnActive()
+	defer a.PublishTurnActive()
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -1879,7 +1899,7 @@ func claudeSupportedEfforts(supported map[string]bool) []*EffortInfo {
 // does not report one, so we prefer xhigh, else high -- the product-chosen sweet
 // spot, deliberately NOT merely the strongest level (max is overkill as a default
 // for a model that also offers xhigh). Every effort-capable model in the current
-// catalog reports xhigh, so the "else high" arm is the fallback for a model whose
+// catalog reports xhigh, so the "else high" branch is the fallback for a model whose
 // live level set turns out narrower, not a description of Sonnet. A model with no
 // effort support gets "" -- inert, since the effort selector is hidden and the
 // launch path omits --effort for it.

--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -660,6 +660,23 @@ func (a *ClaudeCodeAgent) publishTurnActive() {
 	publishTurnActiveTo(a.sink, active)
 }
 
+// armTurn records a turn that the CLI runs and this Worker did not start. The
+// output handler calls it for root output that only a live turn produces.
+//
+// It publishes on the rising edge alone. Every assistant message of one turn
+// reaches it, and the publish reconciles the Worker's input queue, so a
+// streaming turn would otherwise repeat that work once per message block.
+func (a *ClaudeCodeAgent) armTurn() {
+	a.mu.Lock()
+	already := a.turnActive
+	a.turnActive = true
+	a.mu.Unlock()
+	if already {
+		return
+	}
+	a.publishTurnActive()
+}
+
 // SupportsSteering always reports true. The Claude Code stream-json protocol
 // accepts a priority:"next" user message during any turn, so the capability
 // needs no handshake discovery.
@@ -679,8 +696,9 @@ func (a *ClaudeCodeAgent) sendInput(content string, attachments []*leapmuxv1.Att
 	// Registered BEFORE the unlock below, so it runs AFTER it: deferred calls
 	// run last-registered-first. Publishing under a.mu would hold the agent lock
 	// across a broadcast. It re-reads the flag, so the error paths below -- and a
-	// steer, which opens no turn -- publish the unchanged value and the sink
-	// drops it.
+	// steer, which opens no turn -- publish the unchanged value, and the Worker
+	// reconciles rather than moves. That covers the busy refusal for this
+	// provider, which the other four publish explicitly.
 	defer a.publishTurnActive()
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -547,6 +547,21 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		return
 	}
 
+	// A root assistant message carries this turn's reply, so a turn IS in
+	// flight. Claude Code emits no turn-start frame of its own
+	// (Codex has turn/started, ZCode turn.started), and without this the Worker
+	// learns of a turn only from its own SendInput -- so a turn the CLI runs by
+	// itself, or one it continues past a `result` already consumed, stayed
+	// invisible. Both the turn flag and the input queue then read idle, and the
+	// next message the user sent went straight into the running turn.
+	//
+	// The clear needs no counterpart rule: Claude ends EVERY turn with a
+	// `result`, including an interrupted or a failed one, and a `result` always
+	// follows the assistant messages of the turn it ends.
+	if msgType == claudeMsgTypeAssistant {
+		a.armTurn()
+	}
+
 	// Extract agent context metadata from top-level assistant and result
 	// messages. Subagent messages (with parent_tool_use_id) have their own
 	// smaller context and would make the bar show a misleadingly low value.
@@ -617,7 +632,6 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		a.mu.Lock()
 		a.turnActive = false
 		a.mu.Unlock()
-		a.publishTurnActive()
 		scheduleOrCancelAPIErrorAutoContinue(a.sink, env.IsError && isRetryableClaudeResultError(env.Result), content)
 
 		// Reset all span tracking so the next turn starts clean.
@@ -632,7 +646,11 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		// arms at its own turn end, so wiping every arm here would drop a live
 		// subagent's before its task_started arrived.
 		a.tasks.clearClaudeRestarts("")
-		notifyInputReady(a.sink)
+		// Published LAST, because the publish releases the Worker's input queue:
+		// the next message dispatches on it, and it must find the spans of the
+		// finished turn already reset -- a passthrough column captured before
+		// ResetSpans draws the dead turn's bars beside the new message.
+		a.publishTurnActive()
 	}
 }
 

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -157,6 +157,8 @@ func (a *ClaudeCodeAgent) handleClaudeOutput(content []byte, msgType string) {
 
 	slog.Debug("HandleOutput", "agent_id", a.agentID, "type", msgType, "len", len(content))
 
+	a.armTurnFromOutput(content, msgType)
+
 	switch msgType {
 	case claudeMsgTypeAssistant, claudeMsgTypeSystem, claudeMsgTypeResult:
 		if msgType == claudeMsgTypeSystem {
@@ -547,21 +549,6 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		return
 	}
 
-	// A root assistant message carries this turn's reply, so a turn IS in
-	// flight. Claude Code emits no turn-start frame of its own
-	// (Codex has turn/started, ZCode turn.started), and without this the Worker
-	// learns of a turn only from its own SendInput -- so a turn the CLI runs by
-	// itself, or one it continues past a `result` already consumed, stayed
-	// invisible. Both the turn flag and the input queue then read idle, and the
-	// next message the user sent went straight into the running turn.
-	//
-	// The clear needs no counterpart rule: Claude ends EVERY turn with a
-	// `result`, including an interrupted or a failed one, and a `result` always
-	// follows the assistant messages of the turn it ends.
-	if msgType == claudeMsgTypeAssistant {
-		a.armTurn()
-	}
-
 	// Extract agent context metadata from top-level assistant and result
 	// messages. Subagent messages (with parent_tool_use_id) have their own
 	// smaller context and would make the bar show a misleadingly low value.
@@ -595,7 +582,7 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 	// so the assistant message stays at the parent depth.
 	var persistErr error
 	if msgType == claudeMsgTypeResult {
-		// Terminal turn-end envelope — routes through PersistTurnEnd so
+		// Final turn-end envelope — routes through PersistTurnEnd so
 		// the sink fires the git-status auto-broadcast explicitly.
 		persistErr = a.sink.PersistTurnEnd(content, spanInfo)
 	} else {
@@ -629,9 +616,6 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		// After PersistTurnEnd, which records this turn's tool-call count for the
 		// settle the clear is about to produce. An interrupted or errored turn
 		// ends with a `result` too, so this one site covers those paths as well.
-		a.mu.Lock()
-		a.turnActive = false
-		a.mu.Unlock()
 		scheduleOrCancelAPIErrorAutoContinue(a.sink, env.IsError && isRetryableClaudeResultError(env.Result), content)
 
 		// Reset all span tracking so the next turn starts clean.
@@ -646,11 +630,11 @@ func (a *ClaudeCodeAgent) handlePersistableMessage(content []byte, msgType strin
 		// arms at its own turn end, so wiping every arm here would drop a live
 		// subagent's before its task_started arrived.
 		a.tasks.clearClaudeRestarts("")
-		// Published LAST, because the publish releases the Worker's input queue:
+		// LAST, because the publish inside releases the Worker's input queue:
 		// the next message dispatches on it, and it must find the spans of the
 		// finished turn already reset -- a passthrough column captured before
 		// ResetSpans draws the dead turn's bars beside the new message.
-		a.publishTurnActive()
+		a.disarmTurn()
 	}
 }
 
@@ -1417,4 +1401,44 @@ func isSimpleUserTextEcho(content []byte) bool {
 	}
 	trimmed := bytes.TrimSpace(msg.Message.Content)
 	return len(trimmed) > 0 && trimmed[0] == '"'
+}
+
+// armTurnFromOutput records a turn that the CLI runs and this Worker did not
+// start. Claude Code emits no turn-start frame of its own (Codex has
+// turn/started, ZCode turn.started), so without this the Worker learns of a turn
+// only from its own SendInput -- and a turn the CLI runs by itself, or one it
+// continues past a `result` the Worker already consumed, stayed invisible. Both
+// the turn flag and the input queue then read idle, and the next message the
+// user sent went straight into the running turn.
+//
+// It runs BEFORE the type switch, because the frames that prove a live turn
+// earliest are the ones that return early: the thinking-token telemetry and the
+// notification-threaded `system` lines never reach handlePersistableMessage, and
+// a root `user` tool_result is skipped there. Arming from the assistant message
+// alone left the whole extended-thinking window of a CLI-run turn invisible,
+// which is the longest part of it.
+//
+// The class is "a ROOT frame that only a live turn produces". A forwarded
+// subagent envelope carries parent_tool_use_id and belongs to the child, and it
+// says nothing about the root, which may well be idle while a restarted subagent
+// runs on. `result` ENDS a turn, and `control_*` frames are the Worker's own
+// traffic, so neither arms anything.
+//
+// The clear needs no counterpart rule: Claude ends EVERY turn with a `result`,
+// including an interrupted or a failed one, and a `result` always follows the
+// frames of the turn it ends. A process that dies without one is answered at the
+// process boundary instead, where the Worker releases a turn no dispatch owns.
+func (a *ClaudeCodeAgent) armTurnFromOutput(content []byte, msgType string) {
+	switch msgType {
+	case claudeMsgTypeAssistant, claudeMsgTypeUser, claudeMsgTypeSystem:
+	default:
+		return
+	}
+	var envelope struct {
+		ParentToolUseID string `json:"parent_tool_use_id"`
+	}
+	if err := json.Unmarshal(content, &envelope); err != nil || envelope.ParentToolUseID != "" {
+		return
+	}
+	a.armTurn()
 }

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -704,6 +704,11 @@ func (a *CodexAgent) SendInput(content string, attachments []*leapmuxv1.Attachme
 	// Normal queue dispatch never changes the active turn. Steering is an
 	// explicit queue operation through SteerInput.
 	if turnID != "" {
+		// The refusal is proof that this turn is in flight, and the Worker
+		// dispatched into it, so its view of the turn was wrong. Publish before
+		// the return: the same signal drives the agent's activity state and the
+		// input queue's guard, and both are what the refusal just disproved.
+		a.publishTurnActive()
 		return fmt.Errorf("%w: %s", ErrAgentBusy, turnID)
 	}
 

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -124,6 +124,13 @@ type CodexAgent struct {
 	reasoningStreamKind map[string]string
 	availableModels     []*ModelInfo
 	collabThreadSpans   map[string]string // child thread ID -> owning spawnAgent span ID (child index)
+	// collabChildAgents remembers the child AGENT id each thread resolved to.
+	// The span index above answers the same question, but it is torn down on a
+	// ClearContext and a registry write can fail, and a thread whose id cannot
+	// be resolved publishes no turn end -- which holds that child's own input
+	// queue with a turn that nothing will ever clear. The agent id does not
+	// change once assigned, so remembering it makes the clear survive both.
+	collabChildAgents map[string]string // child thread ID -> child agent ID
 	// collabChildItems records the child agent id that owns a streamed item
 	// (commandExecution/fileChange itemID -> childID). Populated when
 	// persistItemStartedChild routes the item/started to a child; consulted by
@@ -628,7 +635,7 @@ func (a *CodexAgent) ClearContext() (string, bool) {
 	clear(a.childTurnIDs)
 	clear(a.childTurnStartAcks)
 	a.mu.Unlock()
-	a.publishTurnActive()
+	a.PublishTurnActive()
 	// The thread was replaced; drop any in-flight thinking-token estimate so it
 	// doesn't leak into the new context (mirrors acpBase.ClearContext). The next
 	// turn/started also resets, but resetting here keeps every provider's context
@@ -645,7 +652,7 @@ func (a *CodexAgent) ClearContext() (string, bool) {
 	return thread.ID, true
 }
 
-// publishTurnActive republishes the Worker-visible turn state from turnID, the
+// PublishTurnActive republishes the Worker-visible turn state from turnID, the
 // single source. Call it after EVERY critical section that writes turnID.
 //
 // It re-reads rather than taking a value, so a caller cannot publish something
@@ -655,14 +662,15 @@ func (a *CodexAgent) ClearContext() (string, bool) {
 //
 // Never called with a.mu held: the sink broadcasts, and a broadcast can block
 // on a slow transport.
-func (a *CodexAgent) publishTurnActive() {
+func (a *CodexAgent) PublishTurnActive() {
 	a.mu.Lock()
 	active := a.turnID != ""
+	seq := a.nextTurnSeq()
 	a.mu.Unlock()
 	// Codex tracks collab child turns in childTurnIDs, deliberately not here: a
 	// child's own run is its background-task registry row, and the Worker reads
 	// that for the child tab. This is the MAIN thread's turn only.
-	publishTurnActiveTo(a.sink, active)
+	publishTurnActiveTo(a.sink, active, seq)
 }
 
 // SendInput starts a new turn with the current settings. It refuses an active
@@ -704,11 +712,8 @@ func (a *CodexAgent) SendInput(content string, attachments []*leapmuxv1.Attachme
 	// Normal queue dispatch never changes the active turn. Steering is an
 	// explicit queue operation through SteerInput.
 	if turnID != "" {
-		// The refusal is proof that this turn is in flight, and the Worker
-		// dispatched into it, so its view of the turn was wrong. Publish before
-		// the return: the same signal drives the agent's activity state and the
-		// input queue's guard, and both are what the refusal just disproved.
-		a.publishTurnActive()
+		// Manager.SendInput republishes the flag for this refusal. See
+		// Agent.PublishTurnActive for why the rule lives there.
 		return fmt.Errorf("%w: %s", ErrAgentBusy, turnID)
 	}
 
@@ -1589,4 +1594,14 @@ func (a *CodexAgent) handleOutput(line *parsedLine) {
 // HandleOutput processes a single JSONL notification from Codex.
 func (a *CodexAgent) HandleOutput(content []byte) {
 	handleCodexOutput(a, parseLine(content))
+}
+
+// childTurnSeq issues the ordering token for a collab CHILD's turn flag. Both
+// edges arrive on the one reader goroutine, so the token only has to be
+// monotonic -- the counter the main thread shares supplies that, and the Worker
+// tracks the last token for each agent id separately.
+func (a *CodexAgent) childTurnSeq() uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.nextTurnSeq()
 }

--- a/backend/internal/worker/agent/codex_compaction_test.go
+++ b/backend/internal/worker/agent/codex_compaction_test.go
@@ -11,17 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type blockingInputReadySink struct {
-	testSink
-	entered chan struct{}
-	release chan struct{}
-}
-
-func (s *blockingInputReadySink) InputReady() {
-	close(s.entered)
-	<-s.release
-}
-
 func TestCodexCompactContextUsesNativeCompaction(t *testing.T) {
 	t.Parallel()
 
@@ -158,12 +147,11 @@ func TestHandleCodexOutput_ContextCompactionCompletionPersistsBoundary(t *testin
 	}, codexProvider{}.Classify(last.Content),
 		"the consolidator drops the compacting status only for a compaction boundary")
 
-	assert.Equal(t, 0, sink.InputReadyCount(), "the item boundary must not end its enclosing turn")
+	assert.Empty(t, sink.TurnActives(), "the item boundary must not end its enclosing turn")
 
 	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed"}}}`)))
-	require.Eventually(t, func() bool {
-		return sink.InputReadyCount() == 1
-	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []bool{false}, sink.TurnActives(),
+		"the turn's own completion releases the Worker's input queue")
 }
 
 // The Codex app-server still emits thread/compacted for an auto-compaction. It
@@ -190,34 +178,25 @@ func TestHandleCodexOutput_ThreadCompactedPersistsRawAsAgent(t *testing.T) {
 		"item/completed is the compaction boundary now; thread/compacted stays a plain threadable notification")
 }
 
-func TestHandleCodexOutput_CompactionTurnCompletionDoesNotBlockReader(t *testing.T) {
+func TestHandleCodexOutput_CompactionTurnCompletionReportsTheEndInWireOrder(t *testing.T) {
 	t.Parallel()
 
-	sink := &blockingInputReadySink{
-		entered: make(chan struct{}),
-		release: make(chan struct{}),
-	}
-	defer close(sink.release)
+	// The Worker's input queue takes its turn state from this publish, and the
+	// state carries no turn identity -- so ORDER is the only thing that keeps
+	// the clear attached to the turn it belongs to. Reporting it from a new
+	// goroutine (this site once did, to keep the reader free for the response
+	// to a compaction the app-server submits before it answers) lets the clear
+	// land after the NEXT turn already opened, and that turn is then dispatched
+	// into.
+	sink := &testSink{}
 	agent := newCodexAgentWithSink(sink)
 	// Bypass the thinking-token wrapper so this test isolates the output-reader
 	// callback order. A separate assertion verifies wrapper forwarding.
 	agent.sink = sink
-	done := make(chan struct{})
 
-	go func() {
-		handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed"}}}`)))
-		close(done)
-	}()
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"main-thread","turn":{"id":"turn-1"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed"}}}`)))
 
-	select {
-	case <-sink.entered:
-	case <-time.After(time.Second):
-		t.Fatal("compaction completion did not notify the input queue")
-	}
-
-	select {
-	case <-done:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("input queue callback blocked the Codex output reader")
-	}
+	assert.Equal(t, []bool{true, false}, sink.TurnActives(),
+		"the handler reports the end before it returns, so the reader's next line cannot overtake it")
 }

--- a/backend/internal/worker/agent/codex_compaction_test.go
+++ b/backend/internal/worker/agent/codex_compaction_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -178,24 +179,65 @@ func TestHandleCodexOutput_ThreadCompactedPersistsRawAsAgent(t *testing.T) {
 		"item/completed is the compaction boundary now; thread/compacted stays a plain threadable notification")
 }
 
-func TestHandleCodexOutput_CompactionTurnCompletionReportsTheEndInWireOrder(t *testing.T) {
+// blockingTurnFlagSink blocks inside SetTurnActive until the test releases it,
+// which is what tells a synchronous publish apart from one a goroutine carries.
+// Asserting the recorded order alone cannot: a spawned goroutine usually wins
+// the race to the slice, so the same sequence appears either way.
+type blockingTurnFlagSink struct {
+	testSink
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingTurnFlagSink) SetTurnActive(active bool, seq uint64) {
+	if !active {
+		s.once.Do(func() {
+			close(s.entered)
+			<-s.release
+		})
+	}
+	s.testSink.SetTurnActive(active, seq)
+}
+
+func TestHandleCodexOutput_TurnCompletionPublishesTheClearBeforeItReturns(t *testing.T) {
 	t.Parallel()
 
 	// The Worker's input queue takes its turn state from this publish, and the
 	// state carries no turn identity -- so ORDER is the only thing that keeps
-	// the clear attached to the turn it belongs to. Reporting it from a new
-	// goroutine (this site once did, to keep the reader free for the response
-	// to a compaction the app-server submits before it answers) lets the clear
-	// land after the NEXT turn already opened, and that turn is then dispatched
-	// into.
-	sink := &testSink{}
+	// the clear attached to the turn it belongs to. A clear that a goroutine
+	// carries can land after the NEXT turn already opened, and the queue then
+	// dispatches the next message into that running turn.
+	//
+	// This site once did carry it that way, to keep the reader free for the
+	// response to a compaction the app-server submits before it answers. The
+	// publish is safe inline instead, because Manager.drain never holds the
+	// coordinator lock across dispatcher.Dispatch.
+	sink := &blockingTurnFlagSink{entered: make(chan struct{}), release: make(chan struct{})}
 	agent := newCodexAgentWithSink(sink)
 	// Bypass the thinking-token wrapper so this test isolates the output-reader
 	// callback order. A separate assertion verifies wrapper forwarding.
 	agent.sink = sink
 
 	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"main-thread","turn":{"id":"turn-1"}}}`)))
-	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed"}}}`)))
+	returned := make(chan struct{})
+	go func() {
+		handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed"}}}`)))
+		close(returned)
+	}()
+
+	select {
+	case <-sink.entered:
+	case <-time.After(time.Second):
+		t.Fatal("the turn end published no clear")
+	}
+	select {
+	case <-returned:
+		t.Fatal("the handler returned before the clear reached the sink, so a new goroutine carried it")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(sink.release)
+	<-returned
 
 	assert.Equal(t, []bool{true, false}, sink.TurnActives(),
 		"the handler reports the end before it returns, so the reader's next line cannot overtake it")

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -158,7 +158,7 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 				// The child's own turn. publishTurnActive covers the MAIN thread
 				// alone, so the child's flag is published against the child's
 				// sink -- which is what its own input queue follows.
-				publishTurnActiveTo(a.sink.ChildSink(childID), true)
+				publishTurnActiveTo(a.sink.ChildSink(childID), true, a.childTurnSeq())
 			}
 			return
 		}
@@ -178,7 +178,7 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 		// can't leak across turns (e.g. a reasoning item left open by an abort).
 		clear(a.reasoningStreamKind)
 		a.mu.Unlock()
-		a.publishTurnActive()
+		a.PublishTurnActive()
 		// A fresh turn begins: restart the thinking-token estimate from zero. The
 		// reset is lock-free (the estimator self-locks), so it stays outside the
 		// critical section above.
@@ -597,7 +597,7 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 				slog.Warn("codex persist child turn/completed", "agent_id", a.agentID, "thread", notif.ThreadID, "error", err)
 			}
 			a.clearChildTurnID(notif.ThreadID)
-			publishTurnActiveTo(a.sink.ChildSink(childID), false)
+			publishTurnActiveTo(a.sink.ChildSink(childID), false, a.childTurnSeq())
 			return
 		}
 		a.clearChildTurnID(notif.ThreadID)
@@ -655,7 +655,14 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 	// the assignment above would settle the agent with no count and ring the
 	// completion sound for a turn that used no tool. The turn state itself
 	// still clears early, which is what lets the next queued input start a turn.
-	defer a.publishTurnActive()
+	//
+	// The publish runs INLINE on this reader goroutine, although it reaches the
+	// input queue's store. That is safe because Manager.drain never holds the
+	// coordinator lock across dispatcher.Dispatch, so nothing an in-flight RPC
+	// waits for can hold what this publish needs. An earlier version escaped to
+	// a new goroutine for that reason, and the escape reordered the clear past
+	// the next turn's start.
+	defer a.PublishTurnActive()
 	a.clearInterruptCallsForThread(notif.ThreadID)
 
 	// Persist as a result divider.
@@ -665,7 +672,7 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 
 	// Reset all span tracking at turn-end so the next turn starts clean.
 	// The collab child index is NOT cleared here: background tasks outlive
-	// turns, and the child-index entries are removed only on terminal collab
+	// turns, and the child-index entries are removed only on a final collab
 	// status (collabAgentsStatesToRegistry). Clearing on ClearContext/restart
 	// stays.
 	a.sink.ResetSpans()
@@ -1044,7 +1051,7 @@ func parseCollabToolCall(item json.RawMessage) *codexCollabAgentToolCall {
 
 // registerCollabReceiver records a child thread -> spawnSpanID mapping (the
 // child index). Idempotent. The index is NOT cleared at turn end (background
-// tasks outlive turns); entries are removed on terminal collab status by
+// tasks outlive turns); entries are removed on a final collab status by
 // collabAgentsStatesToRegistry -> removeCollabChildIndex.
 func (a *CodexAgent) registerCollabReceiver(threadID, spanID string) bool {
 	if threadID == "" || spanID == "" {
@@ -1079,14 +1086,40 @@ func (a *CodexAgent) routeChildItemIfApplicable(threadID string) string {
 		return ""
 	}
 	if spanID == "" {
-		return ""
+		// The span index is gone (a ClearContext wiped it, or the spawn was
+		// never registered). A thread that resolved before still has to resolve
+		// now: its turn end is the only thing that clears the child's own input
+		// queue, and nothing else ever will.
+		return a.rememberedChildAgent(threadID)
 	}
 	childID, err := a.sink.EnsureChildAgent(spanID, threadID, a.collabChildTitle(threadID))
 	if err != nil {
 		slog.Warn("codex route child ensure failed", "thread", threadID, "error", err)
-		return ""
+		return a.rememberedChildAgent(threadID)
 	}
+	a.rememberChildAgent(threadID, childID)
 	return childID
+}
+
+// rememberChildAgent records the agent id a child thread resolved to, and
+// rememberedChildAgent reads it back. removeCollabChildIndex drops both together
+// when the child reaches a final status.
+func (a *CodexAgent) rememberChildAgent(threadID, childID string) {
+	if threadID == "" || childID == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.collabChildAgents == nil {
+		a.collabChildAgents = make(map[string]string)
+	}
+	a.collabChildAgents[threadID] = childID
+}
+
+func (a *CodexAgent) rememberedChildAgent(threadID string) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.collabChildAgents[threadID]
 }
 
 // persistItemStartedChild runs the item/started per-type persist/span logic

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -155,7 +155,10 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 				}))
 			}
 			if childID := a.routeChildItemIfApplicable(notif.ThreadID); childID != "" {
-				notifyInputStarted(a.sink.ChildSink(childID))
+				// The child's own turn. publishTurnActive covers the MAIN thread
+				// alone, so the child's flag is published against the child's
+				// sink -- which is what its own input queue follows.
+				publishTurnActiveTo(a.sink.ChildSink(childID), true)
 			}
 			return
 		}
@@ -180,9 +183,6 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 		// reset is lock-free (the estimator self-locks), so it stays outside the
 		// critical section above.
 		a.thinkingTokens.reset()
-		// The queue normally marks a turn active before delivery. This callback
-		// repairs that state when a delayed acceptance follows an uncertain result.
-		notifyInputStarted(a.sink)
 	}
 }
 
@@ -597,7 +597,7 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 				slog.Warn("codex persist child turn/completed", "agent_id", a.agentID, "thread", notif.ThreadID, "error", err)
 			}
 			a.clearChildTurnID(notif.ThreadID)
-			notifyInputReady(a.sink.ChildSink(childID))
+			publishTurnActiveTo(a.sink.ChildSink(childID), false)
 			return
 		}
 		a.clearChildTurnID(notif.ThreadID)
@@ -642,8 +642,8 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 		}
 	}
 
-	// Clear provider turn state before the queue receives the input-ready
-	// notification. This lets the next queued input start a new turn.
+	// Clear provider turn state before the deferred publish below releases the
+	// Worker's input queue. This lets the next queued input start a new turn.
 	a.mu.Lock()
 	a.turnID = ""
 	a.turnSawPlan = false
@@ -693,10 +693,6 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 			}
 		}
 	}
-	// The app-server submits compaction before it sends the RPC response. A
-	// fast compaction turn can end while CompactContext's caller holds the
-	// queue coordinator. Keep this reader free to deliver the RPC response.
-	go notifyInputReady(a.sink)
 }
 
 func isRetryableCodexTurnFailure(message string) bool {

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -891,7 +891,7 @@ func TestHandleCodexOutput_WaitCompletedClosesOnlyFinalReceivers(t *testing.T) {
 	handleCodexOutput(agent, parseLine([]byte(completed)))
 
 	// The collab span closes at completion regardless of which receivers are
-	// terminal -- the span lifecycle is about the tool_call, not the children.
+	// finished -- the span lifecycle is about the tool_call, not the children.
 	require.Contains(t, sink.ClosedSpans(), "call-4", "wait span closes at completion")
 }
 
@@ -1809,7 +1809,7 @@ func TestCodexCollabStatusToRegistry_ResumableInterrupted(t *testing.T) {
 			if tc.wantNonBlank {
 				assert.NotEmpty(t, gotActivity, "resumable interrupted carries a paused activity line")
 			}
-			// The mapped status must NOT be terminal for a resumable interrupt.
+			// The mapped status must NOT be final for a resumable interrupt.
 			if !tc.wantFinal {
 				assert.False(t, gotStatus.IsFinished(), "%s must not map to a final status", tc.status)
 			}
@@ -1893,4 +1893,33 @@ func TestHandleCodexOutput_ASubAgentActivityAloneDoesNotReopenARow(t *testing.T)
 	_, status, ok, _ := sink.LookupBackgroundTask("child-1")
 	require.True(t, ok)
 	assert.True(t, status.IsFinished(), "the row keeps its final status")
+}
+
+func TestHandleCodexOutput_ChildTurnEndSurvivesALostSpanIndex(t *testing.T) {
+	t.Parallel()
+
+	// The child's turn end is the ONLY thing that clears the child's own input
+	// queue. It resolves the child agent id through the span index, and a
+	// ClearContext wipes that index -- so a turn that ends after one left the
+	// child holding every later message with a turn nothing would clear. The
+	// agent id does not change once assigned, so it is remembered.
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	agent.threadID = "main-thread"
+
+	spawnStarted := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
+	handleCodexOutput(agent, parseLine([]byte(spawnStarted)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"child-1","turn":{"id":"turn-1"}}}`)))
+	child := sink.ChildSink("child-of-call-1").(*testSink)
+	require.Equal(t, []bool{true}, child.TurnActives(), "the child's turn opened")
+
+	// The span index goes away, the way ClearContext wipes it.
+	agent.mu.Lock()
+	clear(agent.collabThreadSpans)
+	agent.mu.Unlock()
+
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"child-1","turn":{"id":"turn-1","status":"completed","items":[],"error":null}}}`)))
+
+	assert.Equal(t, []bool{true, false}, child.TurnActives(),
+		"the child's turn still ends, so its input queue is released")
 }

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -54,9 +54,8 @@ func TestHandleCodexOutput_TurnStartedOpensTheTurn(t *testing.T) {
 	agent.mu.Unlock()
 	assert.Equal(t, 0, statusActiveCount, "turn/started must NOT re-broadcast full status")
 	assert.Equal(t, "turn-42", turnID, "interrupts and steering target this turn")
-	assert.Equal(t, []bool{true}, sink.TurnActives(), "the Worker's activity state opens with the turn")
-	assert.Equal(t, 1, sink.InputStartedCount(),
-		"turn/started must reactivate a queue after uncertain delivery")
+	assert.Equal(t, []bool{true}, sink.TurnActives(),
+		"turn/started opens the Worker's activity state AND its input queue's turn")
 	// The turn id used to ride an ephemeral session-info frame as well, for a
 	// browser-side working-state heuristic that no longer exists. Nothing reads
 	// it now, so nothing sends it.
@@ -1304,8 +1303,6 @@ func TestHandleCodexOutput_TurnCompletedChildPersistsChildTurnEnd(t *testing.T) 
 
 	// The turn-end divider lands in the CHILD transcript, not the parent's.
 	child := sink.ChildSink("child-of-call-1").(*testSink)
-	assert.Equal(t, 1, child.InputStartedCount(),
-		"child turn/started must activate the child input queue")
 	turnEnds := 0
 	for _, m := range child.Messages() {
 		if m.TurnEnd {
@@ -1314,8 +1311,11 @@ func TestHandleCodexOutput_TurnCompletedChildPersistsChildTurnEnd(t *testing.T) 
 	}
 	assert.Equal(t, 1, turnEnds,
 		"child turn/completed must persist a turn-end divider into the child transcript")
-	assert.Equal(t, 1, child.InputReadyCount(),
-		"child turn/completed must release the child input queue")
+	// publishTurnActive covers the MAIN thread alone, so a collab child's turn
+	// is published against the CHILD's sink -- which is what the child tab's
+	// own input queue follows.
+	assert.Equal(t, []bool{true, false}, child.TurnActives(),
+		"the child's own turn opens and releases the child input queue")
 }
 
 func TestHandleCodexOutput_TurnCompletedPlanModePersistsRealPlanAndPrompts(t *testing.T) {

--- a/backend/internal/worker/agent/codex_subagent.go
+++ b/backend/internal/worker/agent/codex_subagent.go
@@ -234,6 +234,9 @@ func (a *CodexAgent) removeCollabChildIndex(threadID string) {
 	if a.collabThreadSpans != nil {
 		delete(a.collabThreadSpans, threadID)
 	}
+	if a.collabChildAgents != nil {
+		delete(a.collabChildAgents, threadID)
+	}
 	if a.collabChildTitles != nil {
 		delete(a.collabChildTitles, threadID)
 	}

--- a/backend/internal/worker/agent/codex_subagent.go
+++ b/backend/internal/worker/agent/codex_subagent.go
@@ -294,6 +294,11 @@ func (a *CodexAgent) SendChildInput(childKey, content string, attachments []*lea
 	// would tell the queue to store a permanent failure whose text says the
 	// child has no turn, while the child is visibly working.
 	if a.childTurnID(threadID) != "" {
+		// No publish here, unlike the main-thread refusals. A child's activity
+		// state comes from its background-task registry row rather than from a
+		// turn flag, and the child's own queue already holds the turn that its
+		// dispatch opened -- so the publish would need a registry write to
+		// resolve the child agent id, and would then tell nobody anything new.
 		return ErrAgentBusy
 	}
 	return a.sendTurnStartChild(threadID, codexChildInput(content, attachments))

--- a/backend/internal/worker/agent/copilot_test.go
+++ b/backend/internal/worker/agent/copilot_test.go
@@ -282,7 +282,11 @@ func TestCopilotAssistedApprovalChangeRequiresRestart(t *testing.T) {
 // restart must start with the flag off on the FIRST attempt instead of paying a failed
 // spawn, and a relaunch must not resurrect a flag this binary already refused.
 func TestCopilotBinaryFlagCapabilityIsRememberedPerBinary(t *testing.T) {
-	shell := "/bin/zsh-" + t.Name()
+	// The cache is process-global and stores only a negative, so it has nothing
+	// to invalidate and no reset. t.TempDir gives a key no other run reuses,
+	// which keeps the case correct under `go test -count=N` -- t.Name() alone
+	// repeats, and the second run then reads the mark the first one left.
+	shell := "/bin/zsh-" + t.TempDir()
 
 	assert.False(t, BinaryFlagUnsupported(shell, false, copilotBinaryName, copilotAssistedApprovalFlag),
 		"an unprobed binary is not known to refuse the flag")

--- a/backend/internal/worker/agent/manager.go
+++ b/backend/internal/worker/agent/manager.go
@@ -408,7 +408,17 @@ func (m *Manager) SendInput(agentID, content string, attachments []*leapmuxv1.At
 	if err != nil {
 		return err
 	}
-	return p.SendInput(content, attachments)
+	err = p.SendInput(content, attachments)
+	if errors.Is(err, ErrAgentBusy) {
+		// The refusal disproves the Worker's view of the turn, and both consumers
+		// of the turn flag -- the activity state and the input queue's dispatch
+		// guard -- are wrong at exactly this moment. Repairing here rather than
+		// in each provider's SendInput is what stops a sixth provider from
+		// leaving it out. SendChildInput does NOT do this: a collab child's
+		// activity comes from its background-task registry row.
+		p.PublishTurnActive()
+	}
+	return err
 }
 
 func (m *Manager) CompactContext(agentID string) error {

--- a/backend/internal/worker/agent/manager_startup_concurrency_test.go
+++ b/backend/internal/worker/agent/manager_startup_concurrency_test.go
@@ -26,6 +26,7 @@ type idleAgent struct{}
 
 func (idleAgent) AgentID() string                                 { return "idle" }
 func (idleAgent) SendInput(string, []*leapmuxv1.Attachment) error { return nil }
+func (idleAgent) PublishTurnActive()                              {}
 func (idleAgent) SendRawInput([]byte) error                       { return nil }
 func (idleAgent) Stop()                                           {}
 func (idleAgent) IsStopped() bool                                 { return false }

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -26,10 +26,14 @@ type stubProvider struct {
 
 func (s *stubProvider) AgentID() string                                 { return "stub" }
 func (s *stubProvider) SendInput(string, []*leapmuxv1.Attachment) error { return nil }
-func (s *stubProvider) SendRawInput([]byte) error                       { return nil }
-func (s *stubProvider) Stop()                                           {}
-func (s *stubProvider) IsStopped() bool                                 { return false }
-func (s *stubProvider) DiscardOutput()                                  {}
+
+// PublishTurnActive is inert here: a stub holds no turn flag and no sink, and
+// Manager.SendInput calls it only after a refusal this stub never returns.
+func (s *stubProvider) PublishTurnActive()        {}
+func (s *stubProvider) SendRawInput([]byte) error { return nil }
+func (s *stubProvider) Stop()                     {}
+func (s *stubProvider) IsStopped() bool           { return false }
+func (s *stubProvider) DiscardOutput()            {}
 func (s *stubProvider) ClearContext() (string, bool) {
 	if s.clearContextFn != nil {
 		return s.clearContextFn()

--- a/backend/internal/worker/agent/pi.go
+++ b/backend/internal/worker/agent/pi.go
@@ -343,10 +343,6 @@ func (a *PiAgent) sendInput(content string, attachments []*leapmuxv1.Attachment,
 		return ErrNoActiveTurn
 	}
 	if !steer && turnActive {
-		// The refusal is proof that this turn is in flight, and the Worker
-		// dispatched into it, so its view of the turn was wrong. See
-		// CodexAgent.SendInput for why the publish belongs here.
-		a.publishTurnActive()
 		return ErrAgentBusy
 	}
 
@@ -477,7 +473,7 @@ func (a *PiAgent) ClearContext() (string, bool) {
 	a.toolCallPrompts.clear()
 	handle := a.sessionHandleLocked()
 	a.mu.Unlock()
-	a.publishTurnActive()
+	a.PublishTurnActive()
 	// The session was replaced; drop any in-flight thinking-token estimate so it
 	// doesn't leak into the new context (mirrors acpBase.ClearContext). The next
 	// agent_start also resets, but resetting here keeps every provider's context

--- a/backend/internal/worker/agent/pi.go
+++ b/backend/internal/worker/agent/pi.go
@@ -343,6 +343,10 @@ func (a *PiAgent) sendInput(content string, attachments []*leapmuxv1.Attachment,
 		return ErrNoActiveTurn
 	}
 	if !steer && turnActive {
+		// The refusal is proof that this turn is in flight, and the Worker
+		// dispatched into it, so its view of the turn was wrong. See
+		// CodexAgent.SendInput for why the publish belongs here.
+		a.publishTurnActive()
 		return ErrAgentBusy
 	}
 

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -157,7 +157,7 @@ func handlePiOutput(a *PiAgent, line *parsedLine) {
 	}
 }
 
-// publishTurnActive republishes the Worker-visible turn state from
+// PublishTurnActive republishes the Worker-visible turn state from
 // currentTurnActive, the single source. Call it after EVERY critical section
 // that writes that field.
 //
@@ -171,11 +171,12 @@ func handlePiOutput(a *PiAgent, line *parsedLine) {
 // nothing streams and no envelope arrives, and where a client that inferred
 // idleness would drop the spinner and hide the Interrupt button on a run that is
 // still going.
-func (a *PiAgent) publishTurnActive() {
+func (a *PiAgent) PublishTurnActive() {
 	a.mu.Lock()
 	active := a.currentTurnActive
+	seq := a.nextTurnSeq()
 	a.mu.Unlock()
-	publishTurnActiveTo(a.sink, active)
+	publishTurnActiveTo(a.sink, active, seq)
 }
 
 func (a *PiAgent) handlePiAgentStart() {
@@ -190,7 +191,7 @@ func (a *PiAgent) handlePiAgentStart() {
 		a.turnStartedAt = startedAt
 	}
 	a.mu.Unlock()
-	a.publishTurnActive()
+	a.PublishTurnActive()
 	// A fresh turn begins: start the thinking-token estimate from zero.
 	a.thinkingTokens.reset()
 }
@@ -226,7 +227,7 @@ func (a *PiAgent) handlePiAgentEnd(raw []byte) {
 	// would settle the agent with no count. Pi reports no count today
 	// (https://github.com/leapmux/leapmux/issues/435), which is exactly why the
 	// order has to be right before it does.
-	defer a.publishTurnActive()
+	defer a.PublishTurnActive()
 	// Recover from any tool calls that didn't get a matching
 	// tool_execution_end (e.g. aborted turn). Otherwise the map retains the
 	// cumulative result text indefinitely across sessions.

--- a/backend/internal/worker/agent/pi_output.go
+++ b/backend/internal/worker/agent/pi_output.go
@@ -246,9 +246,6 @@ func (a *PiAgent) handlePiAgentEnd(raw []byte) {
 	// The failed attempt's spans are dead either way: a retried run reopens its
 	// own, so the reset is unconditional.
 	a.sink.ResetSpans()
-	if !env.WillRetry {
-		notifyInputReady(a.sink)
-	}
 	if a.canRequestPiSessionStats() {
 		go func() {
 			_, _ = a.refreshPiSessionStats(piSessionStatsTimeout(a.APITimeout()))

--- a/backend/internal/worker/agent/process.go
+++ b/backend/internal/worker/agent/process.go
@@ -41,6 +41,12 @@ type processBase struct {
 	mu      sync.Mutex
 	stopped bool
 
+	// turnSeqSource issues the ordering token that rides every publish of this
+	// provider's turn flag. It lives here so all five providers get it from one
+	// embed and a sixth cannot forget it, and because mu -- the lock that makes
+	// the token atomic with the flag read -- lives here too.
+	turnSeqSource
+
 	// stdinMu serializes Write syscalls to p.stdin without coupling them to
 	// p.mu, so a slow stdin (full kernel pipe buffer, e.g. when a large
 	// inline image attachment is being shipped) cannot stall state operations

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -73,6 +73,7 @@ type testSink struct {
 	// double from drifting from the behavior it stands in for.
 	tracker        spantrack.SpanTracker
 	resetSpanCount int
+	turnSeqs       []uint64
 	statusActives  []string
 	// goals records every UpsertGoal in arrival order, and goalClears counts
 	// ClearGoal. A provider's goal parser is tested through these: they hold the
@@ -224,11 +225,22 @@ func (s *testSink) PersistTurnEnd(content []byte, span SpanInfo) error {
 
 // SetTurnActive records the provider's turn flag transitions in order, so a
 // provider test can assert the exact sequence it published.
-func (s *testSink) SetTurnActive(active bool) {
+func (s *testSink) SetTurnActive(active bool, seq uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.TurnActiveCalls = append(s.TurnActiveCalls, active)
+	s.turnSeqs = append(s.turnSeqs, seq)
 	s.turnLifecycle = append(s.turnLifecycle, fmt.Sprintf("turn_active:%t", active))
+}
+
+// TurnSeqs returns the ordering token of each publish, in arrival order. A
+// provider test asserts these to pin that the token comes from the same
+// critical section as the flag: without that, two goroutines publish out of
+// order and the Worker latches a turn that is over.
+func (s *testSink) TurnSeqs() []uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]uint64(nil), s.turnSeqs...)
 }
 
 // TurnLifecycle returns the turn-end envelopes and the turn-flag transitions in
@@ -292,9 +304,15 @@ func (s *testSink) CloseSpan(spanID string) {
 	s.tracker.CloseSpan(spanID)
 }
 
+// ResetSpans joins the turn lifecycle, because WHERE it falls relative to the
+// clear is a requirement on every provider: the clear releases the Worker's
+// input queue, and the next message must find the finished turn's spans already
+// reset. A passthrough column captured before the reset draws the dead turn's
+// bars beside the new message.
 func (s *testSink) ResetSpans() {
 	s.mu.Lock()
 	s.resetSpanCount++
+	s.turnLifecycle = append(s.turnLifecycle, "reset_spans")
 	s.mu.Unlock()
 	s.tracker.Reset()
 }
@@ -1167,7 +1185,7 @@ func (noopSink) PersistMessage(leapmuxv1.MessageSource, []byte, SpanInfo) error 
 	return nil
 }
 func (noopSink) PersistTurnEnd([]byte, SpanInfo) error                             { return nil }
-func (noopSink) SetTurnActive(bool)                                                {}
+func (noopSink) SetTurnActive(bool, uint64)                                        {}
 func (noopSink) PersistNotification(leapmuxv1.MessageSource, []byte) (bool, error) { return true, nil }
 func (noopSink) OpenSpan(string, string)                                           {}
 func (noopSink) CloseSpan(string)                                                  {}

--- a/backend/internal/worker/agent/sink_test.go
+++ b/backend/internal/worker/agent/sink_test.go
@@ -71,11 +71,9 @@ type testSink struct {
 	reservedColorSpans []testSinkSpanOpen
 	// tracker is the REAL span engine. Delegating to it is what keeps this
 	// double from drifting from the behavior it stands in for.
-	tracker           spantrack.SpanTracker
-	resetSpanCount    int
-	inputStartedCount int
-	inputReadyCount   int
-	statusActives     []string
+	tracker        spantrack.SpanTracker
+	resetSpanCount int
+	statusActives  []string
 	// goals records every UpsertGoal in arrival order, and goalClears counts
 	// ClearGoal. A provider's goal parser is tested through these: they hold the
 	// neutral GoalUpdate, so a test asserts what the parser MEANT rather than
@@ -978,30 +976,6 @@ func (s *testSink) MessageCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.messages)
-}
-
-func (s *testSink) InputReady() {
-	s.mu.Lock()
-	s.inputReadyCount++
-	s.mu.Unlock()
-}
-
-func (s *testSink) InputStarted() {
-	s.mu.Lock()
-	s.inputStartedCount++
-	s.mu.Unlock()
-}
-
-func (s *testSink) InputStartedCount() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.inputStartedCount
-}
-
-func (s *testSink) InputReadyCount() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.inputReadyCount
 }
 
 func (s *testSink) NotificationCount() int {

--- a/backend/internal/worker/agent/steering_test.go
+++ b/backend/internal/worker/agent/steering_test.go
@@ -70,20 +70,27 @@ func TestManagerSupportsSteeringAsksTheProvider(t *testing.T) {
 // ErrNoActiveTurn. The two sentinels state opposite conditions, and the queue
 // reads them differently: ErrAgentBusy is transient, so the item waits for the
 // turn to end, while ErrNoActiveTurn says that steering has no target.
+//
+// The refusal also PUBLISHES the turn it refused for. The Worker sent this
+// input, so its view of the turn disagreed with the provider's, and the
+// refusal is the proof. The publish repairs the agent's activity state and the
+// input queue's dispatch guard at the one moment both are known to be wrong.
 func TestSendInputDuringActiveTurnReportsAgentBusy(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
 		name string
-		send func(t *testing.T) error
+		send func(t *testing.T, sink OutputSink) error
 	}{
 		{
 			name: "acpBase",
-			send: func(t *testing.T) error {
+			send: func(t *testing.T, sink OutputSink) error {
 				agent, requests := newACPAgentForRPC(t,
 					func() *OpenCodeAgent { return &OpenCodeAgent{} },
 					func(agent *OpenCodeAgent) *acpBase { return &agent.acpBase },
 				)
+				agent.sink = sink
+				agent.wireTurnActive(sink)
 				agent.promptActive = true
 				err := agent.SendInput("later turn", nil)
 				assert.Empty(t, requests(), "a refused send must reach no RPC")
@@ -92,10 +99,11 @@ func TestSendInputDuringActiveTurnReportsAgentBusy(t *testing.T) {
 		},
 		{
 			name: "codex",
-			send: func(t *testing.T) error {
+			send: func(t *testing.T, sink OutputSink) error {
 				agent, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage {
 					return json.RawMessage(`{}`)
 				})
+				agent.sink = sink
 				agent.threadID = "thread-1"
 				agent.turnID = "turn-1"
 				err := agent.SendInput("later turn", nil)
@@ -105,26 +113,27 @@ func TestSendInputDuringActiveTurnReportsAgentBusy(t *testing.T) {
 		},
 		{
 			name: "claude",
-			send: func(t *testing.T) error {
-				agent := &ClaudeCodeAgent{turnActive: true}
+			send: func(t *testing.T, sink OutputSink) error {
+				agent := &ClaudeCodeAgent{turnActive: true, sink: sink}
 				return agent.SendInput("later turn", nil)
 			},
 		},
 		{
 			name: "pi",
-			send: func(t *testing.T) error {
+			send: func(t *testing.T, sink OutputSink) error {
 				agent := &PiAgent{
 					processBase:       processBase{agentID: "test-agent"},
 					currentTurnActive: true,
+					sink:              sink,
 				}
 				return agent.SendInput("later turn", nil)
 			},
 		},
 		{
 			name: "zcode",
-			send: func(t *testing.T) error {
+			send: func(t *testing.T, sink OutputSink) error {
 				stdin := &zcodeRecordedStdin{}
-				agent := newZCodeTestAgentWithStdin(t, &recordingControlSink{}, stdin)
+				agent := newZCodeTestAgentWithStdin(t, sink, stdin)
 				agent.mu.Lock()
 				agent.sessionID = "session-1"
 				agent.model = "provider/model"
@@ -137,10 +146,13 @@ func TestSendInputDuringActiveTurnReportsAgentBusy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tc.send(t)
+			sink := &testSink{}
+			err := tc.send(t, sink)
 			assert.ErrorIs(t, err, ErrAgentBusy)
 			assert.NotErrorIs(t, err, ErrNoActiveTurn,
 				"a busy agent has a turn; the no-active-turn sentinel states the opposite")
+			assert.Equal(t, []bool{true}, sink.TurnActives(),
+				"the refusal publishes the turn that caused it")
 		})
 	}
 }

--- a/backend/internal/worker/agent/steering_test.go
+++ b/backend/internal/worker/agent/steering_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -71,35 +73,35 @@ func TestManagerSupportsSteeringAsksTheProvider(t *testing.T) {
 // reads them differently: ErrAgentBusy is transient, so the item waits for the
 // turn to end, while ErrNoActiveTurn says that steering has no target.
 //
-// The refusal also PUBLISHES the turn it refused for. The Worker sent this
-// input, so its view of the turn disagreed with the provider's, and the
-// refusal is the proof. The publish repairs the agent's activity state and the
-// input queue's dispatch guard at the one moment both are known to be wrong.
+// Manager.SendInput turns that refusal into a republish of the turn flag, and
+// TestManagerSendInputRepublishesTheTurnARefusalDisproves pins that half. This
+// one pins the sentinel, and that every provider can republish on demand --
+// PublishTurnActive is the interface method the Manager calls.
 func TestSendInputDuringActiveTurnReportsAgentBusy(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
 		name string
-		send func(t *testing.T, sink OutputSink) error
+		send func(t *testing.T, sink OutputSink) (Agent, error)
 	}{
 		{
 			name: "acpBase",
-			send: func(t *testing.T, sink OutputSink) error {
+			send: func(t *testing.T, sink OutputSink) (Agent, error) {
 				agent, requests := newACPAgentForRPC(t,
 					func() *OpenCodeAgent { return &OpenCodeAgent{} },
 					func(agent *OpenCodeAgent) *acpBase { return &agent.acpBase },
 				)
 				agent.sink = sink
-				agent.wireTurnActive(sink)
+				agent.wireTurnActive()
 				agent.promptActive = true
 				err := agent.SendInput("later turn", nil)
 				assert.Empty(t, requests(), "a refused send must reach no RPC")
-				return err
+				return agent, err
 			},
 		},
 		{
 			name: "codex",
-			send: func(t *testing.T, sink OutputSink) error {
+			send: func(t *testing.T, sink OutputSink) (Agent, error) {
 				agent, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage {
 					return json.RawMessage(`{}`)
 				})
@@ -108,30 +110,30 @@ func TestSendInputDuringActiveTurnReportsAgentBusy(t *testing.T) {
 				agent.turnID = "turn-1"
 				err := agent.SendInput("later turn", nil)
 				assert.Empty(t, requests(), "a refused send must reach no RPC")
-				return err
+				return agent, err
 			},
 		},
 		{
 			name: "claude",
-			send: func(t *testing.T, sink OutputSink) error {
+			send: func(t *testing.T, sink OutputSink) (Agent, error) {
 				agent := &ClaudeCodeAgent{turnActive: true, sink: sink}
-				return agent.SendInput("later turn", nil)
+				return agent, agent.SendInput("later turn", nil)
 			},
 		},
 		{
 			name: "pi",
-			send: func(t *testing.T, sink OutputSink) error {
+			send: func(t *testing.T, sink OutputSink) (Agent, error) {
 				agent := &PiAgent{
 					processBase:       processBase{agentID: "test-agent"},
 					currentTurnActive: true,
 					sink:              sink,
 				}
-				return agent.SendInput("later turn", nil)
+				return agent, agent.SendInput("later turn", nil)
 			},
 		},
 		{
 			name: "zcode",
-			send: func(t *testing.T, sink OutputSink) error {
+			send: func(t *testing.T, sink OutputSink) (Agent, error) {
 				stdin := &zcodeRecordedStdin{}
 				agent := newZCodeTestAgentWithStdin(t, sink, stdin)
 				agent.mu.Lock()
@@ -139,7 +141,7 @@ func TestSendInputDuringActiveTurnReportsAgentBusy(t *testing.T) {
 				agent.model = "provider/model"
 				agent.turnActive = true
 				agent.mu.Unlock()
-				return agent.SendInput("later turn", nil)
+				return agent, agent.SendInput("later turn", nil)
 			},
 		},
 	} {
@@ -147,12 +149,20 @@ func TestSendInputDuringActiveTurnReportsAgentBusy(t *testing.T) {
 			t.Parallel()
 
 			sink := &testSink{}
-			err := tc.send(t, sink)
+			provider, err := tc.send(t, sink)
 			assert.ErrorIs(t, err, ErrAgentBusy)
 			assert.NotErrorIs(t, err, ErrNoActiveTurn,
 				"a busy agent has a turn; the no-active-turn sentinel states the opposite")
-			assert.Equal(t, []bool{true}, sink.TurnActives(),
-				"the refusal publishes the turn that caused it")
+
+			// What Manager.SendInput does with that refusal. Every provider must
+			// answer it with the turn the refusal proves is in flight. The LAST
+			// value is what matters, not the count: Claude's sendInput already
+			// publishes from a defer that also covers its error paths and its
+			// steer, so it answers twice and the others answer once.
+			provider.PublishTurnActive()
+			last, published := sink.LastTurnActive()
+			require.True(t, published, "the refused provider republishes on demand")
+			assert.True(t, last, "and what it republishes is the turn that caused the refusal")
 		})
 	}
 }
@@ -372,4 +382,51 @@ func TestZCodeSteerTimeoutIsDeliveryUncertain(t *testing.T) {
 	agent.mu.Unlock()
 
 	assert.ErrorIs(t, agent.SteerInput("guide", nil), ErrDeliveryUncertain)
+}
+
+// busyProvider refuses every send the way a provider inside its own turn does,
+// and counts the republishes the Manager asks for. It embeds idleAgent for the
+// rest of the Agent surface, for the same reason steeringStub does.
+type busyProvider struct {
+	idleAgent
+	refuse    error
+	republish int
+}
+
+func (p *busyProvider) SendInput(string, []*leapmuxv1.Attachment) error { return p.refuse }
+func (p *busyProvider) PublishTurnActive()                              { p.republish++ }
+
+func TestManagerSendInputRepublishesTheTurnARefusalDisproves(t *testing.T) {
+	t.Parallel()
+
+	// A busy refusal is PROOF that the Worker's view of the turn was wrong: it
+	// dispatched into a turn the provider was already running. Both consumers of
+	// the flag -- the activity state and the input queue's dispatch guard -- are
+	// wrong at that moment, and this is where they are repaired. Doing it here
+	// rather than in each provider is what stops a sixth provider from leaving
+	// it out.
+	for _, tc := range []struct {
+		name      string
+		refuse    error
+		republish int
+	}{
+		{name: "busy", refuse: fmt.Errorf("send: %w", ErrAgentBusy), republish: 1},
+		{name: "delivered", refuse: nil, republish: 0},
+		{name: "other failure", refuse: errors.New("broken pipe"), republish: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := &busyProvider{refuse: tc.refuse}
+			m := NewManager(nil)
+			m.mu.Lock()
+			m.agents["agent-1"] = provider
+			m.mu.Unlock()
+
+			err := m.SendInput("agent-1", "later turn", nil)
+			assert.Equal(t, tc.refuse != nil, err != nil)
+			assert.Equal(t, tc.republish, provider.republish,
+				"only a busy refusal disproves the Worker's view of the turn")
+		})
+	}
 }

--- a/backend/internal/worker/agent/thinking_tokens.go
+++ b/backend/internal/worker/agent/thinking_tokens.go
@@ -233,11 +233,3 @@ func (s *thinkingResetSink) BroadcastControlRequest(requestID string, payload []
 	s.est.reset()
 	s.OutputSink.BroadcastControlRequest(requestID, payload, claimToken)
 }
-
-func (s *thinkingResetSink) InputStarted() {
-	notifyInputStarted(s.OutputSink)
-}
-
-func (s *thinkingResetSink) InputReady() {
-	notifyInputReady(s.OutputSink)
-}

--- a/backend/internal/worker/agent/thinking_tokens_test.go
+++ b/backend/internal/worker/agent/thinking_tokens_test.go
@@ -198,15 +198,17 @@ func TestThinkingResetSink_ResetsOnFrontendClearBoundariesOnly(t *testing.T) {
 	}
 }
 
-func TestThinkingResetSink_ForwardsQueueLifecycle(t *testing.T) {
+func TestThinkingResetSink_ForwardsTheTurnFlag(t *testing.T) {
 	t.Parallel()
 
+	// The decorator wraps every provider's sink, and the turn flag it carries
+	// drives both the agent's activity state and the Worker's input queue. A
+	// decorator that swallowed it would hold every later message forever.
 	inner := &testSink{}
 	sink := newThinkingResetSink(inner, &thinkingTokenEstimator{})
 
-	notifyInputStarted(sink)
-	notifyInputReady(sink)
+	publishTurnActiveTo(sink, true)
+	publishTurnActiveTo(sink, false)
 
-	assert.Equal(t, 1, inner.InputStartedCount())
-	assert.Equal(t, 1, inner.InputReadyCount())
+	assert.Equal(t, []bool{true, false}, inner.TurnActives())
 }

--- a/backend/internal/worker/agent/thinking_tokens_test.go
+++ b/backend/internal/worker/agent/thinking_tokens_test.go
@@ -207,8 +207,8 @@ func TestThinkingResetSink_ForwardsTheTurnFlag(t *testing.T) {
 	inner := &testSink{}
 	sink := newThinkingResetSink(inner, &thinkingTokenEstimator{})
 
-	publishTurnActiveTo(sink, true)
-	publishTurnActiveTo(sink, false)
+	publishTurnActiveTo(sink, true, 1)
+	publishTurnActiveTo(sink, false, 2)
 
 	assert.Equal(t, []bool{true, false}, inner.TurnActives())
 }

--- a/backend/internal/worker/agent/turn_active_test.go
+++ b/backend/internal/worker/agent/turn_active_test.go
@@ -425,3 +425,58 @@ func TestTurnEndPrecedesTheClear_PiRetryEndsNoTurn(t *testing.T) {
 
 	assert.Equal(t, []string{"turn_active:true", "turn_active:true", "turn_end", "turn_active:false"}, sink.TurnLifecycle())
 }
+
+// --- a turn the Worker did not start -----------------------------------------
+
+func TestClaudeTurnActive_RootAssistantOutputArmsATurnTheWorkerDidNotStart(t *testing.T) {
+	t.Parallel()
+
+	// Claude Code emits no turn-start frame, so the Worker used to learn of a
+	// turn only from its own SendInput. A turn the CLI runs by itself -- one it
+	// continues after the `result` the Worker already consumed -- then left the
+	// flag clear, and the next queued message went straight into that running
+	// turn.
+	sink := &testSink{}
+	a, _ := newClaudeAgentWithStdin(sink)
+
+	a.HandleOutput([]byte(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"still working"}]}}`))
+
+	assert.Equal(t, []bool{true}, sink.TurnActives(), "root assistant output means a turn is in flight")
+	assert.ErrorIs(t, a.SendInput("second", nil), ErrAgentBusy)
+
+	a.HandleOutput([]byte(`{"type":"result","subtype":"success"}`))
+	// The refused send republishes the unchanged flag, which is what reconciles
+	// a queue that dispatched into it. The clear that follows is the result's.
+	assert.Equal(t, []bool{true, true, false}, sink.TurnActives(),
+		"the CLI's own result still ends the turn")
+}
+
+func TestClaudeTurnActive_RootAssistantOutputPublishesOncePerTurn(t *testing.T) {
+	t.Parallel()
+
+	// Every assistant message of one turn reaches this path. Only the first
+	// arms anything, so a streaming turn does not republish -- and does not
+	// reconcile the Worker's input queue -- once per message block.
+	sink := &testSink{}
+	a, _ := newClaudeAgentWithStdin(sink)
+
+	for range 3 {
+		a.HandleOutput([]byte(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"chunk"}]}}`))
+	}
+
+	assert.Equal(t, []bool{true}, sink.TurnActives())
+}
+
+func TestClaudeTurnActive_SubagentAssistantOutputArmsNoRootTurn(t *testing.T) {
+	t.Parallel()
+
+	// A forwarded subagent envelope carries parent_tool_use_id and belongs to
+	// the child's transcript. It says nothing about the root, which may well be
+	// idle while a restarted subagent runs on.
+	sink := &testSink{}
+	a, _ := newClaudeAgentWithStdin(sink)
+
+	a.HandleOutput([]byte(`{"type":"assistant","parent_tool_use_id":"parent-1","message":{"role":"assistant","content":[{"type":"text","text":"child"}]}}`))
+
+	assert.Empty(t, sink.TurnActives(), "only ROOT output arms the root's turn")
+}

--- a/backend/internal/worker/agent/turn_active_test.go
+++ b/backend/internal/worker/agent/turn_active_test.go
@@ -267,8 +267,37 @@ func newACPTurnBase(t *testing.T, stdin io.WriteCloser) (*acpBase, *testSink) {
 	t.Cleanup(cancel)
 	b.ctx = ctx
 	b.processDone = make(chan struct{})
-	b.wireTurnActive(sink)
+	b.wireTurnActive()
 	return b, sink
+}
+
+// swallowingSink stands in for a decorator that forgets to forward the turn
+// flag. thinkingResetSink promotes SetTurnActive from the embedded interface
+// today, so only a type like this one can tell a hook that re-reads b.sink from
+// one that captured the sink it was wired with.
+type swallowingSink struct {
+	OutputSink
+}
+
+func (s *swallowingSink) SetTurnActive(bool, uint64) {}
+
+func TestACPTurnActive_ThePublishFollowsALaterSinkWrap(t *testing.T) {
+	t.Parallel()
+
+	// acpStart wires the hook and startACPHandshake THEN replaces b.sink with
+	// thinkingResetSink. A hook that captured the raw sink would publish past
+	// every decorator for the life of the process -- and this flag is the input
+	// queue's only dispatch guard, so a decorator that ever overrode
+	// SetTurnActive would silently hold every later message of all six ACP
+	// providers.
+	var out bytes.Buffer
+	b, sink := newACPTurnBase(t, nopWriteCloser{&out})
+	b.sink = &swallowingSink{OutputSink: sink}
+
+	b.publishTurnActive(true, 1)
+
+	assert.Empty(t, sink.TurnActives(),
+		"the hook re-reads b.sink, so the wrap installed after wireTurnActive is honored")
 }
 
 func TestACPTurnActive_PromptOpensTheTurnAndTheResponseCloses(t *testing.T) {
@@ -334,6 +363,10 @@ func TestACPTurnActive_ClearActivePromptCloses(t *testing.T) {
 // different handler and the order is easy to invert while every other assertion
 // in the suite stays green.
 
+// reset_spans is in the sequence for the same reason turn_end is: the clear
+// releases the Worker's input queue, so the next message dispatches on it and
+// must find the finished turn's spans already reset. A provider that publishes
+// the clear before ResetSpans draws the dead turn's bars beside that message.
 func TestTurnEndPrecedesTheClear_Claude(t *testing.T) {
 	t.Parallel()
 
@@ -343,7 +376,7 @@ func TestTurnEndPrecedesTheClear_Claude(t *testing.T) {
 
 	a.HandleOutput([]byte(`{"type":"result","subtype":"success","num_tool_uses":2}`))
 
-	assert.Equal(t, []string{"turn_active:true", "turn_end", "turn_active:false"}, sink.TurnLifecycle())
+	assert.Equal(t, []string{"turn_active:true", "turn_end", "reset_spans", "turn_active:false"}, sink.TurnLifecycle())
 }
 
 func TestTurnEndPrecedesTheClear_Codex(t *testing.T) {
@@ -355,7 +388,7 @@ func TestTurnEndPrecedesTheClear_Codex(t *testing.T) {
 	handleCodexOutput(a, parseLine([]byte(`{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"main-thread","turn":{"id":"turn-42"}}}`)))
 	handleCodexOutput(a, parseLine([]byte(`{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-42","status":"completed"}}}`)))
 
-	assert.Equal(t, []string{"turn_active:true", "turn_end", "turn_active:false"}, sink.TurnLifecycle())
+	assert.Equal(t, []string{"turn_active:true", "turn_end", "reset_spans", "turn_active:false"}, sink.TurnLifecycle())
 }
 
 func TestTurnEndPrecedesTheClear_ZCode(t *testing.T) {
@@ -371,7 +404,7 @@ func TestTurnEndPrecedesTheClear_ZCode(t *testing.T) {
 	a.HandleOutput(zcodeEventLine(t, 1, contracts.ZCodeEventTurnStarted, `{"turnNumber":1,"input":"hi"}`))
 	a.HandleOutput(zcodeEventLine(t, 2, contracts.ZCodeEventTurnCompleted, `{"toolCallCount":1}`))
 
-	assert.Equal(t, []string{"turn_active:true", "turn_end", "turn_active:false"}, sink.TurnLifecycle())
+	assert.Equal(t, []string{"turn_active:true", "turn_end", "reset_spans", "turn_active:false"}, sink.TurnLifecycle())
 }
 
 func TestTurnEndPrecedesTheClear_Pi(t *testing.T) {
@@ -383,7 +416,7 @@ func TestTurnEndPrecedesTheClear_Pi(t *testing.T) {
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_start"}`)))
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","willRetry":false}`)))
 
-	assert.Equal(t, []string{"turn_active:true", "turn_end", "turn_active:false"}, sink.TurnLifecycle())
+	assert.Equal(t, []string{"turn_active:true", "turn_end", "reset_spans", "turn_active:false"}, sink.TurnLifecycle())
 }
 
 func TestTurnEndPrecedesTheClear_ACP(t *testing.T) {
@@ -398,8 +431,8 @@ func TestTurnEndPrecedesTheClear_ACP(t *testing.T) {
 	require.NoError(t, b.SendInput("hi", nil))
 	b.handleJSONRPCResponse(parseLine([]byte(`{"jsonrpc":"2.0","id":1,"result":{"stopReason":"end_turn"}}`)))
 
-	assert.Eventually(t, func() bool { return len(sink.TurnLifecycle()) == 3 }, time.Second, 5*time.Millisecond)
-	assert.Equal(t, []string{"turn_active:true", "turn_end", "turn_active:false"}, sink.TurnLifecycle())
+	assert.Eventually(t, func() bool { return len(sink.TurnLifecycle()) == 4 }, time.Second, 5*time.Millisecond)
+	assert.Equal(t, []string{"turn_active:true", "turn_end", "reset_spans", "turn_active:false"}, sink.TurnLifecycle())
 }
 
 // Pi keeps the turn open across a retry it drives itself, so the retried
@@ -418,12 +451,14 @@ func TestTurnEndPrecedesTheClear_PiRetryEndsNoTurn(t *testing.T) {
 	// turn. It is harmless because the Worker's latch is edge-triggered, and it
 	// is the price of publishing from the field rather than from an argument --
 	// which is what makes a MISSING publish the only way the two can drift.
-	assert.Equal(t, []string{"turn_active:true", "turn_active:true"}, sink.TurnLifecycle(),
+	assert.Equal(t, []string{"turn_active:true", "reset_spans", "turn_active:true"}, sink.TurnLifecycle(),
 		"a retried attempt neither ends the turn nor clears the flag")
 
 	handlePiOutput(a, parseLine([]byte(`{"type":"agent_end","willRetry":false}`)))
 
-	assert.Equal(t, []string{"turn_active:true", "turn_active:true", "turn_end", "turn_active:false"}, sink.TurnLifecycle())
+	assert.Equal(t, []string{
+		"turn_active:true", "reset_spans", "turn_active:true", "turn_end", "reset_spans", "turn_active:false",
+	}, sink.TurnLifecycle())
 }
 
 // --- a turn the Worker did not start -----------------------------------------
@@ -467,6 +502,77 @@ func TestClaudeTurnActive_RootAssistantOutputPublishesOncePerTurn(t *testing.T) 
 	assert.Equal(t, []bool{true}, sink.TurnActives())
 }
 
+func TestClaudeTurnActive_EveryRootFrameOfALiveTurnArmsIt(t *testing.T) {
+	t.Parallel()
+
+	// The frames that prove a live turn EARLIEST are the ones that return before
+	// the persist path: the thinking-token telemetry and the notification-
+	// threaded system lines, and a root user tool_result. Arming from the
+	// assistant message alone left the whole extended-thinking window of a
+	// CLI-run turn invisible, and a message the user sent inside it went
+	// straight into that turn.
+	for _, tc := range []struct {
+		name string
+		line string
+	}{
+		{
+			name: "thinking tokens",
+			line: `{"type":"system","subtype":"thinking_tokens","thinking_tokens":120}`,
+		},
+		{
+			name: "notification-threaded status",
+			line: `{"type":"system","subtype":"compacting","status":"compacting"}`,
+		},
+		{
+			name: "root user tool_result",
+			line: `{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}}`,
+		},
+		{
+			name: "root user text echo",
+			line: `{"type":"user","message":{"role":"user","content":"hello"}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			a, _ := newClaudeAgentWithStdin(sink)
+
+			a.HandleOutput([]byte(tc.line))
+
+			assert.Equal(t, []bool{true}, sink.TurnActives(),
+				"a root frame only a live turn produces arms the turn")
+			assert.ErrorIs(t, a.SendInput("second", nil), ErrAgentBusy)
+		})
+	}
+}
+
+func TestClaudeTurnActive_TheWorkersOwnTrafficArmsNothing(t *testing.T) {
+	t.Parallel()
+
+	// A result ENDS a turn, and the control frames are the Worker talking to
+	// itself. Neither is evidence that the CLI is working.
+	for _, tc := range []struct {
+		name string
+		line string
+	}{
+		{name: "result", line: `{"type":"result","subtype":"success"}`},
+		{name: "control_response", line: `{"type":"control_response","response":{"request_id":"r1","subtype":"success"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			a, _ := newClaudeAgentWithStdin(sink)
+
+			a.HandleOutput([]byte(tc.line))
+
+			assert.NotContains(t, sink.TurnActives(), true,
+				"no turn is in flight because of this frame")
+		})
+	}
+}
+
 func TestClaudeTurnActive_SubagentAssistantOutputArmsNoRootTurn(t *testing.T) {
 	t.Parallel()
 
@@ -479,4 +585,80 @@ func TestClaudeTurnActive_SubagentAssistantOutputArmsNoRootTurn(t *testing.T) {
 	a.HandleOutput([]byte(`{"type":"assistant","parent_tool_use_id":"parent-1","message":{"role":"assistant","content":[{"type":"text","text":"child"}]}}`))
 
 	assert.Empty(t, sink.TurnActives(), "only ROOT output arms the root's turn")
+}
+
+func TestTurnActive_EveryProviderIssuesRisingOrderingTokens(t *testing.T) {
+	t.Parallel()
+
+	// The token is what lets the Worker tell a publish it overtook from a
+	// current one, and it only does that if it RISES with each publish and comes
+	// from the same critical section that reads the flag. A provider that reused
+	// a token, or took one outside that section, would order nothing -- and a
+	// stale value would latch a turn that is over.
+	for _, tc := range []struct {
+		name    string
+		publish func(t *testing.T, sink OutputSink)
+	}{
+		{
+			name: "claude",
+			publish: func(t *testing.T, sink OutputSink) {
+				a, _ := newClaudeAgentWithStdin(sink)
+				a.PublishTurnActive()
+				a.PublishTurnActive()
+				a.PublishTurnActive()
+			},
+		},
+		{
+			name: "codex",
+			publish: func(t *testing.T, sink OutputSink) {
+				a := newCodexAgentWithSink(sink)
+				a.sink = sink
+				a.PublishTurnActive()
+				a.PublishTurnActive()
+				a.PublishTurnActive()
+			},
+		},
+		{
+			name: "pi",
+			publish: func(t *testing.T, sink OutputSink) {
+				a := newPiAgentWithSink(sink)
+				a.PublishTurnActive()
+				a.PublishTurnActive()
+				a.PublishTurnActive()
+			},
+		},
+		{
+			name: "zcode",
+			publish: func(t *testing.T, sink OutputSink) {
+				a := newZCodeTestAgentWithStdin(t, sink, &zcodeRecordedStdin{})
+				a.PublishTurnActive()
+				a.PublishTurnActive()
+				a.PublishTurnActive()
+			},
+		},
+		{
+			name: "acpBase",
+			publish: func(t *testing.T, sink OutputSink) {
+				var out bytes.Buffer
+				b, _ := newACPTurnBase(t, nopWriteCloser{&out})
+				b.sink = sink
+				b.wireTurnActive()
+				b.PublishTurnActive()
+				b.PublishTurnActive()
+				b.PublishTurnActive()
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			tc.publish(t, sink)
+
+			seqs := sink.TurnSeqs()
+			require.Len(t, seqs, 3, "each publish carries a token")
+			assert.Greater(t, seqs[1], seqs[0], "the token rises with each publish")
+			assert.Greater(t, seqs[2], seqs[1])
+		})
+	}
 }

--- a/backend/internal/worker/agent/zcode.go
+++ b/backend/internal/worker/agent/zcode.go
@@ -577,6 +577,10 @@ func (a *zcodeAgent) sendInput(content string, attachments []*leapmuxv1.Attachme
 		return fmt.Errorf("agent has no ZCode session")
 	}
 	if requestedDelivery == "" && turnActive {
+		// The refusal is proof that this turn is in flight, and the Worker
+		// dispatched into it, so its view of the turn was wrong. See
+		// CodexAgent.SendInput for why the publish belongs here.
+		a.publishTurnActive()
 		return ErrAgentBusy
 	}
 	if requestedDelivery != "" && !turnActive {

--- a/backend/internal/worker/agent/zcode.go
+++ b/backend/internal/worker/agent/zcode.go
@@ -577,10 +577,6 @@ func (a *zcodeAgent) sendInput(content string, attachments []*leapmuxv1.Attachme
 		return fmt.Errorf("agent has no ZCode session")
 	}
 	if requestedDelivery == "" && turnActive {
-		// The refusal is proof that this turn is in flight, and the Worker
-		// dispatched into it, so its view of the turn was wrong. See
-		// CodexAgent.SendInput for why the publish belongs here.
-		a.publishTurnActive()
 		return ErrAgentBusy
 	}
 	if requestedDelivery != "" && !turnActive {
@@ -723,7 +719,7 @@ func (a *zcodeAgent) ClearContext() (string, bool) {
 	clear(a.pendingControls)
 	sessionID := a.sessionID
 	a.mu.Unlock()
-	a.publishTurnActive()
+	a.PublishTurnActive()
 	a.toolCallPrompts.clear()
 	a.children.clear()
 	a.resetCumulativeDeltas()

--- a/backend/internal/worker/agent/zcode_output.go
+++ b/backend/internal/worker/agent/zcode_output.go
@@ -354,7 +354,6 @@ func (a *zcodeAgent) finishZCodeTurn(event zcodeEventEnvelope, toolCallCount int
 		}
 	}
 	a.mu.Unlock()
-	notifyInputReady(a.sink)
 
 	// The app-server's own reading is authoritative, and reading it takes an RPC --
 	// which the read loop must stay free to deliver, so it cannot run inline here.

--- a/backend/internal/worker/agent/zcode_output.go
+++ b/backend/internal/worker/agent/zcode_output.go
@@ -170,7 +170,7 @@ func (a *zcodeAgent) persistZCodeNotification(event zcodeEventEnvelope) {
 
 // --- turn lifecycle ---
 
-// publishTurnActive republishes the Worker-visible turn state from turnActive,
+// PublishTurnActive republishes the Worker-visible turn state from turnActive,
 // the single source. Call it after EVERY critical section that writes that
 // field.
 //
@@ -183,11 +183,12 @@ func (a *zcodeAgent) persistZCodeNotification(event zcodeEventEnvelope) {
 // and closes none of the user's spans, but the agent IS processing, and
 // turnActive is already what Interrupt and Stop read to decide the session is
 // live.
-func (a *zcodeAgent) publishTurnActive() {
+func (a *zcodeAgent) PublishTurnActive() {
 	a.mu.Lock()
 	active := a.turnActive
+	seq := a.nextTurnSeq()
 	a.mu.Unlock()
-	publishTurnActiveTo(a.sink, active)
+	publishTurnActiveTo(a.sink, active, seq)
 }
 
 // zcodeTurnStarted is the turn.started payload.
@@ -221,7 +222,7 @@ func (a *zcodeAgent) handleZCodeTurnStarted(event zcodeEventEnvelope) {
 		a.turnToolUses = 0
 	}
 	a.mu.Unlock()
-	a.publishTurnActive()
+	a.PublishTurnActive()
 
 	if !background {
 		// A fresh user turn begins: restart the thinking-token estimate from zero.
@@ -322,7 +323,7 @@ func (a *zcodeAgent) finishZCodeTurn(event zcodeEventEnvelope, toolCallCount int
 	// latch: the clear is what produces the settle edge that spends the count,
 	// so publishing it first would settle the agent with no count and ring the
 	// completion sound for a turn that used no tool.
-	defer a.publishTurnActive()
+	defer a.PublishTurnActive()
 
 	content := event.persistBytes()
 	if content == nil {

--- a/backend/internal/worker/inputqueue/manager.go
+++ b/backend/internal/worker/inputqueue/manager.go
@@ -16,9 +16,10 @@ type coordinator struct {
 	// drainAgain records a drain request that arrived while the drain loop held
 	// the flag above. scheduleDrain cannot start a second loop for it, and the
 	// running loop released the coordinator lock across a provider call, so the
-	// request can carry state the loop has not read: a turn that ended inside
-	// that call, or an item enqueued during it. The loop consumes the request
-	// before it stops, and the request dies with the read that answers it.
+	// request can carry state that the loop still misses: a turn that ended
+	// inside that call, or an item enqueued during it. The loop consumes the
+	// request before it stops, and the request dies with the read that answers
+	// it.
 	drainAgain bool
 	// plannedRestarts counts the restarts in flight for this agent. The last
 	// one to finish resumes the pause that the first one created.
@@ -74,9 +75,9 @@ func NewManager(store *Store, dispatcher Dispatcher, observer Observer) *Manager
 // The order is load-bearing: scheduleDrain takes the same non-reentrant mutex,
 // so a copy that called it while holding the lock would deadlock.
 //
-// A mutation that reports no change broadcasts nothing and drains nothing. The
-// turn signal reconciles the queue on every publish of the provider's flag,
-// including the many that repeat the state the queue already holds.
+// A mutation that reports no change broadcasts nothing. The turn signal
+// reconciles the queue on every publish of the provider's flag, including the
+// many that repeat the state the queue already holds.
 func (m *Manager) mutateAndDrain(agentID string, mutate func() (Snapshot, bool, error)) (Snapshot, error) {
 	if !m.beginActivity() {
 		return Snapshot{}, ErrManagerStopped
@@ -94,8 +95,38 @@ func (m *Manager) mutateAndDrain(agentID string, mutate func() (Snapshot, bool, 
 	}
 	if changed {
 		m.scheduleDrain(agentID)
+		return snapshot, nil
 	}
+	// A mutation that moved nothing still restarts a drain loop that a store
+	// error stopped. That loop leaves the items queued with no turn and no
+	// pause, and it schedules nothing further, so the queue waits for an event
+	// that only a new user action produces. The turn signal repeats often
+	// enough to be that event.
+	m.drainIfReleased(agentID, snapshot)
 	return snapshot, nil
+}
+
+// drainIfReleased schedules a drain when the snapshot shows a queue that can
+// move: no turn in flight, no pause, and at least one item that waits. A drain
+// for a queue that cannot move costs a transaction and delivers nothing.
+//
+// The caller must NOT hold the coordinator lock, because scheduleDrain takes
+// that same non-reentrant mutex.
+func (m *Manager) drainIfReleased(agentID string, snapshot Snapshot) {
+	if snapshot.ActiveTurn || snapshot.Paused || len(snapshot.Items) == 0 {
+		return
+	}
+	m.scheduleDrain(agentID)
+}
+
+// alwaysChanged adapts a store call whose every success moves the queue. The
+// changed Boolean belongs to the two calls that reconcile against a signal the
+// provider repeats; for an explicit user action the answer is always yes.
+func alwaysChanged(mutate func() (Snapshot, error)) func() (Snapshot, bool, error) {
+	return func() (Snapshot, bool, error) {
+		snapshot, err := mutate()
+		return snapshot, true, err
+	}
 }
 
 func (m *Manager) beginActivity() bool {
@@ -132,17 +163,19 @@ func (m *Manager) StopAndWait() {
 	m.Stop()()
 }
 
-// finishOrRepeatLocked answers whether the drain loop stops at this exit. A
-// drain request that arrived during the provider call is news the loop has not
-// read, so the loop repeats for it instead of ending; nothing else can pick
-// that request up, because scheduleDrain refused to start a second loop while
-// this one held the draining flag.
+// stopRoundAndUnlock ends one pass of the drain loop, releases the coordinator
+// lock, and reports whether the loop stops. A drain request that arrived during
+// the provider call is news that the loop still misses, so the loop repeats for
+// it instead of stopping. Nothing else can take that request, because
+// scheduleDrain refused to start a second loop while this one held the draining
+// flag.
 //
-// The repeat is bounded: it happens once for each request, and each request
+// The repeat has a limit: it happens once for each request, and each request
 // costs one scheduleDrain call from a real state change.
 //
-// The caller must hold c.mu.
-func (c *coordinator) finishOrRepeatLocked() bool {
+// The caller must hold c.mu. This method releases it on every path.
+func (c *coordinator) stopRoundAndUnlock() bool {
+	defer c.mu.Unlock()
 	if c.drainAgain {
 		c.drainAgain = false
 		return false
@@ -204,10 +237,9 @@ func (m *Manager) Enqueue(ctx context.Context, input NewItem) (Snapshot, error) 
 	if err := m.refuseUnacceptedKind(input.AgentID, m.store.Classify(input.Kind, input.Text)); err != nil {
 		return Snapshot{}, err
 	}
-	return m.mutateAndDrain(input.AgentID, func() (Snapshot, bool, error) {
-		snapshot, err := m.store.Enqueue(ctx, input)
-		return snapshot, true, err
-	})
+	return m.mutateAndDrain(input.AgentID, alwaysChanged(func() (Snapshot, error) {
+		return m.store.Enqueue(ctx, input)
+	}))
 }
 
 func (m *Manager) Snapshot(ctx context.Context, agentID string) (Snapshot, error) {
@@ -248,31 +280,27 @@ func (m *Manager) Update(ctx context.Context, agentID, inputID, clientID string,
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return Snapshot{}, err
 	}
-	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
-		snapshot, err := m.store.Update(ctx, agentID, inputID, clientID, expectedVersion, text, attachments)
-		return snapshot, true, err
-	})
+	return m.mutateAndDrain(agentID, alwaysChanged(func() (Snapshot, error) {
+		return m.store.Update(ctx, agentID, inputID, clientID, expectedVersion, text, attachments)
+	}))
 }
 
 func (m *Manager) CancelEdit(ctx context.Context, agentID, inputID, clientID string) (Snapshot, error) {
-	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
-		snapshot, err := m.store.CancelEdit(ctx, agentID, inputID, clientID)
-		return snapshot, true, err
-	})
+	return m.mutateAndDrain(agentID, alwaysChanged(func() (Snapshot, error) {
+		return m.store.CancelEdit(ctx, agentID, inputID, clientID)
+	}))
 }
 
 func (m *Manager) Delete(ctx context.Context, agentID, inputID string) (Snapshot, error) {
-	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
-		snapshot, err := m.store.Delete(ctx, agentID, inputID)
-		return snapshot, true, err
-	})
+	return m.mutateAndDrain(agentID, alwaysChanged(func() (Snapshot, error) {
+		return m.store.Delete(ctx, agentID, inputID)
+	}))
 }
 
 func (m *Manager) Move(ctx context.Context, agentID, inputID, beforeInputID string) (Snapshot, error) {
-	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
-		snapshot, err := m.store.Move(ctx, agentID, inputID, beforeInputID)
-		return snapshot, true, err
-	})
+	return m.mutateAndDrain(agentID, alwaysChanged(func() (Snapshot, error) {
+		return m.store.Move(ctx, agentID, inputID, beforeInputID)
+	}))
 }
 
 func (m *Manager) SetPaused(ctx context.Context, agentID string, paused bool) (Snapshot, error) {
@@ -322,21 +350,9 @@ func (m *Manager) PauseForArchive(ctx context.Context, agentID string) (Snapshot
 
 // ResumeAfterArchive resumes only a pause that PauseForArchive created.
 func (m *Manager) ResumeAfterArchive(ctx context.Context, agentID string) (Snapshot, error) {
-	if !m.beginActivity() {
-		return Snapshot{}, ErrManagerStopped
-	}
-	defer m.endActivity()
-	c := m.coordinator(agentID)
-	c.mu.Lock()
-	snapshot, changed, err := m.store.ResumeAfterArchive(ctx, agentID)
-	if err == nil && changed {
-		m.observer.QueueChanged(snapshot)
-	}
-	c.mu.Unlock()
-	if err == nil && changed {
-		m.scheduleDrain(agentID)
-	}
-	return snapshot, err
+	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
+		return m.store.ResumeAfterArchive(ctx, agentID)
+	})
 }
 
 // TurnEnded and TurnStarted reconcile the queue against the turn flag that the
@@ -349,6 +365,16 @@ func (m *Manager) ResumeAfterArchive(ctx context.Context, agentID string) (Snaps
 func (m *Manager) TurnEnded(ctx context.Context, agentID string) (Snapshot, error) {
 	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
 		return m.store.TurnEnded(ctx, agentID)
+	})
+}
+
+// TurnAbandoned clears a turn that no dispatch owns. A process boundary calls
+// it: a process that starts or exits runs no turn, and a turn the agent process
+// reported has no other end once that process is gone. See
+// Store.AbandonUnownedTurn for why a turn a dispatch owns is left alone.
+func (m *Manager) TurnAbandoned(ctx context.Context, agentID string) (Snapshot, error) {
+	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
+		return m.store.AbandonUnownedTurn(ctx, agentID)
 	})
 }
 
@@ -391,7 +417,14 @@ func (m *Manager) Retry(ctx context.Context, agentID, inputID string, confirmUnc
 	if dispatchErr != nil {
 		snapshot, storeErr := m.recordDispatchFailure(ctx, *prepared, dispatchErr)
 		c.mu.Unlock()
-		return snapshot, storeErr
+		if storeErr != nil {
+			return snapshot, storeErr
+		}
+		// A busy refusal returns the item to an OPEN queue, and the turn that
+		// refused it delivers it. A turn that ended inside the provider call
+		// leaves no later edge, so only this drain moves the item.
+		m.drainIfReleased(agentID, snapshot)
+		return snapshot, nil
 	}
 	snapshot, _, err = m.acceptDispatch(ctx, *prepared, result)
 	if err != nil {
@@ -431,24 +464,24 @@ func (m *Manager) Steer(ctx context.Context, agentID, inputID string) (Snapshot,
 	c.mu.Lock()
 	if errors.Is(err, ErrSteeringUnsupported) {
 		snapshot, storeErr := m.store.RequeuePrepared(ctx, agentID, inputID)
-		if storeErr == nil {
-			m.observer.QueueChanged(snapshot)
-		}
-		shouldDrain := storeErr == nil && !snapshot.ActiveTurn && !snapshot.Paused
-		c.mu.Unlock()
-		if shouldDrain {
-			m.scheduleDrain(agentID)
-		}
 		if storeErr != nil {
+			c.mu.Unlock()
 			return Snapshot{}, storeErr
 		}
+		m.observer.QueueChanged(snapshot)
+		c.mu.Unlock()
+		m.drainIfReleased(agentID, snapshot)
 		return snapshot, ErrSteeringUnsupported
 	}
 	turnEnded := errors.Is(err, ErrTurnEnded)
 	if err != nil && !turnEnded {
 		snapshot, storeErr := m.recordDispatchFailure(ctx, *prepared, err)
 		c.mu.Unlock()
-		return snapshot, storeErr
+		if storeErr != nil {
+			return snapshot, storeErr
+		}
+		m.drainIfReleased(agentID, snapshot)
+		return snapshot, nil
 	}
 	if !turnEnded {
 		current, storeErr := m.store.Snapshot(ctx, agentID)
@@ -465,11 +498,8 @@ func (m *Manager) Steer(ctx context.Context, agentID, inputID string) (Snapshot,
 			return Snapshot{}, storeErr
 		}
 		m.observer.QueueChanged(snapshot)
-		shouldDrain := !snapshot.ActiveTurn && !snapshot.Paused
 		c.mu.Unlock()
-		if shouldDrain {
-			m.scheduleDrain(agentID)
-		}
+		m.drainIfReleased(agentID, snapshot)
 		return snapshot, nil
 	}
 	result.StartsTurn = true
@@ -479,11 +509,8 @@ func (m *Manager) Steer(ctx context.Context, agentID, inputID string) (Snapshot,
 		c.mu.Unlock()
 		return Snapshot{}, err
 	}
-	shouldDrain := !snapshot.ActiveTurn && !snapshot.Paused
 	c.mu.Unlock()
-	if shouldDrain {
-		m.scheduleDrain(agentID)
-	}
+	m.drainIfReleased(agentID, snapshot)
 	return snapshot, nil
 }
 
@@ -536,11 +563,11 @@ func (r *PlannedRestart) Finish(ctx context.Context, processReplaced, restartSuc
 		if err == nil && changed {
 			r.manager.observer.QueueChanged(snapshot)
 		}
-		shouldDrain := err == nil && changed && !snapshot.Paused && !snapshot.ActiveTurn && len(snapshot.Items) > 0
+		shouldDrain := err == nil && changed
 		r.coordinator.mu.Unlock()
 		r.manager.endActivity()
 		if shouldDrain {
-			r.manager.scheduleDrain(r.agentID)
+			r.manager.drainIfReleased(r.agentID, snapshot)
 		}
 		r.err = err
 	})
@@ -658,7 +685,7 @@ func (m *Manager) drain(agentID string, c *coordinator) {
 		}
 		// The read below answers every drain request made so far, so a request
 		// recorded before it is spent. Only one that arrives during the provider
-		// call carries news this loop has not seen.
+		// call carries news that this loop still misses.
 		c.drainAgain = false
 		prepared, snapshot, err := m.store.PrepareDispatch(context.Background(), agentID)
 		if err != nil {
@@ -682,21 +709,17 @@ func (m *Manager) drain(agentID string, c *coordinator) {
 			if _, storeErr := m.recordDispatchFailure(context.Background(), *prepared, dispatchErr); storeErr != nil {
 				slog.Error("agent input queue failure persistence failed", "agent_id", agentID, "input_id", prepared.Item.ID, "error", storeErr)
 			}
-			if c.finishOrRepeatLocked() {
-				c.mu.Unlock()
+			if c.stopRoundAndUnlock() {
 				return
 			}
-			c.mu.Unlock()
 			continue
 		}
 		snapshot, persisted, err := m.acceptDispatch(context.Background(), *prepared, result)
 		if err != nil {
 			slog.Error("agent input queue acceptance persistence failed", "agent_id", agentID, "input_id", prepared.Item.ID, "error", err)
-			if c.finishOrRepeatLocked() {
-				c.mu.Unlock()
+			if c.stopRoundAndUnlock() {
 				return
 			}
-			c.mu.Unlock()
 			continue
 		}
 		// The COMMITTED state decides, not the dispatch's own report. A turn
@@ -705,11 +728,9 @@ func (m *Manager) drain(agentID string, c *coordinator) {
 		// nothing -- so reading result.StartsTurn here left the queue holding
 		// the rest of its items with no turn to wait for.
 		if !persisted || snapshot.ActiveTurn {
-			if c.finishOrRepeatLocked() {
-				c.mu.Unlock()
+			if c.stopRoundAndUnlock() {
 				return
 			}
-			c.mu.Unlock()
 			continue
 		}
 		c.mu.Unlock()
@@ -736,41 +757,28 @@ func (m *Manager) acceptDispatch(ctx context.Context, prepared PreparedDispatch,
 }
 
 // recordDispatchFailure stores the outcome of a dispatch that the provider
-// refused. Delivery has four outcomes, not two.
-//
-// ErrDispatchBusy means the agent is inside a turn of its own. Nothing failed
-// and nothing has to change for the item to go out, so the item returns to the
-// queue unchanged and the queue stays open. The turn it collided with holds the
-// item, and the end of that turn drains it -- the same path an item that waited
-// its turn from the start takes.
-//
-// ErrDispatchNotReady means the input never reached the provider AND the agent
-// must change state before it can, so the item returns to the queue and the
-// queue pauses: a message the user typed must not need a manual retry because
-// the agent was between processes.
-//
-// The other two outcomes mark the item FAILED or DELIVERY_UNCERTAIN, which the
-// user resolves explicitly.
+// refused. DispatchOutcome states which of the four it was, and the switch is
+// exhaustive so a fifth cannot be added without answering for it here.
 func (m *Manager) recordDispatchFailure(ctx context.Context, prepared PreparedDispatch, dispatchErr error) (Snapshot, error) {
-	if errors.Is(dispatchErr, ErrDispatchBusy) {
-		snapshot, err := m.store.RequeuePrepared(ctx, prepared.Item.AgentID, prepared.Item.ID)
-		if err != nil {
-			return Snapshot{}, err
+	item := prepared.Item
+	var record func() (Snapshot, error)
+	switch dispatchOutcome(dispatchErr) {
+	case DispatchBusy:
+		record = func() (Snapshot, error) { return m.store.RequeueBusy(ctx, item.AgentID, item.ID) }
+	case DispatchNotReady:
+		record = func() (Snapshot, error) {
+			return m.store.RequeueAndPause(ctx, item.AgentID, item.ID, dispatchErr)
 		}
-		m.observer.QueueChanged(snapshot)
-		return snapshot, nil
-	}
-	if errors.Is(dispatchErr, ErrDispatchNotReady) {
-		snapshot, err := m.store.RequeueAndPause(ctx, prepared.Item.AgentID, prepared.Item.ID, dispatchErr)
-		if err != nil {
-			return Snapshot{}, err
+	case DispatchUncertain:
+		record = func() (Snapshot, error) {
+			return m.store.FailDispatch(ctx, item.AgentID, item.ID, dispatchErr, true)
 		}
-		m.observer.QueueChanged(snapshot)
-		return snapshot, nil
+	case DispatchFailed:
+		record = func() (Snapshot, error) {
+			return m.store.FailDispatch(ctx, item.AgentID, item.ID, dispatchErr, false)
+		}
 	}
-	var deliveryErr *DeliveryError
-	uncertain := errors.As(dispatchErr, &deliveryErr) && deliveryErr.Uncertain
-	snapshot, err := m.store.FailDispatch(ctx, prepared.Item.AgentID, prepared.Item.ID, dispatchErr, uncertain)
+	snapshot, err := record()
 	if err != nil {
 		return Snapshot{}, err
 	}

--- a/backend/internal/worker/inputqueue/manager.go
+++ b/backend/internal/worker/inputqueue/manager.go
@@ -13,6 +13,13 @@ import (
 type coordinator struct {
 	mu       sync.Mutex
 	draining bool
+	// drainAgain records a drain request that arrived while the drain loop held
+	// the flag above. scheduleDrain cannot start a second loop for it, and the
+	// running loop released the coordinator lock across a provider call, so the
+	// request can carry state the loop has not read: a turn that ended inside
+	// that call, or an item enqueued during it. The loop consumes the request
+	// before it stops, and the request dies with the read that answers it.
+	drainAgain bool
 	// plannedRestarts counts the restarts in flight for this agent. The last
 	// one to finish resumes the pause that the first one created.
 	//
@@ -66,22 +73,28 @@ func NewManager(store *Store, dispatcher Dispatcher, observer Observer) *Manager
 // broadcasts the new snapshot, and then schedules a drain OUTSIDE that lock.
 // The order is load-bearing: scheduleDrain takes the same non-reentrant mutex,
 // so a copy that called it while holding the lock would deadlock.
-func (m *Manager) mutateAndDrain(agentID string, mutate func() (Snapshot, error)) (Snapshot, error) {
+//
+// A mutation that reports no change broadcasts nothing and drains nothing. The
+// turn signal reconciles the queue on every publish of the provider's flag,
+// including the many that repeat the state the queue already holds.
+func (m *Manager) mutateAndDrain(agentID string, mutate func() (Snapshot, bool, error)) (Snapshot, error) {
 	if !m.beginActivity() {
 		return Snapshot{}, ErrManagerStopped
 	}
 	defer m.endActivity()
 	c := m.coordinator(agentID)
 	c.mu.Lock()
-	snapshot, err := mutate()
-	if err == nil {
+	snapshot, changed, err := mutate()
+	if err == nil && changed {
 		m.observer.QueueChanged(snapshot)
 	}
 	c.mu.Unlock()
 	if err != nil {
 		return snapshot, err
 	}
-	m.scheduleDrain(agentID)
+	if changed {
+		m.scheduleDrain(agentID)
+	}
 	return snapshot, nil
 }
 
@@ -117,6 +130,25 @@ func (m *Manager) Stop() func() {
 // StopAndWait closes queue admission and then joins active work.
 func (m *Manager) StopAndWait() {
 	m.Stop()()
+}
+
+// finishOrRepeatLocked answers whether the drain loop stops at this exit. A
+// drain request that arrived during the provider call is news the loop has not
+// read, so the loop repeats for it instead of ending; nothing else can pick
+// that request up, because scheduleDrain refused to start a second loop while
+// this one held the draining flag.
+//
+// The repeat is bounded: it happens once for each request, and each request
+// costs one scheduleDrain call from a real state change.
+//
+// The caller must hold c.mu.
+func (c *coordinator) finishOrRepeatLocked() bool {
+	if c.drainAgain {
+		c.drainAgain = false
+		return false
+	}
+	c.draining = false
+	return true
 }
 
 func (m *Manager) coordinator(agentID string) *coordinator {
@@ -172,8 +204,9 @@ func (m *Manager) Enqueue(ctx context.Context, input NewItem) (Snapshot, error) 
 	if err := m.refuseUnacceptedKind(input.AgentID, m.store.Classify(input.Kind, input.Text)); err != nil {
 		return Snapshot{}, err
 	}
-	return m.mutateAndDrain(input.AgentID, func() (Snapshot, error) {
-		return m.store.Enqueue(ctx, input)
+	return m.mutateAndDrain(input.AgentID, func() (Snapshot, bool, error) {
+		snapshot, err := m.store.Enqueue(ctx, input)
+		return snapshot, true, err
 	})
 }
 
@@ -215,26 +248,30 @@ func (m *Manager) Update(ctx context.Context, agentID, inputID, clientID string,
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return Snapshot{}, err
 	}
-	return m.mutateAndDrain(agentID, func() (Snapshot, error) {
-		return m.store.Update(ctx, agentID, inputID, clientID, expectedVersion, text, attachments)
+	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
+		snapshot, err := m.store.Update(ctx, agentID, inputID, clientID, expectedVersion, text, attachments)
+		return snapshot, true, err
 	})
 }
 
 func (m *Manager) CancelEdit(ctx context.Context, agentID, inputID, clientID string) (Snapshot, error) {
-	return m.mutateAndDrain(agentID, func() (Snapshot, error) {
-		return m.store.CancelEdit(ctx, agentID, inputID, clientID)
+	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
+		snapshot, err := m.store.CancelEdit(ctx, agentID, inputID, clientID)
+		return snapshot, true, err
 	})
 }
 
 func (m *Manager) Delete(ctx context.Context, agentID, inputID string) (Snapshot, error) {
-	return m.mutateAndDrain(agentID, func() (Snapshot, error) {
-		return m.store.Delete(ctx, agentID, inputID)
+	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
+		snapshot, err := m.store.Delete(ctx, agentID, inputID)
+		return snapshot, true, err
 	})
 }
 
 func (m *Manager) Move(ctx context.Context, agentID, inputID, beforeInputID string) (Snapshot, error) {
-	return m.mutateAndDrain(agentID, func() (Snapshot, error) {
-		return m.store.Move(ctx, agentID, inputID, beforeInputID)
+	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
+		snapshot, err := m.store.Move(ctx, agentID, inputID, beforeInputID)
+		return snapshot, true, err
 	})
 }
 
@@ -302,8 +339,15 @@ func (m *Manager) ResumeAfterArchive(ctx context.Context, agentID string) (Snaps
 	return snapshot, err
 }
 
+// TurnEnded and TurnStarted reconcile the queue against the turn flag that the
+// agent's provider publishes. The provider owns that flag -- its own SendInput
+// refuses input from the same value -- so the queue follows it rather than
+// keeping a second answer of its own.
+//
+// Both are idempotent, because a provider republishes the unchanged value
+// freely. A call that moves nothing broadcasts nothing.
 func (m *Manager) TurnEnded(ctx context.Context, agentID string) (Snapshot, error) {
-	return m.mutateAndDrain(agentID, func() (Snapshot, error) {
+	return m.mutateAndDrain(agentID, func() (Snapshot, bool, error) {
 		return m.store.TurnEnded(ctx, agentID)
 	})
 }
@@ -314,8 +358,7 @@ func (m *Manager) TurnStarted(ctx context.Context, agentID string) (Snapshot, er
 	}
 	defer m.endActivity()
 	return m.mutateLocked(agentID, func() (Snapshot, bool, error) {
-		snapshot, err := m.store.TurnStarted(ctx, agentID)
-		return snapshot, true, err
+		return m.store.TurnStarted(ctx, agentID)
 	})
 }
 
@@ -576,6 +619,7 @@ func (m *Manager) scheduleDrain(agentID string) {
 	c := m.coordinator(agentID)
 	c.mu.Lock()
 	if c.draining {
+		c.drainAgain = true
 		c.mu.Unlock()
 		m.endActivity()
 		return
@@ -608,9 +652,14 @@ func (m *Manager) drain(agentID string, c *coordinator) {
 		c.mu.Lock()
 		if m.isStopped() {
 			c.draining = false
+			c.drainAgain = false
 			c.mu.Unlock()
 			return
 		}
+		// The read below answers every drain request made so far, so a request
+		// recorded before it is spent. Only one that arrives during the provider
+		// call carries news this loop has not seen.
+		c.drainAgain = false
 		prepared, snapshot, err := m.store.PrepareDispatch(context.Background(), agentID)
 		if err != nil {
 			slog.Error("agent input queue prepare failed", "agent_id", agentID, "error", err)
@@ -633,21 +682,35 @@ func (m *Manager) drain(agentID string, c *coordinator) {
 			if _, storeErr := m.recordDispatchFailure(context.Background(), *prepared, dispatchErr); storeErr != nil {
 				slog.Error("agent input queue failure persistence failed", "agent_id", agentID, "input_id", prepared.Item.ID, "error", storeErr)
 			}
-			c.draining = false
+			if c.finishOrRepeatLocked() {
+				c.mu.Unlock()
+				return
+			}
 			c.mu.Unlock()
-			return
+			continue
 		}
-		_, persisted, err := m.acceptDispatch(context.Background(), *prepared, result)
+		snapshot, persisted, err := m.acceptDispatch(context.Background(), *prepared, result)
 		if err != nil {
 			slog.Error("agent input queue acceptance persistence failed", "agent_id", agentID, "input_id", prepared.Item.ID, "error", err)
-			c.draining = false
+			if c.finishOrRepeatLocked() {
+				c.mu.Unlock()
+				return
+			}
 			c.mu.Unlock()
-			return
+			continue
 		}
-		if !persisted || result.StartsTurn {
-			c.draining = false
+		// The COMMITTED state decides, not the dispatch's own report. A turn
+		// that ended while the provider call ran cleared the flag, and the
+		// scheduleDrain it fired found this loop still marked draining and did
+		// nothing -- so reading result.StartsTurn here left the queue holding
+		// the rest of its items with no turn to wait for.
+		if !persisted || snapshot.ActiveTurn {
+			if c.finishOrRepeatLocked() {
+				c.mu.Unlock()
+				return
+			}
 			c.mu.Unlock()
-			return
+			continue
 		}
 		c.mu.Unlock()
 	}
@@ -673,12 +736,30 @@ func (m *Manager) acceptDispatch(ctx context.Context, prepared PreparedDispatch,
 }
 
 // recordDispatchFailure stores the outcome of a dispatch that the provider
-// refused. Delivery has three outcomes, not two. ErrDispatchNotReady means the
-// input never reached the provider, so the item returns to the queue and only
-// the queue pauses: a message the user typed must not need a manual retry
-// because the agent was between processes. The other two outcomes mark the
-// item FAILED or DELIVERY_UNCERTAIN, which the user resolves explicitly.
+// refused. Delivery has four outcomes, not two.
+//
+// ErrDispatchBusy means the agent is inside a turn of its own. Nothing failed
+// and nothing has to change for the item to go out, so the item returns to the
+// queue unchanged and the queue stays open. The turn it collided with holds the
+// item, and the end of that turn drains it -- the same path an item that waited
+// its turn from the start takes.
+//
+// ErrDispatchNotReady means the input never reached the provider AND the agent
+// must change state before it can, so the item returns to the queue and the
+// queue pauses: a message the user typed must not need a manual retry because
+// the agent was between processes.
+//
+// The other two outcomes mark the item FAILED or DELIVERY_UNCERTAIN, which the
+// user resolves explicitly.
 func (m *Manager) recordDispatchFailure(ctx context.Context, prepared PreparedDispatch, dispatchErr error) (Snapshot, error) {
+	if errors.Is(dispatchErr, ErrDispatchBusy) {
+		snapshot, err := m.store.RequeuePrepared(ctx, prepared.Item.AgentID, prepared.Item.ID)
+		if err != nil {
+			return Snapshot{}, err
+		}
+		m.observer.QueueChanged(snapshot)
+		return snapshot, nil
+	}
 	if errors.Is(dispatchErr, ErrDispatchNotReady) {
 		snapshot, err := m.store.RequeueAndPause(ctx, prepared.Item.AgentID, prepared.Item.ID, dispatchErr)
 		if err != nil {

--- a/backend/internal/worker/inputqueue/manager_test.go
+++ b/backend/internal/worker/inputqueue/manager_test.go
@@ -624,3 +624,196 @@ func TestManagerStopRefusesNewWorkAndWaitJoinsDispatch(t *testing.T) {
 	close(dispatchRelease)
 	<-stopped
 }
+
+// turnEndingDispatcher reports the turn end from INSIDE the provider call, the
+// way a provider's reader goroutine does for a turn that ends before the
+// dispatch it belongs to finishes committing. Only the first dispatch does it,
+// so the test can watch the queue continue past it.
+type turnEndingDispatcher struct {
+	recordingDispatcher
+	manager *Manager
+	agentID string
+	once    sync.Once
+}
+
+func (d *turnEndingDispatcher) Dispatch(item Item) (DispatchResult, error) {
+	result, err := d.recordingDispatcher.Dispatch(item)
+	d.once.Do(func() {
+		_, _ = d.manager.TurnEnded(context.Background(), d.agentID)
+	})
+	return result, err
+}
+
+func TestManagerKeepsDrainingWhenTheTurnEndsDuringItsOwnDispatch(t *testing.T) {
+	t.Parallel()
+
+	// The manager releases the coordinator lock across the provider call, so a
+	// turn that ends inside it commits its clear first, and the drain it
+	// scheduled finds this loop still marked draining and does nothing. The
+	// acceptance must neither write that turn back nor stop the loop, or every
+	// item behind the first waits for a turn that already ended.
+	_, store := newStoreFixture(t)
+	dispatcher := &turnEndingDispatcher{agentID: "agent-1"}
+	manager := NewManager(store, dispatcher, &recordingObserver{})
+	dispatcher.manager = manager
+	ctx := context.Background()
+	for _, inputID := range []string{"one", "two"} {
+		_, err := manager.Enqueue(ctx, NewItem{ID: inputID, AgentID: "agent-1", Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, Text: inputID})
+		require.NoError(t, err)
+	}
+
+	require.Eventually(t, func() bool { return len(dispatcher.dispatches()) == 2 }, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []string{"one", "two"}, dispatcher.dispatches())
+	snapshot, err := manager.Snapshot(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Empty(t, snapshot.Items)
+	assert.True(t, snapshot.ActiveTurn, "the second dispatch's own turn is the one that stands")
+}
+
+func TestManagerTurnSignalIsIdempotentInBothDirections(t *testing.T) {
+	t.Parallel()
+
+	// Every publish of a provider's turn flag reaches the manager, and a
+	// provider republishes the unchanged value freely. A repeat must move no
+	// revision, or every watcher takes a snapshot that says what it already
+	// holds.
+	_, store := newStoreFixture(t)
+	observer := &recordingObserver{}
+	manager := NewManager(store, &recordingDispatcher{}, observer)
+	ctx := context.Background()
+
+	started, err := manager.TurnStarted(ctx, "agent-1")
+	require.NoError(t, err)
+	require.True(t, started.ActiveTurn)
+
+	repeated, err := manager.TurnStarted(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, started.Revision, repeated.Revision)
+
+	ended, err := manager.TurnEnded(ctx, "agent-1")
+	require.NoError(t, err)
+	require.False(t, ended.ActiveTurn)
+	assert.Greater(t, ended.Revision, started.Revision)
+
+	endedAgain, err := manager.TurnEnded(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.Equal(t, ended.Revision, endedAgain.Revision)
+
+	observer.mu.Lock()
+	broadcasts := len(observer.snapshots)
+	observer.mu.Unlock()
+	assert.Equal(t, 2, broadcasts, "only the two real transitions broadcast")
+}
+
+func TestManagerTurnStartedKeepsTheTurnADispatchAlreadyOwns(t *testing.T) {
+	t.Parallel()
+
+	// A provider publishes "a turn is in flight" for the very turn the queue
+	// just dispatched. That report carries no input id, so adopting it would
+	// drop the identity the dispatch recorded -- and the acceptance, which
+	// writes the turn back only while the state still holds its own dispatch,
+	// would then find no match and treat the live turn as finished.
+	_, store := newStoreFixture(t)
+	release := make(chan struct{})
+	dispatcher := &recordingDispatcher{dispatchStarted: make(chan struct{}), dispatchRelease: release}
+	manager := NewManager(store, dispatcher, &recordingObserver{})
+	ctx := context.Background()
+	_, err := manager.Enqueue(ctx, NewItem{ID: "one", AgentID: "agent-1", Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, Text: "one"})
+	require.NoError(t, err)
+	<-dispatcher.dispatchStarted
+
+	_, err = manager.TurnStarted(ctx, "agent-1")
+	require.NoError(t, err)
+	close(release)
+
+	require.Eventually(t, func() bool {
+		snapshot, snapshotErr := manager.Snapshot(ctx, "agent-1")
+		return snapshotErr == nil && len(snapshot.Items) == 0
+	}, time.Second, 10*time.Millisecond)
+	snapshot, err := manager.Snapshot(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.True(t, snapshot.ActiveTurn, "the dispatched turn survives the provider's own report of it")
+}
+
+// busyOnceDispatcher refuses the first dispatch the way a provider refuses one
+// that collided with a turn of its own, and takes every later dispatch. endTurn
+// runs inside the refusal, which is where a provider's reader goroutine reports
+// a turn that ends while the dispatch it collided with is still in flight.
+type busyOnceDispatcher struct {
+	recordingDispatcher
+	endTurn func()
+	once    sync.Once
+}
+
+func (d *busyOnceDispatcher) Dispatch(item Item) (DispatchResult, error) {
+	result, err := d.recordingDispatcher.Dispatch(item)
+	refused := false
+	d.once.Do(func() {
+		refused = true
+		if d.endTurn != nil {
+			d.endTurn()
+		}
+	})
+	if refused {
+		return DispatchResult{}, fmt.Errorf("%w: turn-1", ErrDispatchBusy)
+	}
+	return result, err
+}
+
+func TestManagerBusyRefusalHoldsTheItemWithoutPausingTheQueue(t *testing.T) {
+	t.Parallel()
+
+	// The provider refused because a turn of its own is in flight. Nothing
+	// failed, so the item waits with no error and the queue stays open: the
+	// turn that refused it ends and delivers it. A pause here stopped a healthy
+	// queue until the user resumed it by hand.
+	_, store := newStoreFixture(t)
+	dispatcher := &busyOnceDispatcher{}
+	manager := NewManager(store, dispatcher, &recordingObserver{})
+	ctx := context.Background()
+	_, err := manager.Enqueue(ctx, NewItem{ID: "one", AgentID: "agent-1", Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, Text: "one"})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return len(dispatcher.dispatches()) == 1 }, time.Second, 10*time.Millisecond)
+	var snapshot Snapshot
+	require.Eventually(t, func() bool {
+		snapshot, err = manager.Snapshot(ctx, "agent-1")
+		return err == nil && len(snapshot.Items) == 1 &&
+			snapshot.Items[0].State == leapmuxv1.AgentInputState_AGENT_INPUT_STATE_QUEUED
+	}, time.Second, 10*time.Millisecond)
+	assert.False(t, snapshot.Paused, "a busy agent is not a stopped one")
+	assert.Empty(t, snapshot.Items[0].Error, "nothing failed, so the item carries no error")
+	assert.True(t, snapshot.ActiveTurn, "the turn the item collided with is what holds it")
+
+	_, err = manager.TurnEnded(ctx, "agent-1")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		snapshot, err = manager.Snapshot(ctx, "agent-1")
+		return err == nil && len(snapshot.Items) == 0
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []string{"one", "one"}, dispatcher.dispatches(),
+		"the same item goes out again once the turn that refused it ends")
+}
+
+func TestManagerBusyRefusalRepeatsWhenTheTurnEndsInsideIt(t *testing.T) {
+	t.Parallel()
+
+	// The turn ends while the provider call that it refused is still running.
+	// Its drain request finds this loop still marked draining, so nothing else
+	// can act on it -- and the item would then wait for a turn that already
+	// ended, with no later event to release it.
+	_, store := newStoreFixture(t)
+	dispatcher := &busyOnceDispatcher{}
+	manager := NewManager(store, dispatcher, &recordingObserver{})
+	dispatcher.endTurn = func() { _, _ = manager.TurnEnded(context.Background(), "agent-1") }
+	ctx := context.Background()
+	_, err := manager.Enqueue(ctx, NewItem{ID: "one", AgentID: "agent-1", Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, Text: "one"})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		snapshot, snapshotErr := manager.Snapshot(ctx, "agent-1")
+		return snapshotErr == nil && len(snapshot.Items) == 0
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []string{"one", "one"}, dispatcher.dispatches(),
+		"the loop repeats for the turn end it could not see, with no outside trigger")
+}

--- a/backend/internal/worker/inputqueue/manager_test.go
+++ b/backend/internal/worker/inputqueue/manager_test.go
@@ -2,6 +2,7 @@ package inputqueue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -238,7 +239,7 @@ func TestManagerSteerMarksUncertainDelivery(t *testing.T) {
 	_, store := newStoreFixture(t)
 	dispatcher := &recordingDispatcher{
 		steering:  true,
-		steerFail: &DeliveryError{Err: assert.AnError, Uncertain: true},
+		steerFail: &DeliveryError{Err: assert.AnError, Outcome: DispatchUncertain},
 	}
 	manager := NewManager(store, dispatcher, &recordingObserver{})
 	ctx := context.Background()
@@ -625,22 +626,31 @@ func TestManagerStopRefusesNewWorkAndWaitJoinsDispatch(t *testing.T) {
 	<-stopped
 }
 
-// turnEndingDispatcher reports the turn end from INSIDE the provider call, the
-// way a provider's reader goroutine does for a turn that ends before the
-// dispatch it belongs to finishes committing. Only the first dispatch does it,
-// so the test can watch the queue continue past it.
-type turnEndingDispatcher struct {
+// onceDispatcher acts on the FIRST dispatch alone and takes every later one
+// normally, so a test can watch the queue continue past the one event it
+// stages. firstEffect runs from inside the provider call, which is where a
+// provider's reader goroutine reports a turn that ends while the dispatch it
+// belongs to is still in flight. firstErr, when set, is what that first
+// dispatch returns instead of a result.
+type onceDispatcher struct {
 	recordingDispatcher
-	manager *Manager
-	agentID string
-	once    sync.Once
+	firstEffect func()
+	firstErr    error
+	once        sync.Once
 }
 
-func (d *turnEndingDispatcher) Dispatch(item Item) (DispatchResult, error) {
+func (d *onceDispatcher) Dispatch(item Item) (DispatchResult, error) {
 	result, err := d.recordingDispatcher.Dispatch(item)
+	first := false
 	d.once.Do(func() {
-		_, _ = d.manager.TurnEnded(context.Background(), d.agentID)
+		first = true
+		if d.firstEffect != nil {
+			d.firstEffect()
+		}
 	})
+	if first && d.firstErr != nil {
+		return DispatchResult{}, d.firstErr
+	}
 	return result, err
 }
 
@@ -653,16 +663,23 @@ func TestManagerKeepsDrainingWhenTheTurnEndsDuringItsOwnDispatch(t *testing.T) {
 	// acceptance must neither write that turn back nor stop the loop, or every
 	// item behind the first waits for a turn that already ended.
 	_, store := newStoreFixture(t)
-	dispatcher := &turnEndingDispatcher{agentID: "agent-1"}
+	dispatcher := &onceDispatcher{}
 	manager := NewManager(store, dispatcher, &recordingObserver{})
-	dispatcher.manager = manager
+	dispatcher.firstEffect = func() { _, _ = manager.TurnEnded(context.Background(), "agent-1") }
 	ctx := context.Background()
 	for _, inputID := range []string{"one", "two"} {
 		_, err := manager.Enqueue(ctx, NewItem{ID: inputID, AgentID: "agent-1", Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, Text: inputID})
 		require.NoError(t, err)
 	}
 
-	require.Eventually(t, func() bool { return len(dispatcher.dispatches()) == 2 }, time.Second, 10*time.Millisecond)
+	// recordingDispatcher records the call before it returns, and the drain
+	// commits the acceptance after it. Waiting on the count alone would let the
+	// assertions below read the queue while the second item is still
+	// DISPATCHING, which snapshotTx still lists.
+	require.Eventually(t, func() bool {
+		s, snapshotErr := manager.Snapshot(ctx, "agent-1")
+		return snapshotErr == nil && len(dispatcher.dispatches()) == 2 && len(s.Items) == 0
+	}, time.Second, 10*time.Millisecond)
 	assert.Equal(t, []string{"one", "two"}, dispatcher.dispatches())
 	snapshot, err := manager.Snapshot(ctx, "agent-1")
 	require.NoError(t, err)
@@ -735,29 +752,10 @@ func TestManagerTurnStartedKeepsTheTurnADispatchAlreadyOwns(t *testing.T) {
 	assert.True(t, snapshot.ActiveTurn, "the dispatched turn survives the provider's own report of it")
 }
 
-// busyOnceDispatcher refuses the first dispatch the way a provider refuses one
-// that collided with a turn of its own, and takes every later dispatch. endTurn
-// runs inside the refusal, which is where a provider's reader goroutine reports
-// a turn that ends while the dispatch it collided with is still in flight.
-type busyOnceDispatcher struct {
-	recordingDispatcher
-	endTurn func()
-	once    sync.Once
-}
-
-func (d *busyOnceDispatcher) Dispatch(item Item) (DispatchResult, error) {
-	result, err := d.recordingDispatcher.Dispatch(item)
-	refused := false
-	d.once.Do(func() {
-		refused = true
-		if d.endTurn != nil {
-			d.endTurn()
-		}
-	})
-	if refused {
-		return DispatchResult{}, fmt.Errorf("%w: turn-1", ErrDispatchBusy)
-	}
-	return result, err
+// busyRefusal is what a provider returns when a dispatch collided with a turn
+// of its own.
+func busyRefusal() error {
+	return &DeliveryError{Err: errors.New("turn-1"), Outcome: DispatchBusy}
 }
 
 func TestManagerBusyRefusalHoldsTheItemWithoutPausingTheQueue(t *testing.T) {
@@ -768,7 +766,7 @@ func TestManagerBusyRefusalHoldsTheItemWithoutPausingTheQueue(t *testing.T) {
 	// turn that refused it ends and delivers it. A pause here stopped a healthy
 	// queue until the user resumed it by hand.
 	_, store := newStoreFixture(t)
-	dispatcher := &busyOnceDispatcher{}
+	dispatcher := &onceDispatcher{firstErr: busyRefusal()}
 	manager := NewManager(store, dispatcher, &recordingObserver{})
 	ctx := context.Background()
 	_, err := manager.Enqueue(ctx, NewItem{ID: "one", AgentID: "agent-1", Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, Text: "one"})
@@ -803,9 +801,9 @@ func TestManagerBusyRefusalRepeatsWhenTheTurnEndsInsideIt(t *testing.T) {
 	// can act on it -- and the item would then wait for a turn that already
 	// ended, with no later event to release it.
 	_, store := newStoreFixture(t)
-	dispatcher := &busyOnceDispatcher{}
+	dispatcher := &onceDispatcher{firstErr: busyRefusal()}
 	manager := NewManager(store, dispatcher, &recordingObserver{})
-	dispatcher.endTurn = func() { _, _ = manager.TurnEnded(context.Background(), "agent-1") }
+	dispatcher.firstEffect = func() { _, _ = manager.TurnEnded(context.Background(), "agent-1") }
 	ctx := context.Background()
 	_, err := manager.Enqueue(ctx, NewItem{ID: "one", AgentID: "agent-1", Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, Text: "one"})
 	require.NoError(t, err)
@@ -816,4 +814,125 @@ func TestManagerBusyRefusalRepeatsWhenTheTurnEndsInsideIt(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 	assert.Equal(t, []string{"one", "one"}, dispatcher.dispatches(),
 		"the loop repeats for the turn end it could not see, with no outside trigger")
+}
+
+func TestManagerBusyRefusalReleasesTheTurnIdentityItClaimed(t *testing.T) {
+	t.Parallel()
+
+	// PrepareDispatch records the item's kind and id as the running turn's
+	// BEFORE the provider call. A busy refusal means that dispatch never
+	// happened, so the turn that stands is the provider's own -- and it carries
+	// neither. A claim left behind makes CanSteer and PrepareSteer judge the
+	// running turn by the refused item's kind: a bounced /compact hides Steer
+	// for a plain reply, and a bounced plain message offers it for a compaction.
+	_, store := newStoreFixture(t)
+	dispatcher := &onceDispatcher{firstErr: busyRefusal()}
+	manager := NewManager(store, dispatcher, &recordingObserver{})
+	ctx := context.Background()
+	_, err := manager.Enqueue(ctx, NewItem{
+		ID: "compact", AgentID: "agent-1", Text: "/compact",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_COMPACT_CONTEXT,
+	})
+	require.NoError(t, err)
+
+	var snapshot Snapshot
+	require.Eventually(t, func() bool {
+		snapshot, err = manager.Snapshot(ctx, "agent-1")
+		return err == nil && len(dispatcher.dispatches()) == 1 && len(snapshot.Items) == 1 &&
+			snapshot.Items[0].State == leapmuxv1.AgentInputState_AGENT_INPUT_STATE_QUEUED
+	}, time.Second, 10*time.Millisecond)
+	assert.True(t, snapshot.ActiveTurn, "the refusal proves a turn is in flight")
+	assert.Equal(t, leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_UNSPECIFIED, snapshot.ActiveTurnKind,
+		"the refused item's kind does not describe the provider's own turn")
+
+	// The identity is gone, so the head item is judged against a turn the queue
+	// admits it knows nothing about, and the steer is refused rather than
+	// misrouted into whatever the provider actually runs.
+	_, err = manager.Enqueue(ctx, NewItem{
+		ID: "reply", AgentID: "agent-1", Text: "and also",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE,
+	})
+	require.NoError(t, err)
+	snapshot, err = manager.Snapshot(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.False(t, snapshot.Items[0].CanSteer,
+		"a turn the queue did not dispatch states no kind, so no steer is offered")
+}
+
+func TestManagerRetryBusyRefusalDrainsWhenTheTurnEndsInsideIt(t *testing.T) {
+	t.Parallel()
+
+	// Retry runs its own dispatch outside the drain loop, so the drainAgain
+	// latch cannot cover it: the TurnEnded that lands during the provider call
+	// schedules a drain that finds the item still DISPATCHING and gives up.
+	// Retry must re-read the committed state and drain for itself, or the item
+	// waits for a turn that already ended.
+	_, store := newStoreFixture(t)
+	dispatcher := &recordingDispatcher{fail: errors.New("provider exploded")}
+	manager := NewManager(store, dispatcher, &recordingObserver{})
+	ctx := context.Background()
+	_, err := manager.Enqueue(ctx, NewItem{
+		ID: "one", AgentID: "agent-1", Text: "one",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE,
+	})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		snapshot, snapshotErr := manager.Snapshot(ctx, "agent-1")
+		return snapshotErr == nil && len(snapshot.Items) == 1 &&
+			snapshot.Items[0].State == leapmuxv1.AgentInputState_AGENT_INPUT_STATE_FAILED
+	}, time.Second, 10*time.Millisecond)
+
+	// The retry collides with a turn, and that turn ends inside the refusal.
+	busy := &onceDispatcher{firstErr: busyRefusal()}
+	busy.firstEffect = func() { _, _ = manager.TurnEnded(context.Background(), "agent-1") }
+	manager.dispatcher = busy
+	_, err = manager.Retry(ctx, "agent-1", "one", false)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		snapshot, snapshotErr := manager.Snapshot(ctx, "agent-1")
+		return snapshotErr == nil && len(snapshot.Items) == 0
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []string{"one", "one"}, busy.dispatches(),
+		"the retried item goes out again with no further user action")
+}
+
+func TestManagerRepeatedTurnEndRestartsADrainAStoreErrorStopped(t *testing.T) {
+	t.Parallel()
+
+	// A store error stops the drain loop with the items still queued, the queue
+	// unpaused and no turn in flight. Nothing schedules another drain, so the
+	// only event left is the provider's turn flag -- which repeats a state the
+	// queue already holds, and therefore moves no revision.
+	_, store := newStoreFixture(t)
+	dispatcher := &recordingDispatcher{}
+	manager := NewManager(store, dispatcher, &recordingObserver{})
+	ctx := context.Background()
+
+	// Enqueue through the STORE, which writes the item and schedules nothing.
+	// That is exactly what the drain loop leaves behind when PrepareDispatch
+	// fails: an item queued, the queue open, and no turn in flight.
+	_, err := store.Enqueue(ctx, NewItem{
+		ID: "one", AgentID: "agent-1", Text: "one",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE,
+	})
+	require.NoError(t, err)
+	before, err := manager.Snapshot(ctx, "agent-1")
+	require.NoError(t, err)
+	require.Len(t, before.Items, 1)
+	require.False(t, before.ActiveTurn)
+	require.False(t, before.Paused)
+	require.Empty(t, dispatcher.dispatches(), "nothing scheduled a drain")
+
+	// The clear repeats a state the queue already holds, so it moves no
+	// revision -- and a drain that fires only on a real change never runs.
+	_, err = manager.TurnEnded(ctx, "agent-1")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		snapshot, snapshotErr := manager.Snapshot(ctx, "agent-1")
+		return snapshotErr == nil && len(snapshot.Items) == 0
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []string{"one"}, dispatcher.dispatches(),
+		"the repeated clear restarted the loop the store error stopped")
 }

--- a/backend/internal/worker/inputqueue/model.go
+++ b/backend/internal/worker/inputqueue/model.go
@@ -72,18 +72,50 @@ var (
 	// the agent process. The durable pause_owner records the restart, so the
 	// refusal survives a Worker restart that leaves the marker behind.
 	ErrPlannedRestart = errors.New("agent input queue waits for a planned agent restart")
-	// ErrDispatchNotReady marks a dispatch failure that never reached the
-	// provider. The manager returns the item to the queue instead of storing a
-	// permanent failure, so an agent that starts later delivers it.
-	ErrDispatchNotReady = errors.New("agent cannot accept input yet")
-	// ErrDispatchBusy marks a dispatch that the provider refused because a turn
-	// of its own is already in flight. The item returns to the queue and the
-	// queue stays OPEN, which is what separates it from ErrDispatchNotReady: an
-	// agent that runs needs no pause and no manual resume, because the turn that
-	// refused the item ends, publishes that end, and releases the drain that
-	// delivers it.
-	ErrDispatchBusy = errors.New("agent input waits for the turn in flight")
 )
+
+// DispatchOutcome states what a refused dispatch means for the item and for the
+// queue. It replaces a set of sentinel errors, so the decode site is one
+// exhaustive switch that the linter checks rather than a chain of errors.Is
+// whose ORDER decided the answer.
+type DispatchOutcome int
+
+const (
+	// DispatchFailed: the provider took the input and something went wrong, or
+	// it refused for a reason nothing will resolve. The item is marked FAILED
+	// and the user retries it explicitly.
+	DispatchFailed DispatchOutcome = iota
+	// DispatchUncertain: the Worker cannot tell whether the input arrived.
+	// Redispatch could duplicate it, so the user confirms.
+	DispatchUncertain
+	// DispatchBusy: the agent is inside a turn of its own. Nothing failed and
+	// nothing has to change for the item to go out, so the item returns to the
+	// queue and the queue stays OPEN. The turn it collided with holds it, and
+	// the end of that turn drains it.
+	DispatchBusy
+	// DispatchNotReady: the input never reached the provider AND the agent must
+	// change state before it can. The item returns to the queue and the queue
+	// PAUSES: a message the user typed must not need a manual retry because the
+	// agent was between processes.
+	DispatchNotReady
+)
+
+// String gives the text that a refusal carries into the item's error column,
+// which the browser renders. DispatchFailed adds nothing, because there the
+// cause already says what happened.
+func (o DispatchOutcome) String() string {
+	switch o {
+	case DispatchBusy:
+		return "agent input waits for the turn in flight"
+	case DispatchNotReady:
+		return "agent cannot accept input yet"
+	case DispatchUncertain:
+		return "agent input delivery is uncertain"
+	case DispatchFailed:
+		return ""
+	}
+	return ""
+}
 
 type Attachment struct {
 	Filename string
@@ -171,16 +203,34 @@ type DispatchResult struct {
 	AfterAccept func()
 }
 
+// DeliveryError carries a refused dispatch: the provider's own error, and what
+// the queue must do about it.
 type DeliveryError struct {
-	Err       error
-	Uncertain bool
+	Err     error
+	Outcome DispatchOutcome
 }
 
 func (e *DeliveryError) Error() string {
 	if e == nil || e.Err == nil {
 		return "input delivery failed"
 	}
+	// The prefix is what a user reads on a held item, so it states the outcome
+	// rather than only the provider's wording.
+	if prefix := e.Outcome.String(); prefix != "" {
+		return prefix + ": " + e.Err.Error()
+	}
 	return e.Err.Error()
+}
+
+// dispatchOutcome reads the outcome a refusal carries. An error that is not a
+// DeliveryError is a plain failure: only the queue's own classifier builds one,
+// and everything else that reaches the manager already went wrong.
+func dispatchOutcome(err error) DispatchOutcome {
+	var deliveryErr *DeliveryError
+	if errors.As(err, &deliveryErr) {
+		return deliveryErr.Outcome
+	}
+	return DispatchFailed
 }
 
 func (e *DeliveryError) Unwrap() error {

--- a/backend/internal/worker/inputqueue/model.go
+++ b/backend/internal/worker/inputqueue/model.go
@@ -76,6 +76,13 @@ var (
 	// provider. The manager returns the item to the queue instead of storing a
 	// permanent failure, so an agent that starts later delivers it.
 	ErrDispatchNotReady = errors.New("agent cannot accept input yet")
+	// ErrDispatchBusy marks a dispatch that the provider refused because a turn
+	// of its own is already in flight. The item returns to the queue and the
+	// queue stays OPEN, which is what separates it from ErrDispatchNotReady: an
+	// agent that runs needs no pause and no manual resume, because the turn that
+	// refused the item ends, publishes that end, and releases the drain that
+	// delivers it.
+	ErrDispatchBusy = errors.New("agent input waits for the turn in flight")
 )
 
 type Attachment struct {

--- a/backend/internal/worker/inputqueue/model_test.go
+++ b/backend/internal/worker/inputqueue/model_test.go
@@ -1,0 +1,43 @@
+package inputqueue
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeliveryErrorStatesTheOutcomeItCarries(t *testing.T) {
+	t.Parallel()
+
+	// RequeueAndPause persists this text into the item's error column, and the
+	// browser renders it. The provider's own wording says what went wrong on the
+	// wire; the prefix says what it means for the queue, which is the part a
+	// user can act on. A plain failure adds nothing, because there the cause
+	// already reads as the whole answer.
+	cause := errors.New("write |1: file already closed")
+	for _, tc := range []struct {
+		name    string
+		outcome DispatchOutcome
+		want    string
+	}{
+		{name: "busy", outcome: DispatchBusy, want: "agent input waits for the turn in flight: " + cause.Error()},
+		{name: "not ready", outcome: DispatchNotReady, want: "agent cannot accept input yet: " + cause.Error()},
+		{name: "uncertain", outcome: DispatchUncertain, want: "agent input delivery is uncertain: " + cause.Error()},
+		{name: "failed", outcome: DispatchFailed, want: cause.Error()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := &DeliveryError{Err: cause, Outcome: tc.outcome}
+			assert.Equal(t, tc.want, err.Error())
+			assert.ErrorIs(t, err, cause, "the cause stays reachable whatever the outcome")
+			assert.Equal(t, tc.outcome, dispatchOutcome(err))
+		})
+	}
+
+	// An error the classifier never built is a plain failure, so a provider
+	// error that reaches the manager unwrapped fails the item rather than
+	// silently taking a branch that requeues it.
+	assert.Equal(t, DispatchFailed, dispatchOutcome(cause))
+}

--- a/backend/internal/worker/inputqueue/store.go
+++ b/backend/internal/worker/inputqueue/store.go
@@ -824,13 +824,31 @@ func (s *Store) Accept(ctx context.Context, prepared PreparedDispatch, result Di
 	stateUpdate := `UPDATE agent_input_queue_state SET active_turn = 0, active_turn_kind = 0, active_input_id = '', revision = revision + 1, updated_at = ? WHERE agent_id = ?`
 	stateArgs := []any{nowText(), item.AgentID}
 	if result.StartsTurn && !result.Steering {
-		stateUpdate = `UPDATE agent_input_queue_state SET active_turn = 1, active_turn_kind = ?, active_input_id = ?, revision = revision + 1, updated_at = ? WHERE agent_id = ?`
-		stateArgs = []any{item.Kind, item.ID, nowText(), item.AgentID}
+		// The turn is asserted only while the state still holds THIS dispatch.
+		// PrepareDispatch opened the turn and recorded the input id before the
+		// provider call, and the manager releases the coordinator lock across
+		// that call -- so a turn that ends inside it clears both fields first.
+		// A write of the turn here would restore one that no envelope ever ends
+		// again, and the queue would then hold every later message for the life
+		// of the process.
+		stateUpdate = `UPDATE agent_input_queue_state SET active_turn = 1, active_turn_kind = ?, active_input_id = ?, revision = revision + 1, updated_at = ? WHERE agent_id = ? AND active_input_id = ?`
+		stateArgs = []any{item.Kind, item.ID, nowText(), item.AgentID, item.ID}
 	} else if result.Steering {
 		stateUpdate = `UPDATE agent_input_queue_state SET revision = revision + 1, updated_at = ? WHERE agent_id = ?`
 	}
-	if _, err := tx.ExecContext(ctx, stateUpdate, stateArgs...); err != nil {
+	stateResult, err := tx.ExecContext(ctx, stateUpdate, stateArgs...)
+	if err != nil {
 		return AcceptedTranscript{}, Snapshot{}, err
+	}
+	// The guarded statement above is the one that can match no row. The item
+	// still left the queue, so the snapshot still moves and owes every watcher
+	// a revision it can order against.
+	if rows, err := stateResult.RowsAffected(); err != nil {
+		return AcceptedTranscript{}, Snapshot{}, err
+	} else if rows == 0 {
+		if err := bumpRevision(ctx, tx, item.AgentID); err != nil {
+			return AcceptedTranscript{}, Snapshot{}, err
+		}
 	}
 	snapshot, err := snapshotTx(ctx, tx, item.AgentID)
 	if err != nil {
@@ -874,61 +892,72 @@ func (s *Store) FailDispatch(ctx context.Context, agentID, inputID string, deliv
 
 // TurnEnded clears the active turn.
 //
-// The clear carries no turn identity, because the provider callback that
-// reports a turn end carries none either: agent.notifyInputReady names only
-// the agent. Order is what keeps the clear correct. Every provider reports a
-// turn end on its own single reader goroutine, in wire order, and drain never
+// The clear carries no turn identity, because the provider signal that reports
+// a turn end carries none either: OutputSink.SetTurnActive names only the
+// agent. Order is what keeps the clear correct. Every provider publishes its
+// turn flag on its own single reader goroutine, in wire order, and drain never
 // starts the next turn before Accept commits, so a turn end for turn N always
 // precedes the turn start for N+1. Two rules preserve that order, and both are
-// load-bearing: no call site may report a turn end from a NEW goroutine (an
-// earlier `go notifyInputReady` in codex_output.go did, to escape the
-// coordinator lock, and reordered the two reports), and drain must not hold
-// the coordinator lock across a provider call, which is what made that escape
-// look necessary.
+// load-bearing: no call site may publish a turn end from a NEW goroutine (the
+// Codex turn/completed handler once did, to escape the coordinator lock, and
+// reordered the two reports), and drain must not hold the coordinator lock
+// across a provider call, which is what made that escape look necessary.
 //
 // One case stays open: a turn end that an agent process emits AFTER the Worker
 // replaced it clears the new process's turn. Only a provider generation
-// threaded through SetInputReadyFunc can reject that, and the callback does not
+// threaded through SetTurnEndedFunc can reject that, and the signal does not
 // carry one today.
-func (s *Store) TurnEnded(ctx context.Context, agentID string) (Snapshot, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return Snapshot{}, err
-	}
-	defer func() { _ = tx.Rollback() }()
-	if err := ensureState(ctx, tx, agentID); err != nil {
-		return Snapshot{}, err
-	}
-	if _, err := tx.ExecContext(ctx, `UPDATE agent_input_queue_state SET active_turn = 0, active_turn_kind = 0, active_input_id = '', revision = revision + 1, updated_at = ? WHERE agent_id = ?`, nowText(), agentID); err != nil {
-		return Snapshot{}, err
-	}
-	return commitSnapshot(ctx, tx, agentID)
+//
+// The Boolean reports whether the durable state moved. Every publish of the
+// provider's turn flag reaches here, and a provider republishes the unchanged
+// value freely, so a call that changes nothing must leave the revision alone.
+func (s *Store) TurnEnded(ctx context.Context, agentID string) (Snapshot, bool, error) {
+	return s.setTurnState(ctx, agentID, false)
 }
 
-func (s *Store) TurnStarted(ctx context.Context, agentID string) (Snapshot, error) {
+// TurnStarted records a turn that the agent process began on its own. It keeps
+// the turn that a dispatch already recorded: that one names its input, and this
+// call carries no identity to replace it with.
+//
+// The Boolean reports whether the durable state moved. See TurnEnded.
+func (s *Store) TurnStarted(ctx context.Context, agentID string) (Snapshot, bool, error) {
+	return s.setTurnState(ctx, agentID, true)
+}
+
+// setTurnState reconciles the durable turn flag with the state the provider
+// reports. It is idempotent in both directions, so the caller may report the
+// same state as often as the provider publishes it.
+func (s *Store) setTurnState(ctx context.Context, agentID string, active bool) (Snapshot, bool, error) {
+	statement := `UPDATE agent_input_queue_state SET active_turn = 0, active_turn_kind = 0, active_input_id = '', revision = revision + 1, updated_at = ? WHERE agent_id = ? AND (active_turn = 1 OR active_turn_kind <> 0 OR active_input_id <> '')`
+	args := []any{nowText(), agentID}
+	if active {
+		statement = `UPDATE agent_input_queue_state SET active_turn = 1, active_turn_kind = ?, active_input_id = '', revision = revision + 1, updated_at = ? WHERE agent_id = ? AND active_turn = 0`
+		args = []any{leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, nowText(), agentID}
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return Snapshot{}, err
+		return Snapshot{}, false, err
 	}
 	defer func() { _ = tx.Rollback() }()
 	if err := ensureState(ctx, tx, agentID); err != nil {
-		return Snapshot{}, err
+		return Snapshot{}, false, err
 	}
-	result, err := tx.ExecContext(ctx, `UPDATE agent_input_queue_state SET active_turn = 1, active_turn_kind = ?, active_input_id = '', revision = revision + 1, updated_at = ? WHERE agent_id = ? AND active_turn = 0`, leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, nowText(), agentID)
+	result, err := tx.ExecContext(ctx, statement, args...)
 	if err != nil {
-		return Snapshot{}, err
+		return Snapshot{}, false, err
 	}
-	if changed, _ := result.RowsAffected(); changed == 0 {
-		snapshot, err := snapshotTx(ctx, tx, agentID)
-		if err != nil {
-			return Snapshot{}, err
-		}
-		if err := tx.Commit(); err != nil {
-			return Snapshot{}, err
-		}
-		return snapshot, nil
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return Snapshot{}, false, err
 	}
-	return commitSnapshot(ctx, tx, agentID)
+	snapshot, err := snapshotTx(ctx, tx, agentID)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return Snapshot{}, false, err
+	}
+	return snapshot, rows == 1, nil
 }
 
 func (s *Store) Pause(ctx context.Context, agentID string, reason leapmuxv1.AgentInputQueuePauseReason) (Snapshot, error) {

--- a/backend/internal/worker/inputqueue/store.go
+++ b/backend/internal/worker/inputqueue/store.go
@@ -722,7 +722,32 @@ func (s *Store) prepare(ctx context.Context, agentID, expectedInputID string, al
 	return &PreparedDispatch{Item: item, ReservedSeq: reservedSeq}, snapshot, nil
 }
 
+// RequeuePrepared returns a prepared item to the queue. The steer path uses it,
+// and PrepareSteer claims no turn identity, so there is none to release.
 func (s *Store) RequeuePrepared(ctx context.Context, agentID, inputID string) (Snapshot, error) {
+	return s.requeuePrepared(ctx, agentID, inputID, false)
+}
+
+// RequeueBusy returns a prepared item to the queue after the provider refused
+// it because a turn of its own is in flight. The queue stays OPEN and the item
+// keeps no error text: nothing failed, and the end of that turn delivers it.
+//
+// It also releases the turn identity that PrepareDispatch claimed. That claim
+// describes THIS dispatch, and this dispatch never reached the provider, so the
+// turn that stands is the provider's own -- which carries no input id, and no
+// kind that the queue can know. A claim left behind makes Snapshot.CanSteer and
+// PrepareSteer judge the running turn by the refused item's kind, and each of
+// them then answers a steer request for the wrong turn.
+//
+// active_turn itself stays as it is. The refusal proves that a turn ran when
+// the provider read its flag, and the same refusal publishes that flag. But a
+// turn that ended inside the provider call already committed its clear, and a
+// write here would restore a turn that no envelope ever ends again.
+func (s *Store) RequeueBusy(ctx context.Context, agentID, inputID string) (Snapshot, error) {
+	return s.requeuePrepared(ctx, agentID, inputID, true)
+}
+
+func (s *Store) requeuePrepared(ctx context.Context, agentID, inputID string, releaseTurnIdentity bool) (Snapshot, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return Snapshot{}, err
@@ -736,6 +761,11 @@ func (s *Store) RequeuePrepared(ctx context.Context, agentID, inputID string) (S
 	}
 	if n, _ := result.RowsAffected(); n != 1 {
 		return Snapshot{}, ErrConflict
+	}
+	if releaseTurnIdentity {
+		if _, err := tx.ExecContext(ctx, `UPDATE agent_input_queue_state SET active_turn_kind = 0, active_input_id = '', revision = revision + 1, updated_at = ? WHERE agent_id = ? AND active_input_id = ?`, nowText(), agentID, inputID); err != nil {
+			return Snapshot{}, err
+		}
 	}
 	if err := bumpRevision(ctx, tx, agentID); err != nil {
 		return Snapshot{}, err
@@ -893,7 +923,7 @@ func (s *Store) FailDispatch(ctx context.Context, agentID, inputID string, deliv
 // TurnEnded clears the active turn.
 //
 // The clear carries no turn identity, because the provider signal that reports
-// a turn end carries none either: OutputSink.SetTurnActive names only the
+// a turn end carries none either: OutputSink.SetTurnActive identifies only the
 // agent. Order is what keeps the clear correct. Every provider publishes its
 // turn flag on its own single reader goroutine, in wire order, and drain never
 // starts the next turn before Accept commits, so a turn end for turn N always
@@ -905,7 +935,7 @@ func (s *Store) FailDispatch(ctx context.Context, agentID, inputID string, deliv
 //
 // One case stays open: a turn end that an agent process emits AFTER the Worker
 // replaced it clears the new process's turn. Only a provider generation
-// threaded through SetTurnEndedFunc can reject that, and the signal does not
+// threaded through SetTurnActiveFunc can reject that, and the signal does not
 // carry one today.
 //
 // The Boolean reports whether the durable state moved. Every publish of the
@@ -916,24 +946,62 @@ func (s *Store) TurnEnded(ctx context.Context, agentID string) (Snapshot, bool, 
 }
 
 // TurnStarted records a turn that the agent process began on its own. It keeps
-// the turn that a dispatch already recorded: that one names its input, and this
-// call carries no identity to replace it with.
+// the turn that a dispatch already recorded: that one identifies its input, and
+// this call carries no identity to replace it with.
 //
 // The Boolean reports whether the durable state moved. See TurnEnded.
 func (s *Store) TurnStarted(ctx context.Context, agentID string) (Snapshot, bool, error) {
 	return s.setTurnState(ctx, agentID, true)
 }
 
+// AbandonUnownedTurn clears a turn that no dispatch owns. A process boundary
+// calls it, because a process that starts or exits runs no turn: the old one
+// died with its process, and the new one never began.
+//
+// Without it a turn the AGENT PROCESS reported has no end at all on two paths.
+// A provider that reports a turn and then neither ends it nor exits (a stalled
+// CLI) holds one; and an explicit stop skips the AGENT_STOPPED pause on
+// purpose, so nothing clears one there either. The queue then holds every later
+// message with no pause, no error, and no Retry -- and stopping the agent, the
+// user's only escape, does not help.
+//
+// active_input_id is the guard, and it is what makes the two cases separable. A
+// turn that a dispatch opened belongs to that dispatch, which records the input
+// id before the provider call; Accept or the failure path resolves it, and a
+// clear here would make Accept's own identity guard miss and drop the turn the
+// dispatch just started. A turn a provider reported carries no input id, and it
+// is exactly the one a boundary must clear.
+func (s *Store) AbandonUnownedTurn(ctx context.Context, agentID string) (Snapshot, bool, error) {
+	return s.execTurnState(ctx, agentID,
+		`UPDATE agent_input_queue_state SET active_turn = 0, active_turn_kind = 0, revision = revision + 1, updated_at = ? WHERE agent_id = ? AND active_input_id = '' AND (active_turn = 1 OR active_turn_kind <> 0)`,
+		[]any{nowText(), agentID})
+}
+
 // setTurnState reconciles the durable turn flag with the state the provider
 // reports. It is idempotent in both directions, so the caller may report the
 // same state as often as the provider publishes it.
+//
+// The rising edge records the turn with NO kind and NO input id, because the
+// signal supplies neither. AGENT_INPUT_KIND_UNSPECIFIED is what the queue
+// really knows, and regularTurnKind refuses it, so Snapshot.CanSteer and
+// PrepareSteer both refuse a steer into a turn that the queue did not dispatch.
+// A concrete kind here would be an invention: the store cannot tell an ordinary
+// reply from an auto-compaction, and both predicates trust the column.
 func (s *Store) setTurnState(ctx context.Context, agentID string, active bool) (Snapshot, bool, error) {
 	statement := `UPDATE agent_input_queue_state SET active_turn = 0, active_turn_kind = 0, active_input_id = '', revision = revision + 1, updated_at = ? WHERE agent_id = ? AND (active_turn = 1 OR active_turn_kind <> 0 OR active_input_id <> '')`
 	args := []any{nowText(), agentID}
 	if active {
 		statement = `UPDATE agent_input_queue_state SET active_turn = 1, active_turn_kind = ?, active_input_id = '', revision = revision + 1, updated_at = ? WHERE agent_id = ? AND active_turn = 0`
-		args = []any{leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, nowText(), agentID}
+		args = []any{leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_UNSPECIFIED, nowText(), agentID}
 	}
+	return s.execTurnState(ctx, agentID, statement, args)
+}
+
+// execTurnState runs one guarded write against the turn columns and reports
+// whether it moved a row. Every turn write shares this shape: the state row must
+// exist, the guard decides whether anything changes, and the caller needs the
+// committed snapshot either way.
+func (s *Store) execTurnState(ctx context.Context, agentID, statement string, args []any) (Snapshot, bool, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return Snapshot{}, false, err

--- a/backend/internal/worker/inputqueue/store_test.go
+++ b/backend/internal/worker/inputqueue/store_test.go
@@ -784,3 +784,115 @@ func TestStoreSnapshotAnswersTheSteerPrecondition(t *testing.T) {
 	require.NotEmpty(t, clearing.Items)
 	assert.False(t, clearing.Items[0].CanSteer, "a clear is not a regular turn")
 }
+
+func TestStoreAcceptKeepsTheRevisionMovingWhenTheTurnEndedMidDispatch(t *testing.T) {
+	t.Parallel()
+
+	// The manager releases the coordinator lock across the provider call, so a
+	// turn end can commit its clear between PrepareDispatch and Accept. Accept
+	// must not write the turn back -- no envelope ever ends it again -- but the
+	// item DID leave the queue, so every watcher still owes a revision it can
+	// order that removal against.
+	_, store := newStoreFixture(t)
+	ctx := context.Background()
+	_, err := store.Enqueue(ctx, NewItem{
+		ID: "one", AgentID: "agent-1", Text: "one",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE,
+	})
+	require.NoError(t, err)
+	prepared, _, err := store.PrepareDispatch(ctx, "agent-1")
+	require.NoError(t, err)
+	require.NotNil(t, prepared)
+
+	cleared, changed, err := store.TurnEnded(ctx, "agent-1")
+	require.NoError(t, err)
+	require.True(t, changed, "the dispatch opened a turn, so the clear moves the state")
+
+	_, snapshot, err := store.Accept(ctx, *prepared, DispatchResult{StartsTurn: true})
+	require.NoError(t, err)
+	assert.False(t, snapshot.ActiveTurn, "a turn that ended inside the dispatch is not restored")
+	assert.Empty(t, snapshot.Items, "the item still left the queue")
+	assert.Greater(t, snapshot.Revision, cleared.Revision,
+		"the removal needs a revision, although the guarded turn write matched no row")
+}
+
+func TestStoreProviderReportedTurnStatesNoKindAndRefusesASteer(t *testing.T) {
+	t.Parallel()
+
+	// SetTurnActive carries no kind, so the store records none. The steer
+	// predicate reads that column, and a fabricated USER_MESSAGE would offer a
+	// steer into whatever the agent process started on its own -- an
+	// auto-compaction, a plan the CLI resumed, a background turn.
+	_, store := newStoreFixture(t)
+	ctx := context.Background()
+	snapshot, changed, err := store.TurnStarted(ctx, "agent-1")
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.True(t, snapshot.ActiveTurn)
+	assert.Equal(t, leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_UNSPECIFIED, snapshot.ActiveTurnKind,
+		"the signal states no kind, so the store invents none")
+
+	_, err = store.Enqueue(ctx, NewItem{
+		ID: "one", AgentID: "agent-1", Text: "steer me",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE,
+	})
+	require.NoError(t, err)
+	snapshot, err = store.Snapshot(ctx, "agent-1")
+	require.NoError(t, err)
+	require.Len(t, snapshot.Items, 1)
+	assert.False(t, snapshot.Items[0].CanSteer, "the browser is offered no steer it cannot make")
+
+	_, _, err = store.PrepareSteer(ctx, "agent-1", "one")
+	assert.ErrorIs(t, err, ErrSteeringState, "and the Worker refuses one that arrives anyway")
+}
+
+func TestStoreAbandonUnownedTurnClearsAProviderReportedTurnOnly(t *testing.T) {
+	t.Parallel()
+
+	// A process boundary runs no turn. The one a provider reported has no other
+	// end once that process is gone -- a stalled CLI never sends its result, and
+	// an explicit stop skips the AGENT_STOPPED pause on purpose -- so the queue
+	// would hold every later message with no pause and no error.
+	_, store := newStoreFixture(t)
+	ctx := context.Background()
+	_, _, err := store.TurnStarted(ctx, "agent-1")
+	require.NoError(t, err)
+
+	snapshot, changed, err := store.AbandonUnownedTurn(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.False(t, snapshot.ActiveTurn, "no process, no turn")
+
+	_, changed, err = store.AbandonUnownedTurn(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.False(t, changed, "a boundary that clears nothing moves no revision")
+}
+
+func TestStoreAbandonUnownedTurnKeepsTheTurnADispatchOwns(t *testing.T) {
+	t.Parallel()
+
+	// ensureAgentRunning starts the process from INSIDE a dispatch, so a
+	// boundary fires while that dispatch is still in flight. Clearing there
+	// would wipe the input id Accept's own identity guard matches on, and the
+	// turn the dispatch just started would be dropped.
+	_, store := newStoreFixture(t)
+	ctx := context.Background()
+	_, err := store.Enqueue(ctx, NewItem{
+		ID: "one", AgentID: "agent-1", Text: "one",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE,
+	})
+	require.NoError(t, err)
+	prepared, _, err := store.PrepareDispatch(ctx, "agent-1")
+	require.NoError(t, err)
+	require.NotNil(t, prepared)
+
+	snapshot, changed, err := store.AbandonUnownedTurn(ctx, "agent-1")
+	require.NoError(t, err)
+	assert.False(t, changed, "the dispatch owns this turn")
+	assert.True(t, snapshot.ActiveTurn)
+
+	_, accepted, err := store.Accept(ctx, *prepared, DispatchResult{StartsTurn: true})
+	require.NoError(t, err)
+	assert.True(t, accepted.ActiveTurn, "the dispatched turn survives the boundary")
+	assert.Equal(t, leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE, accepted.ActiveTurnKind)
+}

--- a/backend/internal/worker/inputqueue/store_test.go
+++ b/backend/internal/worker/inputqueue/store_test.go
@@ -417,7 +417,7 @@ func TestStoreRequeuedSteerReservesASequenceAfterTheEndedTurn(t *testing.T) {
 		VALUES ('turn-end', 'agent-1', ?, ?, '{}', 0)`,
 		turnEndSeq, leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT)
 	require.NoError(t, err)
-	_, err = store.TurnEnded(ctx, "agent-1")
+	_, _, err = store.TurnEnded(ctx, "agent-1")
 	require.NoError(t, err)
 	retried, _, err := store.PrepareDispatch(ctx, "agent-1")
 	require.NoError(t, err)
@@ -770,7 +770,7 @@ func TestStoreSnapshotAnswersTheSteerPrecondition(t *testing.T) {
 	assert.True(t, active.Items[0].CanSteer)
 
 	// A clear runs no regular turn, so the head is not steerable into it.
-	_, err = store.TurnEnded(ctx, "agent-1")
+	_, _, err = store.TurnEnded(ctx, "agent-1")
 	require.NoError(t, err)
 	_, err = store.Enqueue(ctx, NewItem{ID: "clear", AgentID: "agent-1", Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_CLEAR_CONTEXT, Text: "/clear"})
 	require.NoError(t, err)

--- a/backend/internal/worker/service/agent_input_queue.go
+++ b/backend/internal/worker/service/agent_input_queue.go
@@ -165,21 +165,31 @@ func (a *agentInputQueueAdapter) Dispatch(item inputqueue.Item) (inputqueue.Disp
 }
 
 // classifyQueueDeliveryError turns a provider error into the queue's own
-// outcome. Two conditions are transient and must NOT become a permanent
-// failure that the user has to retry by hand:
+// outcome. Three conditions are transient and must NOT become a permanent
+// failure that the user has to retry by hand. All three mean the input never
+// reached the provider, so redispatch is safe.
+//
+// Two of them need the agent to change state first, so the queue pauses and
+// waits for the cause that changes it (ErrDispatchNotReady):
 //
 //   - ErrChildNotSteerableYet: the owner process runs but has not re-fired the
 //     child spawn yet, which happens after every Worker restart.
-//   - ErrAgentBusy: the provider is already inside a turn that the queue's own
-//     active_turn view has not recorded yet.
 //   - ErrAgentNotFound: the process exited between the readiness test and the
 //     write. Manager returns it from providerAfterLifecycle, which resolves the
 //     provider BEFORE any write, so nothing reached the agent.
 //
-// All three mean the input never reached the provider, so redispatch is safe.
+// The third needs nothing (ErrDispatchBusy):
+//
+//   - ErrAgentBusy: the provider is already inside a turn that the queue's own
+//     active_turn view had not recorded. The agent works, and the end of that
+//     turn releases the item on its own -- so a pause here would stop a queue
+//     that has no problem, and hold it stopped until the user resumed it by
+//     hand.
 func classifyQueueDeliveryError(err error) error {
-	if errors.Is(err, agent.ErrChildNotSteerableYet) || errors.Is(err, agent.ErrAgentBusy) ||
-		errors.Is(err, agent.ErrAgentNotFound) {
+	if errors.Is(err, agent.ErrAgentBusy) {
+		return fmt.Errorf("%w: %w", inputqueue.ErrDispatchBusy, err)
+	}
+	if errors.Is(err, agent.ErrChildNotSteerableYet) || errors.Is(err, agent.ErrAgentNotFound) {
 		return fmt.Errorf("%w: %w", inputqueue.ErrDispatchNotReady, err)
 	}
 	return &inputqueue.DeliveryError{Err: err, Uncertain: errors.Is(err, agent.ErrDeliveryUncertain)}

--- a/backend/internal/worker/service/agent_input_queue.go
+++ b/backend/internal/worker/service/agent_input_queue.go
@@ -95,7 +95,7 @@ func (a *agentInputQueueAdapter) Dispatch(item inputqueue.Item) (inputqueue.Disp
 			return inputqueue.DispatchResult{}, err
 		}
 		if !svc.Agents.AgentAlive(row.OwnerAgentID) {
-			return inputqueue.DispatchResult{}, fmt.Errorf("%w: %w", inputqueue.ErrDispatchNotReady, agent.ErrAgentNotFound)
+			return inputqueue.DispatchResult{}, &inputqueue.DeliveryError{Err: agent.ErrAgentNotFound, Outcome: inputqueue.DispatchNotReady}
 		}
 		if err := svc.Agents.SendChildInput(row.OwnerAgentID, row.RowKey, item.Text, attachments); err != nil {
 			if errors.Is(err, agent.ErrChildSteeringUnsupported) {
@@ -116,7 +116,7 @@ func (a *agentInputQueueAdapter) Dispatch(item inputqueue.Item) (inputqueue.Disp
 			// ensureAgentRunning returns at once for a registered slot, so a
 			// start here would resolve the dying provider and write to a
 			// closed pipe. Return the input to the queue instead.
-			return fmt.Errorf("%w: %w", inputqueue.ErrDispatchNotReady, agent.ErrAgentNotFound)
+			return &inputqueue.DeliveryError{Err: agent.ErrAgentNotFound, Outcome: inputqueue.DispatchNotReady}
 		}
 		resumeID := svc.resolveResumeSessionID(item.AgentID, dbAgent.AgentSessionID, dbAgent.Resumed)
 		return svc.ensureAgentRunning(item.AgentID, &resumeID, interactiveStart)
@@ -124,6 +124,16 @@ func (a *agentInputQueueAdapter) Dispatch(item inputqueue.Item) (inputqueue.Disp
 
 	switch item.Kind {
 	case leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_CLEAR_CONTEXT:
+		// A clear STOPS the process, and it is the one dispatch that destroys a
+		// turn instead of joining it. The queue's own active_turn guard already
+		// holds it behind a running turn, but that guard is a durable COPY of
+		// the provider's flag, and the store's own doc records the cases where
+		// the copy can be stale. Ask the flag itself before the stop: a wrong
+		// copy then costs a requeue on an open queue rather than the user's
+		// in-flight reply, killed mid-sentence with no result.
+		if svc.Output.TurnActive(item.AgentID) {
+			return inputqueue.DispatchResult{}, classifyQueueDeliveryError(agent.ErrAgentBusy)
+		}
 		afterAccept, err := svc.prepareClearContext(item.AgentID)
 		if err != nil {
 			return inputqueue.DispatchResult{}, err
@@ -170,29 +180,36 @@ func (a *agentInputQueueAdapter) Dispatch(item inputqueue.Item) (inputqueue.Disp
 // reached the provider, so redispatch is safe.
 //
 // Two of them need the agent to change state first, so the queue pauses and
-// waits for the cause that changes it (ErrDispatchNotReady):
+// waits for the cause that changes it (DispatchNotReady):
 //
-//   - ErrChildNotSteerableYet: the owner process runs but has not re-fired the
-//     child spawn yet, which happens after every Worker restart.
+//   - ErrChildNotSteerableYet: the owner process runs, but it did not re-fire
+//     the child spawn yet. Every Worker restart produces this condition.
 //   - ErrAgentNotFound: the process exited between the readiness test and the
 //     write. Manager returns it from providerAfterLifecycle, which resolves the
 //     provider BEFORE any write, so nothing reached the agent.
 //
-// The third needs nothing (ErrDispatchBusy):
+// The third needs nothing (DispatchBusy):
 //
 //   - ErrAgentBusy: the provider is already inside a turn that the queue's own
-//     active_turn view had not recorded. The agent works, and the end of that
+//     active_turn view did not record. The agent works, and the end of that
 //     turn releases the item on its own -- so a pause here would stop a queue
 //     that has no problem, and hold it stopped until the user resumed it by
 //     hand.
 func classifyQueueDeliveryError(err error) error {
-	if errors.Is(err, agent.ErrAgentBusy) {
-		return fmt.Errorf("%w: %w", inputqueue.ErrDispatchBusy, err)
+	return &inputqueue.DeliveryError{Err: err, Outcome: queueDispatchOutcome(err)}
+}
+
+func queueDispatchOutcome(err error) inputqueue.DispatchOutcome {
+	switch {
+	case errors.Is(err, agent.ErrAgentBusy):
+		return inputqueue.DispatchBusy
+	case errors.Is(err, agent.ErrChildNotSteerableYet), errors.Is(err, agent.ErrAgentNotFound):
+		return inputqueue.DispatchNotReady
+	case errors.Is(err, agent.ErrDeliveryUncertain):
+		return inputqueue.DispatchUncertain
+	default:
+		return inputqueue.DispatchFailed
 	}
-	if errors.Is(err, agent.ErrChildNotSteerableYet) || errors.Is(err, agent.ErrAgentNotFound) {
-		return fmt.Errorf("%w: %w", inputqueue.ErrDispatchNotReady, err)
-	}
-	return &inputqueue.DeliveryError{Err: err, Uncertain: errors.Is(err, agent.ErrDeliveryUncertain)}
 }
 
 func classifyQueueSteerError(err error) error {

--- a/backend/internal/worker/service/agent_input_queue_test.go
+++ b/backend/internal/worker/service/agent_input_queue_test.go
@@ -596,6 +596,19 @@ func TestClassifyQueueDeliveryErrorRequeuesAVanishedProcess(t *testing.T) {
 	assert.ErrorIs(t, err, agent.ErrAgentNotFound)
 }
 
+func TestClassifyQueueDeliveryErrorKeepsTheQueueOpenForABusyAgent(t *testing.T) {
+	t.Parallel()
+
+	// A busy agent works, and its turn end releases the item. Pausing there
+	// stopped a healthy queue on the outcome its own contract calls transient,
+	// and only the user could start it again.
+	err := classifyQueueDeliveryError(fmt.Errorf("send: %w", agent.ErrAgentBusy))
+	assert.ErrorIs(t, err, inputqueue.ErrDispatchBusy)
+	assert.ErrorIs(t, err, agent.ErrAgentBusy)
+	assert.NotErrorIs(t, err, inputqueue.ErrDispatchNotReady,
+		"a busy agent needs no state change, so the queue must not pause for one")
+}
+
 // startEchoAgent registers a mock Claude Code process for agentID. The mock is
 // a `cat`, so every frame the Worker writes to its stdin comes back as agent
 // output: a control_request the Worker sends therefore lands in the

--- a/backend/internal/worker/service/agent_input_queue_test.go
+++ b/backend/internal/worker/service/agent_input_queue_test.go
@@ -478,9 +478,18 @@ func TestClassifyQueueSteerErrorPreservesUncertainDelivery(t *testing.T) {
 	t.Parallel()
 
 	err := classifyQueueSteerError(fmt.Errorf("steer timed out: %w", agent.ErrDeliveryUncertain))
+	assert.Equal(t, inputqueue.DispatchUncertain, dispatchOutcomeOf(t, err))
+}
+
+// dispatchOutcomeOf reads the outcome a classified refusal carries. Every case
+// goes through it rather than through errors.Is on a sentinel: the outcome is
+// the queue's whole answer, so a test that matched only the CAUSE would pass
+// while the queue did the wrong thing with it.
+func dispatchOutcomeOf(t *testing.T, err error) inputqueue.DispatchOutcome {
+	t.Helper()
 	var deliveryErr *inputqueue.DeliveryError
 	require.ErrorAs(t, err, &deliveryErr)
-	assert.True(t, deliveryErr.Uncertain)
+	return deliveryErr.Outcome
 }
 
 func TestAutoContinueProducerUsesGeneratedQueueKind(t *testing.T) {
@@ -592,7 +601,7 @@ func TestClassifyQueueDeliveryErrorRequeuesAVanishedProcess(t *testing.T) {
 	t.Parallel()
 
 	err := classifyQueueDeliveryError(fmt.Errorf("send: %w", agent.ErrAgentNotFound))
-	assert.ErrorIs(t, err, inputqueue.ErrDispatchNotReady)
+	assert.Equal(t, inputqueue.DispatchNotReady, dispatchOutcomeOf(t, err))
 	assert.ErrorIs(t, err, agent.ErrAgentNotFound)
 }
 
@@ -603,10 +612,9 @@ func TestClassifyQueueDeliveryErrorKeepsTheQueueOpenForABusyAgent(t *testing.T) 
 	// stopped a healthy queue on the outcome its own contract calls transient,
 	// and only the user could start it again.
 	err := classifyQueueDeliveryError(fmt.Errorf("send: %w", agent.ErrAgentBusy))
-	assert.ErrorIs(t, err, inputqueue.ErrDispatchBusy)
-	assert.ErrorIs(t, err, agent.ErrAgentBusy)
-	assert.NotErrorIs(t, err, inputqueue.ErrDispatchNotReady,
+	assert.Equal(t, inputqueue.DispatchBusy, dispatchOutcomeOf(t, err),
 		"a busy agent needs no state change, so the queue must not pause for one")
+	assert.ErrorIs(t, err, agent.ErrAgentBusy, "and the cause still reaches the user")
 }
 
 // startEchoAgent registers a mock Claude Code process for agentID. The mock is

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -260,11 +260,17 @@ type OutputHandler struct {
 	// PersistSettingsRefresh consults it to avoid clobbering a settings change
 	// that landed mid-startup with the agent's confirmed launch settings.
 	agentStarting func(agentID string) bool
-	// turnStarted and turnEnded carry the provider's turn flag to the input
-	// queue. Both edges of ONE signal (OutputSink.SetTurnActive), so the queue's
-	// dispatch guard follows the same flag the provider's own SendInput reads.
-	turnStarted func(agentID string)
-	turnEnded   func(agentID string)
+	// turnActive carries the provider's turn flag to the input queue. It takes
+	// the flag itself, not one callback for each edge: the queue's dispatch
+	// guard must follow the SAME signal that the provider's own SendInput
+	// reads, and a wiring that sets one edge and not the other is the exact
+	// fault this callback exists to prevent.
+	turnActive func(agentID string, active bool)
+
+	// turnPublisher holds, for each root agent id, the sink whose turn flag
+	// counts. A launch adopts one; a publish from any other sink comes from a
+	// process the Worker already replaced. See acceptTurnPublish.
+	turnPublisher sync.Map
 
 	// wakeLock prevents system sleep while there is agent/terminal activity.
 	wakeLock *wakelock.ActivityTracker
@@ -349,15 +355,10 @@ func (h *OutputHandler) SetAgentStartingFunc(fn func(agentID string) bool) {
 	h.agentStarting = fn
 }
 
-// SetTurnStartedFunc and SetTurnEndedFunc wire the input queue's turn state to
-// the turn flag every provider publishes. Call both before any agent output is
-// processed.
-func (h *OutputHandler) SetTurnStartedFunc(fn func(agentID string)) {
-	h.turnStarted = fn
-}
-
-func (h *OutputHandler) SetTurnEndedFunc(fn func(agentID string)) {
-	h.turnEnded = fn
+// SetTurnActiveFunc wires the input queue's turn state to the turn flag every
+// provider publishes. Call it before any agent output is processed.
+func (h *OutputHandler) SetTurnActiveFunc(fn func(agentID string, active bool)) {
+	h.turnActive = fn
 }
 
 // CleanupAgent removes all per-agent state from the handler's maps.
@@ -651,6 +652,10 @@ type agentOutputSink struct {
 	h *OutputHandler
 	// agentID is THIS sink's agent id (a child id for a child sink).
 	agentID string
+	// root is the sink this one came from, and nil for a root sink. It is the
+	// PROCESS identity that acceptTurnPublish compares: a child sink stands for
+	// the same process as the root that produced it.
+	root *agentOutputSink
 	// rootAgentID is the ROOT main agent id that owns the registry; it equals
 	// agentID for a root sink. A child sink shares its parent's rootAgentID so
 	// every registry write (EnsureChildAgent, UpsertBackgroundTask, ...) lands
@@ -769,15 +774,30 @@ func (s *agentOutputSink) PersistTurnEnd(content []byte, span agent.SpanInfo) er
 // record at every process boundary, and a reconciliation that the reset drops
 // leaves the queue on a turn state the provider no longer reports. The queue
 // answers idempotently instead, and reports its own change.
-func (s *agentOutputSink) SetTurnActive(active bool) {
+func (s *agentOutputSink) SetTurnActive(active bool, seq uint64) {
+	// Both consumers are downstream of ONE ordering test, because both latch: a
+	// stale value that reaches either one is never corrected by a later publish
+	// of the same state. A child publishes through its own sink, so the test
+	// keys on this sink's agent id but identifies the publisher by the ROOT
+	// sink, which is what a launch adopts.
+	if !s.h.acceptTurnPublish(s.agentID, s.rootAgentID, s.turnPublisher(), seq) {
+		return
+	}
 	s.h.setTurnActive(s.agentID, s.rootAgentID, active)
-	notify := s.h.turnEnded
-	if active {
-		notify = s.h.turnStarted
+	if s.h.turnActive != nil {
+		s.h.turnActive(s.agentID, active)
 	}
-	if notify != nil {
-		notify(s.agentID)
+}
+
+// turnPublisher identifies the PROCESS behind this sink. A child sink stands for
+// the same process as the root it came from, so it reports the root.
+func (s *agentOutputSink) turnPublisher() any { return s.turnPublisherSink() }
+
+func (s *agentOutputSink) turnPublisherSink() *agentOutputSink {
+	if s.root != nil {
+		return s.root
 	}
+	return s
 }
 
 func turnEndEvent(count int32, ok bool) *leapmuxv1.AgentTurnEnd {

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -260,8 +260,11 @@ type OutputHandler struct {
 	// PersistSettingsRefresh consults it to avoid clobbering a settings change
 	// that landed mid-startup with the agent's confirmed launch settings.
 	agentStarting func(agentID string) bool
-	inputReady    func(agentID string)
-	inputStarted  func(agentID string)
+	// turnStarted and turnEnded carry the provider's turn flag to the input
+	// queue. Both edges of ONE signal (OutputSink.SetTurnActive), so the queue's
+	// dispatch guard follows the same flag the provider's own SendInput reads.
+	turnStarted func(agentID string)
+	turnEnded   func(agentID string)
 
 	// wakeLock prevents system sleep while there is agent/terminal activity.
 	wakeLock *wakelock.ActivityTracker
@@ -346,12 +349,15 @@ func (h *OutputHandler) SetAgentStartingFunc(fn func(agentID string) bool) {
 	h.agentStarting = fn
 }
 
-func (h *OutputHandler) SetInputReadyFunc(fn func(agentID string)) {
-	h.inputReady = fn
+// SetTurnStartedFunc and SetTurnEndedFunc wire the input queue's turn state to
+// the turn flag every provider publishes. Call both before any agent output is
+// processed.
+func (h *OutputHandler) SetTurnStartedFunc(fn func(agentID string)) {
+	h.turnStarted = fn
 }
 
-func (h *OutputHandler) SetInputStartedFunc(fn func(agentID string)) {
-	h.inputStarted = fn
+func (h *OutputHandler) SetTurnEndedFunc(fn func(agentID string)) {
+	h.turnEnded = fn
 }
 
 // CleanupAgent removes all per-agent state from the handler's maps.
@@ -690,18 +696,6 @@ func (s *agentOutputSink) PersistMessage(source leapmuxv1.MessageSource, content
 	return s.h.persistAndBroadcast(s.agentID, s.agentProvider, source, content, span, s.tracker)
 }
 
-func (s *agentOutputSink) InputReady() {
-	if s.h.inputReady != nil {
-		s.h.inputReady(s.agentID)
-	}
-}
-
-func (s *agentOutputSink) InputStarted() {
-	if s.h.inputStarted != nil {
-		s.h.inputStarted(s.agentID)
-	}
-}
-
 // PersistTurnEnd persists the universal turn-end divider envelope and
 // fires the git-status auto-broadcast. Each provider's final
 // envelope (Claude type:"result", Codex turn/completed, ACP prompt
@@ -763,8 +757,27 @@ func (s *agentOutputSink) PersistTurnEnd(content []byte, span agent.SpanInfo) er
 // SetTurnActive publishes the provider's own turn bookkeeping. Providers call
 // it from the same site that mutates their private flag, so the two cannot
 // drift.
+//
+// Both consumers are here, because one flag answers both: the activity latch
+// that a client renders, and the input queue that holds a message until the
+// running turn ends. The queue used to have a signal of its own, which only a
+// turn the queue itself dispatched ever raised -- so a turn the agent process
+// started on its own was invisible to it, and the next message the user sent
+// went into that turn instead of waiting behind it.
+//
+// The queue call does NOT depend on the latch's edge. The latch resets its
+// record at every process boundary, and a reconciliation that the reset drops
+// leaves the queue on a turn state the provider no longer reports. The queue
+// answers idempotently instead, and reports its own change.
 func (s *agentOutputSink) SetTurnActive(active bool) {
 	s.h.setTurnActive(s.agentID, s.rootAgentID, active)
+	notify := s.h.turnEnded
+	if active {
+		notify = s.h.turnStarted
+	}
+	if notify != nil {
+		notify(s.agentID)
+	}
 }
 
 func turnEndEvent(count int32, ok bool) *leapmuxv1.AgentTurnEnd {

--- a/backend/internal/worker/service/output_activity.go
+++ b/backend/internal/worker/service/output_activity.go
@@ -47,9 +47,25 @@ type agentActivity struct {
 	rootAgentID string
 
 	// turnActive is what the provider last reported through
-	// OutputSink.SetTurnActive. Meaningful for a root only: a child owns no
-	// process and no turn of its own, and its run IS its registry row.
+	// OutputSink.SetTurnActive. The DERIVED state reads it for a root only:
+	// activityStateLocked answers a child from its background-task registry
+	// row, which IS the child's run.
+	//
+	// A child still publishes the flag, because the input queue follows the
+	// same signal and a collab child owns a queue of its own. So this field is
+	// written for a child and never read for one, and setTurnActive must keep
+	// every other effect of that publish away from a child entry.
 	turnActive bool
+
+	// turnSeq is the ordering token of the last publish this entry accepted. A
+	// provider reads its flag under a lock and calls the sink without one, so
+	// two goroutines reach here unordered and the older value can arrive second.
+	// Comparing the token drops what it overtook.
+	//
+	// The token is monotonic within ONE provider process. It restarts at zero in
+	// the next one, so acceptTurnPublish resets this whenever the publisher
+	// changes -- see turnPublisher.
+	turnSeq uint64
 
 	// pendingControl holds the request ids of the unanswered control requests
 	// (permission prompts) this agent is blocked on. An agent waiting for the
@@ -573,11 +589,18 @@ func (h *OutputHandler) treeChildIDs(rootAgentID string, rows []bgtask.Item) []s
 // setTurnActive records the provider's turn bookkeeping and republishes.
 // Providers reach it through OutputSink.SetTurnActive.
 func (h *OutputHandler) setTurnActive(agentID, rootAgentID string, active bool) {
+	// The settle count belongs to the ROOT's turn. A child publishes this flag
+	// too, because the input queue follows it, but activityStateLocked answers
+	// a child from its registry row and never reads the flag -- so the refresh
+	// below cannot spend a child's count, and clearing it here would only
+	// destroy what PersistTurnEnd just recorded. The child's settle then
+	// reports no tool count at all.
+	root := agentID == rootAgentID
 	st := h.activityFor(agentID, rootAgentID)
 	st.mu.Lock()
 	changed := st.turnActive != active
 	st.turnActive = active
-	if active {
+	if active && root {
 		// A fresh turn supersedes whatever the previous one left unspent, so a
 		// stale count cannot silence the alert for the turn now starting.
 		st.settledToolUses = nil
@@ -587,7 +610,7 @@ func (h *OutputHandler) setTurnActive(agentID, rootAgentID string, active bool) 
 		return
 	}
 	h.refreshActivity(agentID, rootAgentID)
-	if active {
+	if active || !root {
 		return
 	}
 	// Only the settle that THIS clear produces may spend the count. When the
@@ -602,6 +625,72 @@ func (h *OutputHandler) setTurnActive(agentID, rootAgentID string, active bool) 
 	st.mu.Lock()
 	st.settledToolUses = nil
 	st.mu.Unlock()
+}
+
+// acceptTurnPublish answers whether one publish of the turn flag is current,
+// and records it when it is.
+//
+// Two publishes can arrive out of order, and the wrong one winning latches a
+// turn that is over: nothing later clears it, so the input queue holds every
+// message the user sends after it. Two things can reorder them.
+//
+// Inside ONE provider process, the reader goroutine that ends a turn and the
+// drain goroutine that a busy refusal answers both reach here. Their tokens come
+// from one counter under the provider's own lock, so the later token is the
+// later read of the flag, and a lower one is stale.
+//
+// ACROSS processes, a replaced process can still publish: its reader is draining
+// the pipe of an agent the Worker already stopped. Its tokens mean nothing to
+// the new process, whose counter restarted at zero. publisher identifies the
+// SINK the publish came through -- one sink per launch -- so a publish from a
+// superseded sink is dropped whatever its token, and the first publish of a new
+// one is accepted whatever its token.
+func (h *OutputHandler) acceptTurnPublish(agentID, rootAgentID string, publisher any, seq uint64) bool {
+	current, ok := h.turnPublisher.Load(rootAgentID)
+	if ok && current != publisher {
+		return false
+	}
+	st := h.activityFor(agentID, rootAgentID)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if !ok {
+		// No launch adopted a publisher yet, which is the state a bare unit test
+		// and the window before the first NoteAgentProcessStarted both leave.
+		// Accept, because dropping here would lose the only publisher there is.
+		st.turnSeq = seq
+		return true
+	}
+	if seq <= st.turnSeq {
+		return false
+	}
+	st.turnSeq = seq
+	return true
+}
+
+// adoptTurnPublisher makes one sink the only publisher of an agent's turn flag,
+// and forgets the token of the process that came before it. A launch calls it:
+// the sink it registers is the one the new process publishes through, and every
+// later publish from the old process is answering for a turn that died with it.
+func (h *OutputHandler) adoptTurnPublisher(rootAgentID string, publisher any) {
+	h.turnPublisher.Store(rootAgentID, publisher)
+	st := h.activityFor(rootAgentID, rootAgentID)
+	st.mu.Lock()
+	st.turnSeq = 0
+	st.mu.Unlock()
+}
+
+// TurnActive reports the flag the agent's provider last published. It is the
+// SAME value the provider's own SendInput refuses input from, and the same one
+// the input queue's dispatch guard follows -- so a caller that must not run into
+// a turn asks here rather than deriving an answer of its own.
+//
+// It answers for a ROOT. A child owns no turn of its own: its run IS its
+// registry row.
+func (h *OutputHandler) TurnActive(agentID string) bool {
+	st := h.activityFor(agentID, agentID)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.turnActive
 }
 
 // noteTurnEnded records the finished turn's tool-call count for the settle edge
@@ -693,6 +782,11 @@ func (h *OutputHandler) NoteAgentProcessExited(rootAgentID string) {
 // forever, the Interrupt button offers to cancel a turn that does not exist, and
 // the close guard refuses a tab on work that already stopped.
 func (h *OutputHandler) NoteAgentProcessStarted(rootAgentID string) {
+	// The sink registered now belongs to the process starting now, and it is the
+	// only one whose turn flag counts from here on. See acceptTurnPublish.
+	if sink, ok := h.rootSinks.Load(rootAgentID); ok {
+		h.adoptTurnPublisher(rootAgentID, sink)
+	}
 	h.resetAgentActivity(rootAgentID)
 }
 

--- a/backend/internal/worker/service/output_activity_test.go
+++ b/backend/internal/worker/service/output_activity_test.go
@@ -949,3 +949,45 @@ func TestActivity_APendingChildRowCountsAsWorkPastTheCap(t *testing.T) {
 	assert.True(t, got.Working())
 	assert.Equal(t, int32(1), got.ActiveTasks)
 }
+
+func TestActivity_AChildTurnFlagKeepsTheCountItsTurnEndRecorded(t *testing.T) {
+	t.Parallel()
+
+	// A collab child publishes SetTurnActive on its OWN sink, because the input
+	// queue follows that flag and a child owns a queue of its own. The publish
+	// must not touch the settle count: activityStateLocked answers a child from
+	// its registry row and never reads the flag, so the refresh cannot spend the
+	// count, and clearing it would only destroy what PersistTurnEnd recorded one
+	// call earlier. The child's settle then reports no tool count at all, and a
+	// client that reads a missing count alerts unconditionally.
+	h, _ := newActivityHandler(t, "root-1")
+	h.setTurnActive("child-1", "root-1", true)
+	h.noteTurnEnded("child-1", "root-1", 4, true)
+
+	h.setTurnActive("child-1", "root-1", false)
+	require.NotNil(t, unspentToolCount(h, "child-1"),
+		"the child's clear must not discard the count its own turn end recorded")
+	assert.Equal(t, int32(4), *unspentToolCount(h, "child-1"))
+
+	// The next turn's rising edge must not discard it either: the child's
+	// registry row settles the run, and that settle is what spends the count.
+	h.setTurnActive("child-1", "root-1", true)
+	require.NotNil(t, unspentToolCount(h, "child-1"))
+	assert.Equal(t, int32(4), *unspentToolCount(h, "child-1"))
+}
+
+func TestActivity_ARootTurnFlagStillOwnsTheCount(t *testing.T) {
+	t.Parallel()
+
+	// The counterpart to the child rule above: a ROOT's flag keeps both effects.
+	// A fresh turn supersedes an unspent count, and a clear whose refresh could
+	// not spend it drops it so the settle that eventually comes alerts rather
+	// than reading a stale zero.
+	h, _ := newActivityHandler(t, "agent-1")
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.noteTurnEnded("agent-1", "agent-1", 7, true)
+	require.NotNil(t, unspentToolCount(h, "agent-1"))
+
+	h.setTurnActive("agent-1", "agent-1", true)
+	assert.Nil(t, unspentToolCount(h, "agent-1"), "a fresh turn supersedes an unspent count")
+}

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -932,6 +932,7 @@ func (s *agentOutputSink) ChildSink(childAgentID string) agent.OutputSink {
 	}
 	child := &agentOutputSink{
 		h:             s.h,
+		root:          s.turnPublisherSink(),
 		agentID:       childAgentID,
 		rootAgentID:   s.rootAgentID,
 		agentProvider: s.agentProvider,

--- a/backend/internal/worker/service/output_turn_signal_test.go
+++ b/backend/internal/worker/service/output_turn_signal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	"github.com/leapmux/leapmux/internal/worker/agent"
 	db "github.com/leapmux/leapmux/internal/worker/generated/db"
 	"github.com/leapmux/leapmux/internal/worker/inputqueue"
 )
@@ -22,6 +23,29 @@ import (
 // itself dispatched ever raised. A turn the agent process started on its own
 // was then invisible, and the next message the user sent went straight into it
 // instead of waiting in the queue.
+
+// turnPublisher mints the ordering token a provider takes under its own lock,
+// and adopts the sink the way a launch does. Going through both is deliberate:
+// a test that published a bare token would pass against a Worker that stopped
+// ordering the publishes at all.
+type turnPublisher struct {
+	sink agent.OutputSink
+	seq  uint64
+}
+
+func (p *turnPublisher) publish(active bool) {
+	p.seq++
+	p.sink.SetTurnActive(active, p.seq)
+}
+
+// launchTurnPublisher registers a sink and runs the two things startAgent runs
+// for a new process: adopt the publisher, and release a turn the old one left.
+func launchTurnPublisher(svc *Service, agentID string) *turnPublisher {
+	sink := svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	svc.Output.NoteAgentProcessStarted(agentID)
+	svc.abandonUnownedTurn(agentID)
+	return &turnPublisher{sink: sink}
+}
 
 func newTurnSignalFixture(t *testing.T) (*Service, string) {
 	t.Helper()
@@ -41,10 +65,10 @@ func TestProviderReportedTurnHoldsQueuedInputUntilItEnds(t *testing.T) {
 
 	ctx := context.Background()
 	svc, agentID := newTurnSignalFixture(t)
-	sink := svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	sink := launchTurnPublisher(svc, agentID)
 
 	// The agent process reports a turn the queue did not dispatch.
-	sink.SetTurnActive(true)
+	sink.publish(true)
 	require.Eventually(t, func() bool {
 		snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
 		return err == nil && snapshot.ActiveTurn
@@ -60,33 +84,199 @@ func TestProviderReportedTurnHoldsQueuedInputUntilItEnds(t *testing.T) {
 		return snapshotErr == nil && len(snapshot.Items) == 0
 	}, 100*time.Millisecond, 10*time.Millisecond)
 
-	sink.SetTurnActive(false)
+	sink.publish(false)
 	require.Eventually(t, func() bool {
 		snapshot, snapshotErr := svc.InputQueue.Snapshot(ctx, agentID)
 		return snapshotErr == nil && len(snapshot.Items) == 0
 	}, time.Second, 10*time.Millisecond)
 }
 
-func TestProviderReportedTurnEndRepeatsWithoutChurningTheQueueRevision(t *testing.T) {
+func TestProviderReportedTurnRepeatsWithoutChurningTheQueueRevision(t *testing.T) {
 	t.Parallel()
 
 	// Every publish reconciles the queue against the provider's own flag, and a
 	// provider republishes the unchanged value freely (a failed send, a steer,
 	// an interrupt). A reconciliation that changes nothing must not bump the
 	// revision, or every watcher takes a snapshot that says the same thing.
+	//
+	// Both edges are measured after a REAL transition. A queue that never held
+	// a turn answers every clear with "nothing to do", so a repeat measured
+	// from there proves nothing about the guard.
 	ctx := context.Background()
 	svc, agentID := newTurnSignalFixture(t)
-	sink := svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+	sink := launchTurnPublisher(svc, agentID)
 
-	sink.SetTurnActive(false)
-	before, err := svc.InputQueue.Snapshot(ctx, agentID)
+	sink.publish(true)
+	var active inputqueue.Snapshot
+	require.Eventually(t, func() bool {
+		snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
+		if err != nil || !snapshot.ActiveTurn {
+			return false
+		}
+		active = snapshot
+		return true
+	}, time.Second, 10*time.Millisecond)
+
+	sink.publish(true)
+	sink.publish(true)
+	repeated, err := svc.InputQueue.Snapshot(ctx, agentID)
 	require.NoError(t, err)
+	assert.Equal(t, active.Revision, repeated.Revision, "a repeated turn start moves nothing")
+	assert.True(t, repeated.ActiveTurn)
 
-	sink.SetTurnActive(false)
-	sink.SetTurnActive(false)
+	sink.publish(false)
+	var cleared inputqueue.Snapshot
+	require.Eventually(t, func() bool {
+		snapshot, snapshotErr := svc.InputQueue.Snapshot(ctx, agentID)
+		if snapshotErr != nil || snapshot.ActiveTurn {
+			return false
+		}
+		cleared = snapshot
+		return true
+	}, time.Second, 10*time.Millisecond)
+	assert.Greater(t, cleared.Revision, active.Revision, "the real transition does move it")
 
+	sink.publish(false)
+	sink.publish(false)
 	after, err := svc.InputQueue.Snapshot(ctx, agentID)
 	require.NoError(t, err)
-	assert.Equal(t, before.Revision, after.Revision)
+	assert.Equal(t, cleared.Revision, after.Revision, "a repeated clear moves nothing either")
 	assert.False(t, after.ActiveTurn)
+}
+
+func TestProcessExitReleasesATurnTheProviderNeverEnded(t *testing.T) {
+	t.Parallel()
+
+	// A provider can report a turn and then neither end it nor exit -- a CLI
+	// that stalls after its first assistant block. Stopping the agent is the
+	// user's only escape, and an explicit stop skips the AGENT_STOPPED pause on
+	// purpose, so before this the stop left the turn standing and the queue held
+	// every later message with no pause, no error, and no Retry.
+	ctx := context.Background()
+	svc, agentID := newTurnSignalFixture(t)
+	sink := launchTurnPublisher(svc, agentID)
+
+	sink.publish(true)
+	require.Eventually(t, func() bool {
+		snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
+		return err == nil && snapshot.ActiveTurn
+	}, time.Second, 10*time.Millisecond)
+
+	_, err := svc.InputQueue.Enqueue(ctx, inputqueue.NewItem{
+		ID: newTestAgentInputID(), AgentID: agentID, Text: "hello",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE,
+	})
+	require.NoError(t, err)
+
+	assert.Never(t, func() bool {
+		snapshot, snapshotErr := svc.InputQueue.Snapshot(ctx, agentID)
+		return snapshotErr == nil && len(snapshot.Items) == 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	// The user stops the agent. stopped=true, so nothing pauses the queue -- and
+	// nothing ended the turn either, which is what stranded the message.
+	svc.HandleAgentProcessExit(agentID, 0, nil, true)
+
+	require.Eventually(t, func() bool {
+		snapshot, snapshotErr := svc.InputQueue.Snapshot(ctx, agentID)
+		return snapshotErr == nil && len(snapshot.Items) == 0
+	}, time.Second, 10*time.Millisecond)
+	snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
+	require.NoError(t, err)
+	assert.False(t, snapshot.Paused, "an explicit stop still does not pause the queue")
+}
+
+func TestClearContextRefusesToStopAnAgentInsideATurn(t *testing.T) {
+	t.Parallel()
+
+	// A clear STOPS the process, and it is the one dispatch that destroys a turn
+	// instead of joining it. The queue's active_turn guard normally holds it
+	// back, but that guard is a durable COPY of the provider's flag. When the
+	// copy is stale the clear went through and killed the user's in-flight
+	// reply, which ended with no result at all.
+	svc, agentID := newTurnSignalFixture(t)
+	sink := launchTurnPublisher(svc, agentID)
+	sink.publish(true)
+
+	adapter := &agentInputQueueAdapter{svc: svc}
+	_, err := adapter.Dispatch(inputqueue.Item{
+		ID: newTestAgentInputID(), AgentID: agentID, Text: "/clear",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_CLEAR_CONTEXT,
+	})
+	assert.Equal(t, inputqueue.DispatchBusy, dispatchOutcomeOf(t, err),
+		"the flag itself says a turn runs, so the clear waits for it")
+	assert.ErrorIs(t, err, agent.ErrAgentBusy)
+
+	// And once the turn ends, the same clear goes through.
+	sink.publish(false)
+	_, err = adapter.Dispatch(inputqueue.Item{
+		ID: newTestAgentInputID(), AgentID: agentID, Text: "/clear",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_CLEAR_CONTEXT,
+	})
+	require.NoError(t, err)
+}
+
+func TestAStalePublishFromTheSameProcessLosesToTheOneItOvertook(t *testing.T) {
+	t.Parallel()
+
+	// Two goroutines reach the sink unordered: the reader that ends a turn, and
+	// the drain that a busy refusal answers. Each reads the provider's flag under
+	// a lock and calls the sink without one, so the older value can land second.
+	// It must lose, because nothing later clears a turn that is already over --
+	// the queue would hold every message the user sends after it.
+	ctx := context.Background()
+	svc, agentID := newTurnSignalFixture(t)
+	sink := launchTurnPublisher(svc, agentID)
+
+	sink.sink.SetTurnActive(true, 1)
+	sink.sink.SetTurnActive(false, 2)
+	require.Eventually(t, func() bool {
+		snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
+		return err == nil && !snapshot.ActiveTurn
+	}, time.Second, 10*time.Millisecond)
+
+	// The refusal read its flag BEFORE the clear did, so its token is lower.
+	sink.sink.SetTurnActive(true, 1)
+
+	assert.Never(t, func() bool {
+		snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
+		return err == nil && snapshot.ActiveTurn
+	}, 100*time.Millisecond, 10*time.Millisecond)
+	assert.False(t, svc.Output.TurnActive(agentID), "and the activity latch agrees")
+}
+
+func TestAPublishFromAReplacedProcessCannotReopenATurn(t *testing.T) {
+	t.Parallel()
+
+	// A replaced process keeps publishing while its reader drains the pipe, and
+	// its tokens mean nothing to the new process, whose counter restarted at
+	// zero. Identity, not the token, is what separates them: one sink per launch.
+	ctx := context.Background()
+	svc, agentID := newTurnSignalFixture(t)
+	old := launchTurnPublisher(svc, agentID)
+	old.publish(true)
+	old.publish(false)
+	old.publish(true)
+
+	// The Worker replaces the process. The new launch registers its own sink.
+	fresh := launchTurnPublisher(svc, agentID)
+	require.Eventually(t, func() bool {
+		snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
+		return err == nil && !snapshot.ActiveTurn
+	}, time.Second, 10*time.Millisecond)
+
+	// The dead process reports a turn, with a token far above the new one's.
+	old.publish(true)
+	assert.Never(t, func() bool {
+		snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
+		return err == nil && snapshot.ActiveTurn
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	// The new process starts its first turn, whose token is 1 -- far BELOW the
+	// dead process's. The adoption forgot that count, so this one still wins.
+	fresh.publish(true)
+	require.Eventually(t, func() bool {
+		snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
+		return err == nil && snapshot.ActiveTurn
+	}, time.Second, 10*time.Millisecond)
 }

--- a/backend/internal/worker/service/output_turn_signal_test.go
+++ b/backend/internal/worker/service/output_turn_signal_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
+	db "github.com/leapmux/leapmux/internal/worker/generated/db"
+	"github.com/leapmux/leapmux/internal/worker/inputqueue"
+)
+
+// OutputSink.SetTurnActive is the ONE signal a provider publishes for "a turn
+// is in flight", and the Worker derives both answers from it: the activity
+// state a client renders, and the input queue's dispatch guard. These tests pin
+// the second one, on both edges.
+//
+// The queue guard used to have a signal of its own, which only a turn the queue
+// itself dispatched ever raised. A turn the agent process started on its own
+// was then invisible, and the next message the user sent went straight into it
+// instead of waiting in the queue.
+
+func newTurnSignalFixture(t *testing.T) (*Service, string) {
+	t.Helper()
+	svc, _, _ := setupTestService(t)
+	agentID := "agent-turn-signal"
+	require.NoError(t, svc.Queries.CreateAgent(context.Background(), db.CreateAgentParams{
+		ID: agentID, WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE,
+	}))
+	svc.startAgentFn = svc.Agents.MockStartAgent
+	t.Cleanup(func() { svc.Agents.StopAgent(agentID) })
+	return svc, agentID
+}
+
+func TestProviderReportedTurnHoldsQueuedInputUntilItEnds(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, agentID := newTurnSignalFixture(t)
+	sink := svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+
+	// The agent process reports a turn the queue did not dispatch.
+	sink.SetTurnActive(true)
+	require.Eventually(t, func() bool {
+		snapshot, err := svc.InputQueue.Snapshot(ctx, agentID)
+		return err == nil && snapshot.ActiveTurn
+	}, time.Second, 10*time.Millisecond)
+
+	_, err := svc.InputQueue.Enqueue(ctx, inputqueue.NewItem{
+		ID: newTestAgentInputID(), AgentID: agentID, Text: "hello",
+		Kind: leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE,
+	})
+	require.NoError(t, err)
+	assert.Never(t, func() bool {
+		snapshot, snapshotErr := svc.InputQueue.Snapshot(ctx, agentID)
+		return snapshotErr == nil && len(snapshot.Items) == 0
+	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	sink.SetTurnActive(false)
+	require.Eventually(t, func() bool {
+		snapshot, snapshotErr := svc.InputQueue.Snapshot(ctx, agentID)
+		return snapshotErr == nil && len(snapshot.Items) == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestProviderReportedTurnEndRepeatsWithoutChurningTheQueueRevision(t *testing.T) {
+	t.Parallel()
+
+	// Every publish reconciles the queue against the provider's own flag, and a
+	// provider republishes the unchanged value freely (a failed send, a steer,
+	// an interrupt). A reconciliation that changes nothing must not bump the
+	// revision, or every watcher takes a snapshot that says the same thing.
+	ctx := context.Background()
+	svc, agentID := newTurnSignalFixture(t)
+	sink := svc.Output.NewSink(agentID, leapmuxv1.AgentProvider_AGENT_PROVIDER_CLAUDE_CODE)
+
+	sink.SetTurnActive(false)
+	before, err := svc.InputQueue.Snapshot(ctx, agentID)
+	require.NoError(t, err)
+
+	sink.SetTurnActive(false)
+	sink.SetTurnActive(false)
+
+	after, err := svc.InputQueue.Snapshot(ctx, agentID)
+	require.NoError(t, err)
+	assert.Equal(t, before.Revision, after.Revision)
+	assert.False(t, after.ActiveTurn)
+}

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -593,18 +593,17 @@ func New(cfg Config) *Service {
 	queueAdapter := &agentInputQueueAdapter{svc: svc}
 	svc.InputQueue = inputqueue.NewManager(inputqueue.NewStore(cfg.DB), queueAdapter, queueAdapter)
 	svc.Output.SetSupportsSteeringFunc(queueAdapter.SupportsSteering)
-	// Both edges of the one turn flag every provider publishes. A queue that
-	// already closed admission refuses them, and a Worker shutdown stops every
-	// agent it runs -- so that refusal is the expected end of the signal, not a
-	// fault to report.
-	svc.Output.SetTurnEndedFunc(func(agentID string) {
-		if _, err := svc.InputQueue.TurnEnded(bgCtx(), agentID); err != nil && !errors.Is(err, inputqueue.ErrManagerStopped) {
-			slog.Warn("advance agent input queue after turn end failed", "agent_id", agentID, "error", err)
+	// The one turn flag every provider publishes. A queue that already closed
+	// admission refuses it, and a Worker shutdown stops every agent it runs --
+	// so that refusal is the expected end of the signal, not a fault to report.
+	svc.Output.SetTurnActiveFunc(func(agentID string, active bool) {
+		reconcile, what := svc.InputQueue.TurnEnded, "turn end"
+		if active {
+			reconcile, what = svc.InputQueue.TurnStarted, "turn start"
 		}
-	})
-	svc.Output.SetTurnStartedFunc(func(agentID string) {
-		if _, err := svc.InputQueue.TurnStarted(bgCtx(), agentID); err != nil && !errors.Is(err, inputqueue.ErrManagerStopped) {
-			slog.Warn("mark agent input queue turn active failed", "agent_id", agentID, "error", err)
+		if _, err := reconcile(bgCtx(), agentID); err != nil && !errors.Is(err, inputqueue.ErrManagerStopped) {
+			slog.Warn("reconcile agent input queue with the provider's turn flag failed",
+				"agent_id", agentID, "edge", what, "error", err)
 		}
 	})
 	svc.startAgentFn = svc.Agents.StartAgent
@@ -634,6 +633,7 @@ func (svc *Service) startAgent(ctx context.Context, opts agent.Options, sink age
 	// A new process owns no turn. See NoteAgentProcessStarted for why this does
 	// not wait for the old process's exit handler to have said so.
 	svc.Output.NoteAgentProcessStarted(opts.AgentID)
+	svc.abandonUnownedTurn(opts.AgentID)
 	if svc.startAgentFn != nil {
 		return svc.startAgentFn(ctx, opts, sink)
 	}
@@ -651,6 +651,7 @@ func (svc *Service) startAgent(ctx context.Context, opts agent.Options, sink age
 func (svc *Service) startBackgroundAgent(ctx context.Context, opts agent.Options, sink agent.OutputSink) (map[string]string, error) {
 	// Same rule as startAgent: a new process owns no turn.
 	svc.Output.NoteAgentProcessStarted(opts.AgentID)
+	svc.abandonUnownedTurn(opts.AgentID)
 	if svc.startBackgroundAgentFn != nil {
 		return svc.startBackgroundAgentFn(ctx, opts, sink)
 	}
@@ -782,11 +783,19 @@ func (svc *Service) HandleAgentProcessExit(agentID string, _ int, _ error, stopp
 	// holding the tab open, which would otherwise keep a live Active dot and
 	// working Pause and Clear buttons until its next cold load.
 	svc.Output.publishGoalCapabilities(agentID)
-	if !stopped {
-		for _, queueAgentID := range svc.agentSubtreeIDs(agentID) {
-			if _, err := svc.InputQueue.Pause(bgCtx(), queueAgentID, leapmuxv1.AgentInputQueuePauseReason_AGENT_INPUT_QUEUE_PAUSE_REASON_AGENT_STOPPED); err != nil {
-				slog.Warn("pause agent input queue after process exit failed", "agent_id", queueAgentID, "error", err)
-			}
+	for _, queueAgentID := range svc.agentSubtreeIDs(agentID) {
+		if stopped {
+			// An explicit stop does NOT pause: the user asked for this exit, and
+			// the queue's own /clear dispatch stops the process on purpose. The
+			// turn still has to go, because the process that would have ended it
+			// is gone -- otherwise the queue holds every later message and the
+			// stop the user just made is what stranded it.
+			svc.abandonUnownedTurn(queueAgentID)
+			continue
+		}
+		// A crash pauses, and the pause ends the turn with it.
+		if _, err := svc.InputQueue.Pause(bgCtx(), queueAgentID, leapmuxv1.AgentInputQueuePauseReason_AGENT_INPUT_QUEUE_PAUSE_REASON_AGENT_STOPPED); err != nil {
+			slog.Warn("pause agent input queue after process exit failed", "agent_id", queueAgentID, "error", err)
 		}
 	}
 	// Last, so it observes the cleared prompts and the ended registry rows. This
@@ -794,6 +803,20 @@ func (svc *Service) HandleAgentProcessExit(agentID string, _ int, _ error, stopp
 	// this handler broadcasts no AgentStatusChange, so without it a lost process
 	// left every watching tab showing work that had already died.
 	svc.Output.NoteAgentProcessExited(agentID)
+}
+
+// abandonUnownedTurn reconciles the input queue with a process boundary. It is
+// the queue's half of NoteAgentProcessStarted / NoteAgentProcessExited, which
+// reset the activity latch for the same reason: no turn is in flight across a
+// process boundary.
+//
+// A turn the queue itself dispatched is left alone. That dispatch is still in
+// flight -- ensureAgentRunning starts the process from INSIDE it -- and its own
+// acceptance resolves the turn.
+func (svc *Service) abandonUnownedTurn(agentID string) {
+	if _, err := svc.InputQueue.TurnAbandoned(bgCtx(), agentID); err != nil && !errors.Is(err, inputqueue.ErrManagerStopped) {
+		slog.Warn("clear agent input queue turn at a process boundary failed", "agent_id", agentID, "error", err)
+	}
 }
 
 // agentSubtreeIDs returns the agent and every descendant of it. A subagent

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -593,13 +593,17 @@ func New(cfg Config) *Service {
 	queueAdapter := &agentInputQueueAdapter{svc: svc}
 	svc.InputQueue = inputqueue.NewManager(inputqueue.NewStore(cfg.DB), queueAdapter, queueAdapter)
 	svc.Output.SetSupportsSteeringFunc(queueAdapter.SupportsSteering)
-	svc.Output.SetInputReadyFunc(func(agentID string) {
-		if _, err := svc.InputQueue.TurnEnded(bgCtx(), agentID); err != nil {
+	// Both edges of the one turn flag every provider publishes. A queue that
+	// already closed admission refuses them, and a Worker shutdown stops every
+	// agent it runs -- so that refusal is the expected end of the signal, not a
+	// fault to report.
+	svc.Output.SetTurnEndedFunc(func(agentID string) {
+		if _, err := svc.InputQueue.TurnEnded(bgCtx(), agentID); err != nil && !errors.Is(err, inputqueue.ErrManagerStopped) {
 			slog.Warn("advance agent input queue after turn end failed", "agent_id", agentID, "error", err)
 		}
 	})
-	svc.Output.SetInputStartedFunc(func(agentID string) {
-		if _, err := svc.InputQueue.TurnStarted(bgCtx(), agentID); err != nil {
+	svc.Output.SetTurnStartedFunc(func(agentID string) {
+		if _, err := svc.InputQueue.TurnStarted(bgCtx(), agentID); err != nil && !errors.Is(err, inputqueue.ErrManagerStopped) {
 			slog.Warn("mark agent input queue turn active failed", "agent_id", agentID, "error", err)
 		}
 	})


### PR DESCRIPTION
## Motivation
The Worker runs one agent process per tab and dispatches each tab's durable input queue one message at a time, so a message never lands inside a turn that already runs. Before this change, the Worker kept two independent answers to "is a turn in flight": the flag every provider publishes through `OutputSink.SetTurnActive` (which drives the client-visible activity spinner), and the queue's own durable `agent_input_queue_state.active_turn` column, fed by a separate `InputStarted`/`InputReady` callback pair.

Only Codex ever raised the rising edge of that second pair, so every other provider left the queue's turn state stale until the queue dispatched a turn itself. Claude Code emits no turn-start frame at all, so a turn its CLI started on its own left both answers idle, and the user's next message went straight into the running turn instead of queuing behind it.

## Modifications
- `OutputSink.SetTurnActive` gains a monotonic ordering token: `SetTurnActive(active bool, seq uint64)`. The token comes from the same critical section that reads the provider's flag (a new `turnSeqSource`, embedded once in `processBase`), so the Worker can drop a publish that a newer one already overtook.
- New required `Agent.PublishTurnActive()`. `Manager.SendInput` calls it when a provider refuses with `ErrAgentBusy` — the one moment both consumers of the flag are known to be wrong — replacing a rule that used to be hand-written in four providers and enforced in none.
- Removes the `inputReadySink`/`inputStartedSink` interfaces and the `notifyInputStarted`/`notifyInputReady` helpers. `SetTurnActive` is now the single signal.
- Claude: new `armTurnFromOutput` inspects every root output frame (never a forwarded subagent frame) before the type switch and arms the turn on the rising edge, instead of only from the assistant message — which missed the whole extended-thinking window of a CLI-run turn. `disarmTurn` centralizes the falling edge the same way.
- Codex: a new `collabChildAgents` map survives `ClearContext` wiping the span index, so a child thread that cannot be resolved still ends its turn instead of holding its own input queue open forever. The turn-completed publish runs inline instead of in a goroutine, closing a reordering window against the next turn's start.
- ACP: `wireTurnActive` moves to `acpBase` and re-reads `b.sink` on every call, instead of capturing it once — the old capture published past every decorator that `startACPHandshake` wraps on afterward.
- Input queue: a new `DispatchOutcome` enum replaces the `ErrDispatchNotReady`/`ErrDispatchBusy` sentinels and the `DeliveryError.Uncertain` bool. A provider-busy refusal now returns the item to an open queue (`Store.RequeueBusy`) and releases the turn identity `PrepareDispatch` had provisionally claimed, instead of pausing the queue on a dispatch that never happened. A provider-reported turn now records `AGENT_INPUT_KIND_UNSPECIFIED` instead of a hardcoded `USER_MESSAGE`, which used to offer a Steer into a CLI-run compaction. `Store.TurnStarted`/`TurnEnded` report whether the state actually moved, so a repeated publish broadcasts nothing. New `Store.AbandonUnownedTurn`/`Manager.TurnAbandoned` clear a turn no dispatch owns at a process boundary.
- Worker service: a single `SetTurnActiveFunc` callback replaces the `SetInputReadyFunc`/`SetInputStartedFunc` pair. New `OutputHandler.acceptTurnPublish` drops a publish whose token is not newer than the last accepted one, and drops any publish from a sink that is not the currently adopted publisher (a replaced process still draining its pipe). `/clear` now consults the provider's live flag via `OutputHandler.TurnActive` and refuses with `DispatchBusy` while a turn runs, instead of trusting the queue's durable copy, which could go stale and let `/clear` kill an in-flight reply. New `Service.abandonUnownedTurn` runs at every process boundary (`startAgent`, `startBackgroundAgent`, both `HandleAgentProcessExit` branches), so stopping a stalled agent now actually clears its stuck turn. A child sink's publish no longer touches the root-only `settledToolUses` count, which used to erase the tool count the child's own turn-end had just recorded.

## Result
A message sent while an agent runs a turn on its own — most notably Claude Code, which never announces a turn start — now queues behind that turn instead of landing inside it, for every provider. `/clear` no longer terminates a reply that is still in flight. A Codex collaborative child agent no longer stalls its own queue when its span index is wiped mid-run. Stopping a stuck agent reliably releases its turn. The activity spinner and the durable queue state no longer disagree, because both now derive from the same ordered `SetTurnActive` signal.
