### PR TITLE
fix(worker): Adopt Claude Code's own turn-state signal

### DIFF
--- a/backend/internal/worker/agent/claude.go
+++ b/backend/internal/worker/agent/claude.go
@@ -97,9 +97,24 @@ type ClaudeCodeAgent struct {
 	sink       OutputSink
 
 	// Claude Code-specific state.
-	contextUsage           *contextUsageSnapshot
-	lastAgentStatus        string
-	turnActive             bool
+	contextUsage    *contextUsageSnapshot
+	lastAgentStatus string
+	turnActive      bool
+	// sessionStateReported records that this CLI publishes
+	// `system`/`session_state_changed`. Once it does, the output heuristic
+	// stands down for the life of the process: the CLI states its own turn
+	// state, so nothing else needs to be read as evidence of one, and no frame
+	// the vendor adds later can arm a turn that nothing ends.
+	sessionStateReported bool
+
+	// awaitingResult is true from the moment a message reaches the CLI's stdin
+	// until the `result` that answers it. It is what tells a STALE
+	// session_state_changed idle from a live one: the CLI emits idle before it
+	// reads the next message, so an idle that arrives after this Worker handed
+	// one over describes the state before that hand-over, and clearing the turn
+	// on it would open the queue on a turn about to start. See
+	// ClaudeCodeAgent.noteSessionIdle.
+	awaitingResult         bool
 	thirdPartyFromSettings bool // third-party LLM provider detected from settings at startup
 	// hasGoalCommand records whether the running CLI advertises /goal in its
 	// init frame's slash_commands. The command shipped in 2.1.139, so this is
@@ -180,6 +195,51 @@ func claudeResumeArgs(resumeSessionID string) ([]string, error) {
 			fmt.Errorf("the stored session ID is not a valid token: %w", err))
 	}
 	return []string{"--resume", resumeSessionID}, nil
+}
+
+// claudeSessionStateEnv makes Claude Code publish its own turn state on the
+// output stream, as `system`/`session_state_changed` frames carrying
+// running / requires_action / idle.
+//
+// The CLI keeps the frames behind this variable, and the variable alone: it
+// emits nothing without it, whatever the output format. The variable exists for
+// clients whose "is it working" answer is a scan of the last message, which the
+// trailing idle frame pins at "running" -- the exact heuristic this Worker
+// replaced with the flag every provider publishes, so the frame is what this
+// Worker wants and the reason to withhold it does not apply here.
+//
+// A CLI too old to know the variable ignores it and emits nothing. The output
+// heuristic in armTurnFromOutput still covers that build, which is why both
+// exist.
+const claudeSessionStateEnv = "CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1"
+
+// claudeAgentEnv builds the environment for one Claude Code launch, from the
+// environment the worker inherited.
+//
+// It is a function, not a run of appends at the call site, so a test can state
+// what the launch carries without a process. It takes the RAW inherited
+// environment for the same reason: the strip and the assignment for one variable
+// are one decision, and a call site that holds half of it puts that half out of
+// reach of a test.
+//
+// The pins REPLACE an inherited value; they do not layer over it. A worker that
+// a Claude Code session launched inherits each of these markers with the
+// PARENT's value. `exec.Cmd` resolves a duplicate last-wins, so a layered pin
+// still reaches the CLI with the right value, and leaves an environment that
+// states two values for one variable. See envutil.PinEnv.
+//
+// CLAUDECODE cannot go through PinEnv. Its strip is unconditional and its
+// assignment is not.
+func claudeAgentEnv(environ []string, loginShell bool) []string {
+	env := envutil.PinEnv(envutil.FilterEnv(environ, "CLAUDECODE"),
+		"CLAUDE_CODE_ENTRYPOINT=cli", claudeSessionStateEnv)
+	if loginShell {
+		// Set CLAUDECODE=1 so the user's shell rc files can detect they are
+		// being sourced inside Claude Code and skip conflicting aliases.
+		// The inner command unsets it before invoking claude.
+		env = append(env, "CLAUDECODE=1")
+	}
+	return env
 }
 
 // StartClaudeCode spawns a new Claude Code process and begins reading its output.
@@ -264,14 +324,7 @@ func StartClaudeCode(ctx context.Context, opts Options, sink OutputSink) (*Claud
 		WorkingDir:      opts.WorkingDir,
 	})
 
-	cmd.Env = envutil.FilterEnv(cmd.Environ(), "CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT")
-	cmd.Env = append(cmd.Env, "CLAUDE_CODE_ENTRYPOINT=cli")
-	if opts.LoginShell {
-		// Set CLAUDECODE=1 so the user's shell rc files can detect they are
-		// being sourced inside Claude Code and skip conflicting aliases.
-		// The inner command unsets it before invoking claude.
-		cmd.Env = append(cmd.Env, "CLAUDECODE=1")
-	}
+	cmd.Env = claudeAgentEnv(cmd.Environ(), opts.LoginShell)
 	cmd.Env = FinalizeAgentEnv(cmd.Env, opts)
 
 	// setupProcessPipes configures SIGTERM cancel, WaitDelay, and opens
@@ -682,6 +735,58 @@ func (a *ClaudeCodeAgent) armTurn() {
 	a.PublishTurnActive()
 }
 
+// noteSessionState applies one session_state_changed frame, and records that
+// this CLI publishes them at all.
+//
+// That record is what retires the output heuristic. The frame states the turn
+// state that armTurnFromOutput can only infer, so a build that sends it needs no
+// inference -- and the arming surface shrinks to the named signals this file
+// lists, which is what keeps a message the vendor adds later inert.
+func (a *ClaudeCodeAgent) noteSessionState(state string) {
+	a.mu.Lock()
+	a.sessionStateReported = true
+	a.mu.Unlock()
+	if state == claudeSessionStateIdle {
+		a.noteSessionIdle()
+		return
+	}
+	a.armTurn()
+}
+
+// publishesSessionState reports whether this CLI stated its own turn state at
+// least once.
+func (a *ClaudeCodeAgent) publishesSessionState() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.sessionStateReported
+}
+
+// noteSessionIdle applies the CLI's own idle report.
+//
+// It REFUSES an idle that arrives while a message this Worker sent has no
+// `result` yet. Claude Code emits idle when its run loop stops, before it reads
+// the next message, so such a frame describes the state before that message --
+// and the turn it would clear is the one about to start. The Worker's input
+// queue follows this flag, so the clear would dispatch the next message INTO
+// the running turn, which is the failure the flag exists to prevent.
+//
+// Every other idle clears the turn, and that is the point of reading the frame
+// at all. A turn armed from output has only `result` to end it, so one armed by
+// a frame that no turn produced would otherwise hold the queue until the process
+// exits.
+func (a *ClaudeCodeAgent) noteSessionIdle() {
+	a.mu.Lock()
+	stale := a.awaitingResult
+	if !stale {
+		a.turnActive = false
+	}
+	a.mu.Unlock()
+	if stale {
+		return
+	}
+	a.PublishTurnActive()
+}
+
 // disarmTurn records the end of the turn and publishes it, the way armTurn
 // records the start. OutputSink.SetTurnActive requires the mutation and the
 // publish at ONE site, and the falling edge kept them twenty lines apart in the
