### PR TITLE
fix(activity): Stop the turn-end sound for work that continues

### DIFF
--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -1225,6 +1225,12 @@ func (svc *Service) replayAgentCatchUp(
 		return
 	}
 
+	// Resolve the root once for the whole replay. Calling rootAgentIDFor twice
+	// would run the recursive CTE twice and could return different roots if the
+	// parent chain changed between the calls, shipping one root's tasks under
+	// another's id.
+	rootID := svc.rootAgentIDFor(bgCtx(), agentID)
+
 	// Pre-trim marker: read the authoritative live-tail seq and send it BEFORE
 	// the message replay, so a reconnecting windowed client drops phantom rows
 	// (a tail it loaded before disconnect that was deleted while it was away) up
@@ -1232,34 +1238,24 @@ func (svc *Service) replayAgentCatchUp(
 	// An unset field on a query error tells the client to skip the reconcile (see
 	// CatchUpStart.latest_seq). The tail is re-read for CatchUpComplete below so the
 	// final authority reflects any message created mid-replay.
+	//
+	// The derived activity rides the same frame, which puts it ahead of the
+	// message burst: the tab renders the replayed rows as they arrive, and an
+	// activity frame behind them leaves the burst painting with no thinking
+	// indicator on an agent that works. It travels HERE and not as an
+	// AgentActivityChanged because it is a LEVEL. That message means a
+	// transition, and the client rings on one; sending the baseline as a
+	// transition forced the client to suppress the alert for the whole catch-up
+	// window, which discarded each genuine settle that raced the replay.
 	replayStartTail := svc.maxSeqOrNil(agentID, "failed to read max seq for catch-up start")
 	broadcastReplayAgentEvent(sink, &leapmuxv1.AgentEvent{
 		AgentId: agentID,
 		Event: &leapmuxv1.AgentEvent_CatchUpStart{
-			CatchUpStart: &leapmuxv1.CatchUpStart{LatestSeq: replayStartTail},
-		},
-	})
-
-	if !sink.alive() {
-		return
-	}
-
-	// Resolve the root once for the whole replay. Calling rootAgentIDFor twice
-	// would run the recursive CTE twice and could return different roots if the
-	// parent chain changed between the calls, shipping one root's tasks under
-	// another's id.
-	rootID := svc.rootAgentIDFor(bgCtx(), agentID)
-
-	// Replay the derived activity BEFORE the message burst, so a tab that just
-	// promoted to FULL renders the right spinner and the right Interrupt button
-	// while the burst lands rather than after it. Under this agent's OWN id, not
-	// the root's: a child tab's answer is its own registry row, which differs
-	// from its root's.
-	broadcastReplayAgentEvent(sink, &leapmuxv1.AgentEvent{
-		AgentId: agentID,
-		Event: &leapmuxv1.AgentEvent_ActivityChanged{
-			ActivityChanged: &leapmuxv1.AgentActivityChanged{
-				State: svc.Output.AgentActivitySnapshot(agentID, rootID).State,
+			CatchUpStart: &leapmuxv1.CatchUpStart{
+				LatestSeq: replayStartTail,
+				// Under this agent's OWN id, not the root's: a child tab's answer is
+				// its own registry row, which differs from its root's.
+				ActivityState: svc.Output.AgentActivitySnapshot(agentID, rootID).State,
 			},
 		},
 	})

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -832,6 +832,7 @@ func registerAgentHandlers(d registrar, svc *Service) {
 					sendNotFoundError(sender, "agent not found or not running")
 					return
 				}
+				svc.Output.NoteAgentInterrupted(agentID, row.OwnerAgentID)
 				if err := svc.Agents.InterruptChild(row.OwnerAgentID, row.RowKey); err != nil {
 					if errors.Is(err, agent.ErrChildSteeringUnsupported) {
 						sendFailedPrecondition(sender, "this subagent cannot be interrupted")
@@ -850,6 +851,7 @@ func registerAgentHandlers(d registrar, svc *Service) {
 				sendProtoResponse(sender, &leapmuxv1.InterruptAgentResponse{})
 				return
 			}
+			svc.Output.NoteAgentInterrupted(agentID, agentID)
 			if err := svc.Agents.Interrupt(agentID); err != nil {
 				slog.Warn("interrupt failed", "agent_id", agentID, "error", err)
 				sendNotFoundError(sender, "agent not found or not running")
@@ -1240,13 +1242,17 @@ func (svc *Service) replayAgentCatchUp(
 	// final authority reflects any message created mid-replay.
 	//
 	// The derived activity rides the same frame, which puts it ahead of the
-	// message burst: the tab renders the replayed rows as they arrive, and an
+	// message burst. The tab renders the replayed rows as they arrive, and an
 	// activity frame behind them leaves the burst painting with no thinking
 	// indicator on an agent that works. It travels HERE and not as an
-	// AgentActivityChanged because it is a LEVEL. That message means a
-	// transition, and the client rings on one; sending the baseline as a
-	// transition forced the client to suppress the alert for the whole catch-up
-	// window, which discarded each genuine settle that raced the replay.
+	// AgentActivityChanged because it is a LEVEL. That message means a transition,
+	// and the client rings on one.
+	// Sending the baseline as a
+	// transition forced the client to
+	// suppress the alert for the whole
+	// catch-up window, which discarded
+	// each genuine settle that raced
+	// the replay.
 	replayStartTail := svc.maxSeqOrNil(agentID, "failed to read max seq for catch-up start")
 	broadcastReplayAgentEvent(sink, &leapmuxv1.AgentEvent{
 		AgentId: agentID,
@@ -1255,7 +1261,24 @@ func (svc *Service) replayAgentCatchUp(
 				LatestSeq: replayStartTail,
 				// Under this agent's OWN id, not the root's: a child tab's answer is
 				// its own registry row, which differs from its root's.
-				ActivityState: svc.Output.AgentActivitySnapshot(agentID, rootID).State,
+				//
+				// The PUBLISHED value, not the exact one. A settle waiting out its
+				// window makes the two differ. Seeding a tab with the exact IDLE
+				// there costs it the completion sound: the window's own transition
+				// then lands on a client that already holds IDLE, so it sees no
+				// edge. See AgentActivityPublished.
+				//
+				// One residual, stated because it is not free to close. This value
+				// is read microseconds before the frame reaches the send lock, so a
+				// live transition can overtake it and the client's seed then holds a
+				// value older than what it already applied. The spinner is then
+				// wrong until the next transition. Closing it needs a derivation ticket on
+				// the wire AND a process epoch beside it.
+				// activitySeq restarts at zero in a new
+				// worker, so a bare ticket would freeze a
+				// reconnecting client's display for good. The window is microseconds
+				// and the cost is cosmetic, so it stays open on purpose.
+				ActivityState: svc.Output.AgentActivityPublished(agentID, rootID),
 			},
 		},
 	})
@@ -1549,6 +1572,11 @@ func (svc *Service) agentToProto(a *db.Agent, isRunning bool, gs *leapmuxv1.GitR
 	// naming work its own count said was not there.
 	activity := svc.Output.AgentActivitySnapshot(a.ID, info.RootAgentId)
 	info.ActivityState, info.ActiveBackgroundTasks = activity.State, activity.ActiveTasks
+	// Both, because they answer different questions. A close guard wants the
+	// exact state above; a client that CACHES the pushed state seeds its display
+	// from this one, or its cache and the next broadcast disagree. See
+	// AgentInfo.published_activity_state.
+	info.PublishedActivityState = svc.Output.AgentActivityPublished(a.ID, info.RootAgentId)
 
 	if a.ClosedAt.Valid {
 		info.ClosedAt = timefmt.Format(a.ClosedAt.Time)
@@ -3371,6 +3399,10 @@ func (svc *Service) initiatePlanExecutionRestart(agentID, targetMode string, dbA
 // routing them through one helper keeps the four-level envelope from being
 // re-spelled (and the AgentId mis-filled) per event.
 func broadcastReplayAgentEvent(sink *replaySink, event *leapmuxv1.AgentEvent) {
+	// The one place a replayed frame is marked. A client registers its live
+	// watch before this burst runs and both write the same stream, so arrival
+	// order cannot tell a live frame from a replayed one. See AgentEvent.replay.
+	event.Replay = true
 	sink.send(&leapmuxv1.WatchEventsResponse{
 		Event: &leapmuxv1.WatchEventsResponse_AgentEvent{AgentEvent: event},
 	})

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -340,6 +340,10 @@ func setupTestService(t *testing.T, opts ...setupOption) (*Service, *channel.Dis
 	// here gate Shutdown exactly the way they do in production.
 	RegisterAll(d, svc)
 
+	// No case may arm a real 500 ms settle window: it would fire after the case
+	// ended, read a closed database and broadcast to a torn-down watcher. A case
+	// that DRIVES the window calls holdSettles again for the handle.
+	holdSettles(t, svc.Output)
 	return svc, d, newTestWriter()
 }
 

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -337,12 +337,13 @@ func setupTestService(t *testing.T, opts ...setupOption) (*Service, *channel.Dis
 
 	d := channel.NewDispatcher()
 	// RegisterAll binds svc.Cleanup itself, so tracked handlers dispatched
-	// here gate Shutdown exactly the way they do in production.
+	// here make Shutdown wait exactly the way they do in production.
 	RegisterAll(d, svc)
 
-	// No case may arm a real 500 ms settle window: it would fire after the case
-	// ended, read a closed database and broadcast to a torn-down watcher. A case
-	// that DRIVES the window calls holdSettles again for the handle.
+	// No case may arm a real settle window. Such a window waits out settleDelay.
+	// It would fire after the case ended, read a closed database and broadcast to
+	// a torn-down watcher. A case that DRIVES the window calls holdSettles again
+	// for the handle.
 	holdSettles(t, svc.Output)
 	return svc, d, newTestWriter()
 }

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -221,6 +221,12 @@ type OutputHandler struct {
 	// derivation's own rules should depend on.
 	processRunning func(rootAgentID string) bool
 
+	// treeChildren indexes the activity map by ROOT, so a tree refresh asks for
+	// one tree rather than walking every agent this worker ever published for.
+	// Derived from the rootAgentID that activityFor already records, written by
+	// the same call, and pruned by ForgetActivity. See indexTreeChild.
+	treeChildren sync.Map // rootAgentID -> *sync.Map[childAgentID]struct{}
+
 	// rootSinks tracks the root agentOutputSink per root agent id so CleanupAgent
 	// can prune a closed child from its parent's childSinks cache (which would
 	// otherwise retain the child's SpanTracker + OutputHandler ref for the

--- a/backend/internal/worker/service/output.go
+++ b/backend/internal/worker/service/output.go
@@ -209,6 +209,12 @@ type OutputHandler struct {
 	// that already flushed. The zero value works, so nothing constructs it.
 	activityRefreshes sync.WaitGroup
 
+	// newSettleTimer schedules the end of a settle's debounce window. Defaults to
+	// time.AfterFunc; a test replaces it to fire the window on demand, because a
+	// window sized by a real timer lets the machine running the suite decide
+	// whether a case passes. See settleDelay.
+	newSettleTimer func(d time.Duration, f func()) settleStopper
+
 	// processRunning reports whether the feeding process for a ROOT agent id is
 	// up. Defaults to the agent manager; a test replaces it to drive the other
 	// activity inputs in isolation, because a real subprocess is not a seam the

--- a/backend/internal/worker/service/output_activity.go
+++ b/backend/internal/worker/service/output_activity.go
@@ -25,9 +25,11 @@ import (
 // changes -- never per output line.
 //
 // One edge is DEBOUNCED: the stop. A settle waits out settleDelay before it
-// reaches a client, and work that resumes inside that window cancels it, so a
-// wake or a subagent restart never rings the completion sound at the moment the
-// agent starts again. The broadcast alone waits, and this derivation stays
+// reaches a client, and work that resumes
+// inside that window cancels it. So a wake or
+// a subagent restart never rings the
+// completion sound at the moment the agent
+// starts again. The broadcast alone waits, and this derivation stays
 // exact throughout: AgentActivitySnapshot answers from the inputs and never
 // consults the window, so ListAgents and the CLI close guard are unaffected. A
 // client that CACHES the published state is not -- see settleDelay for what
@@ -97,11 +99,44 @@ type agentActivity struct {
 	// turn starts and consumed by the edge.
 	settledToolUses *int32
 
-	// settleTimer runs the debounce window for a settle this entry derived and
-	// has not published. Non-nil means a settle is in flight: `published` still
-	// says WORKING and the client has not been told otherwise, so the window can
-	// still end in silence. See settleDelay.
+	// settleTimer runs the debounce window for a settle this entry derived but
+	// did not publish. See settleDelay.
+	//
+	// The handle alone answers nothing, because three paths release it early:
+	// deliverHeldSettle spends it before the re-derivation, and settleImmediate
+	// and ForgetActivity both cancel it. Read settlePending for the STATE and
+	// this field only to stop the timer.
 	settleTimer settleStopper
+
+	// settlePending says a settle waits: this entry derived a stop and no client
+	// knows about it. `published` still says WORKING, and the client still holds
+	// WORKING, so the window can still end in silence.
+	//
+	// It is the state that settleTimer only looks like. voidHeldSettleLocked and
+	// setTurnActive both read it, and both were wrong while they read the handle.
+	// Cleared where the settle reaches the wire, and where the work comes back.
+	settlePending bool
+
+	// interrupted says the USER stopped this agent, so the stop it produces
+	// cannot be resumed and publishes at once. InterruptAgent pauses the input
+	// queue before it signals, so nothing wakes the agent back into the turn it
+	// just cancelled.
+	//
+	// Cleared wherever the agent moves on: a fresh turn, any publish, and a
+	// process boundary. Without that bound, an interrupt the agent IGNORES would
+	// leave the mark set and let a LATER resumable stop publish early.
+	interrupted bool
+
+	// settleGen counts the windows this entry opened. holdSettleLocked captures
+	// the current value in the timer's closure, and deliverHeldSettle publishes
+	// only when the entry still carries it.
+	//
+	// A Stop cannot recall a callback that already started -- see
+	// cancelSettleLocked. Without the token, a spent callback publishes for an
+	// agent ForgetActivity retired. It also destroys the handle of a window that
+	// a later stop opened. Every cancel moves the token, which retires the
+	// callback it could not stop.
+	settleGen uint64
 
 	// published is the last state broadcast, and hasPublished distinguishes
 	// "published IDLE" from "never published". Without the second field the
@@ -114,9 +149,9 @@ type agentActivity struct {
 	// one that published, one that agreed with what stands, or one that opened a
 	// settle window. A refresh that read its registry rows EARLIER carries a
 	// lower ticket and is dropped, so a slow reader cannot latch a stale answer.
-	// Without it the edge trigger then swallows the correction: the next real
-	// change compares equal to what the stale publish recorded, and the tab keeps
-	// a spinner for a whole turn and misses its settle.
+	// Without it the edge trigger then swallows the correction. The next real
+	// change compares equal to what the stale publish recorded, so the tab keeps a
+	// spinner for a whole turn and misses its settle.
 	publishedSeq uint64
 }
 
@@ -132,34 +167,50 @@ type agentActivity struct {
 // user their agent finished at the moment it started again.
 //
 // Every genuine settle pays it, and the price rises with the value. The sound,
-// the thinking indicator and the Interrupt button are all this much late, and so
-// is the browser's close guard, which reads its cached copy of the published
-// state rather than asking the Worker -- so a tab closed inside the window warns
-// about work that already finished. Three seconds is chosen to cover a wake that
-// needs the CLI to start a whole new turn, not merely the same-burst reopen that
-// a few hundred milliseconds would cover, and it buys that at the cost above.
+// the thinking indicator and the Interrupt button are all this much late. The
+// browser's close guard is late too, because it reads its cached copy of the
+// published state rather than asking the Worker. A tab closed inside the window
+// therefore warns about work that already finished. Three seconds covers a wake
+// that needs the CLI to start a whole new turn. A few hundred milliseconds would
+// cover only the same-burst reopen, so the window takes the longer value and
+// pays the cost above.
+//
+// Only a stop that something can RESUME pays it. A stop the user must clear --
+// a permission prompt -- publishes at once, because no wake can arrive while the
+// agent waits for an answer. See settleCanResumeLocked.
 //
 // This derivation is exact while a settle waits. AgentActivitySnapshot reads the
 // inputs and never consults the window, so ListAgents and the CLI close guard
-// answer correctly throughout; only what was BROADCAST lags.
+// answer correctly throughout; only what was BROADCAST lags. A client that
+// CACHES the published state must therefore read the PUBLISHED value and not
+// this one, or its cache and the later broadcast disagree and the settle edge
+// disappears between them. AgentActivityPublished is that read.
 const settleDelay = 3 * time.Second
 
 // settleStopper is the part of *time.Timer a held settle needs.
 type settleStopper interface{ Stop() bool }
 
 // settleMode says what a refresh does with a settle it derives.
-type settleMode bool
+//
+// An int, not a bool, so the ZERO value is the debounced mode. A bool put
+// settleImmediate at zero, which made a forgotten field or an unset variable
+// silently turn the debounce off.
+type settleMode int
 
 const (
 	// settleHeld waits out the debounce window, so work that resumes at once
-	// never reaches a client as a stop. Every ordinary input uses it.
-	settleHeld settleMode = true
+	// never reaches a client as a stop. Every ordinary input uses it, and it is
+	// the zero value.
+	settleHeld settleMode = iota
 	// settleImmediate publishes at once, and supersedes any window in flight.
-	// Two callers use it: the window closing, which IS the settle's delivery,
-	// and a process boundary, where nothing can resume -- and where a held
-	// settle would leave a timer to fire after shutdown closed the database it
-	// reads.
-	settleImmediate settleMode = false
+	// Three reasons ask for it. The window closing, which IS the settle's
+	// delivery. A process boundary, where a held settle would leave a timer to
+	// fire after shutdown closed the database it reads. And an entry about to be
+	// retired, whose held settle has no later refresh to deliver it.
+	//
+	// "nothing can resume this stop" is NOT one of them. That rule belongs to the
+	// derivation, which reads it from its own inputs -- see settleCanResumeLocked.
+	settleImmediate
 )
 
 // afterSettleDelay schedules f at the end of the settle window.
@@ -178,28 +229,77 @@ func (h *OutputHandler) afterSettleDelay(f func()) settleStopper {
 // Caller must hold st.mu.
 //
 // It never RE-arms. The window opens at the edge that stopped the work, and a
-// second derivation of the same stop is not a second edge -- restarting there
-// would let a busy registry push a real settle out indefinitely.
-func (st *agentActivity) holdSettleLocked(h *OutputHandler, agentID, rootAgentID string) {
-	if st.settleTimer != nil {
-		return
+// second derivation of the same stop is not a second edge.
+// Restarting there would let a busy registry push a real
+// settle out indefinitely.
+//
+// It reports whether a window now runs, which is false only when Shutdown
+// latched h.shuttingDown. The caller must then PUBLISH rather than return: a
+// refusal that swallowed the settle would lose it for good, because the client
+// still holds WORKING and no later refresh can find the edge again. The
+// counterpart of the latch is activityRefreshes: every armed window holds one
+// count, which Shutdown joins after it cancels.
+func (h *OutputHandler) holdSettleLocked(st *agentActivity, agentID, rootAgentID string) bool {
+	if st.settlePending {
+		return true
 	}
+	if h.shuttingDown.Load() {
+		return false
+	}
+	st.settleGen++
+	gen := st.settleGen
+	st.settlePending = true
+	h.activityRefreshes.Add(1)
 	st.settleTimer = h.afterSettleDelay(func() {
-		h.deliverHeldSettle(agentID, rootAgentID)
+		h.deliverHeldSettle(agentID, rootAgentID, gen)
 	})
+	return true
 }
 
-// cancelSettleLocked drops a held settle. Caller must hold st.mu.
+// cancelSettleLocked stops a held settle's timer. Caller must hold st.mu.
 //
-// A Stop that reports false means the timer already fired and its callback is on
-// its way. Nothing is left to undo: that callback RE-DERIVES before it
-// publishes, so it finds the agent working and says nothing.
-func (st *agentActivity) cancelSettleLocked() {
+// A Stop that reports false means the timer already fired and its callback runs
+// now. This call cannot recall it, so it retires the callback instead: moving
+// settleGen makes deliverHeldSettle return without publishing. That token is
+// what the comment
+// here used to
+// claim the
+// re-derivation
+// gave for free,
+// and the
+// re-derivation
+// does not give
+// it. Against a
+// retired entry or
+// a dead process,
+// the callback
+// derives a state
+// that DIFFERS
+// from `published`
+// and publishes
+// it.
+//
+// It leaves settlePending alone. Stopping the timer says nothing about whether a
+// client learned the work stopped; only a publish and voidHeldSettleLocked do.
+func (st *agentActivity) cancelSettleLocked(h *OutputHandler) {
 	if st.settleTimer == nil {
 		return
 	}
-	st.settleTimer.Stop()
+	st.settleGen++
+	if st.settleTimer.Stop() {
+		// The callback will never run, so its count is this caller's to release.
+		// A Stop that reports false leaves the callback to release its own.
+		h.activityRefreshes.Done()
+	}
 	st.settleTimer = nil
+}
+
+// cancelSettle is cancelSettleLocked with the entry's lock. Caller must NOT hold
+// st.mu.
+func (st *agentActivity) cancelSettle(h *OutputHandler) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	st.cancelSettleLocked(h)
 }
 
 // voidHeldSettleLocked drops a held settle because the work came back, and drops
@@ -210,46 +310,86 @@ func (st *agentActivity) cancelSettleLocked() {
 // unconditionally -- the same rule setTurnActive applies to a clear that settles
 // nothing. Keeping a zero here would silence the settle that follows, which is
 // the failure that rule exists to prevent.
-func (st *agentActivity) voidHeldSettleLocked() {
-	if st.settleTimer == nil {
+//
+// It reads settlePending, not settleTimer. The handle is already nil on both
+// paths that reach here through settleImmediate, so testing it made this
+// function a no-op exactly when a resume raced the window's own delivery.
+func (st *agentActivity) voidHeldSettleLocked(h *OutputHandler) {
+	if !st.settlePending {
 		return
 	}
-	st.cancelSettleLocked()
+	st.cancelSettleLocked(h)
+	st.settlePending = false
 	st.settledToolUses = nil
 }
 
-// deliverHeldSettle publishes the settle whose window just closed.
+// deliverHeldSettle publishes the settle whose window just closed. `gen`
+// identifies the window, and a later cancel retires this call by moving it.
 //
 // It re-derives rather than replaying the value the window captured, so a state
-// that moved inside the window reaches the client as what it IS -- and an agent
-// that went back to working publishes nothing at all, which is the case the
-// window exists for.
-func (h *OutputHandler) deliverHeldSettle(agentID, rootAgentID string) {
-	st := h.activityFor(agentID, rootAgentID)
+// that moved inside the window reaches the client as what it IS. An agent that
+// went back to working publishes nothing at all, which is the case the window
+// exists for.
+//
+// It resolves the entry with Load and not activityFor. Minting here would
+// re-create the entry ForgetActivity just deleted, and publish for an agent that
+// no longer has a tab.
+func (h *OutputHandler) deliverHeldSettle(agentID, rootAgentID string, gen uint64) {
+	defer h.activityRefreshes.Done()
+	v, ok := h.activity.Load(agentID)
+	if !ok {
+		return
+	}
+	st := v.(*agentActivity)
 	st.mu.Lock()
-	// Release the slot BEFORE the derivation, and unconditionally. This window is
-	// spent whatever the re-derivation decides, and the ticket guard below can
-	// drop this call -- a handle left standing would then block every later
-	// settle from ever opening a window of its own.
+	if st.settleGen != gen {
+		// A cancel retired this window. Whatever it did with the settle stands,
+		// and the handle now standing belongs to a LATER window that must keep it.
+		st.mu.Unlock()
+		return
+	}
+	// Release the slot, so the ticket guard below can drop this call without
+	// leaving a handle that blocks every later settle from opening a window.
 	st.settleTimer = nil
 	st.mu.Unlock()
 	seq := h.activitySeq.Add(1)
-	h.refreshActivityFrom(agentID, rootAgentID, h.backgroundTaskRows(rootAgentID), seq, settleImmediate)
+	h.refreshActivityIn(st, agentID, rootAgentID, h.backgroundTaskRows(rootAgentID), seq, settleImmediate)
+}
+
+// NoteAgentInterrupted records that the USER stopped this agent, so the stop it
+// produces reaches the client at once rather than waiting out settleDelay.
+//
+// The window exists for a stop the CLI takes back microseconds later. An
+// interrupt is the opposite: InterruptAgent pauses the input queue before it
+// signals, so no wake follows. Holding it left the thinking indicator and the
+// Interrupt button on screen for three seconds after the user cancelled, which
+// invites a second interrupt.
+func (h *OutputHandler) NoteAgentInterrupted(agentID, rootAgentID string) {
+	st := h.activityFor(agentID, rootAgentID)
+	st.mu.Lock()
+	st.interrupted = true
+	st.mu.Unlock()
 }
 
 // CancelHeldSettles drops every settle window still open. Shutdown calls it
-// after the deferred refreshes join, so no timer reads the registry or
+// BEFORE it joins the deferred refreshes, so no timer reads the registry or
 // broadcasts once the caller closes the database.
 //
-// The process exits already cancel each window they reach (they publish through
-// settleImmediate), so this is the belt to that pair of braces: it holds however
-// the exits ran, and it costs one walk of a map that has an entry per open tab.
+// The order matters in both directions. An armed window holds an
+// activityRefreshes count, so joining
+// first would park Shutdown for a whole
+// settleDelay. And holdSettleLocked
+// refuses to arm once the latch is set,
+// so nothing can open a window after this
+// call.
+//
+// The process exits already cancel each window they reach, because they publish
+// through settleImmediate. This call is the redundant guard: it stays correct
+// whatever order the exits ran in. It costs one pass over a map that holds one
+// entry per open tab.
 func (h *OutputHandler) CancelHeldSettles() {
 	h.activity.Range(func(_, v any) bool {
-		st := v.(*agentActivity)
-		st.mu.Lock()
-		st.cancelSettleLocked()
-		st.mu.Unlock()
+		v.(*agentActivity).cancelSettle(h)
 		return true
 	})
 }
@@ -294,6 +434,35 @@ func activityStateLocked(st *agentActivity, in activityInputs) leapmuxv1.AgentAc
 	return idleOrWorking(st.turnActive || in.activeTasks > 0)
 }
 
+// settleCanResumeLocked answers whether a wake can undo the stop this refresh
+// derived, which is the only case the debounce window is worth paying for.
+// Caller must hold st.mu.
+//
+// The window exists for a stop the CLI takes back microseconds later. A
+// backgrounded shell completes and wakes the agent into a new turn, or a
+// subagent's shell completes and the CLI restarts that subagent. An agent
+// blocked on a permission prompt is a different stop. Nothing can resume it
+// until the user answers, so holding it spins the thinking indicator at somebody
+// who is being asked a question, and delays the alert that asks them.
+//
+// Worse than late. If the answer arrives inside the window, the refresh it
+// drives derives WORKING again and VOIDS the settle. The prompt's state then
+// never reaches the client at all, and no alert ever rings for it.
+//
+// A dead process is the same class, reached the other way: nothing can resume a
+// stop whose process is gone. So is a stop the USER asked for -- see
+// NoteAgentInterrupted. The rule lives here rather than at each call site, so no
+// caller can hold a settle that nothing can ever undo.
+//
+// Only a ROOT can be blocked, because activityStateLocked answers a child from
+// its registry row and never reads pendingControl.
+func settleCanResumeLocked(st *agentActivity, in activityInputs) bool {
+	if !in.processAlive || st.interrupted {
+		return false
+	}
+	return in.childID != "" || len(st.pendingControl) == 0
+}
+
 func idleOrWorking(working bool) leapmuxv1.AgentActivityState {
 	if working {
 		return leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING
@@ -314,8 +483,24 @@ func (h *OutputHandler) activityFor(agentID, rootAgentID string) *agentActivity 
 		st.mu.Lock()
 		st.rootAgentID = rootAgentID
 		st.mu.Unlock()
+		h.indexTreeChild(agentID, rootAgentID)
 	}
 	return st
+}
+
+// indexTreeChild records a child under its root, so treeChildIDs can ask for one
+// tree instead of walking every agent this worker ever published for.
+//
+// A derived copy, not a second source of truth: the entry's own rootAgentID is
+// the authority, this is written from the same call that writes it, and
+// ForgetActivity deletes from both. The data flows one way, and rebuilding this
+// from the map is a walk of the map.
+func (h *OutputHandler) indexTreeChild(agentID, rootAgentID string) {
+	if agentID == rootAgentID {
+		return
+	}
+	v, _ := h.treeChildren.LoadOrStore(rootAgentID, &sync.Map{})
+	v.(*sync.Map).Store(agentID, struct{}{})
 }
 
 // resolveRoot fills in the feeding process's id when the caller does not know
@@ -340,16 +525,43 @@ func (h *OutputHandler) resolveRoot(agentID, rootAgentID string) string {
 // that prunes the other per-agent caches, so a closed agent leaves nothing
 // behind in the map.
 func (h *OutputHandler) ForgetActivity(agentID string) {
-	// The window first. A timer left running would re-create the entry it fires
-	// against (activityFor mints one on any touch) and broadcast for an agent
-	// this call just retired.
-	if v, ok := h.activity.Load(agentID); ok {
-		st := v.(*agentActivity)
-		st.mu.Lock()
-		st.cancelSettleLocked()
-		st.mu.Unlock()
+	v, ok := h.activity.Load(agentID)
+	if !ok {
+		return
+	}
+	st := v.(*agentActivity)
+
+	// DELIVER a held settle, do not drop it. A subagent's last registry row
+	// closes and the provider retires the child on the next line (see
+	// CleanupChildAgent), which lands inside the window that close opened.
+	// Cancelling there loses the settle for good. The entry goes away, so no later
+	// refresh can find the edge again, and the child's tab keeps a spinner and an
+	// armed Interrupt button on a run that ended.
+	st.mu.Lock()
+	deliver := st.settlePending
+	// Read the root from the entry rather than through resolveRoot, which takes
+	// this same lock. An entry no sink ever touched records none, and an agent is
+	// its own root.
+	rootAgentID := st.rootAgentID
+	st.cancelSettleLocked(h)
+	st.mu.Unlock()
+	if rootAgentID == "" {
+		rootAgentID = agentID
+	}
+	// Before the delete, so the refresh reaches THIS entry rather than minting a
+	// replacement that no cleanup would ever reap.
+	if deliver {
+		seq := h.activitySeq.Add(1)
+		h.refreshActivityIn(st, agentID, rootAgentID, h.backgroundTaskRows(rootAgentID), seq, settleImmediate)
 	}
 	h.activity.Delete(agentID)
+	if rootAgentID != agentID {
+		if v, ok := h.treeChildren.Load(rootAgentID); ok {
+			v.(*sync.Map).Delete(agentID)
+		}
+	}
+	// A root takes its whole index with it, so a tree that closes leaves nothing.
+	h.treeChildren.Delete(agentID)
 }
 
 // AgentActivity is what the Worker knows about one agent's work: the state, and
@@ -366,10 +578,15 @@ func (a AgentActivity) Working() bool {
 	return a.State == leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING
 }
 
-// InterruptsWork reports whether closing this tab would stop something. Both
-// close guards resolve to it, so they cannot answer differently -- and it
+// InterruptsWork reports whether closing this tab would stop something. It
 // differs from Working precisely for a blocked agent, whose turn a close still
 // kills.
+//
+// Both close guards resolve to this RULE, but they no longer read the same
+// value, and the debounce is why. The CLI guard asks the Worker and gets the
+// exact derivation; the browser guard reads its cached copy of the published
+// state, which lags by up to settleDelay. So for the length of one window the
+// CLI lets a close through and the browser still warns. See settleDelay.
 func (a AgentActivity) InterruptsWork() bool {
 	return a.State == leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING ||
 		a.State == leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WAITING_FOR_USER
@@ -397,6 +614,36 @@ func (h *OutputHandler) AgentBusy(agentID, rootAgentID string) bool {
 func (h *OutputHandler) AgentActivitySnapshot(agentID, rootAgentID string) AgentActivity {
 	rootAgentID = h.resolveRoot(agentID, rootAgentID)
 	return h.activitySnapshotFrom(agentID, rootAgentID, h.backgroundTaskRows(rootAgentID))
+}
+
+// AgentActivityPublished is the last state this Worker BROADCAST for agentID,
+// which is what a client that caches the pushed state already holds.
+//
+// The catch-up baseline reads this rather than AgentActivitySnapshot, and the
+// difference is a lost alert. While a settle waits out its window the snapshot
+// answers IDLE and the broadcast still says WORKING. A tab that promotes to FULL
+// inside the window is then seeded with the exact IDLE. The window's own
+// AgentActivityChanged arrives as a no-op, the client sees no WORKING ->
+// not-WORKING edge, and neither the completion sound nor the tab badge comes. A
+// baseline drawn from the value the live events carry cannot lose that edge.
+// Every other reader wants the exact answer -- see AgentActivitySnapshot.
+//
+// It falls back to the exact derivation when this Worker published nothing yet.
+// That is safe rather than a hole: a window opens only where `published` is
+// WORKING, and `published` is written only together with hasPublished, so no
+// window can be open when this returns the fallback.
+func (h *OutputHandler) AgentActivityPublished(agentID, rootAgentID string) leapmuxv1.AgentActivityState {
+	// Load, not activityFor: a pure read must not mint an entry.
+	if v, ok := h.activity.Load(agentID); ok {
+		st := v.(*agentActivity)
+		st.mu.Lock()
+		published, has := st.published, st.hasPublished
+		st.mu.Unlock()
+		if has {
+			return published
+		}
+	}
+	return h.AgentActivitySnapshot(agentID, rootAgentID).State
 }
 
 // activitySnapshotFrom is AgentActivitySnapshot against a root the caller
@@ -636,9 +883,20 @@ func (h *OutputHandler) refreshActivity(agentID, rootAgentID string) {
 // stale reader overwriting a fresher answer, which the edge trigger then made
 // permanent -- and leaves only a reordering of two genuine transitions.
 func (h *OutputHandler) refreshActivityFrom(agentID, rootAgentID string, rows []bgtask.Item, seq uint64, mode settleMode) {
+	h.refreshActivityIn(h.activityFor(agentID, rootAgentID), agentID, rootAgentID, rows, seq, mode)
+}
+
+// refreshActivityIn is refreshActivityFrom against an entry the caller already
+// resolved.
+//
+// A held settle's delivery needs this: it holds the entry its window was opened
+// on, and resolving again would MINT a replacement for an agent ForgetActivity
+// retired in the meantime. See deliverHeldSettle.
+func (h *OutputHandler) refreshActivityIn(
+	st *agentActivity, agentID, rootAgentID string, rows []bgtask.Item, seq uint64, mode settleMode,
+) {
 	in := h.externalActivityInputs(agentID, rootAgentID, rows)
 
-	st := h.activityFor(agentID, rootAgentID)
 	st.mu.Lock()
 	if st.hasPublished && seq < st.publishedSeq {
 		// This refresh read its rows before the one that already published. Its
@@ -651,7 +909,7 @@ func (h *OutputHandler) refreshActivityFrom(agentID, rootAgentID string, rows []
 		// dead process. AFTER the ticket guard, never before -- an older refresh
 		// that cancels and then drops itself takes the settle with it, and the tab
 		// keeps a spinner for an agent whose process is gone.
-		st.cancelSettleLocked()
+		st.cancelSettleLocked(h)
 	}
 	state := activityStateLocked(st, in)
 	if st.hasPublished && st.published == state {
@@ -661,24 +919,28 @@ func (h *OutputHandler) refreshActivityFrom(agentID, rootAgentID string, rows []
 		// cancel that a wake, a subagent restart and a drained input queue all
 		// reach. The ticket guard above is what makes it safe: a stale reader
 		// cannot cancel a window a fresher one opened.
-		st.voidHeldSettleLocked()
+		st.voidHeldSettleLocked(h)
 		st.mu.Unlock()
 		return
 	}
 	var toolUses *int32
 	working := leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING
-	if state != working && st.published == working && mode == settleHeld {
-		// A settle, and nothing has told this client the work stopped yet. Hold
+	settling := state != working && st.published == working
+	if settling && mode == settleHeld && settleCanResumeLocked(st, in) {
+		// A settle, and this client still does not know the work stopped. Hold
 		// it: the CLI resumes the same work microseconds later often enough that
 		// publishing here rings the completion sound at the moment the agent
 		// starts again. `published` stays WORKING, so the window ending re-derives
 		// against the state the client actually holds.
-		st.publishedSeq = seq
-		st.holdSettleLocked(h, agentID, rootAgentID)
-		st.mu.Unlock()
-		return
+		if h.holdSettleLocked(st, agentID, rootAgentID) {
+			st.publishedSeq = seq
+			st.mu.Unlock()
+			return
+		}
+		// Shutdown refused the window. Fall through and publish: the settle has
+		// nowhere else to come from once this process stops.
 	}
-	if state != working && st.published == working {
+	if settling {
 		// The settle edge spends the count the last turn end recorded. A settle
 		// that follows no turn end -- a control request, a process exit -- leaves
 		// it unset, which is what tells the client to alert unconditionally.
@@ -692,6 +954,25 @@ func (h *OutputHandler) refreshActivityFrom(agentID, rootAgentID string, rows []
 	st.published = state
 	st.hasPublished = true
 	st.publishedSeq = seq
+	// A subagent whose run ended, and whose end the client now knows, has nothing
+	// left to remember. Read the verdict here, under the lock that owns those
+	// fields; the retire itself runs after the broadcast below.
+	retire := in.childID != "" && state != working && in.activeTasks == 0
+	// The client learns the state below, so nothing is pending any more --
+	// whether this publish delivers a held settle or supersedes one.
+	//
+	// Cancel the window with it. A fall-through publish reaches here with a
+	// window still armed: a prompt, a dead process, the shutdown latch. A handle
+	// left behind is one the NEXT settle adopts without opening a window of its
+	// own. That settle then lands on somebody else's deadline, and setTurnActive
+	// drops the count it should have carried.
+	st.cancelSettleLocked(h)
+	st.settlePending = false
+	// The stop the user asked for reached them, so the mark has done its work.
+	// An interrupt the agent IGNORED is cleared here too, by the WORKING publish
+	// that says so -- otherwise it would exempt a later, resumable stop.
+	st.interrupted = false
+	retire = retire && st.retirableLocked()
 	st.mu.Unlock()
 
 	h.watcher.BroadcastAgentEvent(agentID, &leapmuxv1.AgentEvent{
@@ -703,6 +984,48 @@ func (h *OutputHandler) refreshActivityFrom(agentID, rootAgentID string, rows []
 			},
 		},
 	})
+
+	// Drop the finished child here rather than waiting for a provider to retire
+	// it. Only Codex, ZCode and the ACP providers call CleanupChildAgent, so
+	// under Claude and Pi every subagent a session ever spawned kept an entry
+	// until the tab closed. Each of those then cost a point query per registry
+	// mutation once the display cap evicted its row.
+	//
+	// After the broadcast, so the settle it just published is not lost. A child
+	// that is still RUNNING publishes WORKING and keeps its entry, which is what
+	// the display cap needs. See retirableLocked for what else keeps one.
+	if retire {
+		h.ForgetActivity(agentID)
+	}
+}
+
+// retirableLocked answers whether this entry holds nothing worth keeping.
+// Caller must hold st.mu.
+//
+// `published` alone is not worth keeping: a child that comes back mints a fresh
+// entry and publishes WORKING, which is a real transition. Everything else is,
+// and each field here is a way to lose something real. An unspent count belongs
+// to a turn end whose settle has not landed. A held settle has not reached the
+// client. A prompt is unanswered. An interrupt mark is unspent. And a turn flag
+// means a COLLAB
+// child, whose
+// own input queue
+// follows that
+// flag. Its token
+// also orders two
+// publishes that
+// can arrive out
+// of order, so
+// re-minting
+// would reset
+// that token and
+// let a stale
+// publish latch a
+// turn that is
+// over.
+func (st *agentActivity) retirableLocked() bool {
+	return !st.turnActive && st.turnSeq == 0 && len(st.pendingControl) == 0 &&
+		st.settledToolUses == nil && !st.settlePending && st.settleTimer == nil && !st.interrupted
 }
 
 // refreshActivityTree recomputes the root and every child that owns a registry
@@ -754,22 +1077,23 @@ func (h *OutputHandler) treeChildIDs(rootAgentID string, rows []bgtask.Item) []s
 		childIDs = append(childIDs, childID)
 	}
 	for i := range rows {
-		add(rows[i].ChildAgentID)
+		// An ACTIVE row only. A child whose run ended needs recomputing exactly
+		// while it still holds an entry, and the index below supplies every one
+		// of those. Adding it from a finished row as well would re-create the entry
+		// the reap just dropped, on every mutation for the life of the
+		// root. That is the accumulation this pair exists to stop.
+		if !rows[i].Status.IsFinished() {
+			add(rows[i].ChildAgentID)
+		}
 	}
-	h.activity.Range(func(key, v any) bool {
-		agentID, ok := key.(string)
-		if !ok {
+	if v, ok := h.treeChildren.Load(rootAgentID); ok {
+		v.(*sync.Map).Range(func(key, _ any) bool {
+			if childID, ok := key.(string); ok {
+				add(childID)
+			}
 			return true
-		}
-		st := v.(*agentActivity)
-		st.mu.Lock()
-		owner := st.rootAgentID
-		st.mu.Unlock()
-		if owner == rootAgentID {
-			add(agentID)
-		}
-		return true
-	})
+		})
+	}
 	return childIDs
 }
 
@@ -791,6 +1115,9 @@ func (h *OutputHandler) setTurnActive(agentID, rootAgentID string, active bool) 
 		// A fresh turn supersedes whatever the previous one left unspent, so a
 		// stale count cannot silence the alert for the turn now starting.
 		st.settledToolUses = nil
+		// And it is not the turn the user interrupted, so its settle is an
+		// ordinary one that waits out its window.
+		st.interrupted = false
 	}
 	st.mu.Unlock()
 	if !changed {
@@ -810,12 +1137,12 @@ func (h *OutputHandler) setTurnActive(agentID, rootAgentID string, active bool) 
 	// left a zero behind, and the client suppresses a zero. The shell task then
 	// finished hours later in silence.
 	//
-	// A HELD settle is exempt, and reading the window is what tells the two
-	// apart. That settle IS the one this clear produced; it has not landed yet,
-	// so its count is still unspent and clearing here would make every ordinary
-	// turn end ring, zero-tool turns included.
+	// A HELD settle is exempt, and reading settlePending is what tells the two
+	// apart. That settle IS the one this clear produced, and it still waits in
+	// its window. Its count is therefore still unspent. Clearing here would make
+	// every ordinary turn end ring, zero-tool turns included.
 	st.mu.Lock()
-	if st.settleTimer == nil {
+	if !st.settlePending {
 		st.settledToolUses = nil
 	}
 	st.mu.Unlock()
@@ -1010,6 +1337,9 @@ func (h *OutputHandler) resetAgentActivity(rootAgentID string) {
 	// settle it produces alerts unconditionally, the way an agent going INACTIVE
 	// always has.
 	st.settledToolUses = nil
+	// The interrupt mark belongs to the process that carried it, so it dies with
+	// that process rather than exempting the next one's first stop.
+	st.interrupted = false
 	st.mu.Unlock()
 	h.activityRefreshes.Add(1)
 	go func() {

--- a/backend/internal/worker/service/output_activity.go
+++ b/backend/internal/worker/service/output_activity.go
@@ -204,12 +204,19 @@ const (
 	settleHeld settleMode = iota
 	// settleImmediate publishes at once, and supersedes any window in flight.
 	// Three reasons ask for it. The window closing, which IS the settle's
-	// delivery. A process boundary, where a held settle would leave a timer to
-	// fire after shutdown closed the database it reads. And an entry about to be
-	// retired, whose held settle has no later refresh to deliver it.
+	// delivery. An entry about to be retired, whose held settle has no later
+	// refresh to deliver it. And a process boundary -- for the START, not the
+	// exit: resetAgentActivity clears pendingControl and the new process is
+	// alive, so settleCanResumeLocked calls that stop RESUMABLE and would hold
+	// the "a new process took over and it owns no turn" publish for a whole
+	// window. NoteAgentProcessStarted says why idle is the only honest answer
+	// there, and a spinner that waits three seconds for it is not one.
 	//
 	// "nothing can resume this stop" is NOT one of them. That rule belongs to the
 	// derivation, which reads it from its own inputs -- see settleCanResumeLocked.
+	// The two overlap on a dead process and separate on a live one, so neither
+	// replaces the other. Do not delete a settleImmediate because the derivation
+	// appears to cover it: check whether the process is alive at that call site.
 	settleImmediate
 )
 

--- a/backend/internal/worker/service/output_activity.go
+++ b/backend/internal/worker/service/output_activity.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
@@ -22,6 +23,15 @@ import (
 // a marshal and one SendStream per subscribed channel whether or not any tab is
 // on screen, so refreshActivity broadcasts only when the derived value actually
 // changes -- never per output line.
+//
+// One edge is DEBOUNCED: the stop. A settle waits out settleDelay before it
+// reaches a client, and work that resumes inside that window cancels it, so a
+// wake or a subagent restart never rings the completion sound at the moment the
+// agent starts again. The broadcast alone waits, and this derivation stays
+// exact throughout: AgentActivitySnapshot answers from the inputs and never
+// consults the window, so ListAgents and the CLI close guard are unaffected. A
+// client that CACHES the published state is not -- see settleDelay for what
+// that costs.
 //
 // It is also PURELY IN MEMORY, and must stay that way. Do not add a column for
 // it. Every process boundary resets it (see NoteAgentProcessStarted), so a
@@ -87,6 +97,12 @@ type agentActivity struct {
 	// turn starts and consumed by the edge.
 	settledToolUses *int32
 
+	// settleTimer runs the debounce window for a settle this entry derived and
+	// has not published. Non-nil means a settle is in flight: `published` still
+	// says WORKING and the client has not been told otherwise, so the window can
+	// still end in silence. See settleDelay.
+	settleTimer settleStopper
+
 	// published is the last state broadcast, and hasPublished distinguishes
 	// "published IDLE" from "never published". Without the second field the
 	// first genuine idle transition after startup would look like a no-op and
@@ -94,14 +110,148 @@ type agentActivity struct {
 	published    leapmuxv1.AgentActivityState
 	hasPublished bool
 
-	// publishedSeq is the ticket of the refresh that recorded `published`. A
-	// refresh that read its registry rows EARLIER than one which already
-	// published carries a lower ticket and is dropped, so a slow reader cannot
-	// latch a stale answer. Without it the edge trigger then swallows the
-	// correction: the next real change compares equal to what the stale publish
-	// recorded, and the tab keeps a spinner for a whole turn and misses its
-	// settle.
+	// publishedSeq is the ticket of the freshest refresh this entry acted on --
+	// one that published, one that agreed with what stands, or one that opened a
+	// settle window. A refresh that read its registry rows EARLIER carries a
+	// lower ticket and is dropped, so a slow reader cannot latch a stale answer.
+	// Without it the edge trigger then swallows the correction: the next real
+	// change compares equal to what the stale publish recorded, and the tab keeps
+	// a spinner for a whole turn and misses its settle.
 	publishedSeq uint64
+}
+
+// settleDelay is how long a WORKING -> not-WORKING publish waits before it
+// reaches a client.
+//
+// The window exists because the worker sees work ending and the same work
+// resuming as two events microseconds apart. A backgrounded shell completes and
+// the CLI wakes the agent into a new turn. A subagent's own shell completes and
+// the CLI restarts that subagent, which ends its registry row and reopens it in
+// the same output burst. Publishing the gap rings the completion sound and drops
+// the spinner for an instant, and the work then carries on -- which tells the
+// user their agent finished at the moment it started again.
+//
+// Every genuine settle pays it, and the price rises with the value. The sound,
+// the thinking indicator and the Interrupt button are all this much late, and so
+// is the browser's close guard, which reads its cached copy of the published
+// state rather than asking the Worker -- so a tab closed inside the window warns
+// about work that already finished. Three seconds is chosen to cover a wake that
+// needs the CLI to start a whole new turn, not merely the same-burst reopen that
+// a few hundred milliseconds would cover, and it buys that at the cost above.
+//
+// This derivation is exact while a settle waits. AgentActivitySnapshot reads the
+// inputs and never consults the window, so ListAgents and the CLI close guard
+// answer correctly throughout; only what was BROADCAST lags.
+const settleDelay = 3 * time.Second
+
+// settleStopper is the part of *time.Timer a held settle needs.
+type settleStopper interface{ Stop() bool }
+
+// settleMode says what a refresh does with a settle it derives.
+type settleMode bool
+
+const (
+	// settleHeld waits out the debounce window, so work that resumes at once
+	// never reaches a client as a stop. Every ordinary input uses it.
+	settleHeld settleMode = true
+	// settleImmediate publishes at once, and supersedes any window in flight.
+	// Two callers use it: the window closing, which IS the settle's delivery,
+	// and a process boundary, where nothing can resume -- and where a held
+	// settle would leave a timer to fire after shutdown closed the database it
+	// reads.
+	settleImmediate settleMode = false
+)
+
+// afterSettleDelay schedules f at the end of the settle window.
+//
+// It goes through the seam rather than calling time.AfterFunc directly, so a
+// test fires the window on demand. Sizing this window with a real timer would
+// let the machine that runs the suite decide whether a case passes.
+func (h *OutputHandler) afterSettleDelay(f func()) settleStopper {
+	if h.newSettleTimer != nil {
+		return h.newSettleTimer(settleDelay, f)
+	}
+	return time.AfterFunc(settleDelay, f)
+}
+
+// holdSettleLocked opens the window for a settle, unless one already runs.
+// Caller must hold st.mu.
+//
+// It never RE-arms. The window opens at the edge that stopped the work, and a
+// second derivation of the same stop is not a second edge -- restarting there
+// would let a busy registry push a real settle out indefinitely.
+func (st *agentActivity) holdSettleLocked(h *OutputHandler, agentID, rootAgentID string) {
+	if st.settleTimer != nil {
+		return
+	}
+	st.settleTimer = h.afterSettleDelay(func() {
+		h.deliverHeldSettle(agentID, rootAgentID)
+	})
+}
+
+// cancelSettleLocked drops a held settle. Caller must hold st.mu.
+//
+// A Stop that reports false means the timer already fired and its callback is on
+// its way. Nothing is left to undo: that callback RE-DERIVES before it
+// publishes, so it finds the agent working and says nothing.
+func (st *agentActivity) cancelSettleLocked() {
+	if st.settleTimer == nil {
+		return
+	}
+	st.settleTimer.Stop()
+	st.settleTimer = nil
+}
+
+// voidHeldSettleLocked drops a held settle because the work came back, and drops
+// the count that settle was carrying with it. Caller must hold st.mu.
+//
+// The count described the turn that stopped, and that stop did not last. The
+// settle that eventually comes belongs to the work running NOW, so it must alert
+// unconditionally -- the same rule setTurnActive applies to a clear that settles
+// nothing. Keeping a zero here would silence the settle that follows, which is
+// the failure that rule exists to prevent.
+func (st *agentActivity) voidHeldSettleLocked() {
+	if st.settleTimer == nil {
+		return
+	}
+	st.cancelSettleLocked()
+	st.settledToolUses = nil
+}
+
+// deliverHeldSettle publishes the settle whose window just closed.
+//
+// It re-derives rather than replaying the value the window captured, so a state
+// that moved inside the window reaches the client as what it IS -- and an agent
+// that went back to working publishes nothing at all, which is the case the
+// window exists for.
+func (h *OutputHandler) deliverHeldSettle(agentID, rootAgentID string) {
+	st := h.activityFor(agentID, rootAgentID)
+	st.mu.Lock()
+	// Release the slot BEFORE the derivation, and unconditionally. This window is
+	// spent whatever the re-derivation decides, and the ticket guard below can
+	// drop this call -- a handle left standing would then block every later
+	// settle from ever opening a window of its own.
+	st.settleTimer = nil
+	st.mu.Unlock()
+	seq := h.activitySeq.Add(1)
+	h.refreshActivityFrom(agentID, rootAgentID, h.backgroundTaskRows(rootAgentID), seq, settleImmediate)
+}
+
+// CancelHeldSettles drops every settle window still open. Shutdown calls it
+// after the deferred refreshes join, so no timer reads the registry or
+// broadcasts once the caller closes the database.
+//
+// The process exits already cancel each window they reach (they publish through
+// settleImmediate), so this is the belt to that pair of braces: it holds however
+// the exits ran, and it costs one walk of a map that has an entry per open tab.
+func (h *OutputHandler) CancelHeldSettles() {
+	h.activity.Range(func(_, v any) bool {
+		st := v.(*agentActivity)
+		st.mu.Lock()
+		st.cancelSettleLocked()
+		st.mu.Unlock()
+		return true
+	})
 }
 
 // activityInputs are the derivation's inputs from OUTSIDE the entry. Reading
@@ -190,6 +340,15 @@ func (h *OutputHandler) resolveRoot(agentID, rootAgentID string) string {
 // that prunes the other per-agent caches, so a closed agent leaves nothing
 // behind in the map.
 func (h *OutputHandler) ForgetActivity(agentID string) {
+	// The window first. A timer left running would re-create the entry it fires
+	// against (activityFor mints one on any touch) and broadcast for an agent
+	// this call just retired.
+	if v, ok := h.activity.Load(agentID); ok {
+		st := v.(*agentActivity)
+		st.mu.Lock()
+		st.cancelSettleLocked()
+		st.mu.Unlock()
+	}
 	h.activity.Delete(agentID)
 }
 
@@ -454,7 +613,7 @@ func (h *OutputHandler) refreshActivity(agentID, rootAgentID string) {
 	// The ticket is taken BEFORE the rows are read, so it orders refreshes by
 	// the age of the inputs they derive from.
 	seq := h.activitySeq.Add(1)
-	h.refreshActivityFrom(agentID, rootAgentID, h.backgroundTaskRows(rootAgentID), seq)
+	h.refreshActivityFrom(agentID, rootAgentID, h.backgroundTaskRows(rootAgentID), seq, settleHeld)
 }
 
 // refreshActivityFrom is refreshActivity against a root the caller already
@@ -465,6 +624,10 @@ func (h *OutputHandler) refreshActivity(agentID, rootAgentID string) {
 // the answer. Reading them separately let two refreshes derive, then publish in
 // the reverse order, so a stale value latched.
 //
+// A settle it derives is HELD rather than published, unless the caller asks for
+// settleImmediate. See settleDelay for what the window is worth and what it
+// costs.
+//
 // One residual, stated because it is not free to close: the broadcast runs after
 // the unlock, because BroadcastAgentEvent can block on a slow transport and
 // holding a lock across it would serialize every registry op for the root behind
@@ -472,7 +635,7 @@ func (h *OutputHandler) refreshActivity(agentID, rootAgentID string) {
 // reach the wire out of order. The ticket removes the case that mattered -- a
 // stale reader overwriting a fresher answer, which the edge trigger then made
 // permanent -- and leaves only a reordering of two genuine transitions.
-func (h *OutputHandler) refreshActivityFrom(agentID, rootAgentID string, rows []bgtask.Item, seq uint64) {
+func (h *OutputHandler) refreshActivityFrom(agentID, rootAgentID string, rows []bgtask.Item, seq uint64, mode settleMode) {
 	in := h.externalActivityInputs(agentID, rootAgentID, rows)
 
 	st := h.activityFor(agentID, rootAgentID)
@@ -483,14 +646,38 @@ func (h *OutputHandler) refreshActivityFrom(agentID, rootAgentID string, rows []
 		st.mu.Unlock()
 		return
 	}
+	if mode == settleImmediate {
+		// A process boundary supersedes any window in flight: no wake can follow a
+		// dead process. AFTER the ticket guard, never before -- an older refresh
+		// that cancels and then drops itself takes the settle with it, and the tab
+		// keeps a spinner for an agent whose process is gone.
+		st.cancelSettleLocked()
+	}
 	state := activityStateLocked(st, in)
 	if st.hasPublished && st.published == state {
 		st.publishedSeq = seq
+		// The agent is doing what the client already believes it is doing. A held
+		// settle described a stop that did not last, so it is void -- this is the
+		// cancel that a wake, a subagent restart and a drained input queue all
+		// reach. The ticket guard above is what makes it safe: a stale reader
+		// cannot cancel a window a fresher one opened.
+		st.voidHeldSettleLocked()
 		st.mu.Unlock()
 		return
 	}
 	var toolUses *int32
 	working := leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING
+	if state != working && st.published == working && mode == settleHeld {
+		// A settle, and nothing has told this client the work stopped yet. Hold
+		// it: the CLI resumes the same work microseconds later often enough that
+		// publishing here rings the completion sound at the moment the agent
+		// starts again. `published` stays WORKING, so the window ending re-derives
+		// against the state the client actually holds.
+		st.publishedSeq = seq
+		st.holdSettleLocked(h, agentID, rootAgentID)
+		st.mu.Unlock()
+		return
+	}
 	if state != working && st.published == working {
 		// The settle edge spends the count the last turn end recorded. A settle
 		// that follows no turn end -- a control request, a process exit -- leaves
@@ -522,7 +709,7 @@ func (h *OutputHandler) refreshActivityFrom(agentID, rootAgentID string, rows []
 // row under it. A process exit and a registry change both move more than one
 // tab's answer at once, and a child that is never recomputed keeps a spinner
 // that nothing will ever clear.
-func (h *OutputHandler) refreshActivityTree(rootAgentID string) {
+func (h *OutputHandler) refreshActivityTree(rootAgentID string, mode settleMode) {
 	if rootAgentID == "" {
 		return
 	}
@@ -533,9 +720,9 @@ func (h *OutputHandler) refreshActivityTree(rootAgentID string) {
 	// different instant.
 	seq := h.activitySeq.Add(1)
 	rows := h.backgroundTaskRows(rootAgentID)
-	h.refreshActivityFrom(rootAgentID, rootAgentID, rows, seq)
+	h.refreshActivityFrom(rootAgentID, rootAgentID, rows, seq, mode)
 	for _, childID := range h.treeChildIDs(rootAgentID, rows) {
-		h.refreshActivityFrom(childID, rootAgentID, rows, seq)
+		h.refreshActivityFrom(childID, rootAgentID, rows, seq, mode)
 	}
 }
 
@@ -622,8 +809,15 @@ func (h *OutputHandler) setTurnActive(agentID, rootAgentID string, active bool) 
 	// Without this, a turn that used no tool while an unrelated shell task ran
 	// left a zero behind, and the client suppresses a zero. The shell task then
 	// finished hours later in silence.
+	//
+	// A HELD settle is exempt, and reading the window is what tells the two
+	// apart. That settle IS the one this clear produced; it has not landed yet,
+	// so its count is still unspent and clearing here would make every ordinary
+	// turn end ring, zero-tool turns included.
 	st.mu.Lock()
-	st.settledToolUses = nil
+	if st.settleTimer == nil {
+		st.settledToolUses = nil
+	}
 	st.mu.Unlock()
 }
 
@@ -820,7 +1014,7 @@ func (h *OutputHandler) resetAgentActivity(rootAgentID string) {
 	h.activityRefreshes.Add(1)
 	go func() {
 		defer h.activityRefreshes.Done()
-		h.refreshActivityTree(rootAgentID)
+		h.refreshActivityTree(rootAgentID, settleImmediate)
 	}()
 }
 

--- a/backend/internal/worker/service/output_activity_test.go
+++ b/backend/internal/worker/service/output_activity_test.go
@@ -79,9 +79,11 @@ func (r *activityRecorder) agentIDs() []string {
 // delay run would make the machine that runs the suite decide the outcome, which
 // is the reason the handler takes its timer through a seam at all.
 //
-// A window cannot deliver from inside the arm: holdSettleLocked arms while it
-// holds the entry's mutex, and the delivery takes that mutex again.
+// A window cannot deliver while holdSettleLocked arms it, because
+// holdSettleLocked arms under the entry's mutex and the delivery takes that
+// mutex again.
 type settleWindows struct {
+	t    *testing.T
 	mu   sync.Mutex
 	open []*heldWindow
 }
@@ -93,7 +95,11 @@ type heldWindow struct {
 	closed bool
 }
 
-func (w *settleWindows) timer(_ time.Duration, deliver func()) settleStopper {
+func (w *settleWindows) timer(d time.Duration, deliver func()) settleStopper {
+	// The fake ignores the delay otherwise, so nothing else would catch a seam
+	// invoked with the wrong one. assert and not require: a window can be armed
+	// off the test goroutine, where FailNow is undefined.
+	assert.Equal(w.t, settleDelay, d, "every window is sized by settleDelay")
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	held := &heldWindow{windows: w, deliver: deliver}
@@ -112,36 +118,75 @@ func (h *heldWindow) Stop() bool {
 	return true
 }
 
+// expire fires every window open right now, but hands the deliveries back
+// instead of running them.
+//
+// time.AfterFunc runs a callback on its own goroutine, so a window FIRES and
+// lands later, and a cancel and a re-arm both fit in that gap. A case that needs
+// the gap drives the two halves itself; close runs them back to back.
+func (w *settleWindows) expire() []func() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	deliveries := make([]func(), 0, len(w.open))
+	for _, held := range w.open {
+		if !held.closed {
+			held.closed = true
+			deliveries = append(deliveries, held.deliver)
+		}
+	}
+	w.open = nil
+	return deliveries
+}
+
 // close ends every window open right now, exactly as the delay expiring would.
 // It reports how many delivered, so a case can prove a window was open at all
 // rather than asserting against a settle that never waited.
 func (w *settleWindows) close() int {
+	// Outside the lock: each delivery re-derives, which can arm the NEXT window.
+	deliveries := w.expire()
+	for _, deliver := range deliveries {
+		deliver()
+	}
+	return len(deliveries)
+}
+
+// openWindows lists the windows still waiting, so a case can assert that a
+// cancel left none rather than that a delivery did not happen.
+func (w *settleWindows) openWindows() []*heldWindow {
 	w.mu.Lock()
-	delivering := make([]*heldWindow, 0, len(w.open))
+	defer w.mu.Unlock()
+	still := make([]*heldWindow, 0, len(w.open))
 	for _, held := range w.open {
 		if !held.closed {
-			held.closed = true
-			delivering = append(delivering, held)
+			still = append(still, held)
 		}
 	}
-	w.open = nil
-	w.mu.Unlock()
-	// Outside the lock: each delivery re-derives, which can arm the NEXT window.
-	for _, held := range delivering {
-		held.deliver()
-	}
-	return len(delivering)
+	return still
 }
+
+// settleFakes remembers the fake already installed on a handler, so holdSettles
+// is idempotent. Package-level because the handler cannot carry a test type.
+var settleFakes sync.Map // *OutputHandler -> *settleWindows
 
 // holdSettles puts a controllable settle window on h and returns it.
 //
 // Every handler a test builds gets one from its own constructor, so no case ever
-// arms a real 500 ms timer that outlives it. A case that drives the window calls
-// this again for the handle; the second install is safe because it lands at
-// setup time, before any output flows and so before anything can arm.
+// arms a real settleDelay timer that outlives it. A case that drives the window
+// calls this again for the handle, and gets the SAME fake back.
+//
+// Idempotent, and that is load-bearing rather than tidy. Installing a second
+// fake would leave any window already open on the first one stranded: nothing
+// can ever fire it, so a settle disappears and close reports zero while a
+// spinner is genuinely stuck. The old form was safe only while every case
+// happened to call this before any output flowed.
 func holdSettles(t *testing.T, h *OutputHandler) *settleWindows {
 	t.Helper()
-	w := &settleWindows{}
+	if v, ok := settleFakes.Load(h); ok {
+		return v.(*settleWindows)
+	}
+	w := &settleWindows{t: t}
+	settleFakes.Store(h, w)
+	t.Cleanup(func() { settleFakes.Delete(h) })
 	h.newSettleTimer = w.timer
 	return w
 }
@@ -217,7 +262,7 @@ func TestActivity_PendingControlRequestMakesAnAgentIdleMidTurn(t *testing.T) {
 	// prompt. Reporting busy there would spin an indicator at somebody who is
 	// being asked a question.
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
-	settles.close()
+	require.Equal(t, 0, settles.close(), "a prompt publishes at once, so there is no window")
 	assert.Equal(t, []bool{true, false}, rec.busyStates())
 
 	h.noteControlRequestsRemoved("agent-1", "agent-1", "req-1")
@@ -237,14 +282,14 @@ func TestActivity_APromptMidTurnIsWaitingRatherThanIdle(t *testing.T) {
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
 
-	// The SNAPSHOT is exact while the window runs -- it derives from the inputs
-	// and never consults it -- so the assertions below split: the read path
-	// answers now, the wire answers when the window closes.
 	got := h.AgentActivitySnapshot("agent-1", "agent-1")
 	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WAITING_FOR_USER, got.State)
 	assert.False(t, got.Working(), "the indicator must not spin at somebody being asked a question")
 	assert.True(t, got.InterruptsWork(), "but a close would still kill the turn")
-	require.Equal(t, 1, settles.close())
+
+	// No window: only the user can answer a prompt, so no wake can undo this
+	// stop. See settleCanResumeLocked.
+	assert.Equal(t, 0, settles.close(), "a prompt waits out no window")
 	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WAITING_FOR_USER,
 		rec.last().GetState(), "and the state reaches the wire, so both surfaces read the same rule")
 }
@@ -274,7 +319,7 @@ func TestActivity_DuplicateControlRequestPublishesOnce(t *testing.T) {
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
 	h.noteControlRequestsRemoved("agent-1", "agent-1", "req-unknown")
 
-	require.Equal(t, 1, settles.close(), "the duplicate opened no second window either")
+	require.Equal(t, 0, settles.close(), "a prompt publishes at once, so there is no window")
 	assert.Equal(t, []bool{true, false}, rec.busyStates())
 }
 
@@ -286,7 +331,7 @@ func TestActivity_TwoPromptsNeedBothAnswersBeforeWorkResumes(t *testing.T) {
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-2")
-	settles.close()
+	require.Equal(t, 0, settles.close(), "a prompt publishes at once, so there is no window")
 	require.Equal(t, []bool{true, false}, rec.busyStates())
 
 	h.noteControlRequestsRemoved("agent-1", "agent-1", "req-1")
@@ -312,7 +357,7 @@ func TestActivity_DeadProcessIsIdleWhateverElseIsRecorded(t *testing.T) {
 	running = false
 	h.refreshActivity("agent-1", "agent-1")
 
-	require.Equal(t, 1, settles.close(), "a settle waits out its window whatever produced it")
+	require.Equal(t, 0, settles.close(), "a dead process resumes nothing, so its settle publishes at once")
 	assert.Equal(t, []bool{true, false}, rec.busyStates())
 }
 
@@ -323,12 +368,18 @@ func TestActivity_ProcessExitClearsEverythingAndSettles(t *testing.T) {
 	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
-	settles.close()
+	require.Equal(t, 0, settles.close(), "a prompt publishes at once, so there is no window")
 	require.Equal(t, []bool{true, false}, rec.busyStates())
 
 	// HandleAgentProcessExit broadcasts no AgentStatusChange, so this is the only
 	// signal a client gets that a crashed agent stopped working.
 	h.NoteAgentProcessExited("agent-1")
+	h.WaitActivityRefreshes()
+
+	// The settle half, which the name promises and nothing else covers: a dead
+	// process is IDLE, not still waiting on the prompt it died holding.
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE, rec.last().GetState())
+	assert.Equal(t, 0, settles.close(), "and a process boundary opens no window")
 
 	// The reset lands synchronously even though its broadcast does not.
 	st := h.activityFor("agent-1", "agent-1")
@@ -423,10 +474,16 @@ func TestActivity_ProviderThatReportsNoCountLeavesItUnset(t *testing.T) {
 	t.Parallel()
 
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteTurnEnded("agent-1", "agent-1", 0, false)
 	h.setTurnActive("agent-1", "agent-1", false)
+	// The settle waits out its window, so the count has to be read from the
+	// event the window DELIVERS. Read rec.last() before this and it answers with
+	// the busy publish, whose count is nil whatever the settle path decides.
+	require.Equal(t, 1, settles.close(), "the clear opened the settle window")
 
+	require.Equal(t, []bool{true, false}, rec.busyStates(), "the settle reached the wire")
 	assert.Nil(t, rec.last().NumToolUses, "unset, so the client rings rather than guessing 0")
 }
 
@@ -437,9 +494,22 @@ func TestActivity_SettleWithNoTurnEndCarriesNoCount(t *testing.T) {
 	// agent without a turn ending. Neither should inherit an earlier turn's
 	// count, which would silence an alert the user needs.
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+
+	// An earlier turn ends and spends its count, so there IS one to inherit.
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.noteTurnEnded("agent-1", "agent-1", 5, true)
+	h.setTurnActive("agent-1", "agent-1", false)
+	require.Equal(t, 1, settles.close())
+	require.Equal(t, int32(5), rec.last().GetNumToolUses())
+
+	// The next turn is blocked on a prompt. That settle carries no count, and it
+	// publishes at once, because only the user can answer.
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
 
+	require.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WAITING_FOR_USER,
+		rec.last().GetState())
 	assert.Nil(t, rec.last().NumToolUses)
 }
 
@@ -447,13 +517,16 @@ func TestActivity_NewTurnDropsAnUnspentCount(t *testing.T) {
 	t.Parallel()
 
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.noteTurnEnded("agent-1", "agent-1", 9, true)
 
 	// A fresh turn supersedes whatever the previous one left unspent, so a stale
 	// count cannot silence the alert for the turn now starting.
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.setTurnActive("agent-1", "agent-1", false)
+	require.Equal(t, 1, settles.close(), "the clear opened the settle window")
 
+	require.Equal(t, []bool{true, false}, rec.busyStates())
 	assert.Nil(t, rec.last().NumToolUses)
 }
 
@@ -485,14 +558,7 @@ func TestActivity_ASubagentRestartDoesNotSettleTheRoot(t *testing.T) {
 	// the CLI restarts that subagent, and the row ends and reopens in one output
 	// burst. The root has no turn of its own here, so the row IS its work.
 	const rootID = "root-1"
-	svc, sink := setupRootSink(t, rootID)
-	svc.Output.processRunning = func(string) bool { return true }
-	childID, err := sink.EnsureChildAgent("spawn-1", "task-1", "SCAN")
-	require.NoError(t, err)
-	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
-		RowKey: "task-1", Kind: bgtask.KindSubagent, ChildAgentID: childID,
-		Title: "SCAN", Status: bgtask.StatusRunning,
-	}))
+	svc, sink, _ := setupRunningSubagent(t, rootID, bgtask.StatusRunning)
 	rec := watchActivity(t, svc, rootID)
 	settles := holdSettles(t, svc.Output)
 	require.True(t, svc.Output.AgentActivitySnapshot(rootID, rootID).Working())
@@ -505,23 +571,39 @@ func TestActivity_ASubagentRestartDoesNotSettleTheRoot(t *testing.T) {
 	assert.True(t, svc.Output.AgentActivitySnapshot(rootID, rootID).Working())
 }
 
-func TestActivity_TheWindowPublishesTheStateItENDSWith(t *testing.T) {
+func TestActivity_AFallThroughPublishSupersedesTheWindow(t *testing.T) {
 	t.Parallel()
 
-	// The delivery re-derives rather than replaying what opened the window, so a
-	// state that moved inside it reaches the client as what it IS. Here the turn
-	// clear opens the window and a prompt arrives before it closes.
+	// A stop that cannot be resumed publishes at once even while a window runs,
+	// and it must take that window with it. A handle left behind is one the NEXT
+	// settle adopts. holdSettleLocked finds
+	// a window already open, so that settle
+	// never opens one of its own, never owns
+	// its count, and lands on the leftover
+	// of somebody else's deadline.
 	h, rec := newActivityHandler(t, "agent-1")
 	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.setTurnActive("agent-1", "agent-1", false)
+	require.Len(t, settles.openWindows(), 1, "the clear opened the window this case supersedes")
+
+	// A shell task asks for permission after the turn ended, so the agent is
+	// plain idle and only the user can move it. That publishes at once.
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
 
-	require.Equal(t, 1, settles.close())
-
-	require.NotNil(t, rec.last())
-	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE, rec.last().GetState(),
+	assert.Empty(t, settles.openWindows(), "the publish superseded the window")
+	require.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE, rec.last().GetState(),
 		"a prompt with no turn behind it is plain idle, and that is what lands")
+
+	// The next turn's settle must own its own window and its own count.
+	h.noteControlRequestsRemoved("agent-1", "agent-1", "req-1")
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.noteTurnEnded("agent-1", "agent-1", 7, true)
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	require.Equal(t, 1, settles.close(), "and opens a window of its own")
+	require.NotNil(t, rec.last().NumToolUses, "carrying the count its turn recorded")
+	assert.Equal(t, int32(7), rec.last().GetNumToolUses())
 }
 
 func TestActivity_ASecondDerivationDoesNotRestartTheWindow(t *testing.T) {
@@ -586,8 +668,9 @@ func TestActivity_AProcessBoundaryPublishesWithoutWaiting(t *testing.T) {
 func TestActivity_ShutdownDropsAWindowStillOpen(t *testing.T) {
 	t.Parallel()
 
-	// The belt to the process exits' braces. A timer that survived shutdown would
-	// read the registry and broadcast after the caller closed the database.
+	// Shutdown is the redundant guard behind the process exits. A timer that
+	// survived shutdown would read the registry and broadcast after the caller
+	// closed the database.
 	h, rec := newActivityHandler(t, "agent-1")
 	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
@@ -599,20 +682,34 @@ func TestActivity_ShutdownDropsAWindowStillOpen(t *testing.T) {
 	assert.Equal(t, []bool{true}, rec.busyStates(), "and nothing reached the wire")
 }
 
-func TestActivity_ForgettingAnAgentDropsItsWindow(t *testing.T) {
+func TestActivity_ForgettingAnAgentDeliversItsHeldSettle(t *testing.T) {
 	t.Parallel()
 
-	// A timer left running would re-create the entry it fires against and
-	// broadcast for an agent this call just retired.
+	// Retiring an agent is the LAST chance a held settle has. A subagent's row
+	// closes and the
+	// provider retires the
+	// child on the next
+	// line, which lands
+	// inside the window
+	// that close opened.
+	// Dropping it there
+	// loses the settle for
+	// good: the entry that
+	// held the edge is
+	// gone, and no later
+	// refresh can find it. The child's tab kept a spinner on a run that ended.
 	h, rec := newActivityHandler(t, "agent-1")
 	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.setTurnActive("agent-1", "agent-1", false)
+	require.Equal(t, []bool{true}, rec.busyStates(), "the settle is still waiting")
 
 	h.ForgetActivity("agent-1")
 
-	assert.Equal(t, 0, settles.close())
-	assert.Equal(t, []bool{true}, rec.busyStates())
+	assert.Equal(t, []bool{true, false}, rec.busyStates(), "the settle landed on the way out")
+	assert.Equal(t, 0, settles.close(), "and its window is gone, not left to fire later")
+	_, alive := h.activity.Load("agent-1")
+	assert.False(t, alive, "the delivery must not leave the entry behind")
 }
 
 func TestActivity_AStaleRefreshDoesNotCancelAFresherWindow(t *testing.T) {
@@ -648,14 +745,7 @@ func TestActivity_AChildSettleIsHeldAndDeliveredUnderItsOwnID(t *testing.T) {
 	// under the root's id would leave the child spinning and drop the parent's
 	// indicator instead.
 	const rootID = "root-1"
-	svc, sink := setupRootSink(t, rootID)
-	svc.Output.processRunning = func(string) bool { return true }
-	childID, err := sink.EnsureChildAgent("spawn-1", "task-1", "SCAN")
-	require.NoError(t, err)
-	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
-		RowKey: "task-1", Kind: bgtask.KindSubagent, ChildAgentID: childID,
-		Title: "SCAN", Status: bgtask.StatusRunning,
-	}))
+	svc, sink, childID := setupRunningSubagent(t, rootID, bgtask.StatusRunning)
 	rec := watchActivity(t, svc, rootID, childID)
 	settles := holdSettles(t, svc.Output)
 	// The root owes the user a reply, so only the CHILD settles when the row ends.
@@ -672,7 +762,7 @@ func TestActivity_AChildSettleIsHeldAndDeliveredUnderItsOwnID(t *testing.T) {
 		"and the root's turn is untouched")
 }
 
-func TestActivity_TreeRecomputesAChildTheDisplayCapDropped(t *testing.T) {
+func TestActivity_TreeChildIDsIncludeAChildTheDisplayCapDropped(t *testing.T) {
 	t.Parallel()
 
 	// The cap gives up the oldest ACTIVE row when the pool is full, which is
@@ -743,6 +833,9 @@ func TestActivity_AChildTurnEndLeavesTheRootWorking(t *testing.T) {
 	h.setTurnActive("child-1", "root-1", false)
 
 	assert.Equal(t, []bool{true}, rec.busyStates(), "the root published no settle")
+	// The window would SWALLOW a wrong settle, so an unchanged wire is not on its
+	// own proof that the root's derivation stayed WORKING.
+	require.Equal(t, 0, settles.close(), "and opened no window on the root either")
 	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING,
 		h.AgentActivitySnapshot("root-1", "root-1").State)
 
@@ -750,7 +843,7 @@ func TestActivity_AChildTurnEndLeavesTheRootWorking(t *testing.T) {
 	// because no turn end of the ROOT's recorded one -- which is what tells the
 	// client to ring rather than to read a zero.
 	h.setTurnActive("root-1", "root-1", false)
-	settles.close()
+	require.Equal(t, 1, settles.close(), "the root's own clear is the settle that waits")
 	require.Equal(t, []bool{true, false}, rec.busyStates())
 	assert.Nil(t, rec.last().NumToolUses, "a child's count belongs to the child's settle")
 }
@@ -810,14 +903,7 @@ func TestActivity_ARootCountsTheRunningRowsTheCapHid(t *testing.T) {
 	// gives up an ACTIVE one, and retention keeps that row running in the table.
 	// Reading the list alone then makes the root settle -- ringing the completion
 	// sound and letting the close guard pass -- while the subagent still runs.
-	svc, sink := setupRootSink(t, "root-1")
-	svc.Output.processRunning = func(string) bool { return true }
-	childID, err := sink.EnsureChildAgent("spawn-1", "task-1", "SCAN")
-	require.NoError(t, err)
-	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
-		RowKey: "task-1", Kind: bgtask.KindSubagent, ChildAgentID: childID,
-		Title: "SCAN", Status: bgtask.StatusRunning,
-	}))
+	svc, sink, childID := setupRunningSubagent(t, "root-1", bgtask.StatusRunning)
 
 	// Every filler row is active too, so eviction has no finished row to take and
 	// gives up the oldest -- this child's.
@@ -980,6 +1066,40 @@ func TestActivity_AClearThatDoesNotSettleDropsTheCount(t *testing.T) {
 		"the settle the shell task causes belongs to the task, so it must alert")
 }
 
+// setupRunningSubagent builds a root whose single subagent row is open, which is
+// where most of the cases below start. The row's status is the one input that
+// varies, so it is the one parameter.
+//
+// The caller may replace processRunning afterwards: this leaves it answering
+// true, so a case drives the registry inputs in isolation.
+func setupRunningSubagent(
+	t *testing.T, rootID string, status bgtask.Status,
+) (*Service, agent.OutputSink, string) {
+	t.Helper()
+	svc, sink := setupRootSink(t, rootID)
+	svc.Output.processRunning = func(string) bool { return true }
+	childID, err := sink.EnsureChildAgent("spawn-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "task-1", Kind: bgtask.KindSubagent, ChildAgentID: childID,
+		Title: "SCAN", Status: status,
+	}))
+	return svc, sink, childID
+}
+
+// unspentTurnActive reads the turn flag an entry still holds, which for a collab
+// child is what its input queue follows.
+func unspentTurnActive(h *OutputHandler, agentID string) bool {
+	v, ok := h.activity.Load(agentID)
+	if !ok {
+		return false
+	}
+	st := v.(*agentActivity)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	return st.turnActive
+}
+
 // watchActivity attaches a recorder to a service-backed test, so a case can
 // assert what reached the WIRE rather than only what a snapshot read derives.
 func watchActivity(t *testing.T, svc *Service, agentIDs ...string) *activityRecorder {
@@ -1019,6 +1139,7 @@ func TestActivity_TheLastBackgroundTaskSettlesTheAgent(t *testing.T) {
 	svc.Output.setTurnActive(rootID, rootID, false)
 	assert.Equal(t, []bool{true}, rec.busyStates(),
 		"the shell task holds the agent past its own turn end, so nothing rings yet")
+	require.Equal(t, 0, settles.close(), "and no window is waiting to ring it late either")
 
 	require.NoError(t, sink.CloseBackgroundTask("row-shell", bgtask.StatusCompleted))
 	require.Equal(t, 1, settles.close(), "the last task's close opened the settle window")
@@ -1038,6 +1159,7 @@ func TestActivity_AnEarlierBackgroundTaskSettlesNothing(t *testing.T) {
 	svc, sink := setupRootSink(t, rootID)
 	svc.Output.processRunning = func(string) bool { return true }
 	rec := watchActivity(t, svc, rootID)
+	settles := holdSettles(t, svc.Output)
 	for _, rowKey := range []string{"row-shell-1", "row-shell-2"} {
 		require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
 			RowKey: rowKey, Kind: bgtask.KindShell,
@@ -1048,6 +1170,9 @@ func TestActivity_AnEarlierBackgroundTaskSettlesNothing(t *testing.T) {
 
 	require.NoError(t, sink.CloseBackgroundTask("row-shell-1", bgtask.StatusCompleted))
 
+	// The window would SWALLOW a wrong settle, so "nothing was published" alone
+	// no longer distinguishes "no settle derived" from "a settle is waiting".
+	assert.Equal(t, 0, settles.close(), "one of two tasks ending opens no window")
 	assert.Equal(t, []bool{true}, rec.busyStates(), "one of two tasks ending is not a settle")
 	assert.True(t, svc.Output.AgentActivitySnapshot(rootID, rootID).Working())
 }
@@ -1223,14 +1348,7 @@ func TestInspectTerminalProcesses_OmitsWhatItCannotWarnAbout(t *testing.T) {
 func TestActivity_AChildStaysBusyAfterTheCapDropsItsRow(t *testing.T) {
 	t.Parallel()
 
-	svc, sink := setupRootSink(t, "root-1")
-	svc.Output.processRunning = func(string) bool { return true }
-	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
-	require.NoError(t, err)
-	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
-		RowKey: "task-1", Kind: bgtask.KindSubagent, ChildAgentID: childID,
-		Title: "SCAN", Status: bgtask.StatusRunning,
-	}))
+	svc, sink, childID := setupRunningSubagent(t, "root-1", bgtask.StatusRunning)
 	before := svc.Output.AgentActivitySnapshot(childID, "root-1")
 	require.True(t, before.Working(), "the child is running before the cap moves")
 	require.Equal(t, int32(1), before.ActiveTasks)
@@ -1325,14 +1443,7 @@ func TestActivity_APendingChildRowCountsAsWorkPastTheCap(t *testing.T) {
 	// that is the state it sits in for the whole window where the user is most
 	// likely to close the tab by accident. The fallback has to treat it as work,
 	// not just `running`.
-	svc, sink := setupRootSink(t, "root-1")
-	svc.Output.processRunning = func(string) bool { return true }
-	childID, err := sink.EnsureChildAgent("span-1", "task-1", "SCAN")
-	require.NoError(t, err)
-	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
-		RowKey: "task-1", Kind: bgtask.KindSubagent, ChildAgentID: childID,
-		Title: "SCAN", Status: bgtask.StatusPending,
-	}))
+	svc, sink, childID := setupRunningSubagent(t, "root-1", bgtask.StatusPending)
 	fillSubagentDisplayCap(t, sink, bgtask.MaxTasks)
 	displayed, err := svc.Output.LoadBackgroundTasks(context.Background(), "root-1")
 	require.NoError(t, err)
@@ -1384,4 +1495,530 @@ func TestActivity_ARootTurnFlagStillOwnsTheCount(t *testing.T) {
 
 	h.setTurnActive("agent-1", "agent-1", true)
 	assert.Nil(t, unspentToolCount(h, "agent-1"), "a fresh turn supersedes an unspent count")
+}
+
+// --- What a Stop cannot recall. See agentActivity.settleGen. ---
+
+func TestActivity_ALateCallbackDoesNotStealTheNextWindow(t *testing.T) {
+	t.Parallel()
+
+	// time.AfterFunc runs a callback on its own goroutine, so a window FIRES and
+	// lands later. A cancel and a re-arm both fit in that gap, and the spent
+	// callback then owns a handle that belongs to a window it never opened.
+	// Without the generation token it clears that handle and publishes at once, so
+	// the SECOND stop skips its whole window. That is the early completion sound
+	// this file exists to remove, reached the long way round.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	deliveries := settles.expire()
+	require.Len(t, deliveries, 1, "the clear opened one window, and it has now fired")
+
+	// Work resumes and stops again inside the gap, which voids the first settle
+	// and opens a SECOND window.
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	deliveries[0]()
+
+	assert.Equal(t, []bool{true}, rec.busyStates(), "the spent callback published nothing")
+	require.Equal(t, 1, settles.close(), "the second window still owns the delivery")
+	assert.Equal(t, []bool{true, false}, rec.busyStates())
+	// A window holds one activityRefreshes count, released by whichever of the
+	// cancel and the callback got there. A missing release parks Shutdown for
+	// good; a double release panics. This returns at once when they balance.
+	h.WaitActivityRefreshes()
+}
+
+func TestActivity_ALateCallbackDoesNotResurrectAForgottenAgent(t *testing.T) {
+	t.Parallel()
+
+	// ForgetActivity cannot recall a callback that already fired. Before the
+	// token, that
+	// callback called
+	// activityFor,
+	// whose
+	// LoadOrStore
+	// MINTED a
+	// replacement
+	// entry for the
+	// agent just
+	// retired. It
+	// broadcast for a
+	// closed tab, and
+	// nothing ever
+	// reaped that
+	// entry, because
+	// the one cleanup
+	// that deletes it
+	// already ran.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	deliveries := settles.expire()
+	require.Len(t, deliveries, 1)
+
+	// The tab closes while that callback is on its way. The settle it was
+	// carrying lands here, on the way out.
+	h.ForgetActivity("agent-1")
+	require.Equal(t, []bool{true, false}, rec.busyStates())
+
+	deliveries[0]()
+
+	assert.Equal(t, []bool{true, false}, rec.busyStates(), "the spent callback published nothing")
+	_, alive := h.activity.Load("agent-1")
+	assert.False(t, alive, "and minted no replacement entry for a retired agent")
+	h.WaitActivityRefreshes()
+}
+
+func TestActivity_AResumeThatRacesTheDeliveryStillDropsTheCount(t *testing.T) {
+	t.Parallel()
+
+	// The count-void has to key on the SETTLE, not on the timer handle. The
+	// delivery
+	// releases
+	// that
+	// handle
+	// before it
+	// re-derives,
+	// so a
+	// resume
+	// that lands
+	// in between
+	// found a
+	// nil handle
+	// and kept
+	// the count.
+	// A
+	// zero-tool
+	// turn then
+	// left a
+	// zero
+	// behind,
+	// and the
+	// client
+	// suppresses
+	// a zero. The background task
+	// still running finished later in silence.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.noteTurnEnded("agent-1", "agent-1", 0, true)
+	h.setTurnActive("agent-1", "agent-1", false)
+	require.NotNil(t, unspentToolCount(h, "agent-1"), "the held settle still owns the count")
+
+	// The window fires, so deliverHeldSettle releases the handle and then
+	// re-derives. The work comes back in that gap. Setting the flag directly is
+	// what makes the gap reachable. A
+	// provider publishes its turn
+	// flag a moment before the
+	// refresh that reads it lands, so
+	// the delivery's own derivation
+	// sees WORKING while no refresh
+	// has run to void anything.
+	deliveries := settles.expire()
+	require.Len(t, deliveries, 1)
+	st := h.activityFor("agent-1", "agent-1")
+	st.mu.Lock()
+	st.turnActive = true
+	st.mu.Unlock()
+
+	deliveries[0]()
+
+	assert.Nil(t, unspentToolCount(h, "agent-1"), "the resume voided the count the settle carried")
+	assert.Equal(t, []bool{true}, rec.busyStates(), "and published nothing, because the work resumed")
+
+	// A stop that really lasts must now alert unconditionally.
+	st.mu.Lock()
+	st.turnActive = false
+	st.mu.Unlock()
+	h.refreshActivity("agent-1", "agent-1")
+	require.Equal(t, 1, settles.close())
+	assert.Nil(t, rec.last().NumToolUses, "so this settle rings rather than reading a stale zero")
+}
+
+func TestActivity_APromptAnsweredAtOnceStillReachesTheClient(t *testing.T) {
+	t.Parallel()
+
+	// The severe half of holding a prompt. A held WAITING is not merely late. An
+	// answer arriving inside the window
+	// derives WORKING again, which VOIDS the
+	// settle, so the prompt's state never
+	// reaches the client at all and nothing
+	// ever alerts for it. Publishing at once is what makes the state survive an
+	// answer of any speed.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	require.Equal(t, []bool{true}, rec.busyStates())
+
+	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
+	h.noteControlRequestsRemoved("agent-1", "agent-1", "req-1")
+
+	assert.Equal(t, 0, settles.close(), "a prompt opens no window, whoever answers it")
+	assert.Equal(t, []bool{true, false, true}, rec.busyStates(),
+		"the prompt reached the client even though the answer followed at once")
+}
+
+func TestActivity_AProcessExitPublishesTheTreeWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	// MarkAgentBackgroundTasksExited is a process-death boundary: a dead process
+	// resumes nothing. Holding there parked every descendant's idle publish for a
+	// whole settleDelay, and on the tab-close path nothing later delivered it --
+	// the cleanup that follows retires the entry instead. A watcher of a subagent
+	// transcript kept a spinner on work whose process was already gone.
+	const rootID = "root-1"
+	svc, _, childID := setupRunningSubagent(t, rootID, bgtask.StatusRunning)
+	alive := true
+	svc.Output.processRunning = func(string) bool { return alive }
+	rec := watchActivity(t, svc, rootID, childID)
+	settles := holdSettles(t, svc.Output)
+	svc.Output.setTurnActive(rootID, rootID, true)
+	require.True(t, svc.Output.AgentActivitySnapshot(childID, rootID).Working())
+
+	alive = false
+	svc.Output.MarkAgentBackgroundTasksExited(rootID, true)
+
+	assert.Equal(t, 0, settles.close(), "a dead process opens no window")
+	assert.Contains(t, rec.agentIDs(), childID, "the child's idle publish landed at once")
+	assert.False(t, svc.Output.AgentActivitySnapshot(childID, rootID).Working())
+}
+
+func TestActivity_TheCatchUpBaselineIsWhatTheClientWasTold(t *testing.T) {
+	t.Parallel()
+
+	// A client that CACHES the pushed state has to be seeded from the same
+	// version the live events carry. Seeded from the exact derivation instead, a
+	// tab that promotes inside a settle window
+	// holds IDLE before the window's own
+	// AgentActivityChanged arrives. That event then
+	// moves nothing, the client sees no WORKING ->
+	// not-WORKING edge, and the completion sound
+	// never rings.
+	h, _ := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE,
+		h.AgentActivitySnapshot("agent-1", "agent-1").State,
+		"the derivation is exact throughout, which is what ListAgents and the CLI read")
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING,
+		h.AgentActivityPublished("agent-1", "agent-1"),
+		"but the baseline reports what the client actually holds")
+
+	require.Equal(t, 1, settles.close())
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE,
+		h.AgentActivityPublished("agent-1", "agent-1"),
+		"and the two agree again once the settle lands")
+}
+
+func TestActivity_ThePublishedBaselineFallsBackBeforeAnythingIsPublished(t *testing.T) {
+	t.Parallel()
+
+	// An agent this Worker never published for has no cached client answer to
+	// match, so the exact derivation IS the right baseline. The fallback cannot
+	// hide a window either: one opens only where `published` says WORKING, which
+	// requires the publish this branch is the absence of.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE,
+		h.AgentActivityPublished("agent-1", "agent-1"),
+		"nothing was published, so the exact answer is what a client should hold")
+	assert.Empty(t, rec.busyStates(), "and reading the baseline broadcasts nothing")
+
+	// The read above minted the entry, so the fallback now runs its INNER
+	// branch: an entry that exists and has published nothing. Dropping the
+	// hasPublished guard answers UNSPECIFIED here, which the client would ignore.
+	_, minted := h.activity.Load("agent-1")
+	require.True(t, minted, "a read mints the entry this branch is about")
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE,
+		h.AgentActivityPublished("agent-1", "agent-1"),
+		"an entry that published nothing still falls back to the exact answer")
+
+	// A turn then runs and settles. The fallback is gone from here on, because
+	// the first publish supplies the value.
+	h.setTurnActive("agent-1", "agent-1", true)
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING,
+		h.AgentActivityPublished("agent-1", "agent-1"))
+	h.setTurnActive("agent-1", "agent-1", false)
+	require.Equal(t, 1, settles.close())
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE,
+		h.AgentActivityPublished("agent-1", "agent-1"))
+}
+
+func TestActivity_ShutdownCancelsHeldSettlesBeforeItJoins(t *testing.T) {
+	t.Parallel()
+
+	// The WIRING, not the method. Deleting the CancelHeldSettles call in
+	// Service.Shutdown, or moving it after the join, broke no case before this
+	// one -- and both are load-bearing. A window that survives reads the registry
+	// and broadcasts after the caller closes the
+	// database. And because an armed window
+	// holds one of the counts the join waits on,
+	// joining FIRST parks Shutdown for a whole
+	// settleDelay.
+	const rootID = "root-1"
+	svc, _ := setupRootSink(t, rootID)
+	svc.Output.processRunning = func(string) bool { return true }
+	settles := holdSettles(t, svc.Output)
+	svc.Output.setTurnActive(rootID, rootID, true)
+	svc.Output.setTurnActive(rootID, rootID, false)
+	require.Equal(t, 1, len(settles.openWindows()), "this case needs an open window to survive")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		svc.Shutdown()
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Shutdown parked: it joined the refreshes before it cancelled the windows")
+	}
+
+	assert.Empty(t, settles.openWindows(), "Shutdown left no window to fire against a closed database")
+}
+
+func TestActivity_AWindowCannotOpenOnceShutdownBegins(t *testing.T) {
+	t.Parallel()
+
+	// The latch, which is what makes the cancel above final. Without it the sweep
+	// is a one-shot pass. A
+	// refresh that lands
+	// after it, such as a
+	// provider still
+	// draining its pipe,
+	// opens a window that
+	// fires three seconds
+	// later against a
+	// database the caller
+	// already closed.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	require.Equal(t, []bool{true}, rec.busyStates())
+
+	h.SetShuttingDown()
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	assert.Empty(t, settles.openWindows(), "no window opened after the latch")
+	assert.Equal(t, []bool{true, false}, rec.busyStates(),
+		"and the settle publishes at once rather than disappearing")
+}
+
+func TestActivity_ASubagentSettlesWhenTheProviderRetiresIt(t *testing.T) {
+	t.Parallel()
+
+	// The whole path, through the sink the providers actually use. A subagent's
+	// last row closes and the provider calls CleanupChildAgent on the very next
+	// line, so the retire lands INSIDE the window that close opened. Dropping the
+	// settle there
+	// loses it for
+	// good: the
+	// entry that
+	// held the edge
+	// is gone, and
+	// no later
+	// refresh can
+	// find it. The
+	// child's tab
+	// then keeps a
+	// spinner and
+	// an armed
+	// Interrupt
+	// button on a
+	// run that
+	// ended.
+	const rootID = "root-1"
+	svc, sink, childID := setupRunningSubagent(t, rootID, bgtask.StatusRunning)
+	rec := watchActivity(t, svc, rootID, childID)
+	settles := holdSettles(t, svc.Output)
+	svc.Output.setTurnActive(rootID, rootID, true)
+	require.True(t, svc.Output.AgentActivitySnapshot(childID, rootID).Working())
+
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	require.Empty(t, rec.agentIDs(), "the child's settle is still waiting out its window")
+	sink.CleanupChildAgent(childID)
+
+	assert.Equal(t, []string{childID}, rec.agentIDs(), "the retire delivered it")
+	assert.Equal(t, []bool{false}, rec.busyStates())
+	assert.Equal(t, 0, settles.close(), "and left no window to fire against a retired agent")
+	assert.True(t, svc.Output.AgentActivitySnapshot(rootID, rootID).Working(),
+		"the root's own turn is untouched")
+}
+
+func TestSettleWindows_HoldSettlesKeepsTheFakeAlreadyInstalled(t *testing.T) {
+	t.Parallel()
+
+	// The harness's own invariant. A case takes its handle from a SECOND call,
+	// after the constructor already installed one. If that call swapped the fake,
+	// a window opened in between
+	// would be stranded on the
+	// discarded instance. Nothing
+	// could fire it, so a real settle
+	// would vanish and close would
+	// report zero while a spinner
+	// stayed stuck.
+	h, _ := newActivityHandler(t, "agent-1")
+	first := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	second := holdSettles(t, h)
+
+	assert.Same(t, first, second, "the second call must hand back the fake in use")
+	assert.Equal(t, 1, second.close(), "so the window opened in between is still reachable")
+}
+
+// --- The activity map's own lifecycle. See retirableLocked. ---
+
+func TestActivity_AFinishedSubagentLeavesNoEntryBehind(t *testing.T) {
+	t.Parallel()
+
+	// Only Codex, ZCode and the ACP providers retire a child. Under Claude and Pi
+	// every subagent a
+	// session ever spawned
+	// kept its entry until
+	// the tab closed. Each
+	// one then cost a
+	// point query per
+	// registry mutation,
+	// once the display cap
+	// evicted its row. A run that ended, and whose end the
+	// client knows, has nothing left to remember.
+	const rootID = "root-1"
+	svc, sink, childID := setupRunningSubagent(t, rootID, bgtask.StatusRunning)
+	rec := watchActivity(t, svc, rootID, childID)
+	settles := holdSettles(t, svc.Output)
+	svc.Output.setTurnActive(rootID, rootID, true)
+	require.True(t, svc.Output.AgentActivitySnapshot(childID, rootID).Working())
+	_, held := svc.Output.activity.Load(childID)
+	require.True(t, held, "the running child owns an entry")
+
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	require.Equal(t, 1, settles.close(), "the close opened the child's settle window")
+
+	require.Equal(t, []string{childID}, rec.agentIDs(), "the settle reached the client first")
+	_, kept := svc.Output.activity.Load(childID)
+	assert.False(t, kept, "and then the finished child's entry went with it")
+	assert.NotContains(t, svc.Output.treeChildIDs(rootID, nil), childID,
+		"so a later tree refresh does not derive it again")
+	assert.False(t, svc.Output.AgentActivitySnapshot(childID, rootID).Working(),
+		"a read still answers correctly from the registry")
+}
+
+func TestActivity_ARunningSubagentKeepsItsEntryPastTheCap(t *testing.T) {
+	t.Parallel()
+
+	// The mirror, and the reason the reap tests the derived state rather than
+	// the display list. The cap gives up an ACTIVE row when the pool is full, so a
+	// child that is still going can vanish from that list. The
+	// map is the one source the cap cannot truncate.
+	const rootID = "root-1"
+	svc, _, childID := setupRunningSubagent(t, rootID, bgtask.StatusRunning)
+	holdSettles(t, svc.Output)
+	svc.Output.refreshActivityTree(rootID, settleHeld)
+	require.True(t, svc.Output.AgentActivitySnapshot(childID, rootID).Working())
+
+	// An empty list stands in for the cap having dropped every row.
+	assert.Contains(t, svc.Output.treeChildIDs(rootID, nil), childID,
+		"a running child stays reachable when the display list cannot show it")
+	_, kept := svc.Output.activity.Load(childID)
+	assert.True(t, kept, "and keeps the entry that carries its published state")
+}
+
+func TestActivity_ACollabChildKeepsItsEntryWhileItsTurnRuns(t *testing.T) {
+	t.Parallel()
+
+	// A collab child publishes its own turn flag, because its input queue
+	// follows that flag. Its registry row can end while that turn is still open,
+	// and the row's end is what publishes IDLE. The reap then
+	// sees a finished child. It would drop the flag its queue
+	// depends on, plus the token that orders two publishes
+	// arriving out of order. Only an entry that holds
+	// nothing may go.
+	const rootID = "root-1"
+	svc, sink, childID := setupRunningSubagent(t, rootID, bgtask.StatusRunning)
+	settles := holdSettles(t, svc.Output)
+	svc.Output.setTurnActive(rootID, rootID, true)
+	require.True(t, svc.Output.AgentActivitySnapshot(childID, rootID).Working())
+
+	// The child opens a turn of its own, which changes no derived state: a
+	// child answers from its registry row and never reads the flag.
+	svc.Output.setTurnActive(childID, rootID, true)
+
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	require.Equal(t, 1, settles.close(), "the row's end settles the child")
+
+	_, kept := svc.Output.activity.Load(childID)
+	assert.True(t, kept, "the open turn keeps the entry the reap would have taken")
+	assert.True(t, unspentTurnActive(svc.Output, childID), "and the flag its input queue follows")
+	assert.Contains(t, svc.Output.treeChildIDs(rootID, nil), childID)
+}
+
+func TestActivity_AChildWithAnUnspentCountIsNotReaped(t *testing.T) {
+	t.Parallel()
+
+	// The other half of the same rule. A count its turn end recorded belongs to
+	// a settle that has not landed, so an entry holding one is not empty.
+	h, _ := newActivityHandler(t, "root-1")
+	holdSettles(t, h)
+	h.setTurnActive("child-1", "root-1", true)
+	h.noteTurnEnded("child-1", "root-1", 4, true)
+	h.setTurnActive("child-1", "root-1", false)
+
+	require.NotNil(t, unspentToolCount(h, "child-1"), "the child's count survives its own clear")
+	assert.Equal(t, int32(4), *unspentToolCount(h, "child-1"))
+	assert.Contains(t, h.treeChildIDs("root-1", nil), "child-1",
+		"and the entry that carries it is still reachable")
+}
+
+func TestActivity_AUserInterruptPublishesWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	// The window exists for a stop the CLI takes back microseconds later. An
+	// interrupt is the opposite: InterruptAgent pauses the input queue before it
+	// signals, so no wake follows. Holding it left the thinking indicator and
+	// the Interrupt button on screen for three seconds after the user cancelled,
+	// which invites a second interrupt.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	require.Equal(t, []bool{true}, rec.busyStates())
+
+	h.NoteAgentInterrupted("agent-1", "agent-1")
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	assert.Equal(t, 0, settles.close(), "the user stopped it, so nothing can resume it")
+	assert.Equal(t, []bool{true, false}, rec.busyStates())
+}
+
+func TestActivity_AnIgnoredInterruptDoesNotExemptTheNextTurn(t *testing.T) {
+	t.Parallel()
+
+	// The bound on that mark, and the reason it is not simply latched. An agent
+	// can IGNORE an interrupt and keep working. The stop that eventually comes
+	// then belongs to work the user never cancelled, and it is resumable like
+	// any other -- so it must wait out its window.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.NoteAgentInterrupted("agent-1", "agent-1")
+
+	// The agent carries on: a new turn opens, and its WORKING publish is what
+	// says the interrupt did not land.
+	h.setTurnActive("agent-1", "agent-1", false)
+	require.Equal(t, 0, settles.close(), "the interrupt published at once")
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	require.Equal(t, 1, settles.close(), "the next stop is an ordinary settle again")
+	assert.Equal(t, []bool{true, false, true, false}, rec.busyStates())
 }

--- a/backend/internal/worker/service/output_activity_test.go
+++ b/backend/internal/worker/service/output_activity_test.go
@@ -72,6 +72,80 @@ func (r *activityRecorder) agentIDs() []string {
 	return append([]string(nil), r.agents...)
 }
 
+// settleWindows drives the settle debounce in a test.
+//
+// The handler holds a WORKING -> not-WORKING publish for settleDelay, so a case
+// that asserts a settle has to say WHEN that window closes. Letting the real
+// delay run would make the machine that runs the suite decide the outcome, which
+// is the reason the handler takes its timer through a seam at all.
+//
+// A window cannot deliver from inside the arm: holdSettleLocked arms while it
+// holds the entry's mutex, and the delivery takes that mutex again.
+type settleWindows struct {
+	mu   sync.Mutex
+	open []*heldWindow
+}
+
+type heldWindow struct {
+	windows *settleWindows
+	deliver func()
+	// closed covers both ends: delivered, and stopped before it could deliver.
+	closed bool
+}
+
+func (w *settleWindows) timer(_ time.Duration, deliver func()) settleStopper {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	held := &heldWindow{windows: w, deliver: deliver}
+	w.open = append(w.open, held)
+	return held
+}
+
+// Stop reports whether this window was still open, matching *time.Timer.Stop.
+func (h *heldWindow) Stop() bool {
+	h.windows.mu.Lock()
+	defer h.windows.mu.Unlock()
+	if h.closed {
+		return false
+	}
+	h.closed = true
+	return true
+}
+
+// close ends every window open right now, exactly as the delay expiring would.
+// It reports how many delivered, so a case can prove a window was open at all
+// rather than asserting against a settle that never waited.
+func (w *settleWindows) close() int {
+	w.mu.Lock()
+	delivering := make([]*heldWindow, 0, len(w.open))
+	for _, held := range w.open {
+		if !held.closed {
+			held.closed = true
+			delivering = append(delivering, held)
+		}
+	}
+	w.open = nil
+	w.mu.Unlock()
+	// Outside the lock: each delivery re-derives, which can arm the NEXT window.
+	for _, held := range delivering {
+		held.deliver()
+	}
+	return len(delivering)
+}
+
+// holdSettles puts a controllable settle window on h and returns it.
+//
+// Every handler a test builds gets one from its own constructor, so no case ever
+// arms a real 500 ms timer that outlives it. A case that drives the window calls
+// this again for the handle; the second install is safe because it lands at
+// setup time, before any output flows and so before anything can arm.
+func holdSettles(t *testing.T, h *OutputHandler) *settleWindows {
+	t.Helper()
+	w := &settleWindows{}
+	h.newSettleTimer = w.timer
+	return w
+}
+
 // newActivityHandler wires a handler whose process-running check always answers
 // true, so a test can drive the other inputs in isolation. `agents` is nil here,
 // which the derivation reads as "no process": the fake below replaces that.
@@ -81,6 +155,7 @@ func newActivityHandler(t *testing.T, agentID string) (*OutputHandler, *activity
 	rec := newActivityRecorder("ch-1")
 	m.agents.setWatches("ch-1", []watchEntry{{id: agentID, mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY}}, rec)
 	h := &OutputHandler{watcher: m, processRunning: func(string) bool { return true }}
+	holdSettles(t, h)
 	return h, rec
 }
 
@@ -88,9 +163,15 @@ func TestActivity_TurnOpensAndClosesTheBusyState(t *testing.T) {
 	t.Parallel()
 
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.setTurnActive("agent-1", "agent-1", false)
+
+	// Opening the turn is published at once; the settle waits out its window,
+	// because work that resumes inside it never reaches a client as a stop.
+	assert.Equal(t, []bool{true}, rec.busyStates())
+	require.Equal(t, 1, settles.close(), "the clear opened a settle window")
 
 	assert.Equal(t, []bool{true, false}, rec.busyStates())
 	assert.Equal(t, []string{"agent-1", "agent-1"}, rec.agentIDs())
@@ -128,6 +209,7 @@ func TestActivity_PendingControlRequestMakesAnAgentIdleMidTurn(t *testing.T) {
 	t.Parallel()
 
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	require.Equal(t, []bool{true}, rec.busyStates())
 
@@ -135,6 +217,7 @@ func TestActivity_PendingControlRequestMakesAnAgentIdleMidTurn(t *testing.T) {
 	// prompt. Reporting busy there would spin an indicator at somebody who is
 	// being asked a question.
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
+	settles.close()
 	assert.Equal(t, []bool{true, false}, rec.busyStates())
 
 	h.noteControlRequestsRemoved("agent-1", "agent-1", "req-1")
@@ -150,13 +233,18 @@ func TestActivity_APromptMidTurnIsWaitingRatherThanIdle(t *testing.T) {
 	// straight at the prompt, but the turn is still in flight and closing the tab
 	// kills it along with every subagent under it.
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
 
+	// The SNAPSHOT is exact while the window runs -- it derives from the inputs
+	// and never consults it -- so the assertions below split: the read path
+	// answers now, the wire answers when the window closes.
 	got := h.AgentActivitySnapshot("agent-1", "agent-1")
 	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WAITING_FOR_USER, got.State)
 	assert.False(t, got.Working(), "the indicator must not spin at somebody being asked a question")
 	assert.True(t, got.InterruptsWork(), "but a close would still kill the turn")
+	require.Equal(t, 1, settles.close())
 	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WAITING_FOR_USER,
 		rec.last().GetState(), "and the state reaches the wire, so both surfaces read the same rule")
 }
@@ -179,12 +267,14 @@ func TestActivity_DuplicateControlRequestPublishesOnce(t *testing.T) {
 	t.Parallel()
 
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
 	h.noteControlRequestsRemoved("agent-1", "agent-1", "req-unknown")
 
+	require.Equal(t, 1, settles.close(), "the duplicate opened no second window either")
 	assert.Equal(t, []bool{true, false}, rec.busyStates())
 }
 
@@ -192,9 +282,11 @@ func TestActivity_TwoPromptsNeedBothAnswersBeforeWorkResumes(t *testing.T) {
 	t.Parallel()
 
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-2")
+	settles.close()
 	require.Equal(t, []bool{true, false}, rec.busyStates())
 
 	h.noteControlRequestsRemoved("agent-1", "agent-1", "req-1")
@@ -208,6 +300,7 @@ func TestActivity_DeadProcessIsIdleWhateverElseIsRecorded(t *testing.T) {
 	t.Parallel()
 
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	running := true
 	h.processRunning = func(string) bool { return running }
 
@@ -219,6 +312,7 @@ func TestActivity_DeadProcessIsIdleWhateverElseIsRecorded(t *testing.T) {
 	running = false
 	h.refreshActivity("agent-1", "agent-1")
 
+	require.Equal(t, 1, settles.close(), "a settle waits out its window whatever produced it")
 	assert.Equal(t, []bool{true, false}, rec.busyStates())
 }
 
@@ -226,8 +320,10 @@ func TestActivity_ProcessExitClearsEverythingAndSettles(t *testing.T) {
 	t.Parallel()
 
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
+	settles.close()
 	require.Equal(t, []bool{true, false}, rec.busyStates())
 
 	// HandleAgentProcessExit broadcasts no AgentStatusChange, so this is the only
@@ -291,10 +387,12 @@ func TestActivity_SettleCarriesTheToolCountOfTheTurnThatEnded(t *testing.T) {
 	t.Parallel()
 
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 
 	h.noteTurnEnded("agent-1", "agent-1", 3, true)
 	h.setTurnActive("agent-1", "agent-1", false)
+	require.Equal(t, 1, settles.close())
 
 	last := rec.last()
 	require.NotNil(t, last)
@@ -310,9 +408,11 @@ func TestActivity_ZeroToolTurnStaysDistinguishableFromNoCount(t *testing.T) {
 	// not collapse: unset means "ring", 0 means "this turn did nothing worth
 	// interrupting the user for".
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteTurnEnded("agent-1", "agent-1", 0, true)
 	h.setTurnActive("agent-1", "agent-1", false)
+	require.Equal(t, 1, settles.close())
 
 	last := rec.last()
 	require.NotNil(t, last.NumToolUses)
@@ -355,6 +455,221 @@ func TestActivity_NewTurnDropsAnUnspentCount(t *testing.T) {
 	h.setTurnActive("agent-1", "agent-1", false)
 
 	assert.Nil(t, rec.last().NumToolUses)
+}
+
+// --- The settle debounce window. See settleDelay. ---
+
+func TestActivity_WorkThatResumesInsideTheWindowNeverSettles(t *testing.T) {
+	t.Parallel()
+
+	// The window's whole reason. A backgrounded shell completes and the CLI wakes
+	// the agent into a new turn; publishing the gap between the two rings the
+	// completion sound at the moment the agent starts again.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	require.Equal(t, []bool{true}, rec.busyStates())
+
+	h.setTurnActive("agent-1", "agent-1", false)
+	h.setTurnActive("agent-1", "agent-1", true)
+
+	assert.Equal(t, 0, settles.close(), "the wake voided the window")
+	assert.Equal(t, []bool{true}, rec.busyStates(),
+		"the client was never told the work stopped, so there is nothing to correct")
+}
+
+func TestActivity_ASubagentRestartDoesNotSettleTheRoot(t *testing.T) {
+	t.Parallel()
+
+	// The same flicker through the registry. A subagent's own shell completes,
+	// the CLI restarts that subagent, and the row ends and reopens in one output
+	// burst. The root has no turn of its own here, so the row IS its work.
+	const rootID = "root-1"
+	svc, sink := setupRootSink(t, rootID)
+	svc.Output.processRunning = func(string) bool { return true }
+	childID, err := sink.EnsureChildAgent("spawn-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "task-1", Kind: bgtask.KindSubagent, ChildAgentID: childID,
+		Title: "SCAN", Status: bgtask.StatusRunning,
+	}))
+	rec := watchActivity(t, svc, rootID)
+	settles := holdSettles(t, svc.Output)
+	require.True(t, svc.Output.AgentActivitySnapshot(rootID, rootID).Working())
+
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	require.NoError(t, sink.ReviveBackgroundTask("task-1"))
+
+	assert.Equal(t, 0, settles.close(), "the restart voided the window")
+	assert.Empty(t, rec.busyStates(), "the root published nothing at all")
+	assert.True(t, svc.Output.AgentActivitySnapshot(rootID, rootID).Working())
+}
+
+func TestActivity_TheWindowPublishesTheStateItENDSWith(t *testing.T) {
+	t.Parallel()
+
+	// The delivery re-derives rather than replaying what opened the window, so a
+	// state that moved inside it reaches the client as what it IS. Here the turn
+	// clear opens the window and a prompt arrives before it closes.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+	h.noteControlRequestAdded("agent-1", "agent-1", "req-1")
+
+	require.Equal(t, 1, settles.close())
+
+	require.NotNil(t, rec.last())
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE, rec.last().GetState(),
+		"a prompt with no turn behind it is plain idle, and that is what lands")
+}
+
+func TestActivity_ASecondDerivationDoesNotRestartTheWindow(t *testing.T) {
+	t.Parallel()
+
+	// The window opens at the edge that stopped the work. A refresh that derives
+	// the same stop again is not a second edge, and re-arming there would let a
+	// busy registry push a real settle out for as long as it kept mutating.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+	h.refreshActivity("agent-1", "agent-1")
+	h.refreshActivity("agent-1", "agent-1")
+
+	require.Equal(t, 1, settles.close(), "three derivations of one stop, one window")
+	assert.Equal(t, []bool{true, false}, rec.busyStates())
+}
+
+func TestActivity_AVoidedWindowDropsTheCountItCarried(t *testing.T) {
+	t.Parallel()
+
+	// A zero-tool turn ends, work resumes inside the window, and the settle that
+	// eventually comes belongs to that work. Keeping the zero would silence it --
+	// the same failure AClearThatDoesNotSettleDropsTheCount prevents, reached
+	// through the window instead of through the clear.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.noteTurnEnded("agent-1", "agent-1", 0, true)
+	h.setTurnActive("agent-1", "agent-1", false)
+	require.NotNil(t, unspentToolCount(h, "agent-1"), "the held settle still owns the count")
+
+	// The wake, then a stop that really lasts.
+	h.setTurnActive("agent-1", "agent-1", true)
+	require.Equal(t, 0, settles.close())
+	assert.Nil(t, unspentToolCount(h, "agent-1"), "the voided window dropped it")
+
+	h.setTurnActive("agent-1", "agent-1", false)
+	require.Equal(t, 1, settles.close())
+	assert.Nil(t, rec.last().NumToolUses, "so this settle alerts unconditionally")
+}
+
+func TestActivity_AProcessBoundaryPublishesWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	// A dead process resumes nothing, so there is nothing to wait for -- and a
+	// window held there would leave a timer to fire after shutdown closed the
+	// database it reads.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	require.Equal(t, []bool{true}, rec.busyStates())
+
+	h.NoteAgentProcessExited("agent-1")
+	h.WaitActivityRefreshes()
+
+	assert.Equal(t, []bool{true, false}, rec.busyStates(), "the exit lands with no window")
+	assert.Equal(t, 0, settles.close(), "and opened none")
+}
+
+func TestActivity_ShutdownDropsAWindowStillOpen(t *testing.T) {
+	t.Parallel()
+
+	// The belt to the process exits' braces. A timer that survived shutdown would
+	// read the registry and broadcast after the caller closed the database.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	h.CancelHeldSettles()
+
+	assert.Equal(t, 0, settles.close(), "the window was already dropped")
+	assert.Equal(t, []bool{true}, rec.busyStates(), "and nothing reached the wire")
+}
+
+func TestActivity_ForgettingAnAgentDropsItsWindow(t *testing.T) {
+	t.Parallel()
+
+	// A timer left running would re-create the entry it fires against and
+	// broadcast for an agent this call just retired.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	h.ForgetActivity("agent-1")
+
+	assert.Equal(t, 0, settles.close())
+	assert.Equal(t, []bool{true}, rec.busyStates())
+}
+
+func TestActivity_AStaleRefreshDoesNotCancelAFresherWindow(t *testing.T) {
+	t.Parallel()
+
+	// The ticket guard covers the settle window too, and the ORDER inside
+	// refreshActivityFrom is what makes it hold. A refresh that cancels before it
+	// checks its ticket takes a fresher window down and then drops itself, so the
+	// settle is lost and the tab keeps a spinner nothing will ever clear.
+	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
+	h.setTurnActive("agent-1", "agent-1", true)
+	require.Equal(t, []bool{true}, rec.busyStates())
+
+	// A process-boundary refresh, parked between taking its ticket and deriving.
+	staleSeq := h.activitySeq.Add(1)
+
+	// The turn ends meanwhile, on a fresher ticket, and opens the window.
+	h.setTurnActive("agent-1", "agent-1", false)
+
+	// Now the parked one lands, carrying inputs older than that.
+	h.refreshActivityFrom("agent-1", "agent-1", nil, staleSeq, settleImmediate)
+
+	require.Equal(t, 1, settles.close(), "the older refresh must leave the window alone")
+	assert.Equal(t, []bool{true, false}, rec.busyStates(), "so the settle still lands")
+}
+
+func TestActivity_AChildSettleIsHeldAndDeliveredUnderItsOwnID(t *testing.T) {
+	t.Parallel()
+
+	// The window is per AGENT, and the delivery has to address the agent it was
+	// opened for. A subagent tab shows its own spinner, so a settle delivered
+	// under the root's id would leave the child spinning and drop the parent's
+	// indicator instead.
+	const rootID = "root-1"
+	svc, sink := setupRootSink(t, rootID)
+	svc.Output.processRunning = func(string) bool { return true }
+	childID, err := sink.EnsureChildAgent("spawn-1", "task-1", "SCAN")
+	require.NoError(t, err)
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "task-1", Kind: bgtask.KindSubagent, ChildAgentID: childID,
+		Title: "SCAN", Status: bgtask.StatusRunning,
+	}))
+	rec := watchActivity(t, svc, rootID, childID)
+	settles := holdSettles(t, svc.Output)
+	// The root owes the user a reply, so only the CHILD settles when the row ends.
+	svc.Output.setTurnActive(rootID, rootID, true)
+
+	require.NoError(t, sink.CloseBackgroundTask("task-1", bgtask.StatusCompleted))
+	assert.Empty(t, rec.agentIDs(), "the child's settle waits out its window")
+
+	require.Equal(t, 1, settles.close(), "one window, for the child alone")
+
+	assert.Equal(t, []string{childID}, rec.agentIDs())
+	assert.Equal(t, []bool{false}, rec.busyStates())
+	assert.True(t, svc.Output.AgentActivitySnapshot(rootID, rootID).Working(),
+		"and the root's turn is untouched")
 }
 
 func TestActivity_TreeRecomputesAChildTheDisplayCapDropped(t *testing.T) {
@@ -418,6 +733,7 @@ func TestActivity_AChildTurnEndLeavesTheRootWorking(t *testing.T) {
 	// must not settle the root: the root still owes the user a reply, and
 	// dropping the spinner there says it finished while the root still runs.
 	h, rec := newActivityHandler(t, "root-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("root-1", "root-1", true)
 	require.Equal(t, []bool{true}, rec.busyStates())
 
@@ -434,6 +750,7 @@ func TestActivity_AChildTurnEndLeavesTheRootWorking(t *testing.T) {
 	// because no turn end of the ROOT's recorded one -- which is what tells the
 	// client to ring rather than to read a zero.
 	h.setTurnActive("root-1", "root-1", false)
+	settles.close()
 	require.Equal(t, []bool{true, false}, rec.busyStates())
 	assert.Nil(t, rec.last().NumToolUses, "a child's count belongs to the child's settle")
 }
@@ -588,7 +905,7 @@ func TestActivity_AStaleDerivationDoesNotLatchOverAFresherOne(t *testing.T) {
 		"the running task makes the agent busy")
 
 	// Now the slow refresh finishes, carrying its older rows.
-	svc.Output.refreshActivityFrom(rootID, rootID, staleRows, staleSeq)
+	svc.Output.refreshActivityFrom(rootID, rootID, staleRows, staleSeq, settleHeld)
 
 	st := svc.Output.activityFor(rootID, rootID)
 	st.mu.Lock()
@@ -663,6 +980,78 @@ func TestActivity_AClearThatDoesNotSettleDropsTheCount(t *testing.T) {
 		"the settle the shell task causes belongs to the task, so it must alert")
 }
 
+// watchActivity attaches a recorder to a service-backed test, so a case can
+// assert what reached the WIRE rather than only what a snapshot read derives.
+func watchActivity(t *testing.T, svc *Service, agentIDs ...string) *activityRecorder {
+	t.Helper()
+	rec := newActivityRecorder("ch-activity")
+	entries := make([]watchEntry, 0, len(agentIDs))
+	for _, agentID := range agentIDs {
+		entries = append(entries, watchEntry{id: agentID, mode: leapmuxv1.WatchMode_WATCH_MODE_NOTIFY})
+	}
+	svc.Watchers.agents.setWatches("ch-activity", entries, rec)
+	return rec
+}
+
+func TestActivity_TheLastBackgroundTaskSettlesTheAgent(t *testing.T) {
+	t.Parallel()
+
+	// The other end of AClearThatDoesNotSettleDropsTheCount, which stops at the
+	// unspent count. A turn that leaves a shell task running rings nothing, and
+	// the ring the user waits for is the one that task's END produces. Without
+	// this the whole path is asserted up to the last hop and never through it.
+	// setupRootSink, not setupActivityRegistryTest: the latter leaves a running
+	// subagent row behind, and a second live row means the shell task's close is
+	// never the LAST one.
+	const rootID = "root-1"
+	svc, sink := setupRootSink(t, rootID)
+	svc.Output.processRunning = func(string) bool { return true }
+	rec := watchActivity(t, svc, rootID)
+	settles := holdSettles(t, svc.Output)
+	svc.Output.setTurnActive(rootID, rootID, true)
+	require.Equal(t, []bool{true}, rec.busyStates())
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "row-shell", Kind: bgtask.KindShell,
+		Title: "npm run build", Status: bgtask.StatusRunning,
+	}))
+
+	svc.Output.noteTurnEnded(rootID, rootID, 4, true)
+	svc.Output.setTurnActive(rootID, rootID, false)
+	assert.Equal(t, []bool{true}, rec.busyStates(),
+		"the shell task holds the agent past its own turn end, so nothing rings yet")
+
+	require.NoError(t, sink.CloseBackgroundTask("row-shell", bgtask.StatusCompleted))
+	require.Equal(t, 1, settles.close(), "the last task's close opened the settle window")
+
+	require.Equal(t, []bool{true, false}, rec.busyStates(), "the last task ends the work")
+	assert.Nil(t, rec.last().NumToolUses,
+		"the settle belongs to the task, not to the turn, so it alerts unconditionally")
+}
+
+func TestActivity_AnEarlierBackgroundTaskSettlesNothing(t *testing.T) {
+	t.Parallel()
+
+	// LAST, not any. A task that ends while a sibling runs moved nothing the
+	// user is waiting for, and ringing there is the same early alert the
+	// subagent rule exists to prevent.
+	const rootID = "root-1"
+	svc, sink := setupRootSink(t, rootID)
+	svc.Output.processRunning = func(string) bool { return true }
+	rec := watchActivity(t, svc, rootID)
+	for _, rowKey := range []string{"row-shell-1", "row-shell-2"} {
+		require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+			RowKey: rowKey, Kind: bgtask.KindShell,
+			Title: rowKey, Status: bgtask.StatusRunning,
+		}))
+	}
+	require.Equal(t, []bool{true}, rec.busyStates())
+
+	require.NoError(t, sink.CloseBackgroundTask("row-shell-1", bgtask.StatusCompleted))
+
+	assert.Equal(t, []bool{true}, rec.busyStates(), "one of two tasks ending is not a settle")
+	assert.True(t, svc.Output.AgentActivitySnapshot(rootID, rootID).Working())
+}
+
 func TestActivity_AClearThatSettlesStillSpendsTheCount(t *testing.T) {
 	t.Parallel()
 
@@ -671,9 +1060,14 @@ func TestActivity_AClearThatSettlesStillSpendsTheCount(t *testing.T) {
 	// sound for every turn that used no tool, which is the case it exists to
 	// suppress.
 	h, rec := newActivityHandler(t, "agent-1")
+	settles := holdSettles(t, h)
 	h.setTurnActive("agent-1", "agent-1", true)
 	h.noteTurnEnded("agent-1", "agent-1", 0, true)
 	h.setTurnActive("agent-1", "agent-1", false)
+	// The clear runs while the settle it produced still waits, so the count has
+	// to survive the window. Clearing it there made every ordinary turn end ring,
+	// zero-tool turns included.
+	require.Equal(t, 1, settles.close())
 
 	last := rec.last()
 	require.NotNil(t, last)

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -587,9 +587,11 @@ func (h *OutputHandler) MarkAgentBackgroundTasksExited(rootAgentID string, stopp
 	// Unconditional, unlike the broadcast above: the process died, so every
 	// descendant is idle now whether or not the DISPLAY list moved.
 	//
-	// settleImmediate, because a dead process resumes nothing -- the case
-	// settleImmediate exists for. Holding here parked the idle publish for a
-	// whole settleDelay, and on the tab-close path (see rootTeardown) nothing
+	// settleImmediate, and NOT because a dead process resumes nothing:
+	// settleCanResumeLocked already refuses to hold that one, so that reason
+	// would make this argument removable. It is the TAB-CLOSE path that needs
+	// it (see rootTeardown), where the agent can still be alive when this runs.
+	// The derivation then calls the stop resumable and holds it, and nothing
 	// later delivers it: no process-exit reset follows, and the cleanup that
 	// does follow retires the entry. A watcher of a descendant transcript kept a
 	// spinner and an armed Interrupt button on work whose process was gone.

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -586,7 +586,14 @@ func (h *OutputHandler) MarkAgentBackgroundTasksExited(rootAgentID string, stopp
 	}
 	// Unconditional, unlike the broadcast above: the process died, so every
 	// descendant is idle now whether or not the DISPLAY list moved.
-	h.refreshActivityTree(rootAgentID, settleHeld)
+	//
+	// settleImmediate, because a dead process resumes nothing -- the case
+	// settleImmediate exists for. Holding here parked the idle publish for a
+	// whole settleDelay, and on the tab-close path (see rootTeardown) nothing
+	// later delivers it: no process-exit reset follows, and the cleanup that
+	// does follow retires the entry. A watcher of a descendant transcript kept a
+	// spinner and an armed Interrupt button on work whose process was gone.
+	h.refreshActivityTree(rootAgentID, settleImmediate)
 	h.WriteSubagentEndDividers(endedChildIDs, status)
 }
 

--- a/backend/internal/worker/service/output_bgtask.go
+++ b/backend/internal/worker/service/output_bgtask.go
@@ -586,7 +586,7 @@ func (h *OutputHandler) MarkAgentBackgroundTasksExited(rootAgentID string, stopp
 	}
 	// Unconditional, unlike the broadcast above: the process died, so every
 	// descendant is idle now whether or not the DISPLAY list moved.
-	h.refreshActivityTree(rootAgentID)
+	h.refreshActivityTree(rootAgentID, settleHeld)
 	h.WriteSubagentEndDividers(endedChildIDs, status)
 }
 
@@ -668,7 +668,7 @@ func (s *agentOutputSink) EnsureChildAgent(spawnSpanID, providerChildKey, title 
 		//
 		// Safe here and not one line earlier: the lock is released above, and
 		// refreshing reads that same cache.
-		s.h.refreshActivityTree(s.rootAgentID)
+		s.h.refreshActivityTree(s.rootAgentID, settleHeld)
 	}
 	return childID, nil
 }
@@ -1214,7 +1214,7 @@ func (s *agentOutputSink) applyAndBroadcast(rowKey string, apply func(rootAgentI
 		// broadcasts nothing. Safe here and not one line earlier: the appliers
 		// released the cache lock before returning, and refreshing reads that
 		// same cache.
-		s.h.refreshActivityTree(s.rootAgentID)
+		s.h.refreshActivityTree(s.rootAgentID, settleHeld)
 	}
 	// After the broadcast, so a slow transport cannot delay the DB write. The
 	// applier sets endedChildID only on the active -> final transition, and the

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -936,17 +936,24 @@ func (svc *Service) Shutdown() {
 	// it. Terminals the first pass already stamped are skipped by id.
 	svc.broadcastTerminalsDisconnected(notified)
 
-	// Join the deferred activity refreshes the exits above spawned. Each one
-	// reads the registry and broadcasts, so both must finish while the context
-	// below is still live and before the caller closes the database. After
-	// StopAll, which is what produces the exits that spawn them.
-	svc.Output.WaitActivityRefreshes()
-
-	// Then drop every settle still waiting out its debounce window. The exits
-	// above cancel each window they reach, and this holds however they ran: a
-	// timer that survived would read the registry and broadcast after the
-	// context below is cancelled and the caller closes the database.
+	// Drop every settle still waiting out its debounce window FIRST. The exits
+	// above cancel each window they reach, and this holds however they ran. A
+	// timer that survived would read the registry and broadcast after
+	// CancelBackgroundCtx below cancels the context and the caller closes the
+	// database.
+	//
+	// Before the join and not after, because an armed window holds one of the
+	// counts that join waits on -- joining first would park Shutdown here for a
+	// whole settleDelay. Nothing can re-open a window afterwards: the
+	// SetShuttingDown latch at the top of this function makes holdSettleLocked
+	// refuse.
 	svc.Output.CancelHeldSettles()
+
+	// Then join the deferred activity refreshes the exits above spawned. Each
+	// one reads the registry and broadcasts, so both must finish while the
+	// context below is still live and before the caller closes the database.
+	// After StopAll, which is what produces the exits that spawn them.
+	svc.Output.WaitActivityRefreshes()
 
 	// Cancel the background-task write context last, AFTER every drain. Any
 	// in-flight bgtask write the drains did not cover now fails fast

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -942,6 +942,12 @@ func (svc *Service) Shutdown() {
 	// StopAll, which is what produces the exits that spawn them.
 	svc.Output.WaitActivityRefreshes()
 
+	// Then drop every settle still waiting out its debounce window. The exits
+	// above cancel each window they reach, and this holds however they ran: a
+	// timer that survived would read the registry and broadcast after the
+	// context below is cancelled and the caller closes the database.
+	svc.Output.CancelHeldSettles()
+
 	// Cancel the background-task write context last, AFTER every drain. Any
 	// in-flight bgtask write the drains did not cover now fails fast
 	// (context.Canceled) instead of racing the caller's sqlDB.Close() and

--- a/backend/internal/worker/service/watch_events_test.go
+++ b/backend/internal/worker/service/watch_events_test.go
@@ -980,13 +980,15 @@ func TestReplayIncludesBackgroundTasksSnapshot(t *testing.T) {
 // right Interrupt button at once rather than after the replay drains.
 //
 // This is the third leg of the same pattern the background-task registry
-// already uses -- AgentInfo.busy hydrates, this replays, AgentActivityChanged
+// already uses -- AgentInfo.activity_state hydrates, this replays,
+// AgentActivityChanged
 // pushes -- and it is the one that covers the transition into FULL.
 //
 // It rides CatchUpStart, and the case asserts that no AgentActivityChanged
-// carries it. That message means a TRANSITION, and the client rings on one; a
-// baseline sent as a transition forced the client to suppress the alert for the
-// whole catch-up window, which discarded every settle that raced the replay.
+// carries it. That message means a TRANSITION, and the client rings on one. A
+// baseline sent as a transition forced the client to suppress the
+// alert for the whole catch-up window, which discarded every settle
+// that raced the replay.
 func TestReplayIncludesActivitySnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -1099,9 +1101,10 @@ func TestReplayActivityPrecedesTheMessageBurst(t *testing.T) {
 // against.
 //
 // A child's answer is its own registry row, and a root rolls up every
-// descendant. Deriving the level against the ROOT would hand a finished subagent
-// its parent's spinner for the whole time a sibling ran, and the swap is
-// invisible in the root case because there the two ids are equal.
+// descendant. Deriving the level against the ROOT would hand a finished
+// subagent its parent's spinner for the whole time a sibling ran.
+// The swap is invisible in the root case, because there the two ids
+// are equal.
 func TestReplayActivityIsTheWATCHEDAgentsOwnAnswer(t *testing.T) {
 	t.Parallel()
 
@@ -1114,6 +1117,7 @@ func TestReplayActivityIsTheWATCHEDAgentsOwnAnswer(t *testing.T) {
 		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
 	}))
 	svc.Output.processRunning = func(string) bool { return true }
+	settles := holdSettles(t, svc.Output)
 	sink := svc.Output.NewSink("root-own", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX)
 	childID, err := sink.EnsureChildAgent("spawn-own", "row-own", "finished child")
 	require.NoError(t, err)
@@ -1123,6 +1127,10 @@ func TestReplayActivityIsTheWATCHEDAgentsOwnAnswer(t *testing.T) {
 	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
 		RowKey: "row-sibling", Kind: bgtask.KindSubagent, Title: "sibling", Status: bgtask.StatusRunning,
 	}))
+	// The child's close opened a settle window, and the baseline reports what was
+	// PUBLISHED. Let the window close, or the level under test is the WORKING the
+	// child still carries on the wire rather than the id question this case asks.
+	require.Equal(t, 1, settles.close(), "the child's close opened a settle window")
 	require.True(t, svc.Output.AgentActivitySnapshot("root-own", "root-own").Working(),
 		"the sibling keeps the root busy, or this case proves nothing")
 
@@ -1219,4 +1227,84 @@ func TestWatchChildAgentReplaysWithoutProcess(t *testing.T) {
 		"a child watch must not register a process for the child")
 	assert.False(t, svc.Agents.HasAgent("root-2"),
 		"a child watch must not register a process for the root either")
+}
+
+// TestListAgentsCarriesBothActivityAnswers pins the pair of fields, and the one
+// case where they differ.
+//
+// A close guard reads the EXACT derivation, so it never refuses a close for work
+// that already finished. A browser seeds its DISPLAY from the published one, so
+// its cache matches the live events. One field cannot be both while the Worker
+// debounces a settle.
+func TestListAgentsCarriesBothActivityAnswers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, d, w := setupTestService(t)
+	settles := holdSettles(t, svc.Output)
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+	}))
+	svc.Output.processRunning = func(string) bool { return true }
+
+	// A turn runs and then ends, which opens the settle window.
+	svc.Output.setTurnActive("agent-1", "agent-1", true)
+	svc.Output.setTurnActive("agent-1", "agent-1", false)
+	require.Len(t, settles.openWindows(), 1, "this case needs a settle in flight")
+
+	dispatch(d, "ListAgents", &leapmuxv1.ListAgentsRequest{TabIds: []string{"agent-1"}}, w)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListAgentsResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	require.Len(t, resp.GetAgents(), 1)
+	info := resp.GetAgents()[0]
+
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE, info.GetActivityState(),
+		"the close guard reads the exact answer, so it never refuses a finished turn")
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING,
+		info.GetPublishedActivityState(),
+		"the display reads what the client was told, so its cache matches the event stream")
+}
+
+// TestReplayFramesAreMarkedAndLiveOnesAreNot pins the flag the client's
+// replay/live split now rests on.
+//
+// A client registers its live watch before the replay burst runs and both write
+// the same stream, so arrival order cannot tell them apart. Guessing from it
+// dropped a live permission prompt's badge whenever it raced a replay.
+func TestReplayFramesAreMarkedAndLiveOnesAreNot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, d, w := setupTestService(t)
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID: "agent-1", WorkingDir: t.TempDir(), HomeDir: t.TempDir(),
+	}))
+	svc.Output.processRunning = func(string) bool { return true }
+
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: "agent-1", Mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}},
+	}, w)
+	require.Eventually(t, func() bool {
+		return countCatchUpCompletes(w) == 1
+	}, time.Second, 10*time.Millisecond, "the FULL watch must drive one catch-up replay")
+
+	replayed := decodeAgentEvents(w)
+	require.NotEmpty(t, replayed, "this case needs a replay burst to inspect")
+	for _, e := range replayed {
+		assert.True(t, e.GetReplay(), "every replayed frame carries the mark: %T", e.GetEvent())
+	}
+
+	// A live transition afterwards must NOT carry it, or a client would suppress
+	// the alert for work that finished in front of the user.
+	before := len(decodeAgentEvents(w))
+	svc.Output.setTurnActive("agent-1", "agent-1", true)
+	require.Eventually(t, func() bool {
+		return len(decodeAgentEvents(w)) > before
+	}, time.Second, 10*time.Millisecond, "the live transition must reach the stream")
+
+	live := decodeAgentEvents(w)[before:]
+	for _, e := range live {
+		assert.False(t, e.GetReplay(), "a live frame is not a replay: %T", e.GetEvent())
+	}
 }

--- a/backend/internal/worker/service/watch_events_test.go
+++ b/backend/internal/worker/service/watch_events_test.go
@@ -516,7 +516,6 @@ func TestWatchEvents_PromoteWithCappedCursorReplay(t *testing.T) {
 
 			var start *leapmuxv1.CatchUpStart
 			replayed := 0
-			sawActivity := false
 			sawTodos := false
 			sawStatus := false
 			sawControl := false
@@ -527,7 +526,6 @@ func TestWatchEvents_PromoteWithCappedCursorReplay(t *testing.T) {
 				if event.GetAgentMessage() != nil {
 					replayed++
 				}
-				sawActivity = sawActivity || event.GetActivityChanged() != nil
 				sawTodos = sawTodos || event.GetTodosChanged() != nil
 				sawStatus = sawStatus || event.GetStatusChange() != nil
 				sawControl = sawControl || event.GetControlRequest() != nil
@@ -536,7 +534,8 @@ func TestWatchEvents_PromoteWithCappedCursorReplay(t *testing.T) {
 			require.NotNil(t, start.LatestSeq)
 			assert.Equal(t, seqs[len(seqs)-1], start.GetLatestSeq())
 			assert.Equal(t, tc.wantReplayFrames, replayed)
-			assert.True(t, sawActivity, "the replay decision must not skip the activity snapshot")
+			assert.NotEqual(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_UNSPECIFIED,
+				start.GetActivityState(), "the replay decision must not skip the activity level")
 			assert.True(t, sawTodos, "the replay decision must not skip the to-do snapshot")
 			assert.True(t, sawStatus, "the replay decision must not skip the status marker")
 			assert.True(t, sawControl, "the replay decision must not skip pending control requests")
@@ -983,6 +982,11 @@ func TestReplayIncludesBackgroundTasksSnapshot(t *testing.T) {
 // This is the third leg of the same pattern the background-task registry
 // already uses -- AgentInfo.busy hydrates, this replays, AgentActivityChanged
 // pushes -- and it is the one that covers the transition into FULL.
+//
+// It rides CatchUpStart, and the case asserts that no AgentActivityChanged
+// carries it. That message means a TRANSITION, and the client rings on one; a
+// baseline sent as a transition forced the client to suppress the alert for the
+// whole catch-up window, which discarded every settle that raced the replay.
 func TestReplayIncludesActivitySnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -1011,30 +1015,34 @@ func TestReplayIncludesActivitySnapshot(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "FULL watch must drive exactly one catch-up replay")
 	assert.False(t, streamEndedWithError(w), "watch replay must not surface a stream error")
 
-	var activity *leapmuxv1.AgentActivityChanged
-	var activityAgentID string
+	var start *leapmuxv1.CatchUpStart
+	var startAgentID string
+	sawTransition := false
 	for _, e := range decodeAgentEvents(w) {
-		if changed := e.GetActivityChanged(); changed != nil {
-			activity = changed
-			activityAgentID = e.GetAgentId()
-			break
+		if s := e.GetCatchUpStart(); s != nil && start == nil {
+			start = s
+			startAgentID = e.GetAgentId()
 		}
+		sawTransition = sawTransition || e.GetActivityChanged() != nil
 	}
-	require.NotNil(t, activity, "replay must include an AgentActivityChanged event")
+	require.NotNil(t, start, "replay must include a CatchUpStart frame")
 	// Under the WATCHED agent's own id, not the registry owner's: a child tab's
 	// answer is its own row, which differs from its root's.
-	assert.Equal(t, "root-1", activityAgentID)
-	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING, activity.GetState(), "a running registry row makes the agent working")
-	assert.Nil(t, activity.NumToolUses, "a replay completes no turn, so it carries no count")
+	assert.Equal(t, "root-1", startAgentID)
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_WORKING, start.GetActivityState(),
+		"a running registry row makes the agent working")
+	assert.False(t, sawTransition,
+		"a baseline is a level; sending it as a transition makes the client ring for an agent that settled while it was away")
 }
 
 // TestReplayActivityPrecedesTheMessageBurst pins the ORDER, which is the whole
-// reason this event is in the replay at all.
+// reason this state is in the replay at all.
 //
-// The tab renders the replayed messages as they arrive. An activity frame that
+// The tab renders the replayed messages as they arrive. An activity level that
 // lands after them leaves the burst painting with no thinking indicator and no
-// Interrupt button on an agent that is working -- exactly the window the event
-// exists to close.
+// Interrupt button on an agent that is working -- exactly the window the state
+// exists to close. Riding CatchUpStart is what puts it first; this case fails if
+// that state ever moves to a frame of its own again.
 func TestReplayActivityPrecedesTheMessageBurst(t *testing.T) {
 	t.Parallel()
 
@@ -1073,17 +1081,68 @@ func TestReplayActivityPrecedesTheMessageBurst(t *testing.T) {
 
 	activityAt, firstMessageAt := -1, -1
 	for i, e := range decodeAgentEvents(w) {
-		if e.GetActivityChanged() != nil && activityAt < 0 {
+		if s := e.GetCatchUpStart(); s != nil && activityAt < 0 &&
+			s.GetActivityState() != leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_UNSPECIFIED {
 			activityAt = i
 		}
 		if e.GetAgentMessage() != nil && firstMessageAt < 0 {
 			firstMessageAt = i
 		}
 	}
-	require.GreaterOrEqual(t, activityAt, 0, "replay must include an AgentActivityChanged event")
+	require.GreaterOrEqual(t, activityAt, 0, "replay must carry the activity level on CatchUpStart")
 	require.GreaterOrEqual(t, firstMessageAt, 0, "this case needs a message burst to overtake")
 	assert.Less(t, activityAt, firstMessageAt,
 		"the tab must know it is busy before it renders the replayed messages")
+}
+
+// TestReplayActivityIsTheWATCHEDAgentsOwnAnswer pins the id the level derives
+// against.
+//
+// A child's answer is its own registry row, and a root rolls up every
+// descendant. Deriving the level against the ROOT would hand a finished subagent
+// its parent's spinner for the whole time a sibling ran, and the swap is
+// invisible in the root case because there the two ids are equal.
+func TestReplayActivityIsTheWATCHEDAgentsOwnAnswer(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc, d, w := setupTestService(t)
+	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
+		ID:            "root-own",
+		WorkingDir:    t.TempDir(),
+		HomeDir:       t.TempDir(),
+		AgentProvider: leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX,
+	}))
+	svc.Output.processRunning = func(string) bool { return true }
+	sink := svc.Output.NewSink("root-own", leapmuxv1.AgentProvider_AGENT_PROVIDER_CODEX)
+	childID, err := sink.EnsureChildAgent("spawn-own", "row-own", "finished child")
+	require.NoError(t, err)
+	// This child is DONE while a sibling keeps running, so the two ids disagree:
+	// the child is idle and the root still rolls the sibling up.
+	require.NoError(t, sink.CloseBackgroundTask("row-own", bgtask.StatusCompleted))
+	require.NoError(t, sink.UpsertBackgroundTask(bgtask.Upsert{
+		RowKey: "row-sibling", Kind: bgtask.KindSubagent, Title: "sibling", Status: bgtask.StatusRunning,
+	}))
+	require.True(t, svc.Output.AgentActivitySnapshot("root-own", "root-own").Working(),
+		"the sibling keeps the root busy, or this case proves nothing")
+
+	dispatch(d, "WatchEvents", &leapmuxv1.WatchEventsRequest{
+		Agents: []*leapmuxv1.WatchAgentEntry{{AgentId: childID, Mode: leapmuxv1.WatchMode_WATCH_MODE_FULL}},
+	}, w)
+	require.Eventually(t, func() bool {
+		return countCatchUpCompletes(w) == 1
+	}, time.Second, 10*time.Millisecond, "the child's FULL watch must drive one catch-up replay")
+
+	var start *leapmuxv1.CatchUpStart
+	for _, e := range decodeAgentEvents(w) {
+		if s := e.GetCatchUpStart(); s != nil && e.GetAgentId() == childID {
+			start = s
+			break
+		}
+	}
+	require.NotNil(t, start, "the child's replay must carry a CatchUpStart")
+	assert.Equal(t, leapmuxv1.AgentActivityState_AGENT_ACTIVITY_STATE_IDLE, start.GetActivityState(),
+		"the finished child is idle, whatever its root rolls up")
 }
 
 // TestWatchChildAgentReplaysWithoutProcess pins that watching a CHILD agent

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -768,6 +768,7 @@ export const AppShell: Component = () => {
 
   const busyProbe = createTabBusyProbe({
     tasksFor: taskScope.tasksForTab,
+    seedActivity: agentActivityStore.seedPublished,
   })
 
   // Tab operations (select, close, file open, worktree confirm).

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -767,7 +767,6 @@ export const AppShell: Component = () => {
   })
 
   const busyProbe = createTabBusyProbe({
-    activity: agentActivityStore,
     tasksFor: taskScope.tasksForTab,
   })
 

--- a/frontend/src/components/shell/tabBusyProbe.test.ts
+++ b/frontend/src/components/shell/tabBusyProbe.test.ts
@@ -4,11 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTabBusyProbe } from '~/components/shell/tabBusyProbe'
 import { AgentActivityState } from '~/generated/proto/leapmux/v1/agent_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
-import { createAgentActivityStore } from '~/stores/agentActivity.store'
 
 const mockInspect = vi.fn()
+const mockListAgents = vi.fn()
 vi.mock('~/api/workerRpc', () => ({
   inspectTerminalProcesses: (...args: unknown[]) => mockInspect(...args),
+  listAgents: (...args: unknown[]) => mockListAgents(...args),
 }))
 
 function agentTab(id: string, extra: Partial<Tab> = {}): Tab {
@@ -31,36 +32,64 @@ function task(overrides: Partial<BackgroundTaskItem> = {}): BackgroundTaskItem {
 }
 
 function makeProbe(tasks: BackgroundTaskItem[] = []) {
-  const activity = createAgentActivityStore()
-  return { activity, probe: createTabBusyProbe({ activity, tasksFor: () => tasks }) }
+  return { probe: createTabBusyProbe({ tasksFor: () => tasks }) }
+}
+
+/** What the worker reports for one agent, as ListAgents returns it. */
+function agentIs(id: string, activityState: AgentActivityState) {
+  mockListAgents.mockResolvedValue({ agents: [{ id, activityState }], verdicts: [] })
 }
 
 describe('createTabBusyProbe', () => {
   beforeEach(() => {
     mockInspect.mockReset()
     mockInspect.mockResolvedValue({ terminals: [] })
+    mockListAgents.mockReset()
+    mockListAgents.mockResolvedValue({ agents: [], verdicts: [] })
   })
 
   describe('agent tabs', () => {
     it('reports a working agent, with its active tasks', async () => {
-      const { activity, probe } = makeProbe([task(), task({ rowKey: 'r2', status: 'completed' })])
-      activity.apply('a1', AgentActivityState.WORKING)
+      const { probe } = makeProbe([task(), task({ rowKey: 'r2', status: 'completed' })])
+      agentIs('a1', AgentActivityState.WORKING)
 
       const reason = await probe.probe(agentTab('a1'))
 
       expect(reason).toEqual({ kind: 'agent-turn', activeTasks: [task()] })
+      expect(mockListAgents).toHaveBeenCalledWith('w-1', { tabIds: ['a1'] })
       expect(mockInspect).not.toHaveBeenCalled()
+    })
+
+    it('asks the worker rather than reading the debounced pushed state', async () => {
+      // The Worker holds a settle for three seconds so the completion sound does
+      // not ring for work that resumes, which means the pushed state still says
+      // WORKING after the work finished. A guard reading it would raise a
+      // confirmation dialog over nothing, and would disagree with the CLI guard.
+      const { probe } = makeProbe([task()])
+      agentIs('a1', AgentActivityState.IDLE)
+
+      expect(await probe.probe(agentTab('a1'))).toBeNull()
+    })
+
+    it('fails open when the worker cannot answer', async () => {
+      mockListAgents.mockRejectedValue(new Error('worker unreachable'))
+      const { probe } = makeProbe([task()])
+
+      // Refusing a close nobody can confirm strands a tab the user has no other
+      // way to shut, which is the same rule the terminal branch keeps.
+      expect(await probe.probe(agentTab('a1'))).toBeNull()
     })
 
     it('reports an idle agent as not busy', async () => {
       const { probe } = makeProbe()
+      agentIs('a1', AgentActivityState.IDLE)
 
       expect(await probe.probe(agentTab('a1'))).toBeNull()
     })
 
     it('reports a working agent with no background tasks', async () => {
-      const { activity, probe } = makeProbe()
-      activity.apply('a1', AgentActivityState.WORKING)
+      const { probe } = makeProbe()
+      agentIs('a1', AgentActivityState.WORKING)
 
       expect(await probe.probe(agentTab('a1'))).toEqual({ kind: 'agent-turn', activeTasks: [] })
     })
@@ -68,22 +97,22 @@ describe('createTabBusyProbe', () => {
     it('warns about an agent waiting on a permission prompt', async () => {
       // The state the indicator deliberately does NOT spin for. Its turn is
       // still in flight, so this close kills it along with every background task
-      // under it -- which is why the guard reads interruptsWork and not isBusy.
-      const { activity, probe } = makeProbe([task()])
-      activity.apply('a1', AgentActivityState.WAITING_FOR_USER)
+      // under it -- which is why the guard reads activityInterruptsWork.
+      const { probe } = makeProbe([task()])
+      agentIs('a1', AgentActivityState.WAITING_FOR_USER)
 
-      expect(activity.isBusy('a1')).toBe(false)
       expect(await probe.probe(agentTab('a1'))).toEqual({ kind: 'agent-turn', activeTasks: [task()] })
     })
 
     it('never reports a subagent tab, even a busy one', async () => {
-      const { activity, probe } = makeProbe([task()])
-      activity.apply('child-1', AgentActivityState.WORKING)
+      const { probe } = makeProbe([task()])
+      agentIs('child-1', AgentActivityState.WORKING)
 
       // A child tab closes in the UI only: the worker treats CloseAgent on a
       // child as tab-close-only, the transcript survives and the tab can be
       // revived. Nothing stops, so there is nothing to warn about.
       expect(await probe.probe(agentTab('child-1', { parentAgentId: 'a1' }))).toBeNull()
+      expect(mockListAgents, 'and it is not even asked about').not.toHaveBeenCalled()
     })
   })
 
@@ -149,8 +178,8 @@ describe('createTabBusyProbe', () => {
       mockInspect.mockResolvedValue({
         terminals: [{ terminalId: 't1', processes: [{ pid: 7, name: 'sleep' }], totalCount: 1 }],
       })
-      const { activity, probe } = makeProbe()
-      activity.apply('a1', AgentActivityState.WORKING)
+      const { probe } = makeProbe()
+      agentIs('a1', AgentActivityState.WORKING)
 
       const busy = await probe.probeMany([
         agentTab('a1', { title: 'Refactor' }),
@@ -165,18 +194,19 @@ describe('createTabBusyProbe', () => {
       expect(busy[1].reason.kind).toBe('terminal-processes')
     })
 
-    it('makes no request when the set holds no terminals', async () => {
+    it('makes no request for a kind the set does not hold', async () => {
       const { probe } = makeProbe()
 
       await probe.probeMany([agentTab('a1')])
 
-      expect(mockInspect).not.toHaveBeenCalled()
+      expect(mockInspect, 'no terminals, so no terminal request').not.toHaveBeenCalled()
+      expect(mockListAgents).toHaveBeenCalledWith('w-1', { tabIds: ['a1'] })
     })
 
     it('still reports the agents when a terminal worker fails', async () => {
       mockInspect.mockRejectedValue(new Error('down'))
-      const { activity, probe } = makeProbe()
-      activity.apply('a1', AgentActivityState.WORKING)
+      const { probe } = makeProbe()
+      agentIs('a1', AgentActivityState.WORKING)
 
       const busy = await probe.probeMany([agentTab('a1'), terminalTab('t1')])
 

--- a/frontend/src/components/shell/tabBusyProbe.test.ts
+++ b/frontend/src/components/shell/tabBusyProbe.test.ts
@@ -32,12 +32,18 @@ function task(overrides: Partial<BackgroundTaskItem> = {}): BackgroundTaskItem {
 }
 
 function makeProbe(tasks: BackgroundTaskItem[] = []) {
-  return { probe: createTabBusyProbe({ tasksFor: () => tasks }) }
+  const seeded = vi.fn()
+  return { probe: createTabBusyProbe({ tasksFor: () => tasks, seedActivity: seeded }), seeded }
 }
 
-/** What the worker reports for one agent, as ListAgents returns it. */
-function agentIs(id: string, activityState: AgentActivityState) {
-  mockListAgents.mockResolvedValue({ agents: [{ id, activityState }], verdicts: [] })
+/**
+ * What the worker reports for one agent, as ListAgents returns it.
+ *
+ * The two levels differ only inside the Worker's settle window, so they default
+ * to one value and a case that needs the window states both.
+ */
+function agentIs(id: string, activityState: AgentActivityState, publishedActivityState = activityState) {
+  mockListAgents.mockResolvedValue({ agents: [{ id, activityState, publishedActivityState }], verdicts: [] })
 }
 
 describe('createTabBusyProbe', () => {
@@ -60,11 +66,12 @@ describe('createTabBusyProbe', () => {
       expect(mockInspect).not.toHaveBeenCalled()
     })
 
-    it('asks the worker rather than reading the debounced pushed state', async () => {
+    it('asks the worker rather than reading the debounced level', async () => {
       // The Worker holds a settle for three seconds so the completion sound does
-      // not ring for work that resumes, which means the pushed state still says
-      // WORKING after the work finished. A guard reading it would raise a
-      // confirmation dialog over nothing, and would disagree with the CLI guard.
+      // not ring for work that resumes, which means the level this client holds
+      // still says WORKING after the work finished. A guard reading it would
+      // raise a confirmation dialog over nothing, and would disagree with the
+      // CLI guard.
       const { probe } = makeProbe([task()])
       agentIs('a1', AgentActivityState.IDLE)
 
@@ -78,6 +85,60 @@ describe('createTabBusyProbe', () => {
       // Refusing a close nobody can confirm strands a tab the user has no other
       // way to shut, which is the same rule the terminal branch keeps.
       expect(await probe.probe(agentTab('a1'))).toBeNull()
+    })
+
+    it('seeds the published level and answers the close from the exact one', async () => {
+      // The two disagree only inside the settle window: the exact value already
+      // carries the settled state while the transition announcing it waits the
+      // window out. The close reads the exact one, so it never refuses a close
+      // for work that finished. The display takes the published one, because a
+      // level written from the exact value drops the spinner early -- and if the
+      // work then resumes, the Worker derives what it already published and
+      // broadcasts nothing, leaving that tab with no spinner for the rest of the
+      // turn.
+      const { probe, seeded } = makeProbe([task()])
+      agentIs('a1', AgentActivityState.IDLE, AgentActivityState.WORKING)
+
+      expect(await probe.probe(agentTab('a1')), 'the exact level answers the close').toBeNull()
+      expect(seeded, 'the published level seeds the display').toHaveBeenCalledWith('a1', AgentActivityState.WORKING)
+    })
+
+    it('seeds an agent the close does not warn about', async () => {
+      // The seed runs before the busy test, so an idle agent still repairs. A
+      // WORKING left over from a link that dropped with no offline sweep is
+      // exactly the level no later transition corrects, because the Worker has
+      // nothing left to announce.
+      const { probe, seeded } = makeProbe()
+      agentIs('a1', AgentActivityState.IDLE)
+
+      expect(await probe.probe(agentTab('a1'))).toBeNull()
+      expect(seeded).toHaveBeenCalledWith('a1', AgentActivityState.IDLE)
+    })
+
+    it('seeds every agent in the batch, on every worker', async () => {
+      // The seed sits before the busy test, so a BUSY agent takes one too --
+      // the `continue` below it must never skip the repair.
+      mockListAgents.mockImplementation((workerId: string) => Promise.resolve({
+        agents: workerId === 'w-1'
+          ? [{ id: 'a1', activityState: AgentActivityState.WORKING, publishedActivityState: AgentActivityState.WORKING }]
+          : [{ id: 'a2', activityState: AgentActivityState.IDLE, publishedActivityState: AgentActivityState.IDLE }],
+        verdicts: [],
+      }))
+      const { probe, seeded } = makeProbe()
+
+      await probe.probeMany([agentTab('a1'), agentTab('a2', { workerId: 'w-2' })])
+
+      expect(seeded).toHaveBeenCalledTimes(2)
+      expect(seeded, 'a busy agent seeds too').toHaveBeenCalledWith('a1', AgentActivityState.WORKING)
+      expect(seeded).toHaveBeenCalledWith('a2', AgentActivityState.IDLE)
+    })
+
+    it('seeds nothing when the worker cannot answer', async () => {
+      mockListAgents.mockRejectedValue(new Error('worker unreachable'))
+      const { probe, seeded } = makeProbe()
+
+      expect(await probe.probe(agentTab('a1'))).toBeNull()
+      expect(seeded, 'a reply that never arrived states no level').not.toHaveBeenCalled()
     })
 
     it('reports an idle agent as not busy', async () => {
@@ -105,7 +166,7 @@ describe('createTabBusyProbe', () => {
     })
 
     it('never reports a subagent tab, even a busy one', async () => {
-      const { probe } = makeProbe([task()])
+      const { probe, seeded } = makeProbe([task()])
       agentIs('child-1', AgentActivityState.WORKING)
 
       // A child tab closes in the UI only: the worker treats CloseAgent on a
@@ -113,6 +174,7 @@ describe('createTabBusyProbe', () => {
       // revived. Nothing stops, so there is nothing to warn about.
       expect(await probe.probe(agentTab('child-1', { parentAgentId: 'a1' }))).toBeNull()
       expect(mockListAgents, 'and it is not even asked about').not.toHaveBeenCalled()
+      expect(seeded, 'so nothing seeds for it').not.toHaveBeenCalled()
     })
   })
 

--- a/frontend/src/components/shell/tabBusyProbe.ts
+++ b/frontend/src/components/shell/tabBusyProbe.ts
@@ -1,3 +1,4 @@
+import type { AgentActivityState } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { TerminalProcess } from '~/generated/proto/leapmux/v1/terminal_pb'
 import type { BackgroundTaskItem } from '~/stores/chatBackgroundTasks'
 import type { Tab } from '~/stores/tab.types'
@@ -25,6 +26,14 @@ export interface BusyTab {
 export interface TabBusyProbeDeps {
   /** The tab's background-task rows, scoped to that tab (root roll-up or a child's own). */
   tasksFor: (agentId: string) => BackgroundTaskItem[]
+  /**
+   * Write the level the Worker PUBLISHED into the display store --
+   * AgentActivityStore.seedPublished.
+   *
+   * A write, and never a read: which state the guard asks about is the whole
+   * reason this probe exists (see below).
+   */
+  seedActivity: (agentId: string, state: AgentActivityState) => void
 }
 
 /**
@@ -35,12 +44,20 @@ export interface TabBusyProbeDeps {
  * - a TERMINAL asks because nothing watches a terminal's process tree
  *   continuously and nothing should: the answer is wanted once, at the moment
  *   of the close.
- * - an AGENT asks because the pushed state is DEBOUNCED. The Worker holds a
- *   settle for three seconds so the completion sound does not ring for work
- *   that resumes, which means the store says "busy" for that long after the
- *   work finished. A guard reading it would raise a confirmation dialog over
+ * - an AGENT asks because the level this client holds is DEBOUNCED. The Worker
+ *   holds a settle for three seconds so the completion sound does not ring for
+ *   work that resumes, which means the store says "busy" for that long after
+ *   the work finished. A guard reading it would raise a confirmation dialog over
  *   nothing, and would disagree with the CLI guard, which reads the exact
  *   state. One round trip per worker buys one answer for both surfaces.
+ *
+ * The agent round trip also REPAIRS the display store on its way past. It
+ * already holds the Worker's own answer, so it corrects a level that drifted --
+ * a WORKING left over from a link that dropped with no offline sweep, which no
+ * later transition would correct because the Worker has nothing left to
+ * announce. That write takes the PUBLISHED level, never the exact one beside
+ * it: the exact value ignores the settle window, so writing it would drop the
+ * spinner early and a resume inside the window broadcasts nothing.
  *
  * FAIL OPEN throughout. A probe that cannot answer reports "not busy" and lets
  * the close proceed, matching what handleTabClose already does for an
@@ -74,11 +91,9 @@ export function createTabBusyProbe(deps: TabBusyProbeDeps) {
    * state, one request per worker.
    *
    * activityInterruptsWork, not "busy". They differ for an agent blocked on a
-   * permission prompt. The indicator must
-   * not spin at somebody who is being asked
-   * a question, but its turn is still in
-   * flight and this close kills it along
-   * with every background task under it.
+   * permission prompt. The indicator must not spin at somebody who is being
+   * asked a question, but its turn is still in flight and this close kills it
+   * along with every background task under it.
    */
   const agentReasons = async (tabs: readonly Tab[]): Promise<Map<string, TabBusyReason>> => {
     const out = new Map<string, TabBusyReason>()
@@ -86,6 +101,9 @@ export function createTabBusyProbe(deps: TabBusyProbeDeps) {
       try {
         const resp = await workerRpc.listAgents(workerId, { tabIds })
         for (const info of resp.agents) {
+          // Every agent the reply mentions, busy or not: an agent that drifted
+          // to a stale WORKING is exactly the one this answer corrects.
+          deps.seedActivity(info.id, info.publishedActivityState)
           if (!activityInterruptsWork(info.activityState))
             continue
           out.set(info.id, {

--- a/frontend/src/components/shell/tabBusyProbe.ts
+++ b/frontend/src/components/shell/tabBusyProbe.ts
@@ -1,10 +1,10 @@
 import type { TerminalProcess } from '~/generated/proto/leapmux/v1/terminal_pb'
-import type { AgentActivityStore } from '~/stores/agentActivity.store'
 import type { BackgroundTaskItem } from '~/stores/chatBackgroundTasks'
 import type { Tab } from '~/stores/tab.types'
 import * as workerRpc from '~/api/workerRpc'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { createLogger } from '~/lib/logger'
+import { activityInterruptsWork } from '~/stores/agentActivity.store'
 import { isActiveBackgroundTaskStatus } from '~/stores/chatBackgroundTasks'
 import { isSubagentTab, tabDisplayLabel } from '~/stores/tab.helpers'
 
@@ -23,7 +23,6 @@ export interface BusyTab {
 }
 
 export interface TabBusyProbeDeps {
-  activity: AgentActivityStore
   /** The tab's background-task rows, scoped to that tab (root roll-up or a child's own). */
   tasksFor: (agentId: string) => BackgroundTaskItem[]
 }
@@ -31,14 +30,17 @@ export interface TabBusyProbeDeps {
 /**
  * Answers "would closing this tab interrupt running work".
  *
- * The two tab kinds answer from different places, and both are the Worker's
- * word:
+ * BOTH kinds ask the Worker, and the answer is the Worker's exact word:
  *
- * - an AGENT reads the pushed activity state, already in a store. No round
- *   trip, so the common close stays as fast as it was.
- * - a TERMINAL asks, because nothing watches a terminal's process tree
+ * - a TERMINAL asks because nothing watches a terminal's process tree
  *   continuously and nothing should: the answer is wanted once, at the moment
  *   of the close.
+ * - an AGENT asks because the pushed state is DEBOUNCED. The Worker holds a
+ *   settle for three seconds so the completion sound does not ring for work
+ *   that resumes, which means the store says "busy" for that long after the
+ *   work finished. A guard reading it would raise a confirmation dialog over
+ *   nothing, and would disagree with the CLI guard, which reads the exact
+ *   state. One round trip per worker buys one answer for both surfaces.
  *
  * FAIL OPEN throughout. A probe that cannot answer reports "not busy" and lets
  * the close proceed, matching what handleTabClose already does for an
@@ -46,31 +48,17 @@ export interface TabBusyProbeDeps {
  * strands a tab the user has no other way to shut.
  */
 export function createTabBusyProbe(deps: TabBusyProbeDeps) {
-  const agentReason = (tab: Tab): TabBusyReason | null => {
-    // A subagent tab closes in the UI only: the worker treats CloseAgent on a
-    // child as tab-close-only, the transcript survives and the tab can be
-    // revived. Nothing stops, so there is nothing to warn about.
-    if (tab.type !== TabType.AGENT || isSubagentTab(tab))
-      return null
-    // interruptsWork, not isBusy. They differ for an agent blocked on a
-    // permission prompt: the indicator must not spin at somebody who is being
-    // asked a question, but its turn is still in flight and this close kills it
-    // along with every background task under it.
-    if (!deps.activity.interruptsWork(tab.id))
-      return null
-    return {
-      kind: 'agent-turn',
-      // The same predicate the chip counts with. Re-spelling the statuses here
-      // would let the dialog list fewer running tasks than the chip beside it
-      // reports as soon as a new status joins the enum.
-      activeTasks: deps.tasksFor(tab.id).filter(t => isActiveBackgroundTaskStatus(t.status)),
-    }
-  }
+  /**
+   * A subagent tab closes in the UI only: the worker treats CloseAgent on a
+   * child as tab-close-only, the transcript survives and the tab can be
+   * revived. Nothing stops, so there is nothing to warn about.
+   */
+  const guardedAgentTab = (tab: Tab): boolean => tab.type === TabType.AGENT && !isSubagentTab(tab)
 
-  const terminalIdsByWorker = (tabs: readonly Tab[]): Map<string, string[]> => {
+  const idsByWorker = (tabs: readonly Tab[], want: (tab: Tab) => boolean): Map<string, string[]> => {
     const byWorker = new Map<string, string[]>()
     for (const tab of tabs) {
-      if (tab.type !== TabType.TERMINAL || !tab.workerId)
+      if (!want(tab) || !tab.workerId)
         continue
       const ids = byWorker.get(tab.workerId)
       if (ids)
@@ -82,13 +70,50 @@ export function createTabBusyProbe(deps: TabBusyProbeDeps) {
   }
 
   /**
+   * Ask every worker that hosts one of these agents for the EXACT activity
+   * state, one request per worker.
+   *
+   * activityInterruptsWork, not "busy". They differ for an agent blocked on a
+   * permission prompt. The indicator must
+   * not spin at somebody who is being asked
+   * a question, but its turn is still in
+   * flight and this close kills it along
+   * with every background task under it.
+   */
+  const agentReasons = async (tabs: readonly Tab[]): Promise<Map<string, TabBusyReason>> => {
+    const out = new Map<string, TabBusyReason>()
+    await Promise.all([...idsByWorker(tabs, guardedAgentTab)].map(async ([workerId, tabIds]) => {
+      try {
+        const resp = await workerRpc.listAgents(workerId, { tabIds })
+        for (const info of resp.agents) {
+          if (!activityInterruptsWork(info.activityState))
+            continue
+          out.set(info.id, {
+            kind: 'agent-turn',
+            // The same predicate the chip counts with. Re-spelling the statuses
+            // here would let the dialog list fewer running tasks than the chip
+            // beside it reports as soon as a new status joins the enum.
+            activeTasks: deps.tasksFor(info.id).filter(t => isActiveBackgroundTaskStatus(t.status)),
+          })
+        }
+      }
+      catch (err) {
+        // Fail open: the close proceeds unwarned rather than being blocked by a
+        // question nobody could answer.
+        log.warn('listAgents failed; closing without a busy check', err)
+      }
+    }))
+    return out
+  }
+
+  /**
    * Ask every worker that hosts one of these terminals, concurrently, and merge
    * the answers. One request per WORKER rather than per tab: closing a tile of
    * eight terminals on one machine is one round trip.
    */
   const terminalReasons = async (tabs: readonly Tab[]): Promise<Map<string, TabBusyReason>> => {
     const out = new Map<string, TabBusyReason>()
-    await Promise.all([...terminalIdsByWorker(tabs)].map(async ([workerId, terminalIds]) => {
+    await Promise.all([...idsByWorker(tabs, t => t.type === TabType.TERMINAL)].map(async ([workerId, terminalIds]) => {
       try {
         const resp = await workerRpc.inspectTerminalProcesses(workerId, { terminalIds })
         for (const entry of resp.terminals) {
@@ -115,10 +140,12 @@ export function createTabBusyProbe(deps: TabBusyProbeDeps) {
    * shows before it starts closing.
    */
   const probeMany = async (tabs: readonly Tab[]): Promise<BusyTab[]> => {
-    const terminals = await terminalReasons(tabs)
+    // Both kinds concurrently: a tile that mixes them is still one round of
+    // requests, not two in sequence.
+    const [terminals, agents] = await Promise.all([terminalReasons(tabs), agentReasons(tabs)])
     const out: BusyTab[] = []
     for (const tab of tabs) {
-      const reason = tab.type === TabType.TERMINAL ? terminals.get(tab.id) ?? null : agentReason(tab)
+      const reason = tab.type === TabType.TERMINAL ? terminals.get(tab.id) ?? null : agents.get(tab.id) ?? null
       if (reason)
         out.push({ tab, title: tabDisplayLabel(tab), reason })
     }

--- a/frontend/src/components/shell/useTabHydrators.test.ts
+++ b/frontend/src/components/shell/useTabHydrators.test.ts
@@ -54,6 +54,7 @@ function agentInfo(id: string, over: Record<string, unknown> = {}) {
     startupMessage: '',
     gitStatus: undefined,
     activityState: AgentActivityState.IDLE,
+    publishedActivityState: AgentActivityState.IDLE,
     activeBackgroundTasks: 0,
     ...over,
   }
@@ -163,12 +164,18 @@ describe('useTabHydrators', () => {
     // The hydration path of the activity state. It is the ONLY path that
     // reaches a tab watching in NOTIFY mode, which gets no catch-up replay at
     // all -- without it a background tab shows no spinner until its agent's
-    // next transition, and the close guard lets a working agent go unwarned.
+    // next transition.
     it('seeds the worker-derived busy state from the reply', async () => {
       mockListAgents.mockResolvedValue({
         agents: [
-          agentInfo('a1', { activityState: AgentActivityState.WORKING }),
-          agentInfo('a2', { activityState: AgentActivityState.IDLE }),
+          agentInfo('a1', {
+            activityState: AgentActivityState.WORKING,
+            publishedActivityState: AgentActivityState.WORKING,
+          }),
+          agentInfo('a2', {
+            activityState: AgentActivityState.IDLE,
+            publishedActivityState: AgentActivityState.IDLE,
+          }),
         ],
         verdicts: [],
       })
@@ -189,6 +196,39 @@ describe('useTabHydrators', () => {
 
       expect(s.agentActivityStore.isBusy('a1')).toBe(true)
       expect(s.agentActivityStore.isBusy('a2')).toBe(false)
+      d()
+    })
+
+    // The DISPLAY reads what the Worker last broadcast, not what is exactly
+    // true. The two differ for as long as a settle waits out its debounce
+    // window, and seeding the exact value there drops the spinner early.
+    // If the work then resumes, the Worker derives a state equal to what
+    // it already published and broadcasts nothing, so the tab shows no
+    // spinner for the rest of the turn. The exact value belongs to the close guard.
+    it('seeds the published state, not the exact one', async () => {
+      mockListAgents.mockResolvedValue({
+        agents: [agentInfo('a1', {
+          // A settle is waiting: the derivation says idle, the client was told
+          // working, and the client must keep holding working.
+          activityState: AgentActivityState.IDLE,
+          publishedActivityState: AgentActivityState.WORKING,
+        })],
+        verdicts: [],
+      })
+      const s = setup()
+      const d = createRoot((dispose) => {
+        s.add(TabType.AGENT, 'a1')
+        s.mount()
+        return dispose
+      })
+      await flush()
+      await flush()
+
+      expect(s.agentActivityStore.isBusy('a1'), 'the spinner matches the live event stream').toBe(true)
+      expect(
+        s.agentActivityStore.apply('a1', AgentActivityState.IDLE),
+        'and the settle the Worker still holds still rings when it lands',
+      ).toBe(true)
       d()
     })
 

--- a/frontend/src/components/shell/useTabHydrators.ts
+++ b/frontend/src/components/shell/useTabHydrators.ts
@@ -565,12 +565,27 @@ export function useTabHydrators(opts: UseTabHydratorsOpts): void {
           opts.settingsPendingAxes?.(tab.id) ?? EMPTY_PENDING_AXES,
         )
         opts.metadata.patch(tab.id, { ...fields, ...settingsFields })
-        // Hydration, not a transition: seed the store and drop the settle edge
-        // setBusy reports. This batch runs when a tab first appears and on an
-        // explicit re-ask, never as a poll, so an agent that settled between
-        // the two is not news the user asked for -- and the live event that
-        // announced that settle already rang if this client was watching.
-        opts.agentActivityStore.apply(tab.id, agent.activityState)
+        // Hydration, not a transition, so it seeds and raises nothing. This
+        // batch runs when a tab first appears and on an explicit re-ask, never
+        // as a poll, so an agent that settled between the two is not news the
+        // user asked for.
+        //
+        // publishedActivityState, not activityState. The display must match
+        // what the live events
+        // carry. Seeded with the
+        // EXACT value, a tab
+        // hydrating inside the
+        // Worker's settle window
+        // drops its spinner early.
+        // If the work then resumes,
+        // the Worker derives a state
+        // equal to what it already
+        // published and broadcasts
+        // nothing, so that tab shows
+        // no spinner for the rest of
+        // the turn. The exact value belongs to the close guard,
+        // which fetches it at the moment of the close (see createTabBusyProbe).
+        opts.agentActivityStore.seedPublished(tab.id, agent.publishedActivityState)
         resolved.add(tab.id)
       }
       return { resolved, verdicts: resp.verdicts }

--- a/frontend/src/hooks/agentEvents.ts
+++ b/frontend/src/hooks/agentEvents.ts
@@ -7,7 +7,7 @@
  * 1700-line module without changing a line of behaviour.
  */
 import type { Provider } from '~/components/chat/providers/registry'
-import type { AgentChatMessage, AgentControlRequest, AgentStatusChange, AgentStreamChunk, AgentStreamEnd, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
+import type { AgentActivityState, AgentChatMessage, AgentControlRequest, AgentStatusChange, AgentStreamChunk, AgentStreamEnd, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { AgentActivityStore } from '~/stores/agentActivity.store'
@@ -26,7 +26,7 @@ import { pluginFor, providerFor } from '~/components/chat/providers/registry'
 import { mergeStableOptionGroupRefs, OPTION_ID_MODEL, optionGroup } from '~/components/chat/settingsGroups'
 import { GOAL_PROGRESS_FIELD, RATE_LIMIT_FIELD, RUNNING_TOOL_FIELD, RUNNING_TOOL_RETRY_FIELD, SESSION_INFO_KEY } from '~/generated/contracts/session-info'
 import { NOTIFICATION_TYPE } from '~/generated/contracts/worker-vocab'
-import { AgentActivityState, AgentStatus, MessageSource } from '~/generated/proto/leapmux/v1/agent_pb'
+import { AgentStatus, MessageSource } from '~/generated/proto/leapmux/v1/agent_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { isTabOnScreen } from '~/hooks/watchPlan'
 import { assignDefined, isObject, pickBoolean, pickCounter, pickNumber, pickString } from '~/lib/jsonPick'
@@ -942,12 +942,12 @@ export function isAgentTabOnScreen(
  * answers whether this write was the busy -> idle EDGE, which is not the same
  * as an idle report arriving: the same value reaches a client twice when a
  * catch-up replay lands beside a live event, and an idle report can arrive for
- * an agent this client never saw working. See AgentActivityStore.setBusy.
+ * an agent this client never saw working. See AgentActivityStore.apply.
  *
  * Every AgentActivityChanged is a TRANSITION, so this runs in every catch-up
  * phase. A settle that lands while the tab replays is a live settle -- the agent
  * finished while the burst drained -- and it must ring. The catch-up BASELINE is
- * a level and arrives on CatchUpStart instead; handleActivityLevel takes it.
+ * a level and arrives on CatchUpStart instead; AgentActivityStore.seed takes it.
  */
 export function handleActivityChanged(
   agentId: string,
@@ -959,29 +959,6 @@ export function handleActivityChanged(
 ): void {
   if (stores.agentActivityStore.apply(agentId, value.state))
     handleAgentSettled(agentId, value.numToolUses, stores)
-}
-
-/**
- * The CatchUpStart branch of the same state: seed the store, and raise nothing.
- *
- * A LEVEL, not a transition. It says what the agent is doing as the replay
- * begins, so the tab paints the right spinner while the burst lands. An agent
- * that settled while this client was away is not news the user asked for, and
- * ringing for each one on every reconnect is the failure this split prevents.
- * `apply` reports the edge it saw; dropping that return is the whole point, and
- * `useTabHydrators` drops it for the same reason on the list-read path.
- *
- * UNSPECIFIED is "no opinion", not a state: a worker that sends one must not
- * overwrite an answer this client already holds.
- */
-export function handleActivityLevel(
-  agentId: string,
-  state: AgentActivityState,
-  agentActivityStore: AgentActivityStore,
-): void {
-  if (state === AgentActivityState.UNSPECIFIED)
-    return
-  agentActivityStore.apply(agentId, state)
 }
 
 /**
@@ -1005,10 +982,10 @@ export function handleActivityLevel(
  *
  * Runs in every catch-up phase, because its one caller only reaches it on a
  * transition. The phase test that used to stand here dropped a settle that
- * merely RACED a replay -- a background task ending while the burst drained --
- * and that settle is the one the user waits for. The baseline the phase test
+ * merely RACED a replay, such as a background task ending while the
+ * burst drained. That settle is the one the user waits for. The baseline the phase test
  * existed to silence no longer arrives as a transition at all: it rides
- * CatchUpStart, and handleActivityLevel raises nothing for it.
+ * CatchUpStart, and AgentActivityStore.seed raises nothing for it.
  */
 export function handleAgentSettled(
   agentId: string,

--- a/frontend/src/hooks/agentEvents.ts
+++ b/frontend/src/hooks/agentEvents.ts
@@ -7,7 +7,7 @@
  * 1700-line module without changing a line of behaviour.
  */
 import type { Provider } from '~/components/chat/providers/registry'
-import type { AgentActivityState, AgentChatMessage, AgentControlRequest, AgentStatusChange, AgentStreamChunk, AgentStreamEnd, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
+import type { AgentChatMessage, AgentControlRequest, AgentStatusChange, AgentStreamChunk, AgentStreamEnd, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import type { ParsedMessageContent } from '~/lib/messageParser'
 import type { AgentActivityStore } from '~/stores/agentActivity.store'
@@ -26,7 +26,7 @@ import { pluginFor, providerFor } from '~/components/chat/providers/registry'
 import { mergeStableOptionGroupRefs, OPTION_ID_MODEL, optionGroup } from '~/components/chat/settingsGroups'
 import { GOAL_PROGRESS_FIELD, RATE_LIMIT_FIELD, RUNNING_TOOL_FIELD, RUNNING_TOOL_RETRY_FIELD, SESSION_INFO_KEY } from '~/generated/contracts/session-info'
 import { NOTIFICATION_TYPE } from '~/generated/contracts/worker-vocab'
-import { AgentStatus, MessageSource } from '~/generated/proto/leapmux/v1/agent_pb'
+import { AgentActivityState, AgentStatus, MessageSource } from '~/generated/proto/leapmux/v1/agent_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { isTabOnScreen } from '~/hooks/watchPlan'
 import { assignDefined, isObject, pickBoolean, pickCounter, pickNumber, pickString } from '~/lib/jsonPick'
@@ -943,6 +943,11 @@ export function isAgentTabOnScreen(
  * as an idle report arriving: the same value reaches a client twice when a
  * catch-up replay lands beside a live event, and an idle report can arrive for
  * an agent this client never saw working. See AgentActivityStore.setBusy.
+ *
+ * Every AgentActivityChanged is a TRANSITION, so this runs in every catch-up
+ * phase. A settle that lands while the tab replays is a live settle -- the agent
+ * finished while the burst drained -- and it must ring. The catch-up BASELINE is
+ * a level and arrives on CatchUpStart instead; handleActivityLevel takes it.
  */
 export function handleActivityChanged(
   agentId: string,
@@ -951,10 +956,32 @@ export function handleActivityChanged(
     agentActivityStore: AgentActivityStore
     onAgentSettled?: (agentId: string, numToolUses?: number) => void
   },
-  catchUpPhase: CatchUpPhase,
 ): void {
   if (stores.agentActivityStore.apply(agentId, value.state))
-    handleAgentSettled(agentId, value.numToolUses, stores, catchUpPhase)
+    handleAgentSettled(agentId, value.numToolUses, stores)
+}
+
+/**
+ * The CatchUpStart branch of the same state: seed the store, and raise nothing.
+ *
+ * A LEVEL, not a transition. It says what the agent is doing as the replay
+ * begins, so the tab paints the right spinner while the burst lands. An agent
+ * that settled while this client was away is not news the user asked for, and
+ * ringing for each one on every reconnect is the failure this split prevents.
+ * `apply` reports the edge it saw; dropping that return is the whole point, and
+ * `useTabHydrators` drops it for the same reason on the list-read path.
+ *
+ * UNSPECIFIED is "no opinion", not a state: a worker that sends one must not
+ * overwrite an answer this client already holds.
+ */
+export function handleActivityLevel(
+  agentId: string,
+  state: AgentActivityState,
+  agentActivityStore: AgentActivityStore,
+): void {
+  if (state === AgentActivityState.UNSPECIFIED)
+    return
+  agentActivityStore.apply(agentId, state)
 }
 
 /**
@@ -976,8 +1003,12 @@ export function handleActivityChanged(
  * that cannot report one. Explicit 0 means the turn did nothing worth
  * interrupting the user for.
  *
- * Restricted to the 'live' phase: a catch-up replay would otherwise ring for
- * every agent that settled while the tab was closed.
+ * Runs in every catch-up phase, because its one caller only reaches it on a
+ * transition. The phase test that used to stand here dropped a settle that
+ * merely RACED a replay -- a background task ending while the burst drained --
+ * and that settle is the one the user waits for. The baseline the phase test
+ * existed to silence no longer arrives as a transition at all: it rides
+ * CatchUpStart, and handleActivityLevel raises nothing for it.
  */
 export function handleAgentSettled(
   agentId: string,
@@ -985,10 +1016,7 @@ export function handleAgentSettled(
   stores: Pick<AgentMessageStores, 'metadata' | 'selection' | 'getActiveWorkspaceId' | 'view'> & {
     onAgentSettled?: (agentId: string, numToolUses?: number) => void
   },
-  catchUpPhase: CatchUpPhase,
 ): void {
-  if (catchUpPhase !== 'live')
-    return
   const { metadata, selection, getActiveWorkspaceId, view } = stores
   if (!view.getAgentTab(agentId))
     return

--- a/frontend/src/hooks/agentEvents.ts
+++ b/frontend/src/hooks/agentEvents.ts
@@ -947,7 +947,8 @@ export function isAgentTabOnScreen(
  * Every AgentActivityChanged is a TRANSITION, so this runs in every catch-up
  * phase. A settle that lands while the tab replays is a live settle -- the agent
  * finished while the burst drained -- and it must ring. The catch-up BASELINE is
- * a level and arrives on CatchUpStart instead; AgentActivityStore.seed takes it.
+ * a level and arrives on CatchUpStart instead; AgentActivityStore.seedPublished
+ * takes it.
  */
 export function handleActivityChanged(
   agentId: string,
@@ -985,7 +986,7 @@ export function handleActivityChanged(
  * merely RACED a replay, such as a background task ending while the
  * burst drained. That settle is the one the user waits for. The baseline the phase test
  * existed to silence no longer arrives as a transition at all: it rides
- * CatchUpStart, and AgentActivityStore.seed raises nothing for it.
+ * CatchUpStart, and AgentActivityStore.seedPublished raises nothing for it.
  */
 export function handleAgentSettled(
   agentId: string,

--- a/frontend/src/hooks/useWorkspaceConnection.activity.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.activity.test.ts
@@ -1,0 +1,212 @@
+import type { WatchEventsResponse } from '~/generated/proto/leapmux/v1/workspace_pb'
+import type { UseWatchEventsStreamsOpts } from '~/hooks/useWatchEventsStreams'
+import { createRoot } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentActivityState, AgentStatus } from '~/generated/proto/leapmux/v1/agent_pb'
+import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
+import { createLoadingSignal } from '~/hooks/createLoadingSignal'
+import { useWorkspaceConnection } from '~/hooks/useWorkspaceConnection'
+import { createAgentActivityStore } from '~/stores/agentActivity.store'
+import { createAgentInputQueueStore } from '~/stores/agentInputQueue.store'
+import { createAgentSessionStore } from '~/stores/agentSession.store'
+import { createChatStore } from '~/stores/chat.store'
+import { createControlStore } from '~/stores/control.store'
+import { createRepoGitStore } from '~/stores/repoGit.store'
+import { emitAddTab } from '~/stores/tabOps'
+import { installTestBridge } from '~/test-support/crdtBridge'
+import { createTestTabStores } from '~/test-support/tabStores'
+
+vi.mock('~/api/workerRpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/api/workerRpc')>()
+  return {
+    ...actual,
+    // The tail-reconcile effect asks for the newest page of every agent tab.
+    // Answered with an empty page so the hook's own promise chains settle.
+    listAgentMessages: vi.fn().mockResolvedValue({ messages: [], hasMore: false }),
+    channelManager: {
+      getOrOpenChannel: vi.fn().mockResolvedValue('ch-1'),
+      hasOpenChannelForWorker: vi.fn().mockReturnValue(true),
+      fatalCloseInfo: vi.fn(() => null),
+    },
+  }
+})
+
+vi.mock('~/components/common/Toast', () => ({
+  showWarnToast: vi.fn(),
+  showInfoToast: vi.fn(),
+  showWarnToastUnlessDisconnected: vi.fn(),
+}))
+
+/**
+ * The real stream hook dials a channel. Replaced with a capture, so a test
+ * delivers frames to the dispatcher itself.
+ *
+ * This is what makes the `catchUpStart` wiring testable at all. The unit tests
+ * beside it drive `AgentActivityStore` and the extracted handlers directly, so
+ * every one of them passes whichever of the two the switch happens to call.
+ */
+const streams = vi.hoisted(() => ({ opts: undefined as unknown }))
+
+vi.mock('~/hooks/useWatchEventsStreams', () => ({
+  useWatchEventsStreams: (opts: unknown) => {
+    streams.opts = opts
+    return { abortSignalFor: () => undefined }
+  },
+}))
+
+beforeEach(() => {
+  streams.opts = undefined
+})
+
+function streamOpts(): UseWatchEventsStreamsOpts {
+  if (!streams.opts)
+    throw new Error('useWorkspaceConnection did not open its watch streams')
+  return streams.opts as UseWatchEventsStreamsOpts
+}
+
+const WS = 'ws-activity-dispatch'
+const WORKER = 'w-1'
+
+/** One agent tab on one worker, with the activity store and the alert exposed. */
+function mountConnection() {
+  const harness = installTestBridge({ workspaceId: WS })
+  const { view, metadata, selection } = createTestTabStores(WS)
+  const activity = createAgentActivityStore()
+  const controlStore = createControlStore()
+  const settled: string[] = []
+
+  emitAddTab({ type: TabType.AGENT, id: 'a1', tileId: harness.rootTileId, position: 'p1', workerId: WORKER })
+  emitAddTab({ type: TabType.AGENT, id: 'a2', tileId: harness.rootTileId, position: 'p2', workerId: WORKER })
+  metadata.patch('a1', { agentStatus: AgentStatus.ACTIVE })
+  metadata.patch('a2', { agentStatus: AgentStatus.ACTIVE })
+  // a2 is the tile's active tab, so a1 is OFF screen -- which is the tab a
+  // badge is for. A prompt on the tab the user already looks at badges nothing.
+  selection.setActiveById(TabType.AGENT, 'a2')
+
+  let dispose!: () => void
+  createRoot((d) => {
+    dispose = d
+    useWorkspaceConnection({
+      chatStore: createChatStore(),
+      agentInputQueueStore: createAgentInputQueueStore(),
+      view,
+      metadata,
+      selection,
+      controlStore,
+      agentSessionStore: createAgentSessionStore(),
+      agentActivityStore: activity,
+      repoGitStore: createRepoGitStore(),
+      settingsLoading: createLoadingSignal(),
+      getActiveWorkspaceId: () => WS,
+      onAgentSettled: (id: string) => settled.push(id),
+    })
+  })
+  return {
+    dispose,
+    activity,
+    settled,
+    controlStore,
+    tabHasNotification: (id: string) => view.getAgentTab(id)?.hasNotification,
+  }
+}
+
+/** A control request's payload is JSON, and the handler drops one it cannot parse. */
+function controlPayload(): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify({ tool_name: 'Bash' }))
+}
+
+function agentEvent(agentId: string, event: unknown, replay = false): WatchEventsResponse {
+  return { event: { case: 'agentEvent', value: { agentId, event, replay } } } as unknown as WatchEventsResponse
+}
+
+/**
+ * The `catchUpStart` branch of handleAgentEvent, which no other test reaches.
+ *
+ * Swapping that one line to `handleActivityChanged` makes every reconnect ring
+ * once for each agent that settled while the client was away -- the burst the
+ * level/transition split exists to prevent -- and the whole suite stays green
+ * without these cases.
+ */
+describe('useWorkspaceConnection catchUpStart activity', () => {
+  it('seeds the replay baseline instead of ringing for it', () => {
+    const { dispose, activity, settled } = mountConnection()
+    // The client watched this turn start.
+    activity.apply('a1', AgentActivityState.WORKING)
+
+    streamOpts().onEvent(WORKER, agentEvent('a1', {
+      case: 'catchUpStart',
+      value: { activityState: AgentActivityState.IDLE },
+    }))
+
+    expect(activity.isBusy('a1'), 'the level still lands').toBe(false)
+    expect(settled, 'a level is not news the user asked for').toEqual([])
+    dispose()
+  })
+
+  it('paints the spinner from the replay baseline before the burst', () => {
+    const { dispose, activity, settled } = mountConnection()
+
+    streamOpts().onEvent(WORKER, agentEvent('a1', {
+      case: 'catchUpStart',
+      value: { activityState: AgentActivityState.WORKING },
+    }))
+
+    expect(activity.isBusy('a1'), 'the tab knows it is busy before the messages arrive').toBe(true)
+    expect(settled).toEqual([])
+    dispose()
+  })
+
+  it('still rings for the settle that follows the baseline', () => {
+    // The baseline carries the PUBLISHED state, so a settle the Worker is still
+    // holding in its debounce window reads WORKING here and keeps its edge.
+    const { dispose, activity, settled } = mountConnection()
+    activity.apply('a1', AgentActivityState.WORKING)
+
+    streamOpts().onEvent(WORKER, agentEvent('a1', {
+      case: 'catchUpStart',
+      value: { activityState: AgentActivityState.WORKING },
+    }))
+    streamOpts().onEvent(WORKER, agentEvent('a1', {
+      case: 'activityChanged',
+      value: { state: AgentActivityState.IDLE },
+    }))
+
+    expect(settled, 'the turn that ended while the tab replayed still rings').toEqual(['a1'])
+    dispose()
+  })
+})
+
+/**
+ * The replay/live split, now that the FRAME says which it is.
+ *
+ * A client registers its live watch before the replay burst runs and both write
+ * the same stream, so arrival order cannot tell them apart. Guessing from it
+ * dropped a live permission prompt's badge whenever it raced a replay.
+ */
+describe('useWorkspaceConnection replay marking', () => {
+  it('badges an off-screen tab for a live control request that races a replay', () => {
+    const { dispose, controlStore, tabHasNotification } = mountConnection()
+
+    streamOpts().onEvent(WORKER, agentEvent('a1', {
+      case: 'controlRequest',
+      value: { agentId: 'a1', requestId: 'req-1', payload: controlPayload() },
+    }))
+
+    expect(controlStore.getRequests('a1').length, 'the prompt is recorded either way').toBe(1)
+    expect(tabHasNotification('a1'), 'and a live prompt badges the tab it arrived for').toBe(true)
+    dispose()
+  })
+
+  it('does not badge for the same request replayed', () => {
+    const { dispose, controlStore, tabHasNotification } = mountConnection()
+
+    streamOpts().onEvent(WORKER, agentEvent('a1', {
+      case: 'controlRequest',
+      value: { agentId: 'a1', requestId: 'req-1', payload: controlPayload() },
+    }, true))
+
+    expect(controlStore.getRequests('a1').length, 'the replay still hydrates the prompt').toBe(1)
+    expect(tabHasNotification('a1'), 'but a replay is not news the user asked for').not.toBe(true)
+    dispose()
+  })
+})

--- a/frontend/src/hooks/useWorkspaceConnection.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.test.ts
@@ -8,7 +8,7 @@ import { CATCH_UP_GAP_LIMIT } from '~/generated/contracts/chat-history'
 import { AgentActivityState, AgentProvider, AgentStatus, ContentCompression, MessageSource } from '~/generated/proto/leapmux/v1/agent_pb'
 import { TerminalStatus } from '~/generated/proto/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
-import { applyAgentLifecycle, applyNotificationMetadata, applyPendingAxisSuppression, buildAgentStatusTabUpdate, clearCompletedSpanStream, handleActivityChanged, handleAgentInactive, handleAgentMessage, handleAgentSessionInfo, handleAgentSettled, handleAgentStatusChange, handleControlRequest, handleResultDivider, handleStreamChunk, handleStreamEnd, resolveSettingsTabFields, shouldClearThinkingTokensForMessage, wireSessionInfoToUpdates } from '~/hooks/agentEvents'
+import { applyAgentLifecycle, applyNotificationMetadata, applyPendingAxisSuppression, buildAgentStatusTabUpdate, clearCompletedSpanStream, handleActivityChanged, handleActivityLevel, handleAgentInactive, handleAgentMessage, handleAgentSessionInfo, handleAgentSettled, handleAgentStatusChange, handleControlRequest, handleResultDivider, handleStreamChunk, handleStreamEnd, resolveSettingsTabFields, shouldClearThinkingTokensForMessage, wireSessionInfoToUpdates } from '~/hooks/agentEvents'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { applyTerminalStatusChange, handleTerminalBell, handleTerminalNotification, handleTerminalProgress, handleTerminalTitleChanged } from '~/hooks/terminalEvents'
 import { clearOfflineAgentState, collectWorkerOfflineTargets, enqueuePendingTerminalData, MAX_PENDING_TERMINAL_FRAMES, reconcileLaggingTails, useWorkspaceConnection } from '~/hooks/useWorkspaceConnection'
@@ -1972,11 +1972,11 @@ describe('extracted handleAgentEvent arm handlers', () => {
         const ended: Array<{ id: string, uses?: number }> = []
         const stores = activityStores(tabs, activity, (id, uses) => ended.push({ id, uses }))
 
-        handleActivityChanged('a1', { state: AgentActivityState.WORKING }, stores, 'live')
+        handleActivityChanged('a1', { state: AgentActivityState.WORKING }, stores)
         expect(activity.isBusy('a1')).toBe(true)
         expect(ended, 'going busy is not a settle').toEqual([])
 
-        handleActivityChanged('a1', { state: AgentActivityState.IDLE, numToolUses: 3 }, stores, 'live')
+        handleActivityChanged('a1', { state: AgentActivityState.IDLE, numToolUses: 3 }, stores)
         expect(activity.isBusy('a1')).toBe(false)
         expect(ended).toEqual([{ id: 'a1', uses: 3 }])
         expect(tabs.view.getAgentTab('a1')?.hasNotification, 'a1 is off screen').toBe(true)
@@ -1996,9 +1996,9 @@ describe('extracted handleAgentEvent arm handlers', () => {
         const activity = createAgentActivityStore()
         const stores = activityStores(tabs, activity)
 
-        handleActivityChanged('root-1', { state: AgentActivityState.WORKING }, stores, 'live')
-        handleActivityChanged('child-1', { state: AgentActivityState.WORKING }, stores, 'live')
-        handleActivityChanged('child-1', { state: AgentActivityState.IDLE }, stores, 'live')
+        handleActivityChanged('root-1', { state: AgentActivityState.WORKING }, stores)
+        handleActivityChanged('child-1', { state: AgentActivityState.WORKING }, stores)
+        handleActivityChanged('child-1', { state: AgentActivityState.IDLE }, stores)
 
         expect(activity.isBusy('child-1')).toBe(false)
         expect(activity.isBusy('root-1'), 'the parent owes the user a reply').toBe(true)
@@ -2014,12 +2014,12 @@ describe('extracted handleAgentEvent arm handlers', () => {
         const ended: string[] = []
         const stores = activityStores(tabs, activity, id => ended.push(id))
 
-        handleActivityChanged('a1', { state: AgentActivityState.WORKING }, stores, 'live')
-        handleActivityChanged('a1', { state: AgentActivityState.IDLE }, stores, 'live')
+        handleActivityChanged('a1', { state: AgentActivityState.WORKING }, stores)
+        handleActivityChanged('a1', { state: AgentActivityState.IDLE }, stores)
         // A catch-up replay lands beside the live event, and a subprocess
         // teardown drops the worker's "already published" mark, so the same
         // value reaches a client twice.
-        handleActivityChanged('a1', { state: AgentActivityState.IDLE }, stores, 'live')
+        handleActivityChanged('a1', { state: AgentActivityState.IDLE }, stores)
 
         expect(ended).toEqual(['a1'])
         dispose()
@@ -2035,7 +2035,7 @@ describe('extracted handleAgentEvent arm handlers', () => {
 
         // A NOTIFY-mode tab can subscribe after the turn started and receive the
         // idle report alone. Nothing the user watched finished.
-        handleActivityChanged('a1', { state: AgentActivityState.IDLE }, activityStores(tabs, activity, id => ended.push(id)), 'live')
+        handleActivityChanged('a1', { state: AgentActivityState.IDLE }, activityStores(tabs, activity, id => ended.push(id)))
 
         expect(ended).toEqual([])
         expect(activity.isBusy('a1'), 'the write still lands').toBe(false)
@@ -2043,19 +2043,63 @@ describe('extracted handleAgentEvent arm handlers', () => {
       })
     })
 
-    it('stores the replay burst without ringing for it', () => {
+    it('rings for a settle that races the replay it arrives during', () => {
       createRoot((dispose) => {
+        // The reason the catch-up phase no longer stands between this event and
+        // the alert. A background task that ends while the burst drains settles
+        // the agent for real, and that settle is the one the user waits for.
+        // Suppressing it for the whole window discarded it.
         const tabs = makeTabStores()
         tabs.addAgent('a1')
         const activity = createAgentActivityStore()
         const ended: string[] = []
         const stores = activityStores(tabs, activity, id => ended.push(id))
 
-        handleActivityChanged('a1', { state: AgentActivityState.WORKING }, stores, 'catchingUp')
-        handleActivityChanged('a1', { state: AgentActivityState.IDLE }, stores, 'catchingUp')
+        handleActivityLevel('a1', AgentActivityState.WORKING, activity)
+        handleActivityChanged('a1', { state: AgentActivityState.IDLE }, stores)
 
-        expect(ended, 'a reconnect must not greet the user with a burst').toEqual([])
-        expect(activity.isBusy('a1'), 'the state still hydrates').toBe(false)
+        expect(ended).toEqual(['a1'])
+        dispose()
+      })
+    })
+  })
+
+  describe('handleActivityLevel', () => {
+    it('seeds the store without ringing, so a reconnect greets nobody', () => {
+      createRoot((dispose) => {
+        // The catch-up BASELINE. An agent that settled while this client was
+        // away is not news the user asked for, and ringing for each one on
+        // every reconnect is the failure this split prevents.
+        const tabs = makeTabStores()
+        tabs.addAgent('a1')
+        const activity = createAgentActivityStore()
+        const ended: string[] = []
+        const stores = {
+          metadata: tabs.metadata,
+          selection: tabs.selection,
+          getActiveWorkspaceId: () => WS,
+          view: tabs.view,
+          agentActivityStore: activity,
+          onAgentSettled: (id: string) => ended.push(id),
+        }
+
+        handleActivityChanged('a1', { state: AgentActivityState.WORKING }, stores)
+        handleActivityLevel('a1', AgentActivityState.IDLE, activity)
+
+        expect(ended, 'a level is not a transition').toEqual([])
+        expect(activity.isBusy('a1'), 'the state still seeds').toBe(false)
+        dispose()
+      })
+    })
+
+    it('keeps what it holds when the worker sends no opinion', () => {
+      createRoot((dispose) => {
+        const activity = createAgentActivityStore()
+        activity.apply('a1', AgentActivityState.WORKING)
+
+        handleActivityLevel('a1', AgentActivityState.UNSPECIFIED, activity)
+
+        expect(activity.isBusy('a1'), 'UNSPECIFIED must not overwrite a real answer').toBe(true)
         dispose()
       })
     })
@@ -2078,8 +2122,8 @@ describe('extracted handleAgentEvent arm handlers', () => {
         tabs.selection.setActiveById(TabType.AGENT, 'a2')
         const ended: Array<{ id: string, uses?: number }> = []
         const push = (id: string, uses?: number) => ended.push({ id, uses })
-        handleAgentSettled('a1', undefined, settledStores(tabs, push), 'live')
-        handleAgentSettled('a2', 3, settledStores(tabs, push), 'live')
+        handleAgentSettled('a1', undefined, settledStores(tabs, push))
+        handleAgentSettled('a2', 3, settledStores(tabs, push))
         // undefined is not zero: a settle that no turn end caused carries no
         // count and must still alert.
         expect(ended).toEqual([{ id: 'a1', uses: undefined }, { id: 'a2', uses: 3 }])
@@ -2097,23 +2141,8 @@ describe('extracted handleAgentEvent arm handlers', () => {
         tabs.addAgent('a2', {}, { tileId: secondTile, activate: false })
         tabs.selection.setActiveById(TabType.AGENT, 'a2')
         tabs.selection.setActiveById(TabType.AGENT, 'a1')
-        handleAgentSettled('a2', undefined, settledStores(tabs), 'live')
+        handleAgentSettled('a2', undefined, settledStores(tabs))
         expect(tabs.view.getAgentTab('a2')?.hasNotification).not.toBe(true)
-        dispose()
-      })
-    })
-
-    it('stays silent during catch-up', () => {
-      createRoot((dispose) => {
-        const tabs = makeTabStores()
-        tabs.addAgent('a1')
-        tabs.selection.setActiveById(TabType.AGENT, 'a1')
-        const ended: string[] = []
-        // A reconnect replays the activity of every agent that settled while the
-        // tab was closed. Ringing for each would greet the user with a burst.
-        handleAgentSettled('a1', undefined, settledStores(tabs, id => ended.push(id)), 'catchingUp')
-        expect(ended).toEqual([])
-        expect(tabs.view.getAgentTab('a1')?.hasNotification).not.toBe(true)
         dispose()
       })
     })
@@ -2122,7 +2151,7 @@ describe('extracted handleAgentEvent arm handlers', () => {
       createRoot((dispose) => {
         const tabs = makeTabStores()
         const ended: string[] = []
-        handleAgentSettled('never-existed', undefined, settledStores(tabs, id => ended.push(id)), 'live')
+        handleAgentSettled('never-existed', undefined, settledStores(tabs, id => ended.push(id)))
         expect(ended).toEqual([])
         dispose()
       })

--- a/frontend/src/hooks/useWorkspaceConnection.test.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.test.ts
@@ -8,7 +8,7 @@ import { CATCH_UP_GAP_LIMIT } from '~/generated/contracts/chat-history'
 import { AgentActivityState, AgentProvider, AgentStatus, ContentCompression, MessageSource } from '~/generated/proto/leapmux/v1/agent_pb'
 import { TerminalStatus } from '~/generated/proto/leapmux/v1/terminal_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
-import { applyAgentLifecycle, applyNotificationMetadata, applyPendingAxisSuppression, buildAgentStatusTabUpdate, clearCompletedSpanStream, handleActivityChanged, handleActivityLevel, handleAgentInactive, handleAgentMessage, handleAgentSessionInfo, handleAgentSettled, handleAgentStatusChange, handleControlRequest, handleResultDivider, handleStreamChunk, handleStreamEnd, resolveSettingsTabFields, shouldClearThinkingTokensForMessage, wireSessionInfoToUpdates } from '~/hooks/agentEvents'
+import { applyAgentLifecycle, applyNotificationMetadata, applyPendingAxisSuppression, buildAgentStatusTabUpdate, clearCompletedSpanStream, handleActivityChanged, handleAgentInactive, handleAgentMessage, handleAgentSessionInfo, handleAgentSettled, handleAgentStatusChange, handleControlRequest, handleResultDivider, handleStreamChunk, handleStreamEnd, resolveSettingsTabFields, shouldClearThinkingTokensForMessage, wireSessionInfoToUpdates } from '~/hooks/agentEvents'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { applyTerminalStatusChange, handleTerminalBell, handleTerminalNotification, handleTerminalProgress, handleTerminalTitleChanged } from '~/hooks/terminalEvents'
 import { clearOfflineAgentState, collectWorkerOfflineTargets, enqueuePendingTerminalData, MAX_PENDING_TERMINAL_FRAMES, reconcileLaggingTails, useWorkspaceConnection } from '~/hooks/useWorkspaceConnection'
@@ -1106,10 +1106,10 @@ describe('buildAgentStatusTabUpdate', () => {
 })
 
 /**
- * The statusChange arm for an agent the user is NOT looking at.
+ * The statusChange branch for an agent the user is NOT looking at.
  *
  * The sidebar renders every workspace, so a background row must be as correct
- * as a foreground one. This arm used to hand-roll a subset of the foreground
+ * as a foreground one. This branch used to hand-roll a subset of the foreground
  * patch, which is how the pending-message drain and four metadata fields fell
  * out of it. The drain is the one with a permanent consequence: it fires on the
  * single STARTING -> ACTIVE/STARTUP_FAILED edge, and that edge is never
@@ -1861,7 +1861,7 @@ describe('reconcileLaggingTails', () => {
 // Direct coverage for the per-case handlers extracted from handleAgentEvent's
 // dispatcher. The dispatcher closure itself is only driven by gRPC streams, so these
 // exercise the real production handlers (not a re-implementation) against live stores.
-describe('extracted handleAgentEvent arm handlers', () => {
+describe('extracted handleAgentEvent branch handlers', () => {
   const enc = (s: string) => new TextEncoder().encode(s)
   const argStores = () => {
     const tabs = makeTabStores()
@@ -2055,51 +2055,10 @@ describe('extracted handleAgentEvent arm handlers', () => {
         const ended: string[] = []
         const stores = activityStores(tabs, activity, id => ended.push(id))
 
-        handleActivityLevel('a1', AgentActivityState.WORKING, activity)
+        activity.seedPublished('a1', AgentActivityState.WORKING)
         handleActivityChanged('a1', { state: AgentActivityState.IDLE }, stores)
 
         expect(ended).toEqual(['a1'])
-        dispose()
-      })
-    })
-  })
-
-  describe('handleActivityLevel', () => {
-    it('seeds the store without ringing, so a reconnect greets nobody', () => {
-      createRoot((dispose) => {
-        // The catch-up BASELINE. An agent that settled while this client was
-        // away is not news the user asked for, and ringing for each one on
-        // every reconnect is the failure this split prevents.
-        const tabs = makeTabStores()
-        tabs.addAgent('a1')
-        const activity = createAgentActivityStore()
-        const ended: string[] = []
-        const stores = {
-          metadata: tabs.metadata,
-          selection: tabs.selection,
-          getActiveWorkspaceId: () => WS,
-          view: tabs.view,
-          agentActivityStore: activity,
-          onAgentSettled: (id: string) => ended.push(id),
-        }
-
-        handleActivityChanged('a1', { state: AgentActivityState.WORKING }, stores)
-        handleActivityLevel('a1', AgentActivityState.IDLE, activity)
-
-        expect(ended, 'a level is not a transition').toEqual([])
-        expect(activity.isBusy('a1'), 'the state still seeds').toBe(false)
-        dispose()
-      })
-    })
-
-    it('keeps what it holds when the worker sends no opinion', () => {
-      createRoot((dispose) => {
-        const activity = createAgentActivityStore()
-        activity.apply('a1', AgentActivityState.WORKING)
-
-        handleActivityLevel('a1', AgentActivityState.UNSPECIFIED, activity)
-
-        expect(activity.isBusy('a1'), 'UNSPECIFIED must not overwrite a real answer').toBe(true)
         dispose()
       })
     })
@@ -2598,7 +2557,7 @@ describe('shouldClearThinkingTokensForMessage', () => {
  * `streamingText` throws away deltas that are never resent while flipping it
  * INACTIVE hides a thinking indicator for a turn that is still running.
  *
- * The agent arm was missing that filter. Before every workspace became live it
+ * The agent branch was missing that filter. Before every workspace became live it
  * was a one-workspace bug; the widening made it account-wide.
  */
 describe('collectWorkerOfflineTargets', () => {
@@ -2646,7 +2605,7 @@ describe('collectWorkerOfflineTargets', () => {
     ], 'w1')
 
     expect(agents).toEqual([])
-    expect(terminals.size, 'a FILE tab is neither arm').toBe(0)
+    expect(terminals.size, 'a FILE tab is neither branch').toBe(0)
   })
 
   it('returns nothing for a worker that hosts none of these tabs', () => {

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -23,6 +23,7 @@ import { parseTabKey } from '~/stores/tab.helpers'
 import {
   clearPerTurnLiveState,
   handleActivityChanged,
+  handleActivityLevel,
   handleAgentMessage,
   handleAgentStatusChange,
   handleControlRequest,
@@ -403,10 +404,10 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         // and edge-triggered, so an off-screen tab still learns that its agent
         // settled -- which is the tab that most needs to ring and badge.
         //
-        // `catchUpPhase` is this file's shared resolution, which reads 'live'
-        // for an agent with no entry: catchUpPhases carries one only while a tab
-        // replays into FULL, so a tab watching in NOTIFY mode has none -- and
-        // that is exactly the off-screen tab this event exists to ring for.
+        // No `catchUpPhase` here, unlike every other alerting branch. Each of
+        // these is a TRANSITION, so a settle that lands while this tab replays
+        // is a live settle and rings. The catch-up BASELINE is a level and
+        // arrives on catchUpStart below.
         handleActivityChanged(agentId, inner.value, {
           metadata,
           selection,
@@ -414,10 +415,13 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
           getActiveWorkspaceId: params.getActiveWorkspaceId,
           agentActivityStore,
           onAgentSettled: params.onAgentSettled,
-        }, catchUpPhase)
+        })
         break
       case 'catchUpStart':
         chatStore.reconcileAuthoritativeTail(agentId, inner.value.latestSeq, resumeTails.get(agentId))
+        // The activity level the replay opens with. It seeds the spinner ahead
+        // of the message burst and rings nothing -- see handleActivityLevel.
+        handleActivityLevel(agentId, inner.value.activityState, agentActivityStore)
         break
       case 'catchUpComplete':
         catchUpPhases.set(agentId, 'live')

--- a/frontend/src/hooks/useWorkspaceConnection.ts
+++ b/frontend/src/hooks/useWorkspaceConnection.ts
@@ -23,7 +23,6 @@ import { parseTabKey } from '~/stores/tab.helpers'
 import {
   clearPerTurnLiveState,
   handleActivityChanged,
-  handleActivityLevel,
   handleAgentMessage,
   handleAgentStatusChange,
   handleControlRequest,
@@ -215,8 +214,6 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
   const { chatStore, agentInputQueueStore, view, metadata, selection, controlStore, agentSessionStore, agentActivityStore, settingsLoading, repoGitStore } = params
   const [offlineWorkers, setOfflineWorkers] = createSignal<ReadonlySet<string>>(new Set())
 
-  // Per-agent catch-up phase across all workers.
-  const catchUpPhases = new Map<string, CatchUpPhase>()
   // Resume cursor sent per agent on promotion — CatchUpStart reap ceiling.
   const resumeTails = new Map<string, bigint>()
   // TerminalData that arrived before the xterm instance was mounted. Snapshot
@@ -308,7 +305,13 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
     const agentId = agentEvent.agentId
     const inner = agentEvent.event
 
-    const catchUpPhase = catchUpPhases.get(agentId) ?? 'live'
+    // The FRAME says which it is. A client registers its live watch before the
+    // replay burst runs and both write the same
+    // stream, so arrival order cannot tell them
+    // apart. Guessing from it dropped a permission
+    // prompt's badge, a plan-title update and an
+    // INACTIVE sweep whenever they raced a replay. See AgentEvent.replay.
+    const catchUpPhase: CatchUpPhase = agentEvent.replay ? 'catchingUp' : 'live'
     const markLiveAgentActive = () => {
       if (catchUpPhase !== 'live')
         return
@@ -407,7 +410,9 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
         // No `catchUpPhase` here, unlike every other alerting branch. Each of
         // these is a TRANSITION, so a settle that lands while this tab replays
         // is a live settle and rings. The catch-up BASELINE is a level and
-        // arrives on catchUpStart below.
+        // arrives on catchUpStart below, where a level seeds the store. The
+        // replay never sends this message at all, so the frame's own flag would
+        // answer 'live' here in every case.
         handleActivityChanged(agentId, inner.value, {
           metadata,
           selection,
@@ -420,11 +425,17 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
       case 'catchUpStart':
         chatStore.reconcileAuthoritativeTail(agentId, inner.value.latestSeq, resumeTails.get(agentId))
         // The activity level the replay opens with. It seeds the spinner ahead
-        // of the message burst and rings nothing -- see handleActivityLevel.
-        handleActivityLevel(agentId, inner.value.activityState, agentActivityStore)
+        // of the message burst and rings nothing. It is the PUBLISHED level, so
+        // it also resets the edge
+        // baseline. This client may
+        // hold a WORKING from a link
+        // that dropped without an
+        // offline sweep, and the
+        // Worker's own answer is what
+        // supersedes it. See AgentActivityStore.seedPublished.
+        agentActivityStore.seedPublished(agentId, inner.value.activityState)
         break
       case 'catchUpComplete':
-        catchUpPhases.set(agentId, 'live')
         chatStore.setCatchingUp(agentId, false)
         chatStore.reconcileAuthoritativeTail(
           agentId,
@@ -532,7 +543,6 @@ export function useWorkspaceConnection(params: WorkspaceConnectionParams) {
     onWorkerOnline: setWorkerOnline,
     onPromoted: (workerId, agentIds) => {
       for (const agentId of agentIds) {
-        catchUpPhases.set(agentId, 'catchingUp')
         chatStore.setCatchingUp(agentId, true)
         const resumeSeq = untrack(() => chatStore.getResumeAfterSeq(agentId))
         resumeTails.set(agentId, resumeSeq)

--- a/frontend/src/stores/agentActivity.store.test.ts
+++ b/frontend/src/stores/agentActivity.store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { AgentActivityState } from '~/generated/proto/leapmux/v1/agent_pb'
-import { createAgentActivityStore } from '~/stores/agentActivity.store'
+import { activityInterruptsWork, createAgentActivityStore } from '~/stores/agentActivity.store'
 
 const { WORKING, IDLE, WAITING_FOR_USER } = AgentActivityState
 
@@ -89,7 +89,7 @@ describe('createAgentActivityStore', () => {
     store.apply('a1', WAITING_FOR_USER)
 
     expect(store.isBusy('a1')).toBe(false)
-    expect(store.interruptsWork('a1')).toBe(true)
+    expect(activityInterruptsWork(WAITING_FOR_USER)).toBe(true)
   })
 
   it('agrees with itself for the states that are not ambiguous', () => {
@@ -97,14 +97,15 @@ describe('createAgentActivityStore', () => {
 
     store.apply('working', WORKING)
     expect(store.isBusy('working')).toBe(true)
-    expect(store.interruptsWork('working')).toBe(true)
+    expect(activityInterruptsWork(WORKING)).toBe(true)
 
     store.apply('idle', IDLE)
     expect(store.isBusy('idle')).toBe(false)
-    expect(store.interruptsWork('idle')).toBe(false)
+    expect(activityInterruptsWork(IDLE)).toBe(false)
 
     // An agent nothing has reported on yet reads like an idle one.
-    expect(store.interruptsWork('never-seen')).toBe(false)
+    expect(store.isBusy('never-seen')).toBe(false)
+    expect(activityInterruptsWork(AgentActivityState.UNSPECIFIED)).toBe(false)
   })
 
   it('treats a move into waiting as a settle', () => {
@@ -116,5 +117,108 @@ describe('createAgentActivityStore', () => {
     expect(store.apply('a1', WAITING_FOR_USER)).toBe(true)
     // Answering the prompt resumes work, which is no settle.
     expect(store.apply('a1', WORKING)).toBe(false)
+  })
+
+  describe('seedSnapshot', () => {
+    it('writes the state without reporting a settle, so a reconnect greets nobody', () => {
+      const store = createAgentActivityStore()
+      store.apply('a1', WORKING)
+
+      store.seedSnapshot('a1', IDLE)
+
+      expect(store.isBusy('a1'), 'the state still seeds').toBe(false)
+    })
+
+    it('keeps what it holds when the worker sends no opinion', () => {
+      const store = createAgentActivityStore()
+      store.apply('a1', WORKING)
+
+      store.seedSnapshot('a1', AgentActivityState.UNSPECIFIED)
+
+      expect(store.isBusy('a1'), 'UNSPECIFIED must not overwrite a real answer').toBe(true)
+    })
+
+    it('leaves the settle edge for the transition that follows', () => {
+      // AgentInfo carries the EXACT derivation, which ignores the Worker's
+      // debounce window. A list read taken inside that window already carries
+      // the settled value. Written to the baseline, it would make the transition
+      // announcing that settle compare equal, and the sound would never ring.
+      const store = createAgentActivityStore()
+      store.apply('a1', WORKING)
+
+      store.seedSnapshot('a1', IDLE)
+
+      expect(store.apply('a1', IDLE), 'the settle still rings for the turn that ended').toBe(true)
+    })
+
+    it('arms the edge when the level says working, so a settle moments later rings', () => {
+      const store = createAgentActivityStore()
+
+      store.seedSnapshot('a1', WORKING)
+
+      expect(store.apply('a1', IDLE), 'the agent finished while this client watched').toBe(true)
+    })
+
+    it('does not invent a settle for an agent that was never working', () => {
+      const store = createAgentActivityStore()
+
+      store.seedSnapshot('a1', IDLE)
+
+      expect(store.apply('a1', IDLE), 'nothing the user watched started, so nothing finished').toBe(false)
+    })
+  })
+
+  describe('seedPublished', () => {
+    it('writes the state without reporting a settle, so a reconnect greets nobody', () => {
+      const store = createAgentActivityStore()
+      store.apply('a1', WORKING)
+
+      store.seedPublished('a1', IDLE)
+
+      expect(store.isBusy('a1'), 'the state still seeds').toBe(false)
+    })
+
+    it('clears an edge baseline the worker no longer stands behind', () => {
+      // A link that dropped with no offline sweep leaves a WORKING baseline the
+      // Worker retired while this client was away. The published level is what
+      // the Worker last broadcast, so it is the answer that baseline must hold.
+      const store = createAgentActivityStore()
+      store.apply('a1', WORKING)
+
+      store.seedPublished('a1', IDLE)
+
+      expect(store.apply('a1', IDLE), 'a repeat of what the worker already sent is not a settle').toBe(false)
+    })
+
+    it('keeps a settle the worker still holds in its window', () => {
+      // The published level reads WORKING for as long as the debounce runs, so
+      // the transition that ends it still finds an edge to report.
+      const store = createAgentActivityStore()
+      store.apply('a1', WORKING)
+
+      store.seedPublished('a1', WORKING)
+
+      expect(store.apply('a1', IDLE), 'the held settle still rings when it lands').toBe(true)
+    })
+
+    it('keeps what it holds when the worker sends no opinion', () => {
+      const store = createAgentActivityStore()
+      store.apply('a1', WORKING)
+
+      store.seedPublished('a1', AgentActivityState.UNSPECIFIED)
+
+      expect(store.isBusy('a1'), 'UNSPECIFIED must not overwrite a real answer').toBe(true)
+    })
+  })
+
+  describe('forget', () => {
+    it('forgets the edge baseline with the state', () => {
+      const store = createAgentActivityStore()
+      store.apply('a1', WORKING)
+
+      store.forget('a1')
+
+      expect(store.apply('a1', IDLE), 'a retired agent leaves no edge behind').toBe(false)
+    })
   })
 })

--- a/frontend/src/stores/agentActivity.store.test.ts
+++ b/frontend/src/stores/agentActivity.store.test.ts
@@ -119,55 +119,6 @@ describe('createAgentActivityStore', () => {
     expect(store.apply('a1', WORKING)).toBe(false)
   })
 
-  describe('seedSnapshot', () => {
-    it('writes the state without reporting a settle, so a reconnect greets nobody', () => {
-      const store = createAgentActivityStore()
-      store.apply('a1', WORKING)
-
-      store.seedSnapshot('a1', IDLE)
-
-      expect(store.isBusy('a1'), 'the state still seeds').toBe(false)
-    })
-
-    it('keeps what it holds when the worker sends no opinion', () => {
-      const store = createAgentActivityStore()
-      store.apply('a1', WORKING)
-
-      store.seedSnapshot('a1', AgentActivityState.UNSPECIFIED)
-
-      expect(store.isBusy('a1'), 'UNSPECIFIED must not overwrite a real answer').toBe(true)
-    })
-
-    it('leaves the settle edge for the transition that follows', () => {
-      // AgentInfo carries the EXACT derivation, which ignores the Worker's
-      // debounce window. A list read taken inside that window already carries
-      // the settled value. Written to the baseline, it would make the transition
-      // announcing that settle compare equal, and the sound would never ring.
-      const store = createAgentActivityStore()
-      store.apply('a1', WORKING)
-
-      store.seedSnapshot('a1', IDLE)
-
-      expect(store.apply('a1', IDLE), 'the settle still rings for the turn that ended').toBe(true)
-    })
-
-    it('arms the edge when the level says working, so a settle moments later rings', () => {
-      const store = createAgentActivityStore()
-
-      store.seedSnapshot('a1', WORKING)
-
-      expect(store.apply('a1', IDLE), 'the agent finished while this client watched').toBe(true)
-    })
-
-    it('does not invent a settle for an agent that was never working', () => {
-      const store = createAgentActivityStore()
-
-      store.seedSnapshot('a1', IDLE)
-
-      expect(store.apply('a1', IDLE), 'nothing the user watched started, so nothing finished').toBe(false)
-    })
-  })
-
   describe('seedPublished', () => {
     it('writes the state without reporting a settle, so a reconnect greets nobody', () => {
       const store = createAgentActivityStore()
@@ -199,6 +150,18 @@ describe('createAgentActivityStore', () => {
       store.seedPublished('a1', WORKING)
 
       expect(store.apply('a1', IDLE), 'the held settle still rings when it lands').toBe(true)
+    })
+
+    it('establishes the baseline for a tab whose only writer is the seed', () => {
+      // A NOTIFY-mode tab gets no catch-up replay, so a hydration seed is the
+      // only write it takes before the first transition. That seed must leave a
+      // baseline the settle can measure against, or the turn this tab watched
+      // end rings for nobody.
+      const store = createAgentActivityStore()
+
+      store.seedPublished('a1', WORKING)
+
+      expect(store.apply('a1', IDLE), 'the agent finished while this client watched').toBe(true)
     })
 
     it('keeps what it holds when the worker sends no opinion', () => {

--- a/frontend/src/stores/agentActivity.store.ts
+++ b/frontend/src/stores/agentActivity.store.ts
@@ -12,38 +12,49 @@ import { AgentActivityState } from '~/generated/proto/leapmux/v1/agent_pb'
  * a turn flag privately, so the heuristic existed only because nothing published
  * it. Now one boolean arrives on the wire and this store holds it.
  *
- * Three writers, matching how background tasks are already fed:
+ * Every writer carries the level the Worker PUBLISHED, and never the exact
+ * derivation that rides beside it. The Worker holds a settle for three seconds
+ * so the completion sound does not ring for work that resumes, and the exact
+ * value ignores that window. A level written from the exact value drops the
+ * spinner early; if the work then resumes, the Worker derives a state equal to
+ * what it already published and broadcasts nothing, so that tab shows no spinner
+ * for the rest of the turn. The exact value answers one question, and it is not
+ * a level -- see activityInterruptsWork.
  *
- * - hydration, from `AgentInfo.activity_state` on a list read. The only path that reaches a
- *   tab watching in NOTIFY mode, which gets no catch-up replay at all.
+ * Four writers. The first three match how background tasks are already fed:
+ *
+ * - hydration, from `AgentInfo.published_activity_state` on a list read. The
+ *   only path that reaches a tab watching in NOTIFY mode, which gets no
+ *   catch-up replay at all.
  * - catch-up replay, on the transition into FULL, so a tab renders the right
  *   spinner BEFORE the message burst rather than after it.
  * - the live `AgentActivityChanged` event.
  *
+ * The fourth repairs rather than feeds: the close guard's `listAgents` round
+ * trip already carries the Worker's own answer, so it corrects a display that
+ * drifted -- a WORKING left over from a link that dropped with no offline
+ * sweep. See createTabBusyProbe.
+ *
  * NOT persisted, because there is nothing worth persisting. Every load asks the
- * Worker (`AgentInfo.activity_state`), and every process boundary resets the answer: an
- * agent whose process was terminated owns no turn, and the Worker says so the
- * moment a new one takes over. A value written to disk could therefore only be
- * stale -- right by luck, or a spinner shown for the gap before the first
- * hydration reply corrects it.
+ * Worker (`AgentInfo.published_activity_state`), and every process boundary
+ * resets the answer: an agent whose process was terminated owns no turn, and the
+ * Worker says so the moment a new one takes over. A value written to disk could
+ * therefore only be stale -- right by luck, or a spinner shown for the gap
+ * before the first hydration reply corrects it.
  *
  * Nothing here restores state either. A restart does not resume a turn.
  */
 interface AgentActivityStoreState {
-  stateByAgent: Record<string, AgentActivityState>
   /**
-   * The last state the WORKER pushed as a transition, which is the baseline the
-   * settle edge is measured against.
+   * The level the Worker last PUBLISHED for each agent.
    *
-   * Separate from `stateByAgent` because a LEVEL also writes that one, and a
-   * level must not consume an edge. The Worker debounces a settle for three
-   * seconds. A level read in between, such as a
-   * list hydration, can therefore carry the
-   * settled value while the transition
-   * announcing it is still on its way. Measured against the display state, that transition then moves
-   * nothing and the completion sound never rings.
+   * One map, because the display and the settle baseline hold the same value.
+   * Every writer takes what the Worker broadcast, so a seed moves the baseline
+   * with the screen. That is what keeps a settle still held in the Worker's
+   * window ringing when it lands, and what stops a WORKING this client can no
+   * longer stand behind from ringing a settle that already happened.
    */
-  pushedByAgent: Record<string, AgentActivityState>
+  stateByAgent: Record<string, AgentActivityState>
 }
 
 /** An agent nothing has reported on yet. */
@@ -57,20 +68,19 @@ const UNKNOWN = AgentActivityState.IDLE
  * under it. The Worker spells the same rule as AgentActivity.InterruptsWork.
  *
  * A free function, not a store method, because the close guard must NOT read
- * this store. The Worker debounces a settle for three seconds, so the pushed
- * state says "busy" for that long after the work finished, and a guard reading
- * it would refuse a close the CLI already allows. The guard fetches the exact
- * state and applies this rule to it -- see createTabBusyProbe.
+ * this store. The Worker debounces a settle for three seconds, so the level this
+ * store holds says "busy" for that long after the work finished, and a guard
+ * reading it would refuse a close the CLI already allows. The guard fetches the
+ * exact state and applies this rule to it -- see createTabBusyProbe.
  */
 export function activityInterruptsWork(state: AgentActivityState): boolean {
   return state === AgentActivityState.WORKING || state === AgentActivityState.WAITING_FOR_USER
 }
 
 export function createAgentActivityStore() {
-  const [state, setState] = createStore<AgentActivityStoreState>({ stateByAgent: {}, pushedByAgent: {} })
+  const [state, setState] = createStore<AgentActivityStoreState>({ stateByAgent: {} })
 
   const stateOf = (agentId: string): AgentActivityState => state.stateByAgent[agentId] ?? UNKNOWN
-  const pushedFor = (agentId: string): AgentActivityState => state.pushedByAgent[agentId] ?? UNKNOWN
 
   return {
     /**
@@ -100,41 +110,35 @@ export function createAgentActivityStore() {
      * NOTIFY-mode tab that subscribed mid-turn). Ringing on either announces a
      * settle the user never saw start, or announces one settle twice.
      *
-     * The edge is measured against `pushedByAgent`, the last TRANSITION, and not
-     * against what is on screen. A level can move the screen without moving that
-     * baseline -- see seed.
+     * The edge is measured against the level this store already holds, which is
+     * always what the Worker last published -- see AgentActivityStoreState.
      *
      * A move into WAITING_FOR_USER is a settle: the turn stops making progress
      * and the user is the one who must act, which is the alert that used to ride
      * on busy -> false.
      */
     apply(agentId: string, next: AgentActivityState): boolean {
-      const settled = pushedFor(agentId) === AgentActivityState.WORKING && next !== AgentActivityState.WORKING
+      const settled = stateOf(agentId) === AgentActivityState.WORKING && next !== AgentActivityState.WORKING
       if (state.stateByAgent[agentId] !== next)
         setState('stateByAgent', agentId, next)
-      if (state.pushedByAgent[agentId] !== next)
-        setState('pushedByAgent', agentId, next)
       return settled
     },
 
     /**
      * Seed from the level the Worker PUBLISHED -- the catch-up baseline on
-     * CatchUpStart -- and raise nothing.
+     * CatchUpStart, or `AgentInfo.published_activity_state` on a list read --
+     * and raise nothing.
      *
      * A level says what the agent is doing right now. It is not news the user
-     * asked for. An agent that
-     * settled while this client
-     * was away did not finish
-     * in front of them, and
-     * ringing for each one on
-     * every reconnect is the
-     * burst this split
-     * prevents. So this returns nothing, rather than an edge each
+     * asked for. An agent that settled while this client was away did not finish
+     * in front of them, and ringing for each one on every reconnect is the burst
+     * this split prevents. So this returns nothing, rather than an edge each
      * caller has to remember to discard.
      *
-     * It writes the edge baseline too, because this value IS that baseline. The
-     * Worker sends what it last broadcast, so a settle still waiting out its
-     * window reads WORKING here and the transition announcing it still rings.
+     * It moves the settle baseline with the display, because this value IS that
+     * baseline. The Worker sends what it last broadcast, so a settle still
+     * waiting out its window reads WORKING here and the transition announcing it
+     * still rings.
      *
      * Writing it also CLEARS a baseline this client can no longer stand behind:
      * a WORKING left over from a link that dropped with no offline sweep. The
@@ -149,31 +153,6 @@ export function createAgentActivityStore() {
         return
       if (state.stateByAgent[agentId] !== next)
         setState('stateByAgent', agentId, next)
-      if (state.pushedByAgent[agentId] !== next)
-        setState('pushedByAgent', agentId, next)
-    },
-
-    /**
-     * Seed from the EXACT derivation -- AgentInfo on a list read -- and raise
-     * nothing.
-     *
-     * It may ARM the settle edge and may never SPEND it, which is what tells it
-     * apart from seedPublished. This value ignores the Worker's debounce window,
-     * so a read taken inside that window already carries the settled state while
-     * the transition announcing it is still on its way. Writing that to the
-     * baseline would make the transition compare equal, and the settle would ring
-     * for nobody. A level that says WORKING is safe to write, and arms the edge
-     * for a settle that lands moments later.
-     *
-     * UNSPECIFIED is "no opinion", not a state.
-     */
-    seedSnapshot(agentId: string, next: AgentActivityState): void {
-      if (next === AgentActivityState.UNSPECIFIED)
-        return
-      if (state.stateByAgent[agentId] !== next)
-        setState('stateByAgent', agentId, next)
-      if (next === AgentActivityState.WORKING && state.pushedByAgent[agentId] !== next)
-        setState('pushedByAgent', agentId, next)
     },
 
     /**
@@ -183,7 +162,6 @@ export function createAgentActivityStore() {
     forget(agentId: string) {
       setState(produce((s) => {
         delete s.stateByAgent[agentId]
-        delete s.pushedByAgent[agentId]
       }))
     },
 

--- a/frontend/src/stores/agentActivity.store.ts
+++ b/frontend/src/stores/agentActivity.store.ts
@@ -14,14 +14,14 @@ import { AgentActivityState } from '~/generated/proto/leapmux/v1/agent_pb'
  *
  * Three writers, matching how background tasks are already fed:
  *
- * - hydration, from `AgentInfo.busy` on a list read. The only path that reaches a
+ * - hydration, from `AgentInfo.activity_state` on a list read. The only path that reaches a
  *   tab watching in NOTIFY mode, which gets no catch-up replay at all.
  * - catch-up replay, on the transition into FULL, so a tab renders the right
  *   spinner BEFORE the message burst rather than after it.
  * - the live `AgentActivityChanged` event.
  *
  * NOT persisted, because there is nothing worth persisting. Every load asks the
- * Worker (`AgentInfo.busy`), and every process boundary resets the answer: an
+ * Worker (`AgentInfo.activity_state`), and every process boundary resets the answer: an
  * agent whose process was terminated owns no turn, and the Worker says so the
  * moment a new one takes over. A value written to disk could therefore only be
  * stale -- right by luck, or a spinner shown for the gap before the first
@@ -31,15 +31,46 @@ import { AgentActivityState } from '~/generated/proto/leapmux/v1/agent_pb'
  */
 interface AgentActivityStoreState {
   stateByAgent: Record<string, AgentActivityState>
+  /**
+   * The last state the WORKER pushed as a transition, which is the baseline the
+   * settle edge is measured against.
+   *
+   * Separate from `stateByAgent` because a LEVEL also writes that one, and a
+   * level must not consume an edge. The Worker debounces a settle for three
+   * seconds. A level read in between, such as a
+   * list hydration, can therefore carry the
+   * settled value while the transition
+   * announcing it is still on its way. Measured against the display state, that transition then moves
+   * nothing and the completion sound never rings.
+   */
+  pushedByAgent: Record<string, AgentActivityState>
 }
 
 /** An agent nothing has reported on yet. */
 const UNKNOWN = AgentActivityState.IDLE
 
+/**
+ * Whether closing a tab in this state would stop something.
+ *
+ * It differs from "busy" for an agent blocked on a permission prompt: its turn
+ * is still in flight, and the close kills it along with every background task
+ * under it. The Worker spells the same rule as AgentActivity.InterruptsWork.
+ *
+ * A free function, not a store method, because the close guard must NOT read
+ * this store. The Worker debounces a settle for three seconds, so the pushed
+ * state says "busy" for that long after the work finished, and a guard reading
+ * it would refuse a close the CLI already allows. The guard fetches the exact
+ * state and applies this rule to it -- see createTabBusyProbe.
+ */
+export function activityInterruptsWork(state: AgentActivityState): boolean {
+  return state === AgentActivityState.WORKING || state === AgentActivityState.WAITING_FOR_USER
+}
+
 export function createAgentActivityStore() {
-  const [state, setState] = createStore<AgentActivityStoreState>({ stateByAgent: {} })
+  const [state, setState] = createStore<AgentActivityStoreState>({ stateByAgent: {}, pushedByAgent: {} })
 
   const stateOf = (agentId: string): AgentActivityState => state.stateByAgent[agentId] ?? UNKNOWN
+  const pushedFor = (agentId: string): AgentActivityState => state.pushedByAgent[agentId] ?? UNKNOWN
 
   return {
     /**
@@ -50,20 +81,11 @@ export function createAgentActivityStore() {
      *
      * WAITING_FOR_USER answers false here on purpose. The user is looking
      * straight at the permission prompt, so spinning an indicator at them says
-     * nothing -- but see interruptsWork, which the close guard reads instead.
+     * nothing -- but see activityInterruptsWork, which the close guard applies
+     * to the exact state it fetches instead of to this debounced one.
      */
     isBusy(agentId: string): boolean {
       return stateOf(agentId) === AgentActivityState.WORKING
-    },
-
-    /**
-     * Whether closing this tab would stop something. Differs from isBusy for an
-     * agent blocked on a permission prompt: its turn is still in flight, and the
-     * close kills it along with every background task under it.
-     */
-    interruptsWork(agentId: string): boolean {
-      const current = stateOf(agentId)
-      return current === AgentActivityState.WORKING || current === AgentActivityState.WAITING_FOR_USER
     },
 
     /**
@@ -78,15 +100,80 @@ export function createAgentActivityStore() {
      * NOTIFY-mode tab that subscribed mid-turn). Ringing on either announces a
      * settle the user never saw start, or announces one settle twice.
      *
+     * The edge is measured against `pushedByAgent`, the last TRANSITION, and not
+     * against what is on screen. A level can move the screen without moving that
+     * baseline -- see seed.
+     *
      * A move into WAITING_FOR_USER is a settle: the turn stops making progress
      * and the user is the one who must act, which is the alert that used to ride
      * on busy -> false.
      */
     apply(agentId: string, next: AgentActivityState): boolean {
-      const settled = stateOf(agentId) === AgentActivityState.WORKING && next !== AgentActivityState.WORKING
+      const settled = pushedFor(agentId) === AgentActivityState.WORKING && next !== AgentActivityState.WORKING
       if (state.stateByAgent[agentId] !== next)
         setState('stateByAgent', agentId, next)
+      if (state.pushedByAgent[agentId] !== next)
+        setState('pushedByAgent', agentId, next)
       return settled
+    },
+
+    /**
+     * Seed from the level the Worker PUBLISHED -- the catch-up baseline on
+     * CatchUpStart -- and raise nothing.
+     *
+     * A level says what the agent is doing right now. It is not news the user
+     * asked for. An agent that
+     * settled while this client
+     * was away did not finish
+     * in front of them, and
+     * ringing for each one on
+     * every reconnect is the
+     * burst this split
+     * prevents. So this returns nothing, rather than an edge each
+     * caller has to remember to discard.
+     *
+     * It writes the edge baseline too, because this value IS that baseline. The
+     * Worker sends what it last broadcast, so a settle still waiting out its
+     * window reads WORKING here and the transition announcing it still rings.
+     *
+     * Writing it also CLEARS a baseline this client can no longer stand behind:
+     * a WORKING left over from a link that dropped with no offline sweep. The
+     * next transition is then measured against the Worker's own answer, and not
+     * against a value from a session that ended.
+     *
+     * UNSPECIFIED is "no opinion", not a state: a worker that sends one must not
+     * overwrite an answer this client already holds.
+     */
+    seedPublished(agentId: string, next: AgentActivityState): void {
+      if (next === AgentActivityState.UNSPECIFIED)
+        return
+      if (state.stateByAgent[agentId] !== next)
+        setState('stateByAgent', agentId, next)
+      if (state.pushedByAgent[agentId] !== next)
+        setState('pushedByAgent', agentId, next)
+    },
+
+    /**
+     * Seed from the EXACT derivation -- AgentInfo on a list read -- and raise
+     * nothing.
+     *
+     * It may ARM the settle edge and may never SPEND it, which is what tells it
+     * apart from seedPublished. This value ignores the Worker's debounce window,
+     * so a read taken inside that window already carries the settled state while
+     * the transition announcing it is still on its way. Writing that to the
+     * baseline would make the transition compare equal, and the settle would ring
+     * for nobody. A level that says WORKING is safe to write, and arms the edge
+     * for a settle that lands moments later.
+     *
+     * UNSPECIFIED is "no opinion", not a state.
+     */
+    seedSnapshot(agentId: string, next: AgentActivityState): void {
+      if (next === AgentActivityState.UNSPECIFIED)
+        return
+      if (state.stateByAgent[agentId] !== next)
+        setState('stateByAgent', agentId, next)
+      if (next === AgentActivityState.WORKING && state.pushedByAgent[agentId] !== next)
+        setState('pushedByAgent', agentId, next)
     },
 
     /**
@@ -96,6 +183,7 @@ export function createAgentActivityStore() {
     forget(agentId: string) {
       setState(produce((s) => {
         delete s.stateByAgent[agentId]
+        delete s.pushedByAgent[agentId]
       }))
     },
 

--- a/frontend/tests/e2e/106-codex-turn-end-sound.spec.ts
+++ b/frontend/tests/e2e/106-codex-turn-end-sound.spec.ts
@@ -1,61 +1,35 @@
 import { codexTest, expect } from './codex-fixtures'
-import { sendMessage, setInitialBrowserPref, waitForAgentIdle } from './helpers/ui'
+import { armTurnEndSound, expectDoorbellCount, expectDoorbellQuiet } from './helpers/turnEndSound'
+import { sendMessage, waitForAgentIdle } from './helpers/ui'
 
 codexTest.describe('Codex Turn End Sound', () => {
   codexTest('should play ding-dong sound when Codex turn ends with tool use', async ({ page, authenticatedCodexWorkspace, leapmuxServer }) => {
     void authenticatedCodexWorkspace // fixture trigger
 
-    // Set up audio spy and preference
-    await page.addInitScript(() => {
-      (window as any).__audioPlayCalls = [] as string[]
-      HTMLAudioElement.prototype.play = function () {
-        (window as any).__audioPlayCalls.push(this.src)
-        return Promise.resolve()
-      }
-    })
-    await setInitialBrowserPref(page, leapmuxServer.adminUserId, 'turnEndSound', 'ding-dong')
-
-    // Reload so the init scripts take effect
-    await page.reload()
+    await armTurnEndSound(page, leapmuxServer.adminUserId, 'ding-dong')
     await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
 
     // Send a message that triggers tool use (command execution) so num_tool_uses > 0
     await sendMessage(page, 'Run the command `pwd` and tell me the result.')
     await waitForAgentIdle(page, 120_000)
 
-    // Give a short moment for the effect to fire
-    await page.waitForTimeout(500)
-
-    // Verify the doorbell sound was played
-    const calls = await page.evaluate(() => (window as any).__audioPlayCalls as string[])
-    expect(calls.some((src: string) => src.includes('benkirb-electronic-doorbell'))).toBe(true)
+    await expectDoorbellCount(page, 1)
   })
 
   codexTest('should NOT play sound for simple Codex text exchange', async ({ page, authenticatedCodexWorkspace, leapmuxServer }) => {
     void authenticatedCodexWorkspace // fixture trigger
 
-    // Set up audio spy and preference
-    await page.addInitScript(() => {
-      (window as any).__audioPlayCalls = [] as string[]
-      HTMLAudioElement.prototype.play = function () {
-        (window as any).__audioPlayCalls.push(this.src)
-        return Promise.resolve()
-      }
-    })
-    await setInitialBrowserPref(page, leapmuxServer.adminUserId, 'turnEndSound', 'ding-dong')
-
-    // Reload so the init scripts take effect
-    await page.reload()
+    await armTurnEndSound(page, leapmuxServer.adminUserId, 'ding-dong')
     await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
 
     // Send a simple question that completes without tool use (num_tool_uses = 0)
     await sendMessage(page, 'What is 1234 + 5678? Reply with just the number, nothing else.')
     await waitForAgentIdle(page, 120_000)
 
-    await page.waitForTimeout(500)
-
-    // Verify no doorbell sound was played (simple exchange suppressed)
-    const calls = await page.evaluate(() => (window as any).__audioPlayCalls as string[])
-    expect(calls.some((src: string) => src.includes('benkirb-electronic-doorbell'))).toBe(false)
+    // expectDoorbellQuiet, not a fixed sleep. The Worker holds a settle for
+    // settleDelay, so a 500 ms window closed before an unwanted ding could
+    // physically arrive and the assertion proved nothing. waitForAgentIdle
+    // cannot cover the gap either: it swallows its own timeout by design.
+    await expectDoorbellQuiet(page, 0)
   })
 })

--- a/frontend/tests/e2e/helpers/turnEndSound.ts
+++ b/frontend/tests/e2e/helpers/turnEndSound.ts
@@ -14,8 +14,14 @@ const DOORBELL_SRC = 'benkirb-electronic-doorbell'
  * settle is unavoidable here -- but it is the ONLY place these specs sleep.
  * Every wait for a ding that IS expected polls instead (see
  * {@link expectDoorbellCount}), because there the arrival is observable.
+ *
+ * It MUST exceed the Worker's settle debounce (`settleDelay`, three seconds),
+ * with margin. The Worker holds a WORKING -> not-WORKING publish for that long.
+ * A window shorter than it closes before an unwanted ding could physically
+ * arrive, so the assertion passes without proving anything. The extra ding then
+ * lands in a later step, or after the spec ends.
  */
-const QUIET_SETTLE_MS = 1000
+const QUIET_SETTLE_MS = 5000
 
 /**
  * Record every `HTMLAudioElement.play()` call, pin the browser-level turn-end
@@ -50,14 +56,13 @@ export async function doorbellCount(page: Page): Promise<number> {
 /**
  * Wait until the doorbell has played exactly `count` times.
  *
- * Polls rather than sleeping after the turn appears to end, because "the turn
- * ended" and "the ding fired" are driven by DIFFERENT events: the interrupt
- * button hides when `agentWorking` goes false (or a control request opens),
- * while the sound fires from the result divider in `handleResultDivider`. The
- * gap between them is whatever the event stream and the render loop cost,
- * which a loaded machine widens without bound -- so the fixed 200-500ms sleeps
- * these specs used to take were a bet on that gap, and lost it under the full
- * suite's concurrency.
+ * Polls rather than sleeping after the turn appears to end. Both signals come
+ * from the same `AgentActivityChanged` frame: the button hides on the state, and
+ * the sound fires from the settle edge `AgentActivityStore.apply` reports. But
+ * the Worker DEBOUNCES that frame by `settleDelay`, and the render loop adds
+ * whatever a loaded machine costs on top. So the fixed 200-500ms sleeps these
+ * specs used to take were a bet on that gap, and lost it under the full suite's
+ * concurrency.
  */
 export async function expectDoorbellCount(page: Page, count: number) {
   await expect.poll(() => doorbellCount(page)).toBe(count)

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -279,7 +279,22 @@ message AgentInfo {
   // AgentActivityChanged pushes on change: a tab watching in NOTIFY mode gets
   // no catch-up replay, so the list read is where it learns the current value.
   // See AgentActivityState for the rule.
+  //
+  // The EXACT derivation, which ignores the Worker's settle debounce. Both close
+  // guards read it, so neither refuses a close for work that already finished.
   AgentActivityState activity_state = 21;
+
+  // What the Worker last BROADCAST for this agent, which is what a client that
+  // caches the pushed state already holds.
+  //
+  // It differs from activity_state for as long as a settle waits out its
+  // debounce window. A browser seeds its display from THIS one. Seeded with the
+  // exact value instead, a tab that hydrates inside the window
+  // drops its spinner early. If the work then resumes, the
+  // Worker derives a state equal to what it already published
+  // and broadcasts nothing, so that tab shows no spinner for
+  // the rest of the turn. See the Worker's AgentActivityPublished.
+  AgentActivityState published_activity_state = 23;
 
   // Rows in pending/running state in this tab's background-task registry. For a
   // root that is every descendant's work; for a subagent tab it is that

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -405,6 +405,13 @@ message AgentTurnEnd {
 //
 // The WORKING -> not-WORKING edge is the "settled" signal: the turn ended AND no
 // background task of this agent's is still running.
+//
+// EVERY instance of this message is a transition, so a client may ring on one
+// with no further test. The catch-up baseline is a LEVEL and travels on
+// CatchUpStart.activity_state instead. The two rode this message together once,
+// and the client could not tell them apart: it suppressed the alert for the
+// whole catch-up window, which discarded each genuine settle that landed while a
+// tab replayed.
 message AgentActivityChanged {
   AgentActivityState state = 1;
   // Tool calls in the turn that this settle completes. The Worker records the
@@ -418,11 +425,12 @@ message AgentActivityChanged {
   // zero-tool turn, so unset and 0 must stay distinguishable: unset means
   // "ring", 0 means "this turn did nothing worth interrupting the user for".
   optional int32 num_tool_uses = 2;
-
 }
 
 // CatchUpStart is broadcast at the START of a WatchEvents (re)subscribe, BEFORE the
-// message replay burst, carrying the agent's authoritative live-tail seq. A windowed
+// message replay burst. It carries the agent's authoritative live-tail seq and the
+// agent's derived activity, which are the two things a tab needs before it renders
+// the burst. A windowed
 // client that was disconnected reconciles against it FIRST -- dropping any loaded row
 // whose seq exceeds latest_seq (a tail deletion it missed while away) and clamping its
 // recorded live-tail -- so phantom rows are gone before the replay renders rather than
@@ -434,6 +442,19 @@ message CatchUpStart {
   // reconciliation; present 0 = the agent genuinely has no messages; present >0 = the
   // authoritative MAX(seq).
   optional int64 latest_seq = 1;
+  // What the agent is doing at the moment replay begins, so a tab that just
+  // promoted to FULL renders the right spinner and the right Interrupt button
+  // while the burst lands rather than after it drains.
+  //
+  // A LEVEL, not a transition, which is why it rides this frame instead of
+  // AgentActivityChanged: the client rings on that message and must not ring for
+  // an agent that settled while it was away. The client seeds its store from
+  // this field and raises no alert. Under the WATCHED agent's own id, not the
+  // registry owner's -- a child tab's answer is its own registry row.
+  //
+  // UNSPECIFIED when the worker sends no opinion; the client then keeps whatever
+  // it holds rather than overwriting a fresher answer with a blank one.
+  AgentActivityState activity_state = 2;
 }
 
 message CatchUpComplete {

--- a/proto/leapmux/v1/workspace.proto
+++ b/proto/leapmux/v1/workspace.proto
@@ -365,6 +365,17 @@ message AgentEvent {
   string agent_id = 1;
   reserved 8, 9;
   reserved "message_error", "message_deleted";
+
+  // True when the catch-up REPLAY produced this frame, false when it is live.
+  //
+  // A replay re-sends state a client may already hold, so a client must not
+  // alert on one. The client cannot tell the two apart by itself. It registers
+  // its live watch BEFORE the replay burst runs, and both write
+  // the same stream, so a live frame that arrives mid-burst looks
+  // exactly like a replayed one. Guessing from that order dropped a permission prompt's
+  // badge, a plan-title update and an INACTIVE sweep whenever they raced a
+  // replay. broadcastReplayAgentEvent is the one writer that sets this.
+  bool replay = 18;
   oneof event {
     AgentChatMessage agent_message = 2;
     AgentStreamChunk stream_chunk = 3;
@@ -406,12 +417,28 @@ message AgentTurnEnd {
 // The WORKING -> not-WORKING edge is the "settled" signal: the turn ended AND no
 // background task of this agent's is still running.
 //
-// EVERY instance of this message is a transition, so a client may ring on one
-// with no further test. The catch-up baseline is a LEVEL and travels on
-// CatchUpStart.activity_state instead. The two rode this message together once,
-// and the client could not tell them apart: it suppressed the alert for the
-// whole catch-up window, which discarded each genuine settle that landed while a
-// tab replayed.
+// EVERY instance of this message is a TRANSITION: the Worker sends it only where
+// its derived state differs from the one it last sent. The catch-up baseline is
+// a LEVEL and travels on CatchUpStart.activity_state instead. The two rode this
+// message together
+// once, and the
+// client could not
+// tell them apart.
+// It suppressed the
+// alert for the
+// whole catch-up
+// window, which
+// discarded each
+// genuine settle
+// that landed while
+// a tab replayed.
+//
+// A transition is not the same as news, so a client still compares against the
+// state it holds before it alerts. The Worker's "already sent" mark is per
+// process and per agent entry, and a worker
+// restart or a tab teardown drops it. The
+// first send afterwards then repeats a value
+// the client may already hold.
 message AgentActivityChanged {
   AgentActivityState state = 1;
   // Tool calls in the turn that this settle completes. The Worker records the
@@ -442,15 +469,21 @@ message CatchUpStart {
   // reconciliation; present 0 = the agent genuinely has no messages; present >0 = the
   // authoritative MAX(seq).
   optional int64 latest_seq = 1;
-  // What the agent is doing at the moment replay begins, so a tab that just
-  // promoted to FULL renders the right spinner and the right Interrupt button
-  // while the burst lands rather than after it drains.
+  // What the agent is doing at the moment replay begins. A tab that just
+  // promoted to FULL then renders the right spinner and the right Interrupt
+  // button while the burst lands, rather than after it drains.
   //
   // A LEVEL, not a transition, which is why it rides this frame instead of
   // AgentActivityChanged: the client rings on that message and must not ring for
   // an agent that settled while it was away. The client seeds its store from
   // this field and raises no alert. Under the WATCHED agent's own id, not the
   // registry owner's -- a child tab's answer is its own registry row.
+  //
+  // The PUBLISHED state, which is what the live events carry, and not the exact
+  // derivation. The Worker debounces a settle, so the two differ for as long as
+  // one waits. A client seeded with the exact value would hold the
+  // settled state before the transition announcing it arrived, and
+  // would see no edge to ring on. See the Worker's AgentActivityPublished.
   //
   // UNSPECIFIED when the worker sends no opinion; the client then keeps whatever
   // it holds rather than overwriting a fresher answer with a blank one.


### PR DESCRIPTION
## Motivation

- Two paths told the user that the agent finished while it still worked. The
  Worker derives a stop and a resume microseconds apart. A backgrounded shell
  completes and the CLI wakes the agent into a new turn. A subagent's own
  shell completes and the CLI restarts that subagent, which ends its registry
  row and reopens it in the same output burst. Publishing that gap rang the
  turn-end sound and dropped the spinner at the moment the work restarted.
- The catch-up replay sent its activity BASELINE on `AgentActivityChanged`,
  the same message a transition uses. The client could not tell the two
  apart, so it silenced the alert for the whole catch-up window. That also
  discarded every genuine settle that merely raced a replay, such as a
  background task ending while the burst drained.
- A client registers its live watch before the replay burst, and both write
  one stream, so arrival order cannot tell a replayed frame from a live one.
  Guessing from that order dropped a live permission prompt's badge, a
  plan-title update and an INACTIVE sweep.
- The browser's close guard read a debounced cache, so it refused a close for
  work that already finished. A `WORKING` level left over from a link that
  dropped with no offline sweep is the one level no later transition
  corrects, because the Worker has nothing left to announce.
- The activity map kept one entry for every subagent a session ever spawned
  under Claude and Pi, because only three of the providers retire a child.
  Each stale entry cost a point query per registry mutation once the display
  cap evicted its row.

## Modifications

- The settle window.
  - Hold a WORKING to not-WORKING publish for three seconds, and void it when
    the work comes back. The delivery re-derives, so a state that moved
    inside the window lands as what it is.
  - Pay the delay only for a stop that something can RESUME. A permission
    prompt, a dead process and a user interrupt publish at once.
    `NoteAgentInterrupted` marks the user's stop, and the mark clears on the
    next publish, so an interrupt the agent ignores cannot exempt a later,
    resumable stop.
  - Give the window its own lifecycle. A generation token retires a callback
    that a cancel could not recall. A `settlePending` field carries the
    settle's STATE, because three paths release the timer handle early.
  - `Shutdown` cancels every open window before it joins the refresh count,
    so no timer reads the registry after the caller closes the database. No
    window opens once the shutdown latch is set.
  - `ForgetActivity` delivers a held settle rather than dropping it, which is
    what a provider retiring a finished subagent lands on.
- The wire carries both answers, because one field cannot be both.
  - `AgentInfo.activity_state` stays the exact derivation, and both close
    guards read it, so neither refuses a close for work that already
    finished.
  - `AgentInfo.published_activity_state` and `CatchUpStart.activity_state`
    carry what the Worker last broadcast.
  - `AgentEvent.replay` marks each frame the catch-up burst produced. The
    replayed `AgentActivityChanged` is gone, so every instance of that
    message is a transition.
- The client.
  - The display seeds from the published level, never the exact one, so a tab
    that hydrates inside a window keeps its spinner and still rings when the
    settle lands. `seedPublished` is the one seed writer, and one map holds
    the display level and the settle baseline, because every writer wrote the
    same value to both.
  - Delete the client-side catch-up phase map, and read `AgentEvent.replay`
    off the frame instead.
  - The browser's close guard asks the Worker through `listAgents`. One reply
    answers two questions: the exact level decides the close, and the
    published level seeds the display, which repairs a stale `WORKING`.
    `seedActivity` is a required dependency of the probe, so a caller cannot
    leave that write unwired.
  - `activityInterruptsWork` takes a state rather than an agent id, because
    the caller now holds the level that the store does not.
- The activity map holds one entry per live tab. A finished child whose entry
  holds nothing is dropped where it publishes, and an index by root replaces
  a walk of every agent the worker ever published for.
- Tests.
  - Give the settle fake a two-phase expire, so a case reaches the gap
    between a timer firing and its callback landing.
  - Pin each rule with a case that fails without its fix: the late callback,
    the racing resume, the answered prompt, the process exit, the shutdown
    order, the reap and the two wire answers.
  - Raise the E2E quiet window to five seconds, past the settle delay. At one
    second it closed before an unwanted sound could arrive, so the assertion
    proved nothing. Move the Codex sound spec onto the shared polling
    helpers.

## Result

- The turn-end sound rings when the turn ends. It stays quiet when the CLI
  wakes the agent again inside the window, and the spinner no longer flickers
  at that boundary.
- A settle that races the catch-up replay now rings. A live permission
  prompt, a plan-title update and an INACTIVE sweep reach the client although
  a replay burst runs.
- A close never asks for a confirmation for work that already finished,
  because both close guards read the exact state.
- A tab that hydrates inside an open window keeps its spinner, and still
  rings when the settle lands. A stale `WORKING` from a link that dropped is
  repaired by the next close-guard read.
- A long Claude or Pi session no longer accrues one activity entry for each
  subagent it ever spawned.