@@ -693,6 +798,9 @@ func (a *ClaudeCodeAgent) armTurn() {
 func (a *ClaudeCodeAgent) disarmTurn() {
 	a.mu.Lock()
 	a.turnActive = false
+	// The `result` this ends is the answer to whatever the Worker sent, so a
+	// later idle is no longer stale.
+	a.awaitingResult = false
 	a.mu.Unlock()
 	a.PublishTurnActive()
 }
@@ -762,6 +870,7 @@ func (a *ClaudeCodeAgent) sendInput(content string, attachments []*leapmuxv1.Att
 	// already in flight, so it opens none.
 	if priority == "" {
 		a.turnActive = true
+		a.awaitingResult = true
 	}
 
 	return nil

--- a/backend/internal/worker/agent/claude_output.go
+++ b/backend/internal/worker/agent/claude_output.go
@@ -157,7 +157,7 @@ func (a *ClaudeCodeAgent) handleClaudeOutput(content []byte, msgType string) {
 
 	slog.Debug("HandleOutput", "agent_id", a.agentID, "type", msgType, "len", len(content))
 
-	a.armTurnFromOutput(content, msgType)
+	a.observeTurnFromOutput(content, msgType)
 
 	switch msgType {
 	case claudeMsgTypeAssistant, claudeMsgTypeSystem, claudeMsgTypeResult:
@@ -1403,26 +1403,123 @@ func isSimpleUserTextEcho(content []byte) bool {
 	return len(trimmed) > 0 && trimmed[0] == '"'
 }
 
+// claudeSystemSubtypeSessionStateChanged is the `subtype` of the `system` frame
+// Claude Code publishes for its own turn state. It emits the frame only when
+// claudeSessionStateEnv is set.
+//
+// Two paths read it, and the split is deliberate. observeTurnFromOutput reads
+// the STATE it carries, which is the whole reason this Worker asks for the
+// frame. claudeHandleTaskEvent drops the frame from the timeline, because the
+// turn flag already carries what it means and the CLI sends one at every edge of
+// every turn.
+const claudeSystemSubtypeSessionStateChanged = "session_state_changed"
+
+// The states that a `system`/`session_state_changed` frame carries.
+const (
+	claudeSessionStateIdle           = "idle"
+	claudeSessionStateRunning        = "running"
+	claudeSessionStateRequiresAction = "requires_action"
+)
+
+// observeTurnFromOutput reads the CLI's turn state off one output frame and
+// records both edges.
+//
+// It prefers the CLI's OWN answer. With claudeSessionStateEnv set, Claude Code
+// publishes `system`/`session_state_changed` with running, requires_action or
+// idle, and that frame is authoritative: `running` opens the turn at the top of
+// the run loop, `requires_action` reports a turn that a permission prompt
+// blocks (still in flight), and `idle` fires after the last result flushes and
+// the background-agent loop exits. A ROOT frame that carries it therefore
+// decides alone, and the heuristic below never sees it. A forwarded child's copy
+// decides nothing, for the reason claudeIsRootFrame gives.
+//
+// The heuristic below is for a build that publishes no such frame, which is
+// every one that predates the variable. The FIRST session_state_changed frame
+// retires it for the life of the process, so on a current CLI the turn flag
+// moves on the named signals alone -- this frame, the Worker's own SendInput,
+// and `result`. See armTurnFromOutput.
+func (a *ClaudeCodeAgent) observeTurnFromOutput(content []byte, msgType string) {
+	if msgType == claudeMsgTypeSystem && claudeIsRootFrame(content) {
+		if state, ok := claudeSessionStateOf(content); ok {
+			a.noteSessionState(state)
+			return
+		}
+	}
+	if a.publishesSessionState() {
+		// This CLI states its turn state, and it did so already. Reading any
+		// other frame as evidence could only disagree with it.
+		return
+	}
+	a.armTurnFromOutput(content, msgType)
+}
+
+// claudeSessionStateOf reads the state of a `session_state_changed` frame, and
+// reports false for every other frame.
+//
+// An unknown state value is REFUSED rather than treated as a turn. The three
+// states are a closed set that the CLI's own schema states, so a fourth one is
+// a build this Worker does not know -- and answering "a turn runs" for it would
+// latch the queue on a frame nothing here can end.
+func claudeSessionStateOf(content []byte) (string, bool) {
+	var msg struct {
+		Subtype string `json:"subtype"`
+		State   string `json:"state"`
+	}
+	if err := json.Unmarshal(content, &msg); err != nil || msg.Subtype != claudeSystemSubtypeSessionStateChanged {
+		return "", false
+	}
+	switch msg.State {
+	case claudeSessionStateIdle, claudeSessionStateRunning, claudeSessionStateRequiresAction:
+		return msg.State, true
+	default:
+		slog.Warn("unknown claude session state", "state", msg.State)
+		return "", false
+	}
+}
+
 // armTurnFromOutput records a turn that the CLI runs and this Worker did not
-// start. Claude Code emits no turn-start frame of its own (Codex has
-// turn/started, ZCode turn.started), so without this the Worker learns of a turn
-// only from its own SendInput -- and a turn the CLI runs by itself, or one it
-// continues past a `result` the Worker already consumed, stayed invisible. Both
-// the turn flag and the input queue then read idle, and the next message the
-// user sent went straight into the running turn.
+// start, for a build that publishes no session_state_changed frame. Such a
+// build announces a turn start in no other way (Codex has turn/started, ZCode
+// turn.started), so without this the Worker learns of a turn only from its own
+// SendInput -- and a turn the CLI runs by itself, or one it continues past a
+// `result` the Worker already consumed, stayed invisible. Both the turn flag and
+// the input queue then read idle, and the next message the user sent went
+// straight into the running turn.
 //
 // It runs BEFORE the type switch, because the frames that prove a live turn
-// earliest are the ones that return early: the thinking-token telemetry and the
-// notification-threaded `system` lines never reach handlePersistableMessage, and
-// a root `user` tool_result is skipped there. Arming from the assistant message
-// alone left the whole extended-thinking window of a CLI-run turn invisible,
-// which is the longest part of it.
+// earliest are the ones that return early: the thinking-token telemetry never
+// reaches handlePersistableMessage, and a root `user` tool_result is skipped
+// there. Arming from the assistant message alone left the whole
+// extended-thinking window of a CLI-run turn invisible, which is the longest
+// part of it.
 //
-// The class is "a ROOT frame that only a live turn produces". A forwarded
-// subagent envelope carries parent_tool_use_id and belongs to the child, and it
-// says nothing about the root, which may well be idle while a restarted subagent
-// runs on. `result` ENDS a turn, and `control_*` frames are the Worker's own
-// traffic, so neither arms anything.
+// The class is "a ROOT frame that only a live turn produces", and
+// claudeIsRootFrame supplies the first half. `result` ENDS a turn, and
+// `control_*` frames are the Worker's own traffic, so neither arms anything.
+//
+// The `system` type is the narrow one, because it carries four unrelated
+// families and only ONE of them reports the root's own work:
+//
+//   - The thinking-token telemetry, which the model emits as it thinks. This one
+//     arms the turn.
+//   - `init` announces a SESSION. The CLI emits it at startup, and again after a
+//     context clear, at a moment when no turn exists.
+//   - The task_* family and background_tasks_changed belong to a BACKGROUND
+//     task, which outlives the turn that spawned it. A backgrounded shell
+//     reports task_progress for as long as it runs, with the root idle.
+//   - The notification-threaded lines -- status, api_retry, both compaction
+//     boundaries -- report an event, not a live turn. A status CLEAR is the end
+//     of the work it announced, an api_retry can answer a call the CLI makes on
+//     its own, and a compaction boundary lands on a resumed session before any
+//     turn starts.
+//
+// So the `system` test is an allowlist of one, and an unknown subtype arms
+// nothing. That direction is the safe one, and the asymmetry is the whole point.
+// A turn this misses is armed a moment later by the assistant message that
+// follows it. A turn armed with no turn to end it latches until the process
+// exits: `result` is the only falling edge, and nothing ever sends one. The
+// queue then holds every message the user sends, unpaused and with no visible
+// cause, and the client shows a thinking indicator that nothing stops.
 //
 // The clear needs no counterpart rule: Claude ends EVERY turn with a `result`,
 // including an interrupted or a failed one, and a `result` always follows the
@@ -1430,15 +1527,38 @@ func isSimpleUserTextEcho(content []byte) bool {
 // process boundary instead, where the Worker releases a turn no dispatch owns.
 func (a *ClaudeCodeAgent) armTurnFromOutput(content []byte, msgType string) {
 	switch msgType {
-	case claudeMsgTypeAssistant, claudeMsgTypeUser, claudeMsgTypeSystem:
+	case claudeMsgTypeAssistant, claudeMsgTypeUser:
+	case claudeMsgTypeSystem:
+		if _, thinking := parseThinkingTokens(content); !thinking {
+			return
+		}
 	default:
 		return
 	}
-	var envelope struct {
-		ParentToolUseID string `json:"parent_tool_use_id"`
-	}
-	if err := json.Unmarshal(content, &envelope); err != nil || envelope.ParentToolUseID != "" {
+	if !claudeIsRootFrame(content) {
 		return
 	}
 	a.armTurn()
+}
+
+// claudeIsRootFrame reports whether an output frame describes the ROOT agent.
+//
+// A forwarded subagent envelope carries parent_tool_use_id and belongs to the
+// child, whose turn is its own: a child runs on while the root waits for it, and
+// a restarted child runs while the root is idle. So no frame that carries the
+// field may move the root's turn flag, whether it reports the state (a
+// session_state_changed frame) or only implies it (the thinking-token telemetry,
+// an assistant message).
+//
+// A frame this cannot parse is not a root frame. Nothing downstream reads a
+// frame the JSON decoder refused, and answering "root" for one would arm a turn
+// off bytes with no established shape.
+func claudeIsRootFrame(content []byte) bool {
+	var envelope struct {
+		ParentToolUseID string `json:"parent_tool_use_id"`
+	}
+	if err := json.Unmarshal(content, &envelope); err != nil {
+		return false
+	}
+	return envelope.ParentToolUseID == ""
 }

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -142,8 +142,11 @@ func (a *ClaudeCodeAgent) claudeHandleTaskEvent(content []byte) bool {
 		// events and drops a NON-bookend event first when it fills, so one lost
 		// level event would hide a real background shell for its whole run.
 		return true
-	case "session_state_changed":
-		// Consumed silently: carries session bookkeeping we don't surface.
+	case claudeSystemSubtypeSessionStateChanged:
+		// Consumed here so the frame never reaches the timeline. It reports the
+		// CLI's own turn state, which observeTurnFromOutput already read off it
+		// -- and the turn flag carries what it means, so the frame itself has
+		// nothing for a reader. The CLI sends one at every edge of every turn.
 		return true
 	default:
 		return false

--- a/backend/internal/worker/agent/factory_test.go
+++ b/backend/internal/worker/agent/factory_test.go
@@ -35,6 +35,7 @@ func TestFinalizeAgentEnv_ScrubsAgentIdentity(t *testing.T) {
 	// FinalizeAgentEnv, plus auth tokens, provider-selection, and config dirs.
 	mustSurvive := []string{
 		"CLAUDECODE", "CODEX_CI", "OPENCODE_CLIENT", "KILO_CLIENT", "CLAUDE_CODE_ENTRYPOINT",
+		"CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS",
 		"CLAUDE_CODE_OAUTH_TOKEN", "OPENAI_API_KEY", "CODEX_API_KEY",
 		"CLAUDE_CODE_USE_BEDROCK", "CODEX_HOME", "GOOSE_MODEL", "PI_CODING_AGENT_DIR", "PATH",
 	}
@@ -46,7 +47,7 @@ func TestFinalizeAgentEnv_ScrubsAgentIdentity(t *testing.T) {
 		}
 		env = append(env,
 			"CLAUDECODE=1", "CODEX_CI=1", "OPENCODE_CLIENT=1", "KILO_CLIENT=1",
-			"CLAUDE_CODE_ENTRYPOINT=cli",
+			"CLAUDE_CODE_ENTRYPOINT=cli", "CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1",
 			"CLAUDE_CODE_OAUTH_TOKEN=tok", "OPENAI_API_KEY=sk-test", "CODEX_API_KEY=sk-codex",
 			"CLAUDE_CODE_USE_BEDROCK=1", "CODEX_HOME=/home/u/.codex", "GOOSE_MODEL=gpt-x",
 			"PI_CODING_AGENT_DIR=/home/u/.pi", "PATH=/usr/bin:/bin",

--- a/backend/internal/worker/agent/turn_active_test.go
+++ b/backend/internal/worker/agent/turn_active_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/leapmux/leapmux/generated/contracts"
+	"github.com/leapmux/leapmux/internal/util/envutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -506,11 +507,10 @@ func TestClaudeTurnActive_EveryRootFrameOfALiveTurnArmsIt(t *testing.T) {
 	t.Parallel()
 
 	// The frames that prove a live turn EARLIEST are the ones that return before
-	// the persist path: the thinking-token telemetry and the notification-
-	// threaded system lines, and a root user tool_result. Arming from the
-	// assistant message alone left the whole extended-thinking window of a
-	// CLI-run turn invisible, and a message the user sent inside it went
-	// straight into that turn.
+	// the persist path: the thinking-token telemetry, and a root user
+	// tool_result. Arming from the assistant message alone left the whole
+	// extended-thinking window of a CLI-run turn invisible, and a message the
+	// user sent inside it went straight into that turn.
 	for _, tc := range []struct {
 		name string
 		line string
@@ -518,10 +518,6 @@ func TestClaudeTurnActive_EveryRootFrameOfALiveTurnArmsIt(t *testing.T) {
 		{
 			name: "thinking tokens",
 			line: `{"type":"system","subtype":"thinking_tokens","thinking_tokens":120}`,
-		},
-		{
-			name: "notification-threaded status",
-			line: `{"type":"system","subtype":"compacting","status":"compacting"}`,
 		},
 		{
 			name: "root user tool_result",
@@ -661,4 +657,313 @@ func TestTurnActive_EveryProviderIssuesRisingOrderingTokens(t *testing.T) {
 			assert.Greater(t, seqs[2], seqs[1])
 		})
 	}
+}
+
+func TestClaudeTurnActive_ASystemFrameOutsideATurnArmsNothing(t *testing.T) {
+	t.Parallel()
+
+	// `system` carries four families and only the thinking-token telemetry
+	// reports the root's own work. Arming from the whole type latched a turn
+	// that no `result` ever ends, and BOTH consumers of the flag then broke for
+	// the rest of the process: the input queue held every message the user sent
+	// -- unpaused, with nothing to drain it -- and the client ran a thinking
+	// indicator for an agent that does nothing.
+	//
+	// The startup init frame is the one every session emits, so a new agent tab
+	// reached that state before the user typed anything.
+	for _, tc := range []struct {
+		name string
+		line string
+	}{
+		{
+			name: "startup init",
+			line: `{"type":"system","subtype":"init","session_id":"s-1","slash_commands":["clear","compact"]}`,
+		},
+		{
+			name: "background task progress",
+			line: `{"type":"system","subtype":"task_progress","task_id":"t-1","description":"npm test"}`,
+		},
+		{
+			name: "background task notification",
+			line: `{"type":"system","subtype":"task_notification","task_id":"t-1","status":"completed"}`,
+		},
+		{
+			name: "background tasks changed",
+			line: `{"type":"system","subtype":"background_tasks_changed","tasks":[]}`,
+		},
+		{
+			name: "notification-threaded status",
+			line: `{"type":"system","subtype":"status","status":"compacting"}`,
+		},
+		{
+			name: "status clear",
+			line: `{"type":"system","subtype":"status","status":""}`,
+		},
+		{
+			name: "api retry",
+			line: `{"type":"system","subtype":"api_retry","attempt":2}`,
+		},
+		{
+			name: "compaction boundary",
+			line: `{"type":"system","subtype":"compact_boundary","compact_metadata":{"trigger":"auto"}}`,
+		},
+		{
+			name: "unknown subtype",
+			line: `{"type":"system","subtype":"some_future_event"}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			a, _ := newClaudeAgentWithStdin(sink)
+
+			a.HandleOutput([]byte(tc.line))
+
+			assert.NotContains(t, sink.TurnActives(), true, "this frame runs no turn")
+			assert.NoError(t, a.SendInput("first", nil), "the next message must reach the CLI")
+		})
+	}
+}
+
+func TestClaudeTurnActive_TheCLIsOwnSessionStateDecides(t *testing.T) {
+	t.Parallel()
+
+	// With claudeSessionStateEnv set, Claude Code publishes its own turn state.
+	// That frame is authoritative and the output heuristic never sees it:
+	// `running` opens the turn before any assistant message, `requires_action`
+	// reports a turn that a permission prompt blocks, and `idle` ends it after
+	// the last result flushes.
+	for _, tc := range []struct {
+		name string
+		line string
+		want []bool
+	}{
+		{
+			name: "running opens the turn",
+			line: `{"type":"system","subtype":"session_state_changed","state":"running"}`,
+			want: []bool{true},
+		},
+		{
+			name: "requires_action is a turn a prompt blocks",
+			line: `{"type":"system","subtype":"session_state_changed","state":"requires_action"}`,
+			want: []bool{true},
+		},
+		{
+			name: "an unknown state decides nothing",
+			line: `{"type":"system","subtype":"session_state_changed","state":"quiescing"}`,
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sink := &testSink{}
+			a, _ := newClaudeAgentWithStdin(sink)
+
+			a.HandleOutput([]byte(tc.line))
+
+			assert.Equal(t, tc.want, sink.TurnActives())
+		})
+	}
+}
+
+func TestClaudeTurnActive_SessionStateIdleEndsATurnWithNoResult(t *testing.T) {
+	t.Parallel()
+
+	// The idle frame is the recovery this provider otherwise has none of. A turn
+	// the CLI runs is normally ended by its `result`, and a turn armed with no
+	// result behind it would hold the input queue until the process exits. The
+	// CLI's own idle answers that case.
+	sink := &testSink{}
+	a, _ := newClaudeAgentWithStdin(sink)
+
+	a.HandleOutput([]byte(`{"type":"system","subtype":"session_state_changed","state":"running"}`))
+	require.ErrorIs(t, a.SendInput("second", nil), ErrAgentBusy)
+
+	a.HandleOutput([]byte(`{"type":"system","subtype":"session_state_changed","state":"idle"}`))
+
+	assert.Equal(t, []bool{true, true, false}, sink.TurnActives(),
+		"the refused send republishes the flag; idle then clears it")
+	assert.NoError(t, a.SendInput("second", nil), "the queue dispatches again")
+}
+
+func TestClaudeLaunchEnv_CarriesTheTurnSignalOptIn(t *testing.T) {
+	t.Parallel()
+
+	// Claude Code publishes session_state_changed for this variable alone. A
+	// launch that drops it silently falls back to the output heuristic, and
+	// nothing else reports the loss.
+	t.Run("a plain launch", func(t *testing.T) {
+		t.Parallel()
+
+		env := claudeAgentEnv([]string{"PATH=/usr/bin"}, false)
+
+		assert.Contains(t, env, "CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1")
+		assert.Contains(t, env, "CLAUDE_CODE_ENTRYPOINT=cli")
+		assert.Contains(t, env, "PATH=/usr/bin", "the inherited environment survives")
+		assert.False(t, envutil.HasKey(env, "CLAUDECODE"),
+			"only a login shell needs the rc-file marker")
+	})
+
+	t.Run("a login shell", func(t *testing.T) {
+		t.Parallel()
+
+		env := claudeAgentEnv([]string{"PATH=/usr/bin"}, true)
+
+		assert.Contains(t, env, "CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1")
+		assert.Equal(t, []string{"1"}, envutil.ValuesFor(env, "CLAUDECODE"))
+	})
+
+	// A worker that a Claude Code session itself launched inherits all three
+	// markers, and each inherited value is the PARENT's. A pin that layers
+	// instead of replacing still reaches the CLI with the right value, because
+	// exec resolves a duplicate last-wins -- and leaves an environment that says
+	// two things, which is what makes the layering invisible until something
+	// else reads it.
+	t.Run("an inherited value is replaced, not layered", func(t *testing.T) {
+		t.Parallel()
+
+		env := claudeAgentEnv([]string{
+			"PATH=/usr/bin",
+			"CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=0",
+			"CLAUDE_CODE_ENTRYPOINT=sdk-ts",
+			"CLAUDECODE=1",
+		}, false)
+
+		assert.Equal(t, []string{"1"}, envutil.ValuesFor(env, "CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS"))
+		assert.Equal(t, []string{"cli"}, envutil.ValuesFor(env, "CLAUDE_CODE_ENTRYPOINT"))
+		assert.Empty(t, envutil.ValuesFor(env, "CLAUDECODE"),
+			"the inherited marker is stripped, and only a login shell re-adds it")
+	})
+
+	// The inherited environment is the caller's slice. Building the launch env
+	// by appending to it writes into the spare capacity that slice owns, so a
+	// second launch overwrites what the first one holds.
+	t.Run("two launches do not share a backing array", func(t *testing.T) {
+		t.Parallel()
+
+		inherited := make([]string, 0, 8)
+		inherited = append(inherited, "PATH=/usr/bin")
+
+		plain := claudeAgentEnv(inherited, false)
+		login := claudeAgentEnv(inherited, true)
+
+		assert.Contains(t, plain, "CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1")
+		assert.False(t, envutil.HasKey(plain, "CLAUDECODE"), "the second launch wrote over the first")
+		assert.Equal(t, []string{"1"}, envutil.ValuesFor(login, "CLAUDECODE"))
+		assert.Equal(t, []string{"PATH=/usr/bin"}, inherited, "the caller's environment is unchanged")
+	})
+}
+
+func TestClaudeTurnActive_ResultStillEndsATurnTheCLIOpened(t *testing.T) {
+	t.Parallel()
+
+	// Retiring the output heuristic must not retire the falling edge. `result`
+	// ends every Claude turn and arrives BEFORE the idle that reports it, so the
+	// Worker's input queue opens on the result -- one frame earlier than the
+	// CLI's own report, and on the frame every build sends.
+	sink := &testSink{}
+	a, _ := newClaudeAgentWithStdin(sink)
+
+	a.HandleOutput([]byte(`{"type":"system","subtype":"session_state_changed","state":"running"}`))
+	a.HandleOutput([]byte(`{"type":"result","subtype":"success"}`))
+
+	assert.Equal(t, []bool{true, false}, sink.TurnActives())
+	assert.NoError(t, a.SendInput("next", nil), "the queue dispatches on the result")
+}
+
+func TestClaudeTurnActive_AForwardedChildStateDecidesNothing(t *testing.T) {
+	t.Parallel()
+
+	// A forwarded subagent envelope carries parent_tool_use_id, and the child's
+	// turn is not the root's: a restarted subagent runs on while the root sits
+	// idle. So a child's copy of the frame decides nothing -- for the idle, the
+	// clear it would publish is exactly the failure the turn flag exists to
+	// prevent, because the input queue would then dispatch into the root's
+	// running turn.
+	t.Run("a child idle leaves the root's turn running", func(t *testing.T) {
+		t.Parallel()
+
+		sink := &testSink{}
+		a, _ := newClaudeAgentWithStdin(sink)
+
+		a.HandleOutput([]byte(`{"type":"system","subtype":"session_state_changed","state":"running"}`))
+		a.HandleOutput([]byte(`{"type":"system","parent_tool_use_id":"p1","subtype":"session_state_changed","state":"idle"}`))
+
+		assert.Equal(t, []bool{true}, sink.TurnActives(), "only the root's own state moves the flag")
+		assert.ErrorIs(t, a.SendInput("next", nil), ErrAgentBusy)
+	})
+
+	t.Run("a child state does not retire the heuristic", func(t *testing.T) {
+		t.Parallel()
+
+		sink := &testSink{}
+		a, _ := newClaudeAgentWithStdin(sink)
+
+		a.HandleOutput([]byte(`{"type":"system","parent_tool_use_id":"p1","subtype":"session_state_changed","state":"running"}`))
+		require.Empty(t, sink.TurnActives(), "a child's frame arms nothing")
+
+		// The ROOT has still stated nothing, so its assistant message is still
+		// the evidence that a turn runs. A child frame that retired the
+		// heuristic would leave this build with no rising edge at all.
+		a.HandleOutput([]byte(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}`))
+
+		assert.Equal(t, []bool{true}, sink.TurnActives())
+	})
+}
+
+func TestClaudeTurnActive_AStaleSessionIdleDoesNotOpenTheNextTurn(t *testing.T) {
+	t.Parallel()
+
+	// The CLI emits idle when its run loop stops, BEFORE it reads the next
+	// message. The Worker dispatches that message off the turn end it already
+	// saw, so its send can land between the two frames -- and an idle applied
+	// after it would clear the turn that message just opened. The input queue
+	// follows this flag, so the next message would then dispatch INTO the
+	// running turn.
+	sink := &testSink{}
+	a, _ := newClaudeAgentWithStdin(sink)
+
+	require.NoError(t, a.SendInput("first", nil))
+	a.HandleOutput([]byte(`{"type":"result","subtype":"success"}`))
+	// The queue drains on that turn end and hands the CLI the next message.
+	require.NoError(t, a.SendInput("second", nil))
+
+	// The previous turn's idle arrives now.
+	a.HandleOutput([]byte(`{"type":"system","subtype":"session_state_changed","state":"idle"}`))
+
+	assert.Equal(t, []bool{true, false, true}, sink.TurnActives(),
+		"the stale idle publishes nothing")
+	assert.ErrorIs(t, a.SendInput("third", nil), ErrAgentBusy,
+		"the second turn is still in flight")
+
+	// The result for the second message ends it, and a later idle is current
+	// again. The refused send above republished the unchanged flag, which is
+	// what reconciles a queue that dispatched into the turn.
+	a.HandleOutput([]byte(`{"type":"result","subtype":"success"}`))
+	a.HandleOutput([]byte(`{"type":"system","subtype":"session_state_changed","state":"idle"}`))
+	assert.Equal(t, []bool{true, false, true, true, false, false}, sink.TurnActives())
+}
+
+func TestClaudeTurnActive_TheHeuristicRetiresOnceTheCLIStatesItsOwnTurn(t *testing.T) {
+	t.Parallel()
+
+	// The output heuristic exists for a CLI that publishes no
+	// session_state_changed frame. A CLI that publishes one has stated the
+	// answer, so nothing else is read as evidence for the life of the process --
+	// and the arming surface shrinks to the named signals, which is what keeps a
+	// frame the vendor adds later inert.
+	sink := &testSink{}
+	a, _ := newClaudeAgentWithStdin(sink)
+
+	a.HandleOutput([]byte(`{"type":"system","subtype":"session_state_changed","state":"idle"}`))
+	require.Equal(t, []bool{false}, sink.TurnActives())
+
+	// A root assistant frame is the heuristic's strongest evidence. It arms
+	// nothing here: this CLI reports `running` when a turn starts.
+	a.HandleOutput([]byte(`{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}`))
+
+	assert.Equal(t, []bool{false}, sink.TurnActives(), "the CLI's own state is the only source now")
+	assert.NoError(t, a.SendInput("next", nil), "the queue still dispatches")
 }

--- a/backend/internal/worker/agent/turn_signal_whitelist_test.go
+++ b/backend/internal/worker/agent/turn_signal_whitelist_test.go
@@ -1,0 +1,304 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/leapmux/leapmux/generated/contracts"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The turn flag is the input queue's only dispatch guard and the client's only
+// activity signal, and it LATCHES: a turn armed with nothing to end it holds
+// every message the user sends -- queued, unpaused, with no visible cause --
+// and runs a thinking indicator that nothing stops, until the process exits.
+//
+// So each provider NAMES the frames that move that flag, and everything else is
+// inert. The vendors own these vocabularies and extend them between releases, so
+// the rule that matters is the one about frames this build has never seen: a
+// message added after it must move nothing. That is what these tables state, per
+// provider, against the vocabulary each vendor ships today plus a message that
+// does not exist yet.
+//
+// A frame that starts moving the flag is a deliberate act. It shows up here as a
+// changed table entry, not as a wedged tab.
+
+// turnFrameCase is one output frame and whether it may move the turn flag.
+type turnFrameCase struct {
+	name string
+	line string
+	// moves is true for a NAMED turn signal of this provider. Every other frame
+	// must publish nothing at all.
+	moves bool
+}
+
+// assertTurnFrames feeds each frame to a FRESH agent, so no case can be answered
+// by state another one left.
+func assertTurnFrames(t *testing.T, cases []turnFrameCase, feed func(t *testing.T, tc turnFrameCase) []bool) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			published := feed(t, tc)
+			if tc.moves {
+				assert.NotEmpty(t, published, "a named turn signal must move the flag")
+				return
+			}
+			assert.Empty(t, published, "only a named turn signal may move the flag")
+		})
+	}
+}
+
+func TestTurnSignalWhitelist_Claude(t *testing.T) {
+	t.Parallel()
+
+	// Claude Code's `system` type carries four unrelated families under 49
+	// subtypes, and only the thinking-token telemetry reports the root's own
+	// work. session_state_changed is the CLI's own turn state and outranks all
+	// of it (see observeTurnFromOutput).
+	assertTurnFrames(t, []turnFrameCase{
+		// The named signals.
+		{name: "session state running", line: `{"type":"system","subtype":"session_state_changed","state":"running"}`, moves: true},
+		{name: "session state requires_action", line: `{"type":"system","subtype":"session_state_changed","state":"requires_action"}`, moves: true},
+		{name: "session state idle", line: `{"type":"system","subtype":"session_state_changed","state":"idle"}`, moves: true},
+		{name: "thinking tokens", line: `{"type":"system","subtype":"thinking_tokens","estimated_tokens":120}`, moves: true},
+		{name: "root assistant text", line: `{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]}}`, moves: true},
+		{name: "root user echo", line: `{"type":"user","message":{"role":"user","content":"hi"}}`, moves: true},
+		{name: "result", line: `{"type":"result","subtype":"success"}`, moves: true},
+
+		// A session, not a turn.
+		{name: "init", line: `{"type":"system","subtype":"init","session_id":"s-1"}`},
+		{name: "session state unknown", line: `{"type":"system","subtype":"session_state_changed","state":"quiescing"}`},
+
+		// Hooks. These fire on SessionStart, SessionEnd, ConfigChange,
+		// FileChanged and TeammateIdle, none of which is a turn.
+		{name: "hook started", line: `{"type":"system","subtype":"hook_started","hook_event":"SessionStart","hook_id":"h1"}`},
+		{name: "hook progress", line: `{"type":"system","subtype":"hook_progress","hook_event":"SessionStart","hook_id":"h1"}`},
+		{name: "hook response", line: `{"type":"system","subtype":"hook_response","hook_event":"SessionStart","hook_id":"h1","exit_code":0}`},
+
+		// A background task outlives the turn that spawned it.
+		{name: "task started", line: `{"type":"system","subtype":"task_started","task_id":"t-1","task_type":"local_bash","description":"npm test"}`},
+		{name: "task progress", line: `{"type":"system","subtype":"task_progress","task_id":"t-1","description":"npm test"}`},
+		{name: "task notification", line: `{"type":"system","subtype":"task_notification","task_id":"t-1","status":"completed"}`},
+		{name: "task updated", line: `{"type":"system","subtype":"task_updated","task_id":"t-1","patch":{"status":"completed"}}`},
+		{name: "background tasks changed", line: `{"type":"system","subtype":"background_tasks_changed","tasks":[]}`},
+
+		// Notifications: an event, not a live turn.
+		{name: "status compacting", line: `{"type":"system","subtype":"status","status":"compacting"}`},
+		{name: "status clear", line: `{"type":"system","subtype":"status","status":""}`},
+		{name: "permission mode status", line: `{"type":"system","subtype":"status","status":null,"permissionMode":"plan"}`},
+		{name: "api retry", line: `{"type":"system","subtype":"api_retry","attempt":2}`},
+		{name: "compact boundary", line: `{"type":"system","subtype":"compact_boundary","compact_metadata":{"trigger":"auto"}}`},
+		{name: "microcompact boundary", line: `{"type":"system","subtype":"microcompact_boundary"}`},
+
+		// Emitted after the turn its `result` already ended.
+		{name: "turn duration", line: `{"type":"system","subtype":"turn_duration","durationMs":1200}`},
+		{name: "post turn summary", line: `{"type":"system","subtype":"post_turn_summary","status_category":"done"}`},
+		{name: "files persisted", line: `{"type":"system","subtype":"files_persisted","files":[]}`},
+
+		// Bookkeeping the CLI reports whenever it changes.
+		{name: "commands changed", line: `{"type":"system","subtype":"commands_changed"}`},
+		{name: "vcs state changed", line: `{"type":"system","subtype":"vcs_state_changed"}`},
+		{name: "elicitation complete", line: `{"type":"system","subtype":"elicitation_complete","elicitation_id":"e1"}`},
+		{name: "scheduled task fire", line: `{"type":"system","subtype":"scheduled_task_fire"}`},
+		{name: "memory saved", line: `{"type":"system","subtype":"memory_saved"}`},
+
+		// This Worker's own traffic.
+		{name: "control request", line: `{"type":"control_request","request_id":"r1","request":{"subtype":"can_use_tool"}}`},
+		{name: "control response", line: `{"type":"control_response","response":{"request_id":"r1","subtype":"success"}}`},
+		{name: "tool progress", line: `{"type":"tool_progress","parent_tool_use_id":"t1","heartbeat":true}`},
+
+		// A child's frame says nothing about the root. The child's own session
+		// state is the sharpest case: it reports a turn in the same words the
+		// root uses, and the root may be idle while a restarted child runs on.
+		{name: "subagent assistant text", line: `{"type":"assistant","parent_tool_use_id":"p1","message":{"role":"assistant","content":[{"type":"text","text":"child"}]}}`},
+		{name: "subagent result", line: `{"type":"result","parent_tool_use_id":"p1","subtype":"success"}`},
+		{name: "subagent session state running", line: `{"type":"system","parent_tool_use_id":"p1","subtype":"session_state_changed","state":"running"}`},
+		{name: "subagent session state idle", line: `{"type":"system","parent_tool_use_id":"p1","subtype":"session_state_changed","state":"idle"}`},
+
+		// The releases this build will not see.
+		{name: "a subtype from a later release", line: `{"type":"system","subtype":"some_future_event","data":1}`},
+		{name: "a type from a later release", line: `{"type":"some_future_frame","data":1}`},
+	}, func(t *testing.T, tc turnFrameCase) []bool {
+		sink := &testSink{}
+		a, _ := newClaudeAgentWithStdin(sink)
+		a.HandleOutput([]byte(tc.line))
+		return sink.TurnActives()
+	})
+}
+
+func TestTurnSignalWhitelist_Codex(t *testing.T) {
+	t.Parallel()
+
+	// Codex states both edges itself, so every other notification of its ~90 is
+	// inert -- including the hook and item bookends, whose names read like turn
+	// boundaries and are not.
+	assertTurnFrames(t, []turnFrameCase{
+		{name: "turn started", line: `{"jsonrpc":"2.0","method":"turn/started","params":{"threadId":"main-thread","turn":{"id":"turn-1"}}}`, moves: true},
+		{name: "turn completed", line: `{"jsonrpc":"2.0","method":"turn/completed","params":{"threadId":"main-thread","turn":{"id":"turn-1","status":"completed"}}}`, moves: true},
+
+		{name: "item started", line: `{"jsonrpc":"2.0","method":"item/started","params":{"threadId":"main-thread","item":{"id":"i1","itemType":"agentMessage"}}}`},
+		{name: "item completed", line: `{"jsonrpc":"2.0","method":"item/completed","params":{"threadId":"main-thread","item":{"id":"i1","itemType":"agentMessage","text":"hi"}}}`},
+		{name: "agent message delta", line: `{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"threadId":"main-thread","itemId":"i1","delta":"hi"}}`},
+		{name: "hook started", line: `{"jsonrpc":"2.0","method":"hook/started","params":{"threadId":"main-thread"}}`},
+		{name: "hook completed", line: `{"jsonrpc":"2.0","method":"hook/completed","params":{"threadId":"main-thread"}}`},
+		{name: "turn diff updated", line: `{"jsonrpc":"2.0","method":"turn/diff/updated","params":{"threadId":"main-thread"}}`},
+		{name: "turn plan updated", line: `{"jsonrpc":"2.0","method":"turn/plan/updated","params":{"threadId":"main-thread"}}`},
+		{name: "token usage updated", line: `{"jsonrpc":"2.0","method":"thread/tokenUsage/updated","params":{"threadId":"main-thread","usage":{}}}`},
+		{name: "rate limits updated", line: `{"jsonrpc":"2.0","method":"account/rateLimits/updated","params":{}}`},
+		{name: "thread compacted", line: `{"jsonrpc":"2.0","method":"thread/compacted","params":{"threadId":"main-thread"}}`},
+		{name: "fs changed", line: `{"jsonrpc":"2.0","method":"fs/changed","params":{}}`},
+		{name: "warning", line: `{"jsonrpc":"2.0","method":"warning","params":{"message":"careful"}}`},
+		{name: "error", line: `{"jsonrpc":"2.0","method":"error","params":{"message":"boom"}}`},
+
+		{name: "a method from a later release", line: `{"jsonrpc":"2.0","method":"turn/futureSignal","params":{"threadId":"main-thread"}}`},
+	}, func(t *testing.T, tc turnFrameCase) []bool {
+		sink := &recordingControlSink{}
+		a := newCodexAgentWithSink(sink)
+		handleCodexOutput(a, parseLine([]byte(tc.line)))
+		return sink.TurnActives()
+	})
+}
+
+func TestTurnSignalWhitelist_Pi(t *testing.T) {
+	t.Parallel()
+
+	// Pi's run bookends are agent_start and agent_end. Its turn_start/turn_end
+	// pair is the INNER loop -- one assistant response inside the run -- so the
+	// two events whose names match "turn" are the two that must move nothing.
+	assertTurnFrames(t, []turnFrameCase{
+		{name: "agent start", line: `{"type":"agent_start"}`, moves: true},
+		{name: "agent end", line: `{"type":"agent_end","willRetry":false}`, moves: true},
+
+		{name: "turn start", line: `{"type":"turn_start"}`},
+		{name: "turn end", line: `{"type":"turn_end","message":{"role":"assistant","content":[]}}`},
+		{name: "message start", line: `{"type":"message_start","message":{"role":"assistant","content":[]}}`},
+		{name: "message end", line: `{"type":"message_end","message":{"role":"assistant","content":[]}}`},
+		{name: "tool execution start", line: `{"type":"tool_execution_start","toolCallId":"t1","toolName":"bash"}`},
+		{name: "tool execution end", line: `{"type":"tool_execution_end","toolCallId":"t1","toolName":"bash","isError":false}`},
+
+		{name: "an event from a later release", line: `{"type":"agent_future_event"}`},
+	}, func(t *testing.T, tc turnFrameCase) []bool {
+		sink := &recordingControlSink{}
+		a := newPiAgentWithSink(sink)
+		handlePiOutput(a, parseLine([]byte(tc.line)))
+		return sink.TurnActives()
+	})
+}
+
+func TestTurnSignalWhitelist_ACP(t *testing.T) {
+	t.Parallel()
+
+	// The six ACP providers share one rule, and it needs no vocabulary at all:
+	// the turn is the lifetime of the session/prompt request this Worker sent,
+	// so NO notification moves the flag. These are the updates that arrive with
+	// no prompt in flight, which is what makes the rule load-bearing rather than
+	// incidental.
+	assertTurnFrames(t, []turnFrameCase{
+		{name: "agent message chunk", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hi"}}}}`},
+		{name: "agent thought chunk", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"hm"}}}}`},
+		{name: "tool call", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"tool_call","toolCallId":"t1","title":"bash","status":"pending"}}}`},
+		{name: "tool call update", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"tool_call_update","toolCallId":"t1","status":"completed"}}}`},
+		{name: "plan", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"plan","entries":[]}}}`},
+		{name: "available commands update", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update","availableCommands":[]}}}`},
+		{name: "current mode update", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"current_mode_update","currentModeId":"ask"}}}`},
+		{name: "session info update", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"session_info_update"}}}`},
+		{name: "usage update", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"usage_update","usage":{}}}}`},
+		{name: "user message chunk", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"user_message_chunk","content":{"type":"text","text":"hi"}}}}`},
+
+		{name: "an update from a later release", line: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_future_update"}}}`},
+		{name: "a method from a later release", line: `{"jsonrpc":"2.0","method":"session/futureSignal","params":{"sessionId":"session-1"}}`},
+	}, func(t *testing.T, tc turnFrameCase) []bool {
+		b, sink := newACPTurnBase(t, nopWriteCloser{&nopWriter{}})
+		b.HandleOutput([]byte(tc.line))
+		return sink.TurnActives()
+	})
+}
+
+// nopWriter stands in for the agent's stdin. No ACP notification writes to it,
+// which is itself part of what these cases state.
+type nopWriter struct{}
+
+func (*nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// zcodeTurnFrameCases keys each case by the event type, which is what the
+// completeness test compares against the contract.
+func zcodeTurnFrameCases() []turnFrameCase {
+	return []turnFrameCase{
+		{name: contracts.ZCodeEventTurnStarted, line: `{"turnNumber":1,"input":"hi"}`, moves: true},
+		{name: contracts.ZCodeEventTurnCompleted, line: `{"toolCallCount":1}`, moves: true},
+		{name: contracts.ZCodeEventTurnFailed, line: `{"error":{"message":"boom","retryable":false}}`, moves: true},
+
+		{name: contracts.ZCodeEventTurnSteerQueued, line: `{"inputId":"i1"}`},
+		{name: contracts.ZCodeEventTurnSteerDrained, line: `{"inputId":"i1"}`},
+		{name: contracts.ZCodeEventSessionCreated, line: `{"sessionId":"sess-1"}`},
+		{name: contracts.ZCodeEventSessionResumed, line: `{"sessionId":"sess-1"}`},
+		{name: contracts.ZCodeEventSessionUpdated, line: `{"sessionId":"sess-1"}`},
+		{name: contracts.ZCodeEventSessionTitleUpdated, line: `{"title":"a title"}`},
+		{name: contracts.ZCodeEventSessionClosed, line: `{"sessionId":"sess-1"}`},
+		{name: contracts.ZCodeEventMessageUpserted, line: `{"message":{"id":"m1","role":"assistant"}}`},
+		{name: contracts.ZCodeEventMessageRemoved, line: `{"messageId":"m1"}`},
+		{name: contracts.ZCodeEventPartStarted, line: `{"part":{"id":"p1","type":"text"}}`},
+		{name: contracts.ZCodeEventPartDelta, line: `{"partId":"p1","delta":"hi"}`},
+		{name: contracts.ZCodeEventPartUpserted, line: `{"part":{"id":"p1","type":"text","text":"hi"}}`},
+		{name: contracts.ZCodeEventPartRemoved, line: `{"partId":"p1"}`},
+		{name: contracts.ZCodeEventModelStreaming, line: `{"streaming":true}`},
+		{name: contracts.ZCodeEventToolUpdated, line: `{"kind":"progress","toolCallId":"t1"}`},
+		{name: contracts.ZCodeEventPermissionRequested, line: `{"requestId":"r1","toolCallId":"t1"}`},
+		{name: contracts.ZCodeEventPermissionResolved, line: `{"requestId":"r1"}`},
+		{name: contracts.ZCodeEventUserInputRequested, line: `{"requestId":"r1"}`},
+		{name: contracts.ZCodeEventUserInputResolved, line: `{"requestId":"r1"}`},
+		{name: contracts.ZCodeEventCheckpointCreated, line: `{"checkpointId":"c1"}`},
+		{name: contracts.ZCodeEventRewindTriggered, line: `{"checkpointId":"c1"}`},
+		{name: contracts.ZCodeEventStreamRecoveryUpdated, line: `{"state":"recovering"}`},
+
+		{name: "turn.futureSignal", line: `{"turnNumber":2}`},
+	}
+}
+
+func TestTurnSignalWhitelist_ZCode(t *testing.T) {
+	t.Parallel()
+
+	// ZCode is the one provider whose whole event enumeration is a contract this
+	// repository owns, so the table is checked for completeness against it (see
+	// the test underneath). Adding an event to the contract without an entry
+	// there fails that test.
+	var seq atomic.Int64
+	assertTurnFrames(t, zcodeTurnFrameCases(), func(t *testing.T, tc turnFrameCase) []bool {
+		sink := &testSink{}
+		a := newZCodeTestAgentWithStdin(t, sink, &zcodeRecordedStdin{})
+		// Each case gets its own agent, so the seq only has to rise within one.
+		a.HandleOutput(zcodeEventLine(t, seq.Add(1), tc.name, tc.line))
+		return sink.TurnActives()
+	})
+}
+
+func TestTurnSignalWhitelist_ZCodeTableCoversTheContract(t *testing.T) {
+	t.Parallel()
+
+	// contracts/zcode-protocol.json is the vendor vocabulary this repository
+	// tracks. An event listed there is one the app-server can send, so the table
+	// must say whether it moves the turn flag -- and a new one arrives as a
+	// failure here rather than as an unclassified frame in production.
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "contracts", "zcode-protocol.json"))
+	require.NoError(t, err)
+	var contract struct {
+		Events map[string]string `json:"events"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &contract))
+	require.NotEmpty(t, contract.Events, "the contract lists the event vocabulary")
+
+	covered := make(map[string]struct{}, len(zcodeTurnFrameCases()))
+	for _, tc := range zcodeTurnFrameCases() {
+		covered[tc.name] = struct{}{}
+	}
+	for name, eventType := range contract.Events {
+		assert.Contains(t, covered, eventType,
+			"contract event %s (%s) has no turn-signal case", name, eventType)
+	}
+}


### PR DESCRIPTION
## Motivation
Claude Code announces no turn start of its own. Codex sends
`turn/started`, and ZCode sends `turn.started`. Claude Code sends
neither, so the worker inferred turn state from a heuristic that read
output frames.

The heuristic misfired. It treated every root `system` frame as proof
of a live turn, including a `compacting` status notice, the startup
`init` frame, a background-task update, and a hook notice. The turn
flag controls the input queue: `drainIfReleased` refuses to dispatch a
queued message while a turn stays active. A false-positive turn thus
holds every queued message and runs a thinking indicator that nothing
stops, until the process exits.

The frame that removes the guess carries its own hazard, and this PR
closes it in the same change. Claude Code emits `idle` when its run
loop stops, before it reads the next queued message. An `idle` that
arrives after the worker handed over the next message therefore
describes the state before that hand-over. A clear on that frame would
open the queue on the turn that just started.

## Modifications
- `StartClaudeCode` sets `CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1` on
  every launch. A current CLI then publishes `system` /
  `session_state_changed` frames with `running`, `requires_action`, or
  `idle`, an authoritative signal that replaces the old inference.
- The launch-environment logic moved into a new
  `claudeAgentEnv(environ, loginShell)` function, so a test can assert
  what a launch carries without a real process. `CLAUDECODE` is
  stripped unconditionally and re-added only for a login shell. Two
  other variables use `envutil.PinEnv`, so a value inherited from a
  parent Claude Code session is replaced, not layered underneath.
- `observeTurnFromOutput` replaces `armTurnFromOutput` as the top-level
  dispatch in `handleClaudeOutput`. It reads the authoritative
  `session_state_changed` frame first and falls back to the old
  heuristic only for a CLI build that never reports the frame. Once any
  `session_state_changed` frame arrives, a `sessionStateReported` latch
  turns off the heuristic for the rest of the process, so no later
  frame can re-trigger it. An unknown state value decides nothing.
- The old `armTurnFromOutput` `system`-frame match narrowed to the
  thinking-token telemetry subtype alone. It no longer treats a
  compaction notice, an init frame, a background-task update, or a
  hook notice as proof of a live turn. A new `claudeIsRootFrame` helper
  distinguishes a root frame from a forwarded subagent frame by
  `parent_tool_use_id`, and both paths now apply it: a forwarded
  child's own `idle` would otherwise report the root idle while a
  restarted subagent runs on.
- A new `awaitingResult` flag closes the stale-idle hazard. `sendInput`
  sets it alongside `turnActive`; `noteSessionIdle` refuses to clear
  `turnActive` while it stays set; `disarmTurn` clears it once a
  `result` frame answers the in-flight message.
- `claude_subagent.go` renamed its `session_state_changed` case to the
  shared `claudeSystemSubtypeSessionStateChanged` constant and updated
  the comment to state that `observeTurnFromOutput` already consumes
  the frame's meaning.
- Test coverage grew substantially: `turn_active_test.go` gained
  roughly 300 lines covering the session-state path, the stale-idle
  guard, child-frame isolation, and the environment construction. A
  new `turn_signal_whitelist_test.go` adds a cross-provider allowlist
  test: for Claude, Codex, Pi, ACP, and ZCode, only the named frames
  move the turn flag, and every other known frame, plus one synthetic
  "future release" frame per provider, moves nothing. A ZCode-specific
  test cross-checks its table against `contracts/zcode-protocol.json`
  for full coverage.

No breaking change and no deprecation. This PR changes internal worker
behavior only; no wire or API contract changes.

## Result
Claude Code no longer arms a false turn from a status notice, an init
frame, a background-task update, or a hook notice. A queued user
message no longer waits behind a turn that never really started, and
the thinking indicator no longer runs after the real turn ends. When
the running CLI reports its own turn state, the worker trusts that
report over the heuristic, and a stale `idle` from the previous turn
never closes the turn that just started.
