### PR TITLE
feat(files): Root the directory picker at the filesystem root

### DIFF
--- a/backend/cmd/leapmux/control.go
+++ b/backend/cmd/leapmux/control.go
@@ -135,6 +135,7 @@ var controlTree = cmdGroup{
 				{Name: "list", Summary: "List a directory", Run: controlRun(cmdcontrol.RunFileList)},
 				{Name: "read", Summary: "Read a file (with optional --offset/--limit)", Run: controlRun(cmdcontrol.RunFileRead)},
 				{Name: "stat", Summary: "Stat a path", Run: controlRun(cmdcontrol.RunFileStat)},
+				{Name: "roots", Summary: "List the worker's filesystem roots", Run: controlRun(cmdcontrol.RunFileRoots)},
 			},
 		},
 		{

--- a/backend/internal/cli/control/cmd/file.go
+++ b/backend/internal/cli/control/cmd/file.go
@@ -62,7 +62,24 @@ func RunFileList(rawCtx any, args []string) error {
 		// A list, even without --from-root, where it holds one entry. One
 		// output shape means a script does not branch on which flags it
 		// passed.
-		func() any { return map[string]any{"listings": resp.GetListings()} })
+		//
+		// Shaped by hand rather than emitted as the proto: the generated
+		// struct tags carry `omitempty`, and `encoding/json` then drops
+		// `truncated` for every listing that is not truncated and
+		// `total_entries` for every empty directory. A script reading
+		// `.truncated` would get null where false belongs.
+		func() any {
+			listings := make([]map[string]any, 0, len(resp.GetListings()))
+			for _, l := range resp.GetListings() {
+				listings = append(listings, map[string]any{
+					"path":          l.GetPath(),
+					"entries":       l.GetEntries(),
+					"truncated":     l.GetTruncated(),
+					"total_entries": l.GetTotalEntries(),
+				})
+			}
+			return map[string]any{"listings": listings}
+		})
 }
 
 // RunFileRoots prints the worker's filesystem roots: ["/"] on POSIX, the drive
@@ -94,7 +111,7 @@ func RunFileRead(rawCtx any, args []string) error {
 	f := bindPathCmd(cmd, false, "path to read (required)")
 	var offset, limit int64
 	f.FS.Int64Var(&offset, "offset", 0, "byte offset")
-	f.FS.Int64Var(&limit, "limit", 0, "max bytes (0 = default 64KB)")
+	f.FS.Int64Var(&limit, "limit", 0, "max bytes (0 = default 60KB)")
 	if err := parseFlags(f.FS, args, cmd.Description()); err != nil {
 		return err
 	}

--- a/backend/internal/cli/control/cmd/file.go
+++ b/backend/internal/cli/control/cmd/file.go
@@ -36,8 +36,10 @@ func RunFileList(rawCtx any, args []string) error {
 	f := bindPathCmd(cmd, false, "path to list (required)")
 	var maxDepth int
 	var dirsOnly bool
+	var fromRoot string
 	f.FS.IntVar(&maxDepth, "max-depth", 0, "merge single-child directories up to depth")
 	f.FS.BoolVar(&dirsOnly, "dirs-only", false, "directories only")
+	f.FS.StringVar(&fromRoot, "from-root", "", "also list every directory from this ancestor down to --path")
 	if err := parseFlags(f.FS, args, cmd.Description()); err != nil {
 		return err
 	}
@@ -55,14 +57,36 @@ func RunFileList(rawCtx any, args []string) error {
 			Path:     f.Path,
 			MaxDepth: int32(maxDepth),
 			DirsOnly: dirsOnly,
+			FromRoot: fromRoot,
 		}, &resp,
-		func() any {
-			return map[string]any{
-				"path":      resp.GetPath(),
-				"truncated": resp.GetTruncated(),
-				"entries":   resp.GetEntries(),
-			}
-		})
+		// A list, even without --from-root, where it holds one entry. One
+		// output shape means a script does not branch on which flags it
+		// passed.
+		func() any { return map[string]any{"listings": resp.GetListings()} })
+}
+
+// RunFileRoots prints the worker's filesystem roots: ["/"] on POSIX, the drive
+// roots on Windows.
+//
+// It cannot use bindPathCmd, which requires --path. This command asks about
+// the machine, not about a path.
+func RunFileRoots(rawCtx any, args []string) error {
+	cmd := asCtx(rawCtx)
+	var hub string
+	var in resolve.Inputs
+	fs := flagSet(cmd, &hub)
+	resolve.BindEntityFlags(fs, &in, resolve.FlagOptions{})
+	if err := parseFlags(fs, args, cmd.Description()); err != nil {
+		return err
+	}
+	c, workerID, err := resolveWorker(hub, in)
+	if err != nil {
+		return err
+	}
+	var resp leapmuxv1.ListFilesystemRootsResponse
+	return workerUnaryEmitOn(c, workerID, "ListFilesystemRoots",
+		&leapmuxv1.ListFilesystemRootsRequest{}, &resp,
+		func() any { return map[string]any{"roots": resp.GetRoots()} })
 }
 
 func RunFileRead(rawCtx any, args []string) error {

--- a/backend/internal/worker/controlipc/router_test.go
+++ b/backend/internal/worker/controlipc/router_test.go
@@ -272,6 +272,7 @@ func TestRouter_CallInner_FilesystemMethodCrossWorkerDispatchesUnconditionally(t
 	}
 	for _, method := range []string{
 		"worker.ListDirectory",
+		"worker.ListFilesystemRoots",
 		"worker.ReadFile",
 		"worker.StatFile",
 		"worker.GitStatus",

--- a/backend/internal/worker/service/access_control_test.go
+++ b/backend/internal/worker/service/access_control_test.go
@@ -408,6 +408,9 @@ var ownerGuardedProbes = func() []ownerGuardedProbe {
 		ownerGuardedProbe{"ListDirectory", "ListDirectory", func() proto.Message {
 			return &leapmuxv1.ListDirectoryRequest{Path: "/tmp", MaxDepth: 1}
 		}},
+		ownerGuardedProbe{"ListFilesystemRoots", "ListFilesystemRoots", func() proto.Message {
+			return &leapmuxv1.ListFilesystemRootsRequest{}
+		}},
 		ownerGuardedProbe{"ReadFile", "ReadFile", func() proto.Message {
 			return &leapmuxv1.ReadFileRequest{Path: "/tmp/x", Limit: 1}
 		}},

--- a/backend/internal/worker/service/closed_tab_test.go
+++ b/backend/internal/worker/service/closed_tab_test.go
@@ -209,9 +209,10 @@ func (w *testResponseWriter) streamsSnapshot() []*leapmuxv1.InnerStreamMessage {
 type setupOption func(*setupConfig)
 
 type setupConfig struct {
-	remoteIPC    ControlIPCFactory
-	rewriteQuery func(string) string
-	clock        quartz.Clock
+	remoteIPC      ControlIPCFactory
+	rewriteQuery   func(string) string
+	clock          quartz.Clock
+	maxMessageSize int
 }
 
 // withClock installs the clock the Service's startup registries arm their
@@ -241,6 +242,13 @@ func withRemoteIPC(ipc ControlIPCFactory) setupOption {
 // selects the same seam.
 func withQueryRewrite(rewrite func(query string) string) setupOption {
 	return func(c *setupConfig) { c.rewriteQuery = rewrite }
+}
+
+// withMaxMessageSize shrinks the worker's application payload budget, so a
+// test can reach a size guard without building a response of the default
+// budget's size. Zero keeps the default, exactly as production config does.
+func withMaxMessageSize(n int) setupOption {
+	return func(c *setupConfig) { c.maxMessageSize = n }
 }
 
 // rewritingDBTX hands each statement to rewrite and runs whatever comes back.
@@ -326,6 +334,7 @@ func setupTestService(t *testing.T, opts ...setupOption) (*Service, *channel.Dis
 		// connect-time WorkerIdentity rather than at construction.
 		SeedRegisteredBy: "user-1",
 		Clock:            cfg.clock,
+		MaxMessageSize:   cfg.maxMessageSize,
 	})
 	svc.ControlIPC = cfg.remoteIPC
 	// Before RegisterAll, exactly like every other field of Service: the

--- a/backend/internal/worker/service/file.go
+++ b/backend/internal/worker/service/file.go
@@ -13,6 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/leapmux/leapmux/channelwire"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/channel"
@@ -30,18 +32,16 @@ const maxDirEntries = 256
 // that need more raise limit explicitly up to maxReadLimit.
 const defaultReadLimit int64 = 60 * 1024 // 60 KB
 
-// maxReadLimit caps what a ReadFile request may ask for, whatever it
-// asks for.
+// payloadBudget is the largest response body this sender accepts: the tighter
+// of the worker's configured max_message_size and the channel's negotiated
+// payload budget (min(hub, worker)) when the writer is channel-backed.
 //
-// It is the same producer ceiling the agent stdout scanners bound
-// themselves by, for the same reason: a response above it is one the
-// receiver refuses, and on the unary path that refusal surfaces as
-// ResourceExhausted. Without the clamp the limit field also picks the
-// worker's allocation size, so a single request could ask it to reserve
-// gigabytes. Uses the tighter of the worker's configured max_message_size
-// and the channel's negotiated payload budget (min(hub, worker)) when the
-// writer is channel-backed.
-func (svc *Service) maxReadLimit(sender channel.ResponseWriter) int64 {
+// A response above it is one the receiver refuses, and on the unary path that
+// refusal surfaces as ResourceExhausted. Two handlers here spend it, for
+// different reasons: ReadFile clamps what a caller may ASK for
+// (see maxReadLimit), and ListDirectory stops adding listings to a chain
+// before the reply outgrows it.
+func (svc *Service) payloadBudget(sender channel.ResponseWriter) int64 {
 	configured := channelwire.ResolveMaxMessageSize(svc.MaxMessageSize)
 	if sender != nil {
 		if n := sender.MaxPayloadBudget(); n > 0 && n < configured {
@@ -51,8 +51,33 @@ func (svc *Service) maxReadLimit(sender channel.ResponseWriter) int64 {
 	return int64(configured)
 }
 
+// maxReadLimit caps what a ReadFile request may ask for, whatever it
+// asks for.
+//
+// It is the same producer ceiling the agent stdout scanners bound
+// themselves by. Without the clamp the limit field also picks the worker's
+// allocation size, so a single request could ask it to reserve gigabytes.
+func (svc *Service) maxReadLimit(sender channel.ResponseWriter) int64 {
+	return svc.payloadBudget(sender)
+}
+
 // registerFileHandlers registers handlers for file operations on the local filesystem.
 func registerFileHandlers(d ownerOnlyRegistrar, svc *Service) {
+	d.Register("ListFilesystemRoots", leapmuxv1.Scope_SCOPE_FILE_READ, func(ctx context.Context, caller channel.Caller, req *leapmuxv1.InnerRpcRequest, sender channel.ResponseWriter) {
+		var r leapmuxv1.ListFilesystemRootsRequest
+		if err := unmarshalRequest(req, &r); err != nil {
+			sendInvalidArgument(sender, "invalid request")
+			return
+		}
+
+		// No path to sanitize and no directory to read, so there is nothing
+		// here that can fail: the roots are a property of the host, and both
+		// seams guarantee at least one.
+		sendProtoResponse(sender, &leapmuxv1.ListFilesystemRootsResponse{
+			Roots: pathutil.FilesystemRoots(),
+		})
+	})
+
 	d.Register("ListDirectory", leapmuxv1.Scope_SCOPE_FILE_READ, func(ctx context.Context, caller channel.Caller, req *leapmuxv1.InnerRpcRequest, sender channel.ResponseWriter) {
 		var r leapmuxv1.ListDirectoryRequest
 		if err := unmarshalRequest(req, &r); err != nil {
@@ -69,19 +94,53 @@ func registerFileHandlers(d ownerOnlyRegistrar, svc *Service) {
 		// Resolve symlinks so paths are consistent (e.g. /var → /private/var on macOS).
 		dirPath = pathutil.Canonicalize(dirPath)
 
-		entries, truncated, totalEntries, err := listDirectory(dirPath, dirPath, r.GetMaxDepth(), 0, r.GetDirsOnly())
+		dirs, err := chainDirs(dirPath, r.GetFromRoot(), svc.HomeDir)
 		if err != nil {
-			slog.Error("failed to list directory", "path", dirPath, "error", err)
-			sendInternalError(sender, "failed to list directory")
+			sendInvalidArgument(sender, err.Error())
 			return
 		}
 
-		sendProtoResponse(sender, &leapmuxv1.ListDirectoryResponse{
-			Path:         dirPath,
-			Entries:      entries,
-			Truncated:    truncated,
-			TotalEntries: int32(totalEntries),
-		})
+		budget := svc.payloadBudget(sender)
+		listings := make([]*leapmuxv1.DirectoryListing, 0, len(dirs))
+		var used int64
+		for _, dir := range dirs {
+			entries, truncated, totalEntries, err := listDirectory(dir, dir, r.GetMaxDepth(), 0, r.GetDirsOnly())
+			if err != nil {
+				// The FIRST directory is the one the caller asked about, so
+				// its failure is the request's failure. A deeper one failing
+				// only shortens the chain, which the response already allows:
+				// a directory the caller cannot read is one it would have
+				// discovered on its own next request.
+				if len(listings) == 0 {
+					slog.Error("failed to list directory", "path", dir, "error", err)
+					sendInternalError(sender, "failed to list directory")
+					return
+				}
+				break
+			}
+
+			listing := &leapmuxv1.DirectoryListing{
+				Path:         dir,
+				Entries:      entries,
+				Truncated:    truncated,
+				TotalEntries: int32(totalEntries),
+			}
+			// Stop before the response outgrows what the channel accepts,
+			// rather than after. A chain of deep directories listed with
+			// dirs_only=false carries up to maxDirEntries FileInfos per level,
+			// and a response above the negotiated budget comes back to the
+			// caller as ResourceExhausted -- losing the levels it could have
+			// had. The first listing is always kept, because a response with
+			// no listing at all is not an answer.
+			size := int64(proto.Size(listing))
+			if len(listings) > 0 && used+size > budget {
+				break
+			}
+			used += size
+			listings = append(listings, listing)
+		}
+
+		sendProtoResponse(sender, &leapmuxv1.ListDirectoryResponse{Listings: listings})
 	})
 
 	d.Register("ReadFile", leapmuxv1.Scope_SCOPE_FILE_READ, func(ctx context.Context, caller channel.Caller, req *leapmuxv1.InnerRpcRequest, sender channel.ResponseWriter) {
@@ -235,6 +294,87 @@ const modTimeLayout = "2006-01-02T15:04:05.000000000Z07:00"
 // formatModTime renders a modification time in modTimeLayout, in UTC.
 func formatModTime(t time.Time) string {
 	return t.UTC().Format(modTimeLayout)
+}
+
+// maxChainListings caps how many directories one ListDirectory request walks.
+//
+// A cheap O(1) guard against a pathological path, sitting in front of the
+// payload budget that does the real limiting. 64 levels is already past any
+// usable directory depth, so a chain that hits this is a bug or an attack, not
+// a user.
+const maxChainListings = 64
+
+// chainDirs returns the directories one ListDirectory request must list,
+// outermost first.
+//
+// With no fromRoot that is dirPath alone, which is the whole request. With one
+// it is every directory from fromRoot down to dirPath, so a tree rooted at "/"
+// can reveal a deep selection in one round trip instead of one per level.
+//
+// dirPath must already be sanitized and canonicalized. fromRoot is
+// canonicalized here, so a symlinked ancestor -- /tmp on macOS, which resolves
+// to /private/tmp -- passes the containment test that a textual comparison
+// would fail.
+//
+// A dirPath that is not a directory ends the chain at its parent, so revealing
+// a FILE costs one request too. That rule applies only to the chain form: with
+// no fromRoot the caller asked to list a file, and listDirectory reports that
+// as the error it is.
+func chainDirs(dirPath, fromRoot, homeDir string) ([]string, error) {
+	if fromRoot == "" {
+		return []string{dirPath}, nil
+	}
+
+	root, err := validate.SanitizePath(fromRoot, homeDir)
+	if err != nil {
+		return nil, fmt.Errorf("invalid from_root: %w", err)
+	}
+	root = pathutil.Canonicalize(root)
+
+	if !pathutil.HasPathPrefix(dirPath, root) {
+		return nil, fmt.Errorf("from_root %q is not an ancestor of %q", root, dirPath)
+	}
+
+	// Drop a trailing non-directory, so the chain ends at the deepest
+	// directory the caller named. os.Stat, not the dir entry: dirPath may be a
+	// symlink to a directory, and that is a directory to every other part of
+	// this file.
+	tail := dirPath
+	if info, err := os.Stat(tail); err == nil && !info.IsDir() {
+		tail = filepath.Dir(tail)
+		// The parent can fall outside the root only when dirPath WAS the
+		// root and the root is not a directory. Nothing to list then.
+		if !pathutil.HasPathPrefix(tail, root) {
+			return nil, fmt.Errorf("from_root %q is not a directory", root)
+		}
+	}
+
+	// Walk up from the tail, then reverse: filepath.Dir is the one operation
+	// that is correct for every root spelling ("/", "C:\\", "\\\\srv\\share\\"),
+	// because it stops at the volume rather than one segment past it.
+	//
+	// The walk itself is unbounded because it costs only string operations and
+	// the OS already limits how many components a path can hold. The cap below
+	// limits what is expensive: one directory read per surviving entry.
+	dirs := []string{tail}
+	for cur := tail; !pathutil.SamePath(cur, root); {
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break // At a root already; Dir is idempotent there.
+		}
+		dirs = append(dirs, parent)
+		cur = parent
+	}
+	slices.Reverse(dirs)
+
+	// Truncate AFTER the reverse, so the cap drops the deepest levels and
+	// keeps the outermost. A caller renders its tree from the root down, and a
+	// chain missing its root renders nothing at all; a chain missing its tail
+	// just leaves the caller the levels it already knows how to fetch.
+	if len(dirs) > maxChainListings {
+		dirs = dirs[:maxChainListings]
+	}
+	return dirs, nil
 }
 
 // fileInfoToProto converts an os.FileInfo into a protobuf FileInfo.

--- a/backend/internal/worker/service/file.go
+++ b/backend/internal/worker/service/file.go
@@ -3,8 +3,10 @@ package service
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -29,7 +31,7 @@ const maxDirEntries = 256
 // defaultReadLimit is the max bytes returned by ReadFile when the request
 // omits limit (or passes <= 0). Kept near one Noise transport chunk so a
 // default page stays a single chunk after protobuf/AEAD overhead; callers
-// that need more raise limit explicitly up to maxReadLimit.
+// that need more raise limit explicitly, up to the sender's payload budget.
 const defaultReadLimit int64 = 60 * 1024 // 60 KB
 
 // payloadBudget is the largest response body this sender accepts: the tighter
@@ -38,9 +40,9 @@ const defaultReadLimit int64 = 60 * 1024 // 60 KB
 //
 // A response above it is one the receiver refuses, and on the unary path that
 // refusal surfaces as ResourceExhausted. Two handlers here spend it, for
-// different reasons: ReadFile clamps what a caller may ASK for
-// (see maxReadLimit), and ListDirectory stops adding listings to a chain
-// before the reply outgrows it.
+// different reasons: ReadFile clamps what a caller may ASK for, and
+// ListDirectory stops adding listings to a chain before the reply outgrows
+// it.
 func (svc *Service) payloadBudget(sender channel.ResponseWriter) int64 {
 	configured := channelwire.ResolveMaxMessageSize(svc.MaxMessageSize)
 	if sender != nil {
@@ -49,16 +51,6 @@ func (svc *Service) payloadBudget(sender channel.ResponseWriter) int64 {
 		}
 	}
 	return int64(configured)
-}
-
-// maxReadLimit caps what a ReadFile request may ask for, whatever it
-// asks for.
-//
-// It is the same producer ceiling the agent stdout scanners bound
-// themselves by. Without the clamp the limit field also picks the worker's
-// allocation size, so a single request could ask it to reserve gigabytes.
-func (svc *Service) maxReadLimit(sender channel.ResponseWriter) int64 {
-	return svc.payloadBudget(sender)
 }
 
 // registerFileHandlers registers handlers for file operations on the local filesystem.
@@ -94,53 +86,45 @@ func registerFileHandlers(d ownerOnlyRegistrar, svc *Service) {
 		// Resolve symlinks so paths are consistent (e.g. /var → /private/var on macOS).
 		dirPath = pathutil.Canonicalize(dirPath)
 
-		dirs, err := chainDirs(dirPath, r.GetFromRoot(), svc.HomeDir)
+		// from_root is sanitized HERE, not inside chainDirs, so one rejection
+		// class carries one status code: a path this worker refuses to accept
+		// is PermissionDenied whichever field carried it. What chainDirs
+		// reports is the relationship between the two paths, and that is a
+		// genuine InvalidArgument -- the caller can fix it.
+		fromRoot := r.GetFromRoot()
+		if fromRoot != "" {
+			fromRoot, err = validate.SanitizePath(fromRoot, svc.HomeDir)
+			if err != nil {
+				sendPermissionDenied(sender, "access denied")
+				return
+			}
+			fromRoot = pathutil.Canonicalize(fromRoot)
+		}
+
+		dirs, err := chainDirs(dirPath, fromRoot)
 		if err != nil {
 			sendInvalidArgument(sender, err.Error())
 			return
 		}
 
-		budget := svc.payloadBudget(sender)
-		listings := make([]*leapmuxv1.DirectoryListing, 0, len(dirs))
-		var used int64
-		for _, dir := range dirs {
-			entries, truncated, totalEntries, err := listDirectory(dir, dir, r.GetMaxDepth(), 0, r.GetDirsOnly())
-			if err != nil {
-				// The FIRST directory is the one the caller asked about, so
-				// its failure is the request's failure. A deeper one failing
-				// only shortens the chain, which the response already allows:
-				// a directory the caller cannot read is one it would have
-				// discovered on its own next request.
-				if len(listings) == 0 {
-					slog.Error("failed to list directory", "path", dir, "error", err)
-					sendInternalError(sender, "failed to list directory")
-					return
-				}
-				break
+		listings, unreadable, err := listChain(ctx, dirs, svc.payloadBudget(sender), r.GetMaxDepth(), r.GetDirsOnly())
+		if err != nil {
+			// A cancelled session is not a failure to report: the caller is gone,
+			// so an error response only queues bytes nobody reads.
+			if ctx.Err() != nil {
+				return
 			}
-
-			listing := &leapmuxv1.DirectoryListing{
-				Path:         dir,
-				Entries:      entries,
-				Truncated:    truncated,
-				TotalEntries: int32(totalEntries),
-			}
-			// Stop before the response outgrows what the channel accepts,
-			// rather than after. A chain of deep directories listed with
-			// dirs_only=false carries up to maxDirEntries FileInfos per level,
-			// and a response above the negotiated budget comes back to the
-			// caller as ResourceExhausted -- losing the levels it could have
-			// had. The first listing is always kept, because a response with
-			// no listing at all is not an answer.
-			size := int64(proto.Size(listing))
-			if len(listings) > 0 && used+size > budget {
-				break
-			}
-			used += size
-			listings = append(listings, listing)
+			// dirs[0] is the directory that failed, because listChain returns an
+			// error only for the outermost one.
+			slog.Error("failed to list directory", "path", dirs[0], "error", err)
+			sendInternalError(sender, "failed to list directory")
+			return
 		}
 
-		sendProtoResponse(sender, &leapmuxv1.ListDirectoryResponse{Listings: listings})
+		sendProtoResponse(sender, &leapmuxv1.ListDirectoryResponse{
+			Listings:   listings,
+			Unreadable: unreadable,
+		})
 	})
 
 	d.Register("ReadFile", leapmuxv1.Scope_SCOPE_FILE_READ, func(ctx context.Context, caller channel.Caller, req *leapmuxv1.InnerRpcRequest, sender channel.ResponseWriter) {
@@ -197,7 +181,12 @@ func registerFileHandlers(d ownerOnlyRegistrar, svc *Service) {
 		// cannot report. Truncating is the honest answer: the response
 		// already carries total_size, so a caller reading a large file
 		// pages rather than being told nothing.
-		if max := svc.maxReadLimit(sender); limit > max {
+		//
+		// The clamp is the same producer ceiling the agent stdout scanners
+		// hold themselves to. Without it the limit field also picks the
+		// worker's allocation size, so a single request could ask it to
+		// reserve gigabytes.
+		if max := svc.payloadBudget(sender); limit > max {
 			limit = max
 		}
 
@@ -311,32 +300,26 @@ const maxChainListings = 64
 // it is every directory from fromRoot down to dirPath, so a tree rooted at "/"
 // can reveal a deep selection in one round trip instead of one per level.
 //
-// dirPath must already be sanitized and canonicalized. fromRoot is
-// canonicalized here, so a symlinked ancestor -- /tmp on macOS, which resolves
-// to /private/tmp -- passes the containment test that a textual comparison
-// would fail.
+// BOTH paths must already be sanitized and canonicalized, by the same pair of
+// calls: a symlinked ancestor -- /tmp on macOS, which resolves to /private/tmp
+// -- must reach the containment test in the same spelling as its descendant,
+// or a textual comparison rejects a real ancestor.
 //
 // A dirPath that is not a directory ends the chain at its parent, so revealing
 // a FILE costs one request too. That rule applies only to the chain form: with
 // no fromRoot the caller asked to list a file, and listDirectory reports that
 // as the error it is.
-func chainDirs(dirPath, fromRoot, homeDir string) ([]string, error) {
-	if fromRoot == "" {
+func chainDirs(dirPath, root string) ([]string, error) {
+	if root == "" {
 		return []string{dirPath}, nil
 	}
-
-	root, err := validate.SanitizePath(fromRoot, homeDir)
-	if err != nil {
-		return nil, fmt.Errorf("invalid from_root: %w", err)
-	}
-	root = pathutil.Canonicalize(root)
 
 	if !pathutil.HasPathPrefix(dirPath, root) {
 		return nil, fmt.Errorf("from_root %q is not an ancestor of %q", root, dirPath)
 	}
 
 	// Drop a trailing non-directory, so the chain ends at the deepest
-	// directory the caller named. os.Stat, not the dir entry: dirPath may be a
+	// directory the caller gave. os.Stat, not the dir entry: dirPath may be a
 	// symlink to a directory, and that is a directory to every other part of
 	// this file.
 	tail := dirPath
@@ -353,7 +336,7 @@ func chainDirs(dirPath, fromRoot, homeDir string) ([]string, error) {
 	// that is correct for every root spelling ("/", "C:\\", "\\\\srv\\share\\"),
 	// because it stops at the volume rather than one segment past it.
 	//
-	// The walk itself is unbounded because it costs only string operations and
+	// The walk itself has no limit because it costs only string operations and
 	// the OS already limits how many components a path can hold. The cap below
 	// limits what is expensive: one directory read per surviving entry.
 	dirs := []string{tail}
@@ -375,6 +358,93 @@ func chainDirs(dirPath, fromRoot, homeDir string) ([]string, error) {
 		dirs = dirs[:maxChainListings]
 	}
 	return dirs, nil
+}
+
+// unreadableReason turns a listDirectory failure into a short fixed phrase a
+// person can read.
+//
+// Never err.Error(): the operating system's own message carries the path, the
+// errno spelling and the syscall name, all of which differ per platform and
+// none of which a caller needs. The path is already in the response.
+func unreadableReason(err error) string {
+	switch {
+	case errors.Is(err, fs.ErrPermission):
+		return "permission denied"
+	case errors.Is(err, fs.ErrNotExist):
+		return "no such directory"
+	default:
+		return "cannot be read"
+	}
+}
+
+// listChain lists every directory in dirs, outermost first, and stops before
+// the reply outgrows budget.
+//
+// It returns an error only when the OUTERMOST directory fails, which is the
+// request's failure. With no from_root that is the directory the caller asked
+// about. With one it is from_root, and the chain has to start there: the
+// caller keys the first listing to the root it asked for, so a chain that
+// skips its own root mounts every remaining listing under the wrong path.
+//
+// A deeper failure only shortens the chain, which the response already allows:
+// a directory the caller cannot read is one it would have discovered on its
+// own next request.
+//
+// A cancelled ctx returns ctx.Err() and no listing, because the caller is
+// already gone.
+//
+// The second return value names the directory a READ failure stopped the chain
+// at, so the caller can say why that row will not open. It stays nil when the
+// chain is complete and when a cap cut it, because neither is a failure.
+func listChain(ctx context.Context, dirs []string, budget int64, maxDepth int32, dirsOnly bool) ([]*leapmuxv1.DirectoryListing, *leapmuxv1.UnreadableDirectory, error) {
+	listings := make([]*leapmuxv1.DirectoryListing, 0, len(dirs))
+	var used int64
+	for _, dir := range dirs {
+		// One chain request performs up to maxChainListings directory walks,
+		// each with its own ReadDir and up to maxDirEntries Stat calls. The
+		// caller may be gone well before the last one, and the session context
+		// is cancelled when the channel closes.
+		if ctx.Err() != nil {
+			return nil, nil, ctx.Err()
+		}
+
+		entries, truncated, totalEntries, err := listDirectory(dir, dir, maxDepth, 0, dirsOnly)
+		if err != nil {
+			if len(listings) == 0 {
+				return nil, nil, err
+			}
+			return listings, &leapmuxv1.UnreadableDirectory{
+				Path:   dir,
+				Reason: unreadableReason(err),
+			}, nil
+		}
+
+		listing := &leapmuxv1.DirectoryListing{
+			Path:         dir,
+			Entries:      entries,
+			Truncated:    truncated,
+			TotalEntries: int32(totalEntries),
+		}
+		// Stop before the response outgrows what the channel accepts, rather
+		// than after. A chain of deep directories listed with dirs_only=false
+		// carries up to maxDirEntries FileInfos per level, and a response above
+		// the negotiated budget comes back to the caller as ResourceExhausted
+		// -- losing the levels it could have had. The first listing is always
+		// kept, because a response with no listing at all is not an answer.
+		//
+		// proto.Size walks the whole message, so it runs only where its answer
+		// is read: never for the first listing, and therefore never at all on
+		// the single-directory path that every ordinary tree click takes.
+		if len(listings) > 0 {
+			size := int64(proto.Size(listing))
+			if used+size > budget {
+				break
+			}
+			used += size
+		}
+		listings = append(listings, listing)
+	}
+	return listings, nil, nil
 }
 
 // fileInfoToProto converts an os.FileInfo into a protobuf FileInfo.

--- a/backend/internal/worker/service/file_test.go
+++ b/backend/internal/worker/service/file_test.go
@@ -961,8 +961,13 @@ func TestListChain_ReportsPermissionDeniedWithoutTheOsMessage(t *testing.T) {
 // reachable with paths that do not exist.
 func TestChainDirs(t *testing.T) {
 	t.Parallel()
-	// A prefix no test can collide with, and that no filesystem holds.
-	const base = "/leapmux-chaindirs-absent"
+	// A prefix no test can collide with, and that no filesystem holds. The
+	// spelling must be NATIVE: chainDirs derives every parent with
+	// filepath.Dir, which cleans, so a POSIX literal compares unequal to its
+	// own cleaned parent on Windows. The handler sanitizes both the path and
+	// from_root before chainDirs sees them, so a mixed spelling never reaches
+	// it outside this test.
+	base := filepath.FromSlash("/leapmux-chaindirs-absent")
 
 	t.Run("no root lists the path alone", func(t *testing.T) {
 		t.Parallel()

--- a/backend/internal/worker/service/file_test.go
+++ b/backend/internal/worker/service/file_test.go
@@ -1,10 +1,14 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -610,7 +614,7 @@ func TestReadFile_ClampsAnOversizeLimit(t *testing.T) {
 	f, err := os.Create(path)
 	require.NoError(t, err)
 	// Larger than the clamp, so the clamp decides the outcome.
-	maxRead := svc.maxReadLimit(nil)
+	maxRead := svc.payloadBudget(nil)
 	totalSize := maxRead + (1 << 20)
 	require.NoError(t, f.Truncate(totalSize))
 	require.NoError(t, f.Close())
@@ -633,27 +637,27 @@ func TestReadFile_ClampsAnOversizeLimit(t *testing.T) {
 		"a limit above the producer ceiling must be clamped, which makes this file truncated")
 }
 
-func TestMaxReadLimit_UsesConfiguredMaxMessageSize(t *testing.T) {
+func TestPayloadBudget_UsesConfiguredMaxMessageSize(t *testing.T) {
 	t.Parallel()
 
 	svc := &Service{Config: Config{MaxMessageSize: 2 << 20}}
-	assert.Equal(t, int64(2<<20), svc.maxReadLimit(nil))
+	assert.Equal(t, int64(2<<20), svc.payloadBudget(nil))
 
 	svc.MaxMessageSize = 0
-	assert.Equal(t, int64(contracts.MaxMessageSize), svc.maxReadLimit(nil),
+	assert.Equal(t, int64(contracts.MaxMessageSize), svc.payloadBudget(nil),
 		"0 must resolve to the protocol default payload budget")
 }
 
-func TestMaxReadLimit_UsesNegotiatedChannelBudgetWhenTighter(t *testing.T) {
+func TestPayloadBudget_UsesNegotiatedChannelBudgetWhenTighter(t *testing.T) {
 	t.Parallel()
 
 	svc := &Service{Config: Config{MaxMessageSize: 4 << 20}}
 	sender := &budgetWriter{budget: 1 << 20}
-	assert.Equal(t, int64(1<<20), svc.maxReadLimit(sender),
+	assert.Equal(t, int64(1<<20), svc.payloadBudget(sender),
 		"channel negotiated budget must clamp below the worker knob")
-	assert.Equal(t, int64(4<<20), svc.maxReadLimit(&budgetWriter{budget: 8 << 20}),
+	assert.Equal(t, int64(4<<20), svc.payloadBudget(&budgetWriter{budget: 8 << 20}),
 		"worker knob must win when the channel budget is higher")
-	assert.Equal(t, int64(4<<20), svc.maxReadLimit(&budgetWriter{budget: 0}),
+	assert.Equal(t, int64(4<<20), svc.payloadBudget(&budgetWriter{budget: 0}),
 		"zero budget (non-channel writer) must fall back to the worker knob")
 }
 
@@ -793,12 +797,27 @@ func TestListFilesystemRoots_RootsAreListable(t *testing.T) {
 	var roots leapmuxv1.ListFilesystemRootsResponse
 	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &roots))
 
+	require.NotEmpty(t, roots.GetRoots())
 	for _, root := range roots.GetRoots() {
 		lw := &testResponseWriter{channelID: testChannelID}
 		dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{Path: root, DirsOnly: true}, lw)
+
+		// One outcome or the other, never neither. Without this the loop below
+		// is vacuous for an unregistered handler, an owner gate that refused
+		// silently, or a dispatch that routed nowhere -- and the stated
+		// contract goes unverified while the test reports success.
+		require.Equal(t, 1, len(lw.responses)+len(lw.errors),
+			"root %q produced neither a response nor an error", root)
+
 		for _, e := range lw.errors {
 			assert.NotEqual(t, codePermissionDenied, e.code, "root %q was refused: %s", root, e.message)
 			assert.NotEqual(t, codeInvalidArgument, e.code, "root %q was rejected: %s", root, e.message)
+		}
+		if len(lw.responses) == 1 {
+			var listed leapmuxv1.ListDirectoryResponse
+			require.NoError(t, proto.Unmarshal(lw.responses[0].GetPayload(), &listed))
+			require.Len(t, listed.GetListings(), 1)
+			assert.Equal(t, root, listed.GetListings()[0].GetPath())
 		}
 	}
 }
@@ -806,6 +825,199 @@ func TestListFilesystemRoots_RootsAreListable(t *testing.T) {
 // ---------------------------------------------------------------------------
 // ListDirectory: the ancestor chain
 // ---------------------------------------------------------------------------
+
+// listChain and chainDirs, with no ResponseWriter and no registrar: the two
+// rules that interleave in the handler -- the byte budget and "the outermost
+// directory's failure is the request's failure" -- are decided here.
+
+// The first listing survives a budget it alone exceeds. A reply with no
+// listing is not an answer to the directory the caller asked about.
+func TestListChain_KeepsTheFirstListingAboveTheBudget(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	child := filepath.Join(dir, "child")
+	require.NoError(t, os.MkdirAll(child, 0o755))
+
+	listings, _, err := listChain(context.Background(), []string{dir, child}, 1, 0, false)
+
+	require.NoError(t, err)
+	require.Len(t, listings, 1)
+	assert.Equal(t, dir, listings[0].GetPath())
+}
+
+// A budget that fits both keeps both, so the test above cannot pass merely
+// because the chain never grows.
+func TestListChain_KeepsEveryListingThatFitsTheBudget(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	child := filepath.Join(dir, "child")
+	require.NoError(t, os.MkdirAll(child, 0o755))
+
+	listings, _, err := listChain(context.Background(), []string{dir, child}, 1<<20, 0, false)
+
+	require.NoError(t, err)
+	require.Len(t, listings, 2)
+	assert.Equal(t, []string{dir, child}, []string{listings[0].GetPath(), listings[1].GetPath()})
+}
+
+// A caller that is already gone gets no walk and no listing.
+func TestListChain_CancelledContextListsNothing(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	listings, _, err := listChain(ctx, []string{t.TempDir()}, 1<<20, 0, false)
+
+	assert.Nil(t, listings)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestListChain_OutermostFailureIsTheRequestFailure(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	listings, _, err := listChain(context.Background(), []string{missing}, 1<<20, 0, false)
+
+	require.Error(t, err)
+	assert.Nil(t, listings)
+}
+
+// The counterpart rule: a level below the outermost one only shortens the
+// chain, so the caller keeps the levels that did list.
+func TestListChain_DeeperFailureShortensTheChain(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist")
+
+	listings, unreadable, err := listChain(context.Background(), []string{dir, missing}, 1<<20, 0, false)
+
+	require.NoError(t, err)
+	require.Len(t, listings, 1)
+	assert.Equal(t, dir, listings[0].GetPath())
+
+	// The chain says WHY it stopped, so a tree can report it on that row
+	// instead of leaving a directory that silently refuses to open.
+	require.NotNil(t, unreadable)
+	assert.Equal(t, missing, unreadable.GetPath())
+	assert.Equal(t, "no such directory", unreadable.GetReason())
+}
+
+// A cap is not a failure: the caller lists the rest itself, so there is
+// nothing to report and nothing for a tree to render.
+func TestListChain_ACapCutsTheChainWithNoReason(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	child := filepath.Join(dir, "child")
+	require.NoError(t, os.MkdirAll(child, 0o755))
+
+	listings, unreadable, err := listChain(context.Background(), []string{dir, child}, 1, 0, false)
+
+	require.NoError(t, err)
+	require.Len(t, listings, 1)
+	assert.Nil(t, unreadable)
+}
+
+// A complete chain reports nothing either.
+func TestListChain_ACompleteChainHasNoUnreadableDirectory(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	child := filepath.Join(dir, "child")
+	require.NoError(t, os.MkdirAll(child, 0o755))
+
+	listings, unreadable, err := listChain(context.Background(), []string{dir, child}, 1<<20, 0, false)
+
+	require.NoError(t, err)
+	require.Len(t, listings, 2)
+	assert.Nil(t, unreadable)
+}
+
+// The reason is a fixed phrase, never the operating system's own message: that
+// one carries the path, the errno spelling and the syscall name, and all three
+// differ per platform.
+func TestListChain_ReportsPermissionDeniedWithoutTheOsMessage(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory permissions do not govern reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocked")
+	require.NoError(t, os.MkdirAll(blocked, 0o755))
+	require.NoError(t, os.Chmod(blocked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+
+	_, unreadable, err := listChain(context.Background(), []string{dir, blocked}, 1<<20, 0, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, unreadable)
+	assert.Equal(t, "permission denied", unreadable.GetReason())
+	assert.NotContains(t, unreadable.GetReason(), blocked, "the reason must not carry the path")
+}
+
+// chainDirs is pure path algebra apart from one os.Stat on the tail, and that
+// call leaves a path it cannot stat unchanged -- so every rule below is
+// reachable with paths that do not exist.
+func TestChainDirs(t *testing.T) {
+	t.Parallel()
+	// A prefix no test can collide with, and that no filesystem holds.
+	const base = "/leapmux-chaindirs-absent"
+
+	t.Run("no root lists the path alone", func(t *testing.T) {
+		t.Parallel()
+		dirs, err := chainDirs(filepath.Join(base, "a", "b"), "")
+		require.NoError(t, err)
+		assert.Equal(t, []string{filepath.Join(base, "a", "b")}, dirs)
+	})
+
+	t.Run("a root walks down to the path, outermost first", func(t *testing.T) {
+		t.Parallel()
+		dirs, err := chainDirs(filepath.Join(base, "a", "b", "c"), base)
+		require.NoError(t, err)
+		assert.Equal(t, []string{
+			base,
+			filepath.Join(base, "a"),
+			filepath.Join(base, "a", "b"),
+			filepath.Join(base, "a", "b", "c"),
+		}, dirs)
+	})
+
+	t.Run("a root equal to the path is a chain of one", func(t *testing.T) {
+		t.Parallel()
+		dirs, err := chainDirs(base, base)
+		require.NoError(t, err)
+		assert.Equal(t, []string{base}, dirs)
+	})
+
+	t.Run("a root that is not an ancestor is refused", func(t *testing.T) {
+		t.Parallel()
+		_, err := chainDirs(filepath.Join(base, "a"), filepath.Join(base, "b"))
+		assert.Error(t, err)
+	})
+
+	// A sibling whose name merely starts with the root's is NOT under it.
+	t.Run("a sibling with a shared name prefix is refused", func(t *testing.T) {
+		t.Parallel()
+		_, err := chainDirs(filepath.Join(base, "foobar"), filepath.Join(base, "foo"))
+		assert.Error(t, err)
+	})
+
+	// The cap drops the DEEPEST levels: a caller renders from the root down,
+	// and a chain missing its root renders nothing at all.
+	t.Run("the cap keeps the outermost levels", func(t *testing.T) {
+		t.Parallel()
+		deep := base
+		for i := 0; i < maxChainListings+10; i++ {
+			deep = filepath.Join(deep, fmt.Sprintf("d%d", i))
+		}
+		dirs, err := chainDirs(deep, base)
+		require.NoError(t, err)
+		require.Len(t, dirs, maxChainListings)
+		assert.Equal(t, base, dirs[0])
+		assert.Equal(t, filepath.Join(base, "d0"), dirs[1])
+	})
+}
 
 // listingPaths reads a ListDirectory reply and returns the path of each
 // listing, in the order the worker sent them.
@@ -924,7 +1136,7 @@ func TestListDirectory_ChainAcceptsASymlinkedFromRoot(t *testing.T) {
 }
 
 // Revealing a FILE costs one request too: the chain ends at the deepest
-// directory the caller named. Without this a tree that selects a file has to
+// directory the caller gave. Without this a tree that selects a file has to
 // walk the chain itself, one level at a time.
 func TestListDirectory_ChainEndsAtTheParentOfANonDirectory(t *testing.T) {
 	t.Parallel()
@@ -1042,14 +1254,15 @@ func TestListDirectory_ChainFromTheFilesystemRoot(t *testing.T) {
 	assert.Equal(t, target, paths[len(paths)-1], "and end at the requested path")
 }
 
-func TestListDirectory_ChainRejectsAnUnsanitizableFromRoot(t *testing.T) {
+// One rejection class, one status code. A path SanitizePath refuses is
+// PermissionDenied whichever field carried it -- the same answer `path` has
+// always given -- so a caller that branches on the code does not have to know
+// which field it filled in.
+func TestListDirectory_ChainRefusesAnUnsanitizableFromRoot(t *testing.T) {
 	t.Parallel()
 	svc, d, _ := setupTestService(t)
 	target := pathutil.Canonicalize(svc.HomeDir)
 
-	// Each of these fails SanitizePath for its own reason, and every one must
-	// be reported as a bad ARGUMENT rather than as a listing failure: the
-	// caller can fix all three.
 	for name, fromRoot := range map[string]string{
 		"relative":  "not/absolute",
 		"traversal": "/tmp/../etc",
@@ -1063,10 +1276,37 @@ func TestListDirectory_ChainRejectsAnUnsanitizableFromRoot(t *testing.T) {
 			}, w)
 
 			require.Len(t, w.errors, 1)
-			assert.Equal(t, codeInvalidArgument, w.errors[0].code)
+			assert.Equal(t, codePermissionDenied, w.errors[0].code)
 			assert.Empty(t, w.responses)
+
+			// The SAME spelling in `path` answers the same way. This is the
+			// property the split codes broke.
+			pw := &testResponseWriter{channelID: testChannelID}
+			dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{Path: fromRoot}, pw)
+			require.Len(t, pw.errors, 1)
+			assert.Equal(t, w.errors[0].code, pw.errors[0].code,
+				"one rejected spelling must not carry two status codes")
 		})
 	}
+}
+
+// A from_root that IS acceptable but is not an ancestor stays InvalidArgument.
+// Nothing was denied there; the two arguments simply do not agree, and the
+// caller can fix that.
+func TestListDirectory_ChainRejectsAValidFromRootThatIsNotAnAncestor(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	root := pathutil.Canonicalize(svc.HomeDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "a"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "b"), 0o755))
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(root, "a"),
+		FromRoot: filepath.Join(root, "b"),
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	assert.Equal(t, codeInvalidArgument, w.errors[0].code)
 }
 
 // A directory the caller cannot read only SHORTENS the chain. It is one the
@@ -1097,6 +1337,84 @@ func TestListDirectory_ChainStopsAtAnUnreadableDirectory(t *testing.T) {
 		"the readable levels must survive an unreadable one below them")
 }
 
+// The mapper itself, including the branch a real filesystem is awkward to
+// drive into: an error that is neither a refusal nor an absence.
+func TestUnreadableReason(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "permission denied", unreadableReason(fs.ErrPermission))
+	assert.Equal(t, "no such directory", unreadableReason(fs.ErrNotExist))
+	assert.Equal(t, "cannot be read", unreadableReason(errors.New("i/o error")))
+
+	// Wrapped, which is the shape os.ReadDir really returns.
+	assert.Equal(t, "permission denied",
+		unreadableReason(&fs.PathError{Op: "open", Path: "/x", Err: fs.ErrPermission}))
+	assert.Equal(t, "no such directory",
+		unreadableReason(fmt.Errorf("listing %q: %w", "/x", fs.ErrNotExist)))
+}
+
+// The phrase carries no path and no errno spelling: the path is already in the
+// response, and the operating system's own message differs per platform.
+func TestUnreadableReason_CarriesNoPathOrErrno(t *testing.T) {
+	t.Parallel()
+
+	reason := unreadableReason(&fs.PathError{Op: "open", Path: "/secret/place", Err: fs.ErrPermission})
+
+	assert.NotContains(t, reason, "/secret/place")
+	assert.NotContains(t, reason, "open")
+}
+
+// The reason reaches the caller through the RPC, not only through listChain.
+func TestListDirectory_ChainReportsTheUnreadableDirectory(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory permissions do not govern reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	svc, d, w := setupTestService(t)
+	root := pathutil.Canonicalize(svc.HomeDir)
+	blocked := filepath.Join(root, "blocked")
+	require.NoError(t, os.MkdirAll(filepath.Join(blocked, "inner"), 0o755))
+	require.NoError(t, os.Chmod(blocked, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(blocked, "inner"),
+		FromRoot: root,
+	}, w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListDirectoryResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	require.Len(t, resp.GetListings(), 1)
+	require.NotNil(t, resp.GetUnreadable())
+	assert.Equal(t, blocked, resp.GetUnreadable().GetPath())
+	assert.Equal(t, "permission denied", resp.GetUnreadable().GetReason())
+}
+
+// A chain that completes carries no reason, so a tree cannot render a stale
+// one over a directory that lists perfectly well.
+func TestListDirectory_ACompleteChainReportsNoUnreadableDirectory(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	root := pathutil.Canonicalize(svc.HomeDir)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "a", "b"), 0o755))
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(root, "a", "b"),
+		FromRoot: root,
+	}, w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListDirectoryResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	assert.Nil(t, resp.GetUnreadable())
+}
+
 // The FIRST directory is the one the caller asked about, so its failure is the
 // request's failure -- the counterpart to the rule above.
 func TestListDirectory_ChainFailsWhenTheRootIsUnreadable(t *testing.T) {
@@ -1120,6 +1438,118 @@ func TestListDirectory_ChainFailsWhenTheRootIsUnreadable(t *testing.T) {
 
 	require.Len(t, w.errors, 1)
 	assert.Empty(t, w.responses)
+}
+
+// The truncation fields moved onto DirectoryListing, and every test that
+// covers them calls the internal helper directly -- so nothing pinned the
+// wiring from listDirectory's return values onto the message the caller
+// receives. A crossed or dropped field there removes the tree's truncation
+// notice, or makes it claim "N+ entries" for every truncated directory, with
+// no other symptom.
+func TestListDirectory_CarriesTruncationOnTheListing(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	dir := filepath.Join(pathutil.Canonicalize(svc.HomeDir), "big")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	const total = maxDirEntries + 25
+	for i := 0; i < total; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%04d.txt", i)), []byte("x"), 0o644))
+	}
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{Path: dir}, w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListDirectoryResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	require.Len(t, resp.GetListings(), 1)
+	listing := resp.GetListings()[0]
+	assert.True(t, listing.GetTruncated(), "a directory above the entry limit is truncated")
+	assert.Len(t, listing.GetEntries(), maxDirEntries)
+	assert.EqualValues(t, total, listing.GetTotalEntries(), "total_entries reports what the directory really held")
+}
+
+// The same fields, on a DEEPER listing of a chain. The re-key the caller
+// applies touches the first listing alone, so a chain that carried the flags
+// only there would leave every other level unable to report its own
+// truncation.
+func TestListDirectory_ChainCarriesTruncationOnADeeperListing(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	root := pathutil.Canonicalize(svc.HomeDir)
+	dir := filepath.Join(root, "big")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	const total = maxDirEntries + 5
+	for i := 0; i < total; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%04d.txt", i)), []byte("x"), 0o644))
+	}
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{Path: dir, FromRoot: root}, w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListDirectoryResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	require.Len(t, resp.GetListings(), 2)
+	assert.False(t, resp.GetListings()[0].GetTruncated(), "the root holds one entry")
+	last := resp.GetListings()[1]
+	assert.Equal(t, dir, last.GetPath())
+	assert.True(t, last.GetTruncated())
+	assert.EqualValues(t, total, last.GetTotalEntries())
+}
+
+// max_depth WITH from_root -- the only combination the directory picker ever
+// sends, and the one no test covered. The merge rewrites an entry's name and
+// path to its deepest single child, so a chain member can arrive labelled after a
+// directory several levels below it.
+func TestListDirectory_ChainAppliesMaxDepthToEveryListing(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	root := pathutil.Canonicalize(svc.HomeDir)
+	// One single-child spine under the root, plus a sibling at the root so the
+	// root itself has more than one entry and is not merged away.
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "a", "b", "c"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "other"), 0o755))
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(root, "a", "b", "c"),
+		FromRoot: root,
+		MaxDepth: 5,
+		DirsOnly: true,
+	}, w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListDirectoryResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+
+	// Every level of the chain is still listed, whatever the merge did to the
+	// names inside each listing. The caller keys its cache by these paths, so
+	// a missing one is a level it can never fill.
+	var paths []string
+	for _, l := range resp.GetListings() {
+		paths = append(paths, l.GetPath())
+	}
+	assert.Equal(t, []string{
+		root,
+		filepath.Join(root, "a"),
+		filepath.Join(root, "a", "b"),
+		filepath.Join(root, "a", "b", "c"),
+	}, paths)
+
+	// The merge collapses the single-child spine into one entry, so the row
+	// the root offers points at a directory several levels down. Its PATH is the
+	// deepest merged directory, which is what the caller opens.
+	rootEntries := resp.GetListings()[0].GetEntries()
+	var merged *leapmuxv1.FileInfo
+	for _, e := range rootEntries {
+		if strings.HasPrefix(e.GetName(), "a") {
+			merged = e
+		}
+	}
+	require.NotNil(t, merged, "the root must still offer the spine")
+	assert.Equal(t, filepath.Join(root, "a", "b", "c"), merged.GetPath(),
+		"a merged entry points at the deepest directory it collapsed")
 }
 
 // Every listing in a chain is shaped like the single-listing answer. Without

--- a/backend/internal/worker/service/file_test.go
+++ b/backend/internal/worker/service/file_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/leapmux/leapmux/generated/contracts"
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/channel"
+	"github.com/leapmux/leapmux/util/pathutil"
 )
 
 func TestListDirectory_Truncation(t *testing.T) {
@@ -747,5 +748,407 @@ func requireSymlinkSupport(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
 		t.Skip("creating a symlink on Windows needs SeCreateSymbolicLinkPrivilege")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListFilesystemRoots
+// ---------------------------------------------------------------------------
+
+// The dispatcher-level test for the file family's newest handler: it drives
+// the real registration, the real scope gate and the real owner gate, none of
+// which the listDirectory tests above reach.
+func TestListFilesystemRoots(t *testing.T) {
+	t.Parallel()
+	_, d, w := setupTestService(t)
+
+	dispatch(d, "ListFilesystemRoots", &leapmuxv1.ListFilesystemRootsRequest{}, w)
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+
+	var resp leapmuxv1.ListFilesystemRootsResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+
+	require.NotEmpty(t, resp.GetRoots())
+	assert.Equal(t, pathutil.FilesystemRoots(), resp.GetRoots(),
+		"the handler must pass the seam's answer through unreshaped")
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, []string{"/"}, resp.GetRoots())
+	}
+}
+
+// The end-to-end contract between the two RPCs: a root this worker reports is
+// a path the same worker's ListDirectory accepts.
+//
+// It asserts "not refused", not "no error". A machine with an empty optical
+// drive legitimately answers Internal from os.ReadDir, and that is a valid
+// outcome for a listable-but-empty device. What must never happen is
+// PermissionDenied (SanitizePath refused the spelling) or InvalidArgument.
+func TestListFilesystemRoots_RootsAreListable(t *testing.T) {
+	t.Parallel()
+	_, d, w := setupTestService(t)
+
+	dispatch(d, "ListFilesystemRoots", &leapmuxv1.ListFilesystemRootsRequest{}, w)
+	require.Len(t, w.responses, 1)
+	var roots leapmuxv1.ListFilesystemRootsResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &roots))
+
+	for _, root := range roots.GetRoots() {
+		lw := &testResponseWriter{channelID: testChannelID}
+		dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{Path: root, DirsOnly: true}, lw)
+		for _, e := range lw.errors {
+			assert.NotEqual(t, codePermissionDenied, e.code, "root %q was refused: %s", root, e.message)
+			assert.NotEqual(t, codeInvalidArgument, e.code, "root %q was rejected: %s", root, e.message)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListDirectory: the ancestor chain
+// ---------------------------------------------------------------------------
+
+// listingPaths reads a ListDirectory reply and returns the path of each
+// listing, in the order the worker sent them.
+func listingPaths(t *testing.T, w *testResponseWriter) []string {
+	t.Helper()
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListDirectoryResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	paths := make([]string, 0, len(resp.GetListings()))
+	for _, l := range resp.GetListings() {
+		paths = append(paths, l.GetPath())
+	}
+	return paths
+}
+
+func TestListDirectory_SingleListingWithoutFromRoot(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(svc.HomeDir, "a", "b"), 0o755))
+
+	root := pathutil.Canonicalize(svc.HomeDir)
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path: filepath.Join(root, "a"),
+	}, w)
+
+	assert.Equal(t, []string{filepath.Join(root, "a")}, listingPaths(t, w))
+}
+
+func TestListDirectory_ChainIsOutermostFirst(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(svc.HomeDir, "a", "b", "c"), 0o755))
+
+	root := pathutil.Canonicalize(svc.HomeDir)
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(root, "a", "b", "c"),
+		FromRoot: root,
+	}, w)
+
+	assert.Equal(t, []string{
+		root,
+		filepath.Join(root, "a"),
+		filepath.Join(root, "a", "b"),
+		filepath.Join(root, "a", "b", "c"),
+	}, listingPaths(t, w))
+}
+
+func TestListDirectory_ChainOfOneWhenFromRootEqualsPath(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	root := pathutil.Canonicalize(svc.HomeDir)
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{Path: root, FromRoot: root}, w)
+
+	assert.Equal(t, []string{root}, listingPaths(t, w))
+}
+
+func TestListDirectory_ChainRejectsAFromRootThatIsNotAnAncestor(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(svc.HomeDir, "a"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(svc.HomeDir, "b"), 0o755))
+	root := pathutil.Canonicalize(svc.HomeDir)
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(root, "a"),
+		FromRoot: filepath.Join(root, "b"),
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	assert.Equal(t, codeInvalidArgument, w.errors[0].code)
+	assert.Empty(t, w.responses)
+}
+
+// A sibling whose name merely starts with the root's is NOT under it. This is
+// the check HasPathPrefix exists for, and a plain strings.HasPrefix would pass
+// it wrongly.
+func TestListDirectory_ChainRejectsASiblingWithASharedNamePrefix(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(svc.HomeDir, "foo"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(svc.HomeDir, "foobar"), 0o755))
+	root := pathutil.Canonicalize(svc.HomeDir)
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(root, "foobar"),
+		FromRoot: filepath.Join(root, "foo"),
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	assert.Equal(t, codeInvalidArgument, w.errors[0].code)
+}
+
+// The worker canonicalizes `path`, so `from_root` must be canonicalized too
+// before the containment test. Without that, a symlinked ancestor -- /tmp on
+// macOS, which resolves to /private/tmp -- fails a check it should pass.
+func TestListDirectory_ChainAcceptsASymlinkedFromRoot(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs elevation on Windows")
+	}
+	svc, d, w := setupTestService(t)
+	real := filepath.Join(svc.HomeDir, "real")
+	require.NoError(t, os.MkdirAll(filepath.Join(real, "a"), 0o755))
+	link := filepath.Join(svc.HomeDir, "link")
+	require.NoError(t, os.Symlink(real, link))
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(link, "a"),
+		FromRoot: link,
+	}, w)
+
+	canonical := pathutil.Canonicalize(real)
+	assert.Equal(t, []string{canonical, filepath.Join(canonical, "a")}, listingPaths(t, w))
+}
+
+// Revealing a FILE costs one request too: the chain ends at the deepest
+// directory the caller named. Without this a tree that selects a file has to
+// walk the chain itself, one level at a time.
+func TestListDirectory_ChainEndsAtTheParentOfANonDirectory(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	dir := filepath.Join(svc.HomeDir, "a", "b")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644))
+	root := pathutil.Canonicalize(svc.HomeDir)
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(root, "a", "b", "f.txt"),
+		FromRoot: root,
+	}, w)
+
+	assert.Equal(t, []string{
+		root,
+		filepath.Join(root, "a"),
+		filepath.Join(root, "a", "b"),
+	}, listingPaths(t, w))
+}
+
+// The chain form tolerates a file; the plain form still reports one as the
+// error it is. A caller that asked to list a file without a from_root asked
+// for something impossible.
+func TestListDirectory_WithoutFromRootAFileIsStillAnError(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	path := filepath.Join(svc.HomeDir, "f.txt")
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o644))
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{Path: path}, w)
+
+	require.Len(t, w.errors, 1)
+	assert.Empty(t, w.responses)
+}
+
+// maxChainListings is the O(1) guard in front of the payload budget. It drops
+// the DEEPEST levels, so the caller always receives the chain from its root
+// down and can list the rest itself.
+func TestListDirectory_ChainStopsAtTheListingCap(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+
+	root := pathutil.Canonicalize(svc.HomeDir)
+	deep := root
+	for i := 0; i < maxChainListings+10; i++ {
+		deep = filepath.Join(deep, fmt.Sprintf("d%d", i))
+	}
+	require.NoError(t, os.MkdirAll(deep, 0o755))
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{Path: deep, FromRoot: root}, w)
+
+	paths := listingPaths(t, w)
+	assert.Len(t, paths, maxChainListings)
+	assert.Equal(t, root, paths[0], "the cap must drop the deepest levels, not the outermost")
+	assert.Equal(t, filepath.Join(root, "d0"), paths[1])
+}
+
+// The budget stops the chain BEFORE the response outgrows what the channel
+// accepts. The first listing is always kept: a reply with no listing is not an
+// answer, and the caller asked about that directory.
+func TestListDirectory_ChainStopsAtThePayloadBudget(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t, withMaxMessageSize(4096))
+
+	root := pathutil.Canonicalize(svc.HomeDir)
+	deep := root
+	for i := 0; i < 8; i++ {
+		deep = filepath.Join(deep, fmt.Sprintf("dir-%d", i))
+		require.NoError(t, os.MkdirAll(deep, 0o755))
+		// Enough siblings at every level that a few listings exhaust the
+		// budget, so the cut is the budget's and not the depth cap's.
+		for j := 0; j < 40; j++ {
+			require.NoError(t, os.MkdirAll(filepath.Join(deep, fmt.Sprintf("sibling-with-a-long-name-%d", j)), 0o755))
+		}
+	}
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{Path: deep, FromRoot: root}, w)
+
+	paths := listingPaths(t, w)
+	require.NotEmpty(t, paths)
+	assert.Less(t, len(paths), 9, "the budget must cut the chain short")
+	assert.Equal(t, root, paths[0], "the budget must drop the deepest levels, not the outermost")
+}
+
+// The chain that the directory picker actually issues: rooted at the host's
+// own filesystem root, revealing a path under the home directory.
+//
+// The temp-directory roots above cannot catch a prefix test that mishandles a
+// ROOT, because a temp directory is never one. This is the case that broke:
+// HasPathPrefix appended a boundary separator unconditionally, so a root
+// prefix became "//" and every descendant answered "not an ancestor".
+func TestListDirectory_ChainFromTheFilesystemRoot(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	target := pathutil.Canonicalize(svc.HomeDir)
+
+	roots := pathutil.FilesystemRoots()
+	require.NotEmpty(t, roots)
+	root := roots[0]
+	if runtime.GOOS == "windows" {
+		// The temp directory need not live on the first drive.
+		root = filepath.VolumeName(target) + `\`
+	}
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     target,
+		FromRoot: root,
+		DirsOnly: true,
+	}, w)
+
+	paths := listingPaths(t, w)
+	require.NotEmpty(t, paths)
+	assert.Equal(t, root, paths[0], "the chain must start at the filesystem root")
+	assert.Equal(t, target, paths[len(paths)-1], "and end at the requested path")
+}
+
+func TestListDirectory_ChainRejectsAnUnsanitizableFromRoot(t *testing.T) {
+	t.Parallel()
+	svc, d, _ := setupTestService(t)
+	target := pathutil.Canonicalize(svc.HomeDir)
+
+	// Each of these fails SanitizePath for its own reason, and every one must
+	// be reported as a bad ARGUMENT rather than as a listing failure: the
+	// caller can fix all three.
+	for name, fromRoot := range map[string]string{
+		"relative":  "not/absolute",
+		"traversal": "/tmp/../etc",
+		"empty-ish": "   ",
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := &testResponseWriter{channelID: testChannelID}
+			dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+				Path:     target,
+				FromRoot: fromRoot,
+			}, w)
+
+			require.Len(t, w.errors, 1)
+			assert.Equal(t, codeInvalidArgument, w.errors[0].code)
+			assert.Empty(t, w.responses)
+		})
+	}
+}
+
+// A directory the caller cannot read only SHORTENS the chain. It is one the
+// caller would have discovered on its own next request, and failing the whole
+// reply would cost it the levels that did list.
+func TestListDirectory_ChainStopsAtAnUnreadableDirectory(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory permissions do not govern reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	svc, d, w := setupTestService(t)
+	root := pathutil.Canonicalize(svc.HomeDir)
+	blocked := filepath.Join(root, "blocked")
+	require.NoError(t, os.MkdirAll(filepath.Join(blocked, "inner"), 0o755))
+	require.NoError(t, os.Chmod(blocked, 0o000))
+	// Restored so t.TempDir's own cleanup can remove the tree.
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(blocked, "inner"),
+		FromRoot: root,
+	}, w)
+
+	assert.Equal(t, []string{root}, listingPaths(t, w),
+		"the readable levels must survive an unreadable one below them")
+}
+
+// The FIRST directory is the one the caller asked about, so its failure is the
+// request's failure -- the counterpart to the rule above.
+func TestListDirectory_ChainFailsWhenTheRootIsUnreadable(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX directory permissions do not govern reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	svc, d, w := setupTestService(t)
+	root := filepath.Join(pathutil.Canonicalize(svc.HomeDir), "blocked")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "inner"), 0o755))
+	require.NoError(t, os.Chmod(root, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(root, 0o755) })
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(root, "inner"),
+		FromRoot: root,
+	}, w)
+
+	require.Len(t, w.errors, 1)
+	assert.Empty(t, w.responses)
+}
+
+// Every listing in a chain is shaped like the single-listing answer. Without
+// this, a chain could quietly ignore dirs_only and hand a directory picker the
+// files it asked not to receive.
+func TestListDirectory_ChainAppliesDirsOnlyToEveryListing(t *testing.T) {
+	t.Parallel()
+	svc, d, w := setupTestService(t)
+	root := pathutil.Canonicalize(svc.HomeDir)
+	mid := filepath.Join(root, "mid")
+	require.NoError(t, os.MkdirAll(filepath.Join(mid, "leaf"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "root-file.txt"), []byte("x"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(mid, "mid-file.txt"), []byte("x"), 0o644))
+
+	dispatch(d, "ListDirectory", &leapmuxv1.ListDirectoryRequest{
+		Path:     filepath.Join(mid, "leaf"),
+		FromRoot: root,
+		DirsOnly: true,
+	}, w)
+
+	require.Empty(t, w.errors)
+	require.Len(t, w.responses, 1)
+	var resp leapmuxv1.ListDirectoryResponse
+	require.NoError(t, proto.Unmarshal(w.responses[0].GetPayload(), &resp))
+	require.Len(t, resp.GetListings(), 3)
+
+	for _, listing := range resp.GetListings() {
+		for _, e := range listing.GetEntries() {
+			assert.True(t, e.GetIsDir(), "listing %q returned a file: %s", listing.GetPath(), e.GetName())
+		}
 	}
 }

--- a/backend/internal/worker/service/service.go
+++ b/backend/internal/worker/service/service.go
@@ -529,7 +529,7 @@ type Config struct {
 	WakeLock            *wakelock.ActivityTracker // Keep-awake tracker (nil = disabled)
 	// MaxMessageSize is the worker's configured application payload budget
 	// (0 = contracts.MaxMessageSize). Raises agent stdout scanner ceiling
-	// and ReadFile's maxReadLimit; other stream sends still reject at
+	// and ReadFile's payload budget; other stream sends still reject at
 	// sendEncrypted when the reassembled frame exceeds the negotiated gate.
 	MaxMessageSize int
 	// Clock supplies the two startup registries' timers. Nil installs the real

--- a/backend/util/pathutil/pathutil.go
+++ b/backend/util/pathutil/pathutil.go
@@ -12,27 +12,41 @@ import (
 // POSIX. Callers that need symlink resolution should filepath.EvalSymlinks
 // both inputs first.
 func SamePath(a, b string) bool {
-	ca, cb := filepath.Clean(a), filepath.Clean(b)
+	return equalCleaned(filepath.Clean(a), filepath.Clean(b))
+}
+
+// equalCleaned compares two ALREADY-cleaned paths under the host's filesystem
+// case rules: case-insensitive on Windows, byte-exact on POSIX.
+func equalCleaned(a, b string) bool {
 	if runtime.GOOS == "windows" {
-		return strings.EqualFold(ca, cb)
+		return strings.EqualFold(a, b)
 	}
-	return ca == cb
+	return a == b
 }
 
 // HasPathPrefix reports whether path is equal to or nested inside prefix,
 // matching the host's filesystem case rules (case-insensitive on Windows,
-// byte-exact on POSIX). Both inputs are cleaned; a trailing separator is
-// appended to prefix so `/foo` does not match `/foobar`.
+// byte-exact on POSIX). Both inputs are cleaned, and the comparison respects
+// the component boundary, so `/foo` does not match `/foobar`.
 func HasPathPrefix(path, prefix string) bool {
-	cp := filepath.Clean(path) + string(filepath.Separator)
-	pp := filepath.Clean(prefix) + string(filepath.Separator)
+	cp := filepath.Clean(path)
+	pp := filepath.Clean(prefix)
+	if equalCleaned(cp, pp) {
+		return true
+	}
+	// The boundary separator is appended only when the prefix does not already
+	// end in one. A filesystem ROOT is nothing but that separator -- "/" and
+	// `C:\` clean to themselves -- so appending unconditionally built "//" and
+	// `C:\\`, which no real path starts with. Every path under a root then
+	// answered false, and a directory tree rooted at "/" could not prove that
+	// any of its own entries were under it.
+	if !strings.HasSuffix(pp, string(filepath.Separator)) {
+		pp += string(filepath.Separator)
+	}
 	if len(cp) < len(pp) {
 		return false
 	}
-	if runtime.GOOS == "windows" {
-		return strings.EqualFold(cp[:len(pp)], pp)
-	}
-	return cp[:len(pp)] == pp
+	return equalCleaned(cp[:len(pp)], pp)
 }
 
 // Canonicalize returns filepath.EvalSymlinks(p) if it succeeds, otherwise

--- a/backend/util/pathutil/pathutil_test.go
+++ b/backend/util/pathutil/pathutil_test.go
@@ -52,6 +52,35 @@ func TestHasPathPrefix(t *testing.T) {
 	}
 }
 
+// A filesystem ROOT is nothing but a separator, so appending the boundary
+// separator unconditionally built "//" (and `C:\\`) and every path under a
+// root answered false. A directory tree rooted at "/" could not prove that any
+// of its own entries were under it.
+func TestHasPathPrefix_RootPrefix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		assert.True(t, HasPathPrefix(`C:\Users\alice`, `C:\`))
+		assert.True(t, HasPathPrefix(`C:\`, `C:\`))
+		assert.False(t, HasPathPrefix(`D:\Users`, `C:\`))
+		return
+	}
+	assert.True(t, HasPathPrefix("/home/alice", "/"))
+	assert.True(t, HasPathPrefix("/home", "/"))
+	assert.True(t, HasPathPrefix("/", "/"))
+	// A relative path is under no root.
+	assert.False(t, HasPathPrefix("home/alice", "/"))
+}
+
+// A caller that spells the prefix with a trailing separator means the same
+// directory, so it must get the same answer.
+func TestHasPathPrefix_TrailingSeparatorOnPrefix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		assert.True(t, HasPathPrefix(`C:\home\user\plans\a.md`, `C:\home\user\plans\`))
+		return
+	}
+	assert.True(t, HasPathPrefix("/home/user/plans/a.md", "/home/user/plans/"))
+	assert.False(t, HasPathPrefix("/home/user/plansx", "/home/user/plans/"))
+}
+
 func TestNormalizeNative_WindowsForwardSlashes(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("Windows-specific separator normalization")

--- a/backend/util/pathutil/roots.go
+++ b/backend/util/pathutil/roots.go
@@ -1,0 +1,51 @@
+package pathutil
+
+// Mirrors of the two GetDriveType results the drive filter names.
+//
+// Declared here rather than imported from golang.org/x/sys/windows so that
+// drivesFromBitmask -- the bit math AND the filter rule -- compiles and runs
+// on every host. roots_windows_test.go pins them against the real constants,
+// which is what makes the tests on a non-Windows machine trustworthy.
+const (
+	driveUnknown   uint32 = 0 // DRIVE_UNKNOWN: the type is not determinable.
+	driveNoRootDir uint32 = 1 // DRIVE_NO_ROOT_DIR: no volume is mounted here.
+)
+
+// maxDriveLetters is 26. GetLogicalDrives sets bit i for drive 'A'+i, and bits
+// 26..31 are undefined. A loop over all 32 emits "[:\", "\:\" and four more
+// roots that no filesystem has.
+const maxDriveLetters = 26
+
+// drivesFromBitmask turns a GetLogicalDrives mask into drive roots, in
+// ascending letter order, and drops any letter whose driveType probe reports
+// that no volume is mounted there.
+//
+// Split from the syscalls on purpose. The mask is a uint32 and the probe is a
+// func, so a test on macOS or Linux can hand this function any machine's drive
+// layout as one literal. What is left in roots_windows.go is two calls with no
+// branching.
+//
+// A nil probe skips the filter, which is what a caller that only has a mask
+// wants.
+func drivesFromBitmask(mask uint32, driveType func(root string) uint32) []string {
+	roots := make([]string, 0, maxDriveLetters)
+	for i := 0; i < maxDriveLetters; i++ {
+		if mask&(1<<uint(i)) == 0 {
+			continue
+		}
+		root := string(rune('A'+i)) + `:\`
+		// DRIVE_NO_ROOT_DIR is the one answer that means "the letter is in the
+		// mask but nothing is mounted". DRIVE_UNKNOWN is KEPT: it says "I
+		// cannot classify this", not "it is not there", and the mask already
+		// asserted that it is. To hide a real drive from the picker is worse
+		// than to list one whose ListDirectory then fails, which the tree
+		// already renders as an error for any unreadable directory. An empty
+		// optical drive and a mapped share report CDROM and REMOTE, so both
+		// stay.
+		if driveType != nil && driveType(root) == driveNoRootDir {
+			continue
+		}
+		roots = append(roots, root)
+	}
+	return roots
+}

--- a/backend/util/pathutil/roots.go
+++ b/backend/util/pathutil/roots.go
@@ -1,6 +1,6 @@
 package pathutil
 
-// Mirrors of the two GetDriveType results the drive filter names.
+// Mirrors of the two GetDriveType results the drive filter checks for.
 //
 // Declared here rather than imported from golang.org/x/sys/windows so that
 // drivesFromBitmask -- the bit math AND the filter rule -- compiles and runs
@@ -24,9 +24,6 @@ const maxDriveLetters = 26
 // func, so a test on macOS or Linux can hand this function any machine's drive
 // layout as one literal. What is left in roots_windows.go is two calls with no
 // branching.
-//
-// A nil probe skips the filter, which is what a caller that only has a mask
-// wants.
 func drivesFromBitmask(mask uint32, driveType func(root string) uint32) []string {
 	roots := make([]string, 0, maxDriveLetters)
 	for i := 0; i < maxDriveLetters; i++ {
@@ -42,7 +39,7 @@ func drivesFromBitmask(mask uint32, driveType func(root string) uint32) []string
 		// already renders as an error for any unreadable directory. An empty
 		// optical drive and a mapped share report CDROM and REMOTE, so both
 		// stay.
-		if driveType != nil && driveType(root) == driveNoRootDir {
+		if driveType(root) == driveNoRootDir {
 			continue
 		}
 		roots = append(roots, root)

--- a/backend/util/pathutil/roots_other.go
+++ b/backend/util/pathutil/roots_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package pathutil
+
+// FilesystemRoots returns the roots of this host's filesystem.
+//
+// One root on POSIX, always. A mounted volume is a directory under "/", not a
+// second root, so an enumeration of /Volumes or /media would answer with
+// something every caller then has to special-case as "not really a root".
+//
+// A fresh slice per call: the caller owns what it gets, so a caller that sorts
+// or truncates the result in place cannot corrupt a later call.
+func FilesystemRoots() []string {
+	return []string{"/"}
+}

--- a/backend/util/pathutil/roots_test.go
+++ b/backend/util/pathutil/roots_test.go
@@ -70,11 +70,6 @@ func TestDrivesFromBitmask(t *testing.T) {
 			assert.Regexp(t, re, root)
 		}
 	})
-
-	t.Run("a nil probe skips the filter", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, []string{`C:\`, `D:\`}, drivesFromBitmask(maskOf('C', 'D'), nil))
-	})
 }
 
 func TestDrivesFromBitmask_FiltersOnDriveType(t *testing.T) {

--- a/backend/util/pathutil/roots_test.go
+++ b/backend/util/pathutil/roots_test.go
@@ -1,0 +1,161 @@
+package pathutil
+
+import (
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/leapmux/leapmux/util/validate"
+)
+
+// driveFixed is DRIVE_FIXED, the answer for an ordinary hard disk. Used as the
+// default probe result so a test that is not about the filter says so.
+const driveFixed uint32 = 3
+
+func maskOf(letters ...rune) uint32 {
+	var mask uint32
+	for _, c := range letters {
+		mask |= 1 << uint(c-'A')
+	}
+	return mask
+}
+
+func alwaysFixed(string) uint32 { return driveFixed }
+
+func TestDrivesFromBitmask(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mask uint32
+		want []string
+	}{
+		{"an empty mask yields no roots", 0, []string{}},
+		{"a single bit becomes its letter", maskOf('C'), []string{`C:\`}},
+		{
+			"bits are emitted in letter order however the mask was written",
+			maskOf('Z') | maskOf('C') | maskOf('D'),
+			[]string{`C:\`, `D:\`, `Z:\`},
+		},
+		{
+			// Bits 26..31 are undefined. An `i < 32` loop turns them into
+			// "[:\" and "`:\", which are not roots of anything.
+			"bits above Z are ignored",
+			1<<26 | 1<<31 | maskOf('C'),
+			[]string{`C:\`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, drivesFromBitmask(tt.mask, alwaysFixed))
+		})
+	}
+
+	t.Run("all twenty-six letters", func(t *testing.T) {
+		t.Parallel()
+		got := drivesFromBitmask(0x03FFFFFF, alwaysFixed)
+		require.Len(t, got, 26)
+		assert.Equal(t, `A:\`, got[0])
+		assert.Equal(t, `Z:\`, got[25])
+	})
+
+	t.Run("every root is an uppercase letter with a trailing backslash", func(t *testing.T) {
+		t.Parallel()
+		re := regexp.MustCompile(`^[A-Z]:\\$`)
+		for _, root := range drivesFromBitmask(0x03FFFFFF, alwaysFixed) {
+			assert.Regexp(t, re, root)
+		}
+	})
+
+	t.Run("a nil probe skips the filter", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []string{`C:\`, `D:\`}, drivesFromBitmask(maskOf('C', 'D'), nil))
+	})
+}
+
+func TestDrivesFromBitmask_FiltersOnDriveType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a letter with no volume is dropped", func(t *testing.T) {
+		t.Parallel()
+		probe := func(root string) uint32 {
+			if root == `D:\` {
+				return driveNoRootDir
+			}
+			return driveFixed
+		}
+		assert.Equal(t, []string{`C:\`, `E:\`}, drivesFromBitmask(maskOf('C', 'D', 'E'), probe))
+	})
+
+	// DRIVE_UNKNOWN means "cannot classify", not "not present". Hiding a real
+	// drive from the picker is worse than listing one whose ListDirectory then
+	// fails. Changing the fail-open rule must edit this test.
+	t.Run("an unclassifiable drive is kept", func(t *testing.T) {
+		t.Parallel()
+		probe := func(string) uint32 { return driveUnknown }
+		assert.Equal(t, []string{`C:\`}, drivesFromBitmask(maskOf('C'), probe))
+	})
+
+	t.Run("removable cdrom and remote drives are kept", func(t *testing.T) {
+		t.Parallel()
+		// DRIVE_REMOVABLE, DRIVE_REMOTE, DRIVE_CDROM.
+		types := map[string]uint32{`C:\`: 2, `D:\`: 4, `E:\`: 5}
+		probe := func(root string) uint32 { return types[root] }
+		assert.Equal(t, []string{`C:\`, `D:\`, `E:\`}, drivesFromBitmask(maskOf('C', 'D', 'E'), probe))
+	})
+
+	t.Run("the probe sees exactly the roots that are returned", func(t *testing.T) {
+		t.Parallel()
+		var seen []string
+		probe := func(root string) uint32 {
+			seen = append(seen, root)
+			return driveFixed
+		}
+		got := drivesFromBitmask(maskOf('C', 'D'), probe)
+		assert.Equal(t, []string{`C:\`, `D:\`}, seen)
+		assert.Equal(t, seen, got)
+	})
+}
+
+// A caller that sorts or truncates the result in place must not corrupt a
+// later call. Guards against a future cached package-level slice.
+func TestDrivesFromBitmask_ReturnsAFreshSlice(t *testing.T) {
+	t.Parallel()
+	first := drivesFromBitmask(maskOf('C', 'D'), alwaysFixed)
+	first[0] = "clobbered"
+	assert.Equal(t, []string{`C:\`, `D:\`}, drivesFromBitmask(maskOf('C', 'D'), alwaysFixed))
+}
+
+func TestFilesystemRoots(t *testing.T) {
+	t.Parallel()
+	roots := FilesystemRoots()
+
+	// Both branches guarantee this. A picker handed an empty list has nowhere
+	// to browse and no way to say why.
+	require.NotEmpty(t, roots)
+
+	if runtime.GOOS == "windows" {
+		re := regexp.MustCompile(`^[A-Z]:\\$`)
+		for _, root := range roots {
+			assert.Regexp(t, re, root)
+		}
+	} else {
+		assert.Equal(t, []string{"/"}, roots)
+	}
+
+	// The cross-package contract that stops a future spelling change -- "C:"
+	// without the separator, a lowercase letter -- from silently breaking
+	// browsing. A root this RPC reports must be a path ListDirectory accepts.
+	t.Run("every root is a path SanitizePath accepts unchanged", func(t *testing.T) {
+		t.Parallel()
+		for _, root := range roots {
+			got, err := validate.SanitizePath(root, "")
+			require.NoError(t, err, "root %q", root)
+			assert.Equal(t, root, got)
+		}
+	})
+}

--- a/backend/util/pathutil/roots_windows.go
+++ b/backend/util/pathutil/roots_windows.go
@@ -49,7 +49,7 @@ func systemDriveRoot() string {
 // CDROM device class without touching the media -- so an empty optical drive
 // and a disconnected mapped drive both answer promptly. The calls that wait
 // out the SMB timeout are GetVolumeInformationW and GetDiskFreeSpaceExW, and
-// this file makes neither. The loop is also bounded at 26 calls.
+// this file makes neither. The loop also makes at most 26 calls.
 //
 // If a volume label is ever added to the response, that changes: the label
 // needs GetVolumeInformationW, and a timeout wrapper then becomes mandatory.

--- a/backend/util/pathutil/roots_windows.go
+++ b/backend/util/pathutil/roots_windows.go
@@ -1,0 +1,63 @@
+//go:build windows
+
+package pathutil
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// FilesystemRoots returns the drive roots that currently carry a volume.
+//
+// GetLogicalDrives, not GetLogicalDriveStringsW: the bitmask needs no
+// buffer-sizing round trip, no UTF-16 decode and no double-NUL split, and its
+// result is one uint32 -- which is what lets drivesFromBitmask, and therefore
+// the whole filter rule, be unit-tested on a machine that has no drives.
+//
+// x/sys reports a zero mask as an error. No Windows host has no drives, so
+// this answers with the system drive rather than an empty list, which a
+// directory picker would render as "nowhere to browse".
+func FilesystemRoots() []string {
+	mask, err := windows.GetLogicalDrives()
+	if err != nil || mask == 0 {
+		return []string{systemDriveRoot()}
+	}
+	roots := drivesFromBitmask(mask, driveTypeOf)
+	if len(roots) == 0 {
+		return []string{systemDriveRoot()}
+	}
+	return roots
+}
+
+// systemDriveRoot is the last-resort answer: the drive Windows booted from.
+//
+// Read from the environment rather than written as "C:\", because a
+// Windows-To-Go install or one relettered with bcdedit does not boot from C.
+func systemDriveRoot() string {
+	if drive := os.Getenv("SystemDrive"); drive != "" {
+		return drive + `\`
+	}
+	return `C:\`
+}
+
+// driveTypeOf is the real GetDriveTypeW.
+//
+// It is safe to call in a loop, which GetVolumeInformationW would not be.
+// GetDriveTypeW resolves a REMOTE letter through the local redirector's
+// mapping table rather than through the server, and it reports a REMOVABLE or
+// CDROM device class without touching the media -- so an empty optical drive
+// and a disconnected mapped drive both answer promptly. The calls that wait
+// out the SMB timeout are GetVolumeInformationW and GetDiskFreeSpaceExW, and
+// this file makes neither. The loop is also bounded at 26 calls.
+//
+// If a volume label is ever added to the response, that changes: the label
+// needs GetVolumeInformationW, and a timeout wrapper then becomes mandatory.
+func driveTypeOf(root string) uint32 {
+	p, err := windows.UTF16PtrFromString(root)
+	if err != nil {
+		// Kept by the filter, which drops DRIVE_NO_ROOT_DIR alone.
+		return driveUnknown
+	}
+	return windows.GetDriveType(p)
+}

--- a/backend/util/pathutil/roots_windows_test.go
+++ b/backend/util/pathutil/roots_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package pathutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+// The one assertion that makes the drive-filter tests trustworthy on a
+// non-Windows machine: roots.go mirrors these two constants so its filter rule
+// compiles everywhere, and this pins the mirrors against the real values.
+func TestDriveTypeConstantsMirrorWin32(t *testing.T) {
+	t.Parallel()
+	assert.EqualValues(t, windows.DRIVE_UNKNOWN, driveUnknown)
+	assert.EqualValues(t, windows.DRIVE_NO_ROOT_DIR, driveNoRootDir)
+}
+
+// No t.Parallel: this reads SystemDrive, and TestSystemDriveRoot below writes
+// it. Go finishes a non-parallel test, cleanup included, before it resumes the
+// parallel ones -- but relying on that ordering to keep two tests apart is a
+// race waiting for a scheduling change. Sequential costs microseconds.
+func TestFilesystemRoots_IncludesTheSystemDrive(t *testing.T) {
+	drive := os.Getenv("SystemDrive")
+	if drive == "" {
+		t.Skip("SystemDrive is not set")
+	}
+	assert.Contains(t, FilesystemRoots(), drive+`\`)
+}
+
+// The last-resort answer must follow the drive Windows booted from. A
+// Windows-To-Go install, or one relettered with bcdedit, does not boot from C,
+// and a hardcoded "C:\" would send the picker to a drive that may not exist.
+//
+// No t.Parallel: t.Setenv and parallel subtests cannot be combined.
+func TestSystemDriveRoot(t *testing.T) {
+	t.Setenv("SystemDrive", "E:")
+	assert.Equal(t, `E:\`, systemDriveRoot())
+
+	t.Setenv("SystemDrive", "")
+	assert.Equal(t, `C:\`, systemDriveRoot(), "an unset SystemDrive falls back to C")
+}

--- a/frontend/src/api/workerRpc.ts
+++ b/frontend/src/api/workerRpc.ts
@@ -36,6 +36,7 @@ import type {
 import type { EncryptionMode, InnerStreamMessage } from '~/generated/proto/leapmux/v1/channel_pb'
 import type {
   ListDirectoryResponse,
+  ListFilesystemRootsResponse,
   ReadFileResponse,
   StatFileResponse,
 } from '~/generated/proto/leapmux/v1/file_pb'
@@ -137,6 +138,8 @@ import { ChannelService } from '~/generated/proto/leapmux/v1/channel_pb'
 import {
   ListDirectoryRequestSchema,
   ListDirectoryResponseSchema,
+  ListFilesystemRootsRequestSchema,
+  ListFilesystemRootsResponseSchema,
   ReadFileRequestSchema,
   ReadFileResponseSchema,
   StatFileRequestSchema,
@@ -582,6 +585,20 @@ export function listAvailableShells(workerId: string, req: MessageInitShape<type
 
 export function listDirectory(workerId: string, req: MessageInitShape<typeof ListDirectoryRequestSchema>): Promise<ListDirectoryResponse> {
   return callWorker(workerId, 'ListDirectory', ListDirectoryRequestSchema, ListDirectoryResponseSchema, req)
+}
+
+/**
+ * The roots of the worker's own filesystem: `["/"]` on POSIX, the drive roots
+ * that carry a volume (`"C:\\"`, `"D:\\"`) on Windows.
+ *
+ * Lets the tree pick a top node and a drive menu fill itself, instead of the
+ * browser guessing either from the shape of a path.
+ *
+ * Takes no request, like `getWorkerSystemInfo`: it asks about the machine, and
+ * the channel already identifies it.
+ */
+export function listFilesystemRoots(workerId: string): Promise<ListFilesystemRootsResponse> {
+  return callWorker(workerId, 'ListFilesystemRoots', ListFilesystemRootsRequestSchema, ListFilesystemRootsResponseSchema, {})
 }
 
 export function readFile(workerId: string, req: MessageInitShape<typeof ReadFileRequestSchema>): Promise<ReadFileResponse> {

--- a/frontend/src/components/common/FileActionsMenu.test.tsx
+++ b/frontend/src/components/common/FileActionsMenu.test.tsx
@@ -58,6 +58,34 @@ describe('fileActionsMenu — common items', () => {
     expect(screen.queryByTestId('file-actions-copy-relative-path-button')).not.toBeInTheDocument()
   })
 
+  /**
+   * Every absolute path is under a filesystem root, so `relativizePath`
+   * refuses one as a base and answers the absolute path -- byte for byte what
+   * "Copy path" copies. The directory picker roots its tree at `/` (or a
+   * Windows drive), so without this the menu offers two items that do the
+   * same thing for every path outside the home directory.
+   */
+  it('hides Copy relative path when the root IS the filesystem root', () => {
+    renderMenu({ rootPath: '/', path: '/etc/hosts' })
+    expect(screen.getByTestId('file-actions-copy-path-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('file-actions-copy-relative-path-button')).not.toBeInTheDocument()
+  })
+
+  it('hides Copy relative path for a win32 drive root in either spelling', () => {
+    const a = renderMenu({ rootPath: 'C:\\', path: 'C:\\Users\\alice\\a.ts', flavor: 'win32' })
+    expect(screen.queryByTestId('file-actions-copy-relative-path-button')).not.toBeInTheDocument()
+    a.unmount()
+
+    renderMenu({ rootPath: 'C:/', path: 'C:\\Users\\alice\\a.ts', flavor: 'win32' })
+    expect(screen.queryByTestId('file-actions-copy-relative-path-button')).not.toBeInTheDocument()
+  })
+
+  // A real directory base still offers it: the item is only useless for a root.
+  it('keeps Copy relative path for an ordinary directory root', () => {
+    renderMenu({ rootPath: '/repo', path: '/repo/src/main.ts' })
+    expect(screen.getByTestId('file-actions-copy-relative-path-button')).toBeInTheDocument()
+  })
+
   it('shows Mention only when onMention is supplied', () => {
     const { unmount } = renderMenu()
     expect(screen.queryByTestId('file-actions-mention-button')).not.toBeInTheDocument()

--- a/frontend/src/components/common/FileActionsMenu.tsx
+++ b/frontend/src/components/common/FileActionsMenu.tsx
@@ -19,7 +19,7 @@ import { moreHorizontalTrigger } from '~/components/common/moreHorizontalTrigger
 import { copyTextToClipboard } from '~/lib/clipboard'
 import { formatBytes } from '~/lib/formatBytes'
 import { prettifyJson } from '~/lib/jsonFormat'
-import { relativizePath } from '~/lib/paths'
+import { isFilesystemRoot, relativizePath } from '~/lib/paths'
 
 /**
  * Shared file/dir actions context menu. Hosts the size/modified info block,
@@ -203,7 +203,14 @@ export const FileActionsMenu: Component<FileActionsMenuProps> = (props) => {
         <Icon icon={Copy} size="sm" />
         Copy path
       </button>
-      <Show when={props.rootPath !== undefined}>
+      {/*
+        Hidden for a ROOT base. Every absolute path is under `/` (or `C:\`),
+        so `relativizePath` deliberately refuses it and answers the absolute
+        path -- byte for byte what "Copy path" above already copies. The
+        directory picker's tree is rooted at the filesystem root, so without
+        this the menu offers two items that do the same thing.
+      */}
+      <Show when={props.rootPath !== undefined && !isFilesystemRoot(props.rootPath, props.flavor)}>
         <button
           role="menuitem"
           data-testid={tid('copy-relative-path-button')}

--- a/frontend/src/components/settings/PreferencesDialog.css.ts
+++ b/frontend/src/components/settings/PreferencesDialog.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css'
-import { menuSectionHeader } from '~/styles/shared.css'
+import { fieldTrigger, menuSectionHeader } from '~/styles/shared.css'
 import { breakpoints } from '~/styles/tokens'
 
 /**
@@ -76,39 +76,20 @@ export const nav = style({
 })
 
 /** Phone-band section picker: oat-styled trigger (mirrors form select chrome). */
-export const navSelect = style({
-  'width': '100%',
-  'marginBottom': 'var(--space-1)',
-  'padding': 'var(--space-2) var(--space-3)',
-  'fontSize': 'var(--text-7)',
-  'lineHeight': 'var(--leading-normal)',
-  'backgroundColor': 'var(--background)',
-  'color': 'var(--foreground)',
-  'border': '1px solid var(--input)',
-  'borderRadius': 'var(--radius-medium)',
-  'transition': 'border-color var(--transition-fast), box-shadow var(--transition-fast)',
-  'display': 'flex',
-  'alignItems': 'center',
-  'justifyContent': 'space-between',
-  'gap': 'var(--space-3)',
-  'textAlign': 'left',
-  ':focus-visible': {
-    outline: 'none',
-    borderColor: 'var(--ring)',
-    boxShadow: '0 0 0 2px rgb(from var(--ring) r g b / 0.2)',
-  },
-})
+export const navSelect = style([fieldTrigger, {
+  width: '100%',
+  marginBottom: 'var(--space-1)',
+  padding: 'var(--space-2) var(--space-3)',
+  justifyContent: 'space-between',
+  gap: 'var(--space-3)',
+  textAlign: 'left',
+}])
 
 export const navSelectValue = style({
   minWidth: 0,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-})
-
-export const navSelectChevron = style({
-  color: 'var(--muted-foreground)',
-  flexShrink: 0,
 })
 
 /** Compact section menu: themed popover, not the OS native picker. */

--- a/frontend/src/components/settings/PreferencesNav.tsx
+++ b/frontend/src/components/settings/PreferencesNav.tsx
@@ -5,7 +5,7 @@ import { createMemo, For, Show } from 'solid-js'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
 import { createKeyedElementRefs } from '~/lib/keyedElementRefs'
 import { nextRovingValue } from '~/lib/rovingFocus'
-import { menuSectionHeader } from '~/styles/shared.css'
+import { fieldTriggerChevron, menuSectionHeader } from '~/styles/shared.css'
 import * as styles from './PreferencesDialog.css'
 
 export interface PreferencesNavProps {
@@ -82,7 +82,7 @@ export const PreferencesNav: Component<PreferencesNavProps> = (props) => {
           <span class={styles.navSelectValue}>
             {optionLabel(props.active, props.restartGroups().has(props.active.id))}
           </span>
-          <ChevronDown size={16} class={styles.navSelectChevron} aria-hidden="true" />
+          <ChevronDown size={16} class={fieldTriggerChevron} aria-hidden="true" />
         </button>
       )}
     >

--- a/frontend/src/components/shell/AgentProviderSelector.css.ts
+++ b/frontend/src/components/shell/AgentProviderSelector.css.ts
@@ -1,29 +1,14 @@
 import { style } from '@vanilla-extract/css'
+import { fieldTrigger } from '~/styles/shared.css'
 
-export const trigger = style({
+export const trigger = style([fieldTrigger, {
   width: '100%',
   marginTop: 'var(--space-1)',
   padding: 'var(--space-2) var(--space-3)',
-  fontSize: 'var(--text-7)',
-  lineHeight: 'var(--leading-normal)',
-  backgroundColor: 'var(--background)',
-  color: 'var(--foreground)',
-  border: '1px solid var(--input)',
-  borderRadius: 'var(--radius-medium)',
-  transition: 'border-color var(--transition-fast), box-shadow var(--transition-fast)',
-  display: 'flex',
-  alignItems: 'center',
   justifyContent: 'space-between',
   gap: 'var(--space-3)',
   textAlign: 'left',
-  selectors: {
-    '&:focus-visible': {
-      outline: 'none',
-      borderColor: 'var(--ring)',
-      boxShadow: '0 0 0 2px rgb(from var(--ring) r g b / 0.2)',
-    },
-  },
-})
+}])
 
 export const triggerDisabled = style({
   opacity: 0.5,
@@ -35,11 +20,6 @@ export const triggerValue = style({
   alignItems: 'center',
   gap: 'var(--space-2)',
   minWidth: 0,
-})
-
-export const triggerChevron = style({
-  color: 'var(--muted-foreground)',
-  flexShrink: 0,
 })
 
 export const menu = style({

--- a/frontend/src/components/shell/AgentProviderSelector.tsx
+++ b/frontend/src/components/shell/AgentProviderSelector.tsx
@@ -11,7 +11,7 @@ import { LabeledField } from '~/components/common/LabeledField'
 import { RefreshButton } from '~/components/common/RefreshButton'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { getAvailableAgentProviders, sortAgentProvidersByName } from '~/lib/agentProviders'
-import { clippedText } from '~/styles/shared.css'
+import { clippedText, fieldTriggerChevron } from '~/styles/shared.css'
 import * as styles from './AgentProviderSelector.css'
 
 interface AgentProviderSelectorProps {
@@ -79,7 +79,7 @@ export function AgentProviderSelector(props: AgentProviderSelectorProps) {
                 <AgentProviderIcon provider={currentProvider()} size={16} />
                 <ClippedText text={agentProviderLabel(currentProvider())} />
               </span>
-              <ChevronDown size={16} class={styles.triggerChevron} />
+              <ChevronDown size={16} class={fieldTriggerChevron} />
             </button>
           )}
         >

--- a/frontend/src/components/shell/DirectorySelector.test.tsx
+++ b/frontend/src/components/shell/DirectorySelector.test.tsx
@@ -283,4 +283,23 @@ describe('directorySelector drive menu', () => {
     expect(refreshTree).toHaveBeenCalledOnce()
     await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalledTimes(2))
   })
+
+  // The other entry point. The button and the keyboard shortcut must not
+  // disagree, or a user ends up with a re-listed tree beside a stale menu.
+  it('refreshes the drive list from the refresh button', async () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('C:\\Users\\alice')
+    listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
+    const { state, tree, refreshTree } = makeState()
+    state.workingDir = () => ''
+    render(withPreferences(() => (
+      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
+    )))
+    await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByTestId('directory-selector-refresh'))
+
+    expect(refreshTree).toHaveBeenCalledOnce()
+    await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalledTimes(2))
+  })
 })

--- a/frontend/src/components/shell/DirectorySelector.test.tsx
+++ b/frontend/src/components/shell/DirectorySelector.test.tsx
@@ -1,14 +1,42 @@
-import { cleanup, render, screen } from '@solidjs/testing-library'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { createSignal } from 'solid-js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { refreshFileTree, toggleHiddenFiles } from '~/lib/fileTreeOps'
 import { createRepoGitStore } from '~/stores/repoGit.store'
 import { withPreferences } from '~/test-support/preferencesProvider'
 import { DirectorySelector } from './DirectorySelector'
 
 vi.mock('~/components/tree/DirectoryTree', () => ({
-  DirectoryTree: (props: { showGitStatus?: boolean }) => (
-    <div data-testid="directory-tree" data-show-git-status={String(props.showGitStatus ?? true)} />
+  DirectoryTree: (props: {
+    showGitStatus?: boolean
+    rootPath?: string
+    revealPath?: string
+    flavor?: string
+  }) => (
+    <div
+      data-testid="directory-tree"
+      data-show-git-status={String(props.showGitStatus ?? true)}
+      data-root-path={props.rootPath}
+      data-reveal-path={props.revealPath}
+      data-flavor={props.flavor}
+    />
   ),
+}))
+
+const listFilesystemRoots = vi.fn<(...args: unknown[]) => Promise<{ roots: string[] }>>(async () => ({ roots: [] }))
+vi.mock('~/api/workerRpc', () => ({
+  listFilesystemRoots: (...args: unknown[]) => listFilesystemRoots(...args),
+}))
+
+const workerOs = vi.fn<() => string | undefined>(() => 'linux')
+const workerHome = vi.fn(() => '/home/alice')
+vi.mock('~/stores/workerInfo.store', () => ({
+  workerInfoStore: {
+    getOs: () => workerOs(),
+    getHomeDir: () => workerHome(),
+    workerInfo: () => null,
+    fetchWorkerInfo: async () => null,
+  },
 }))
 
 // Partial mock: keep the real key constants (modules in this import graph --
@@ -23,6 +51,13 @@ vi.mock('~/lib/browserStorage', async importOriginal => ({
 vi.mock('~/lib/shortcuts/display', () => ({
   shortcutHint: (label: string) => label,
 }))
+
+beforeEach(() => {
+  listFilesystemRoots.mockReset()
+  listFilesystemRoots.mockResolvedValue({ roots: [] })
+  workerOs.mockReturnValue('linux')
+  workerHome.mockReturnValue('/home/alice')
+})
 
 afterEach(() => {
   cleanup()
@@ -85,5 +120,167 @@ describe('directorySelector', () => {
     render(withPreferences(() => <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />))
 
     expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-show-git-status', 'false')
+  })
+})
+
+describe('directorySelector root derivation', () => {
+  function renderWith(workingDir: string) {
+    const { state, tree } = makeState()
+    state.workingDir = () => workingDir
+    render(withPreferences(() => (
+      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
+    )))
+    return state
+  }
+
+  it('roots the tree at the filesystem root of the selected path', () => {
+    renderWith('/repo/sub')
+
+    expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', '/')
+  })
+
+  it('falls back to the worker home directory when nothing is selected', () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('D:\\Users\\alice')
+
+    renderWith('')
+
+    expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', 'D:\\')
+  })
+
+  it('passes the worker home directory as the tree reveal path', () => {
+    renderWith('')
+
+    expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-reveal-path', '/home/alice')
+  })
+
+  /**
+   * The single-source-of-truth test. The root is DERIVED from the selection,
+   * so there is no drive signal that could disagree with the path box.
+   */
+  it('re-roots the tree when the selection changes drive', async () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('C:\\Users\\alice')
+    const { state, tree } = makeState()
+    const [dir, setDir] = createSignal('C:\\a')
+    state.workingDir = dir
+    render(withPreferences(() => (
+      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
+    )))
+
+    expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', 'C:\\')
+
+    setDir('D:\\b')
+    await waitFor(() => expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', 'D:\\'))
+  })
+
+  // `filesystemRoot` already knows a POSIX worker has exactly one root, so the
+  // round trip would buy nothing. This is also what keeps WSL and Docker
+  // workers out of the Windows path: both report `linux`.
+  it('never asks a posix worker for its roots', () => {
+    renderWith('/repo')
+
+    expect(listFilesystemRoots).not.toHaveBeenCalled()
+    expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', '/')
+  })
+
+  // The last link in the fallback chain: a Windows worker whose home has not
+  // arrived still has somewhere to root once it reports its drives.
+  it('falls back to the first reported root when the home directory is unknown', async () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('')
+    listFilesystemRoots.mockResolvedValue({ roots: ['E:\\', 'F:\\'] })
+
+    renderWith('')
+
+    await waitFor(() => expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', 'E:\\'))
+  })
+
+  it('renders a placeholder instead of a tree while a windows root is unknown', () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('')
+
+    renderWith('')
+
+    expect(screen.queryByTestId('directory-tree')).toBeNull()
+    expect(screen.getByText('Loading drives…')).toBeInTheDocument()
+  })
+})
+
+describe('directorySelector drive menu', () => {
+  function renderPicker(workingDir = '') {
+    const { state, tree } = makeState()
+    state.workingDir = () => workingDir
+    render(withPreferences(() => (
+      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
+    )))
+    return state
+  }
+
+  it('shows the drive selector for a windows worker with more than one root', async () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('C:\\Users\\alice')
+    listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
+
+    renderPicker()
+
+    await waitFor(() => expect(screen.getByTestId('drive-selector-trigger')).toBeInTheDocument())
+  })
+
+  it('hides the drive selector when the worker reports a single root', async () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('C:\\Users\\alice')
+    listFilesystemRoots.mockResolvedValue({ roots: ['C:\\'] })
+
+    renderPicker()
+
+    await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalled())
+    expect(screen.queryByTestId('drive-selector-trigger')).toBeNull()
+  })
+
+  /**
+   * A WSL worker's home looks like a Windows mount, but the worker itself
+   * reports `linux` and really does have a single `/`. Keying on the reported
+   * OS is what excludes it, and this pins that.
+   */
+  it('hides the drive selector for a linux worker whose home looks like a windows mount', async () => {
+    workerOs.mockReturnValue('linux')
+    workerHome.mockReturnValue('/mnt/c/Users/alice')
+
+    renderPicker()
+
+    await Promise.resolve()
+    expect(screen.queryByTestId('drive-selector-trigger')).toBeNull()
+    expect(listFilesystemRoots).not.toHaveBeenCalled()
+  })
+
+  it('makes the chosen drive the working directory', async () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('C:\\Users\\alice')
+    listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
+
+    const state = renderPicker()
+    await waitFor(() => expect(screen.getByTestId('drive-option-d')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('drive-option-d'))
+
+    expect(state.setWorkingDir).toHaveBeenCalledWith('D:\\')
+  })
+
+  it('refreshes the drive list along with the tree', async () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('C:\\Users\\alice')
+    listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
+    const { state, tree, refreshTree } = makeState()
+    state.workingDir = () => ''
+    render(withPreferences(() => (
+      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
+    )))
+    await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalledTimes(1))
+
+    refreshFileTree()
+
+    expect(refreshTree).toHaveBeenCalledOnce()
+    await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalledTimes(2))
   })
 })

--- a/frontend/src/components/shell/DirectorySelector.test.tsx
+++ b/frontend/src/components/shell/DirectorySelector.test.tsx
@@ -382,6 +382,29 @@ describe('directorySelector home button', () => {
     expect(expandTreePath).not.toHaveBeenCalled()
   })
 
+  // The home directory can live on a drive the picker is not showing. The
+  // selection is what re-roots the tree, which is the other reason the button
+  // selects before it expands.
+  it('re-roots onto the home drive when the home directory is on another one', async () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('C:\\Users\\alice')
+    listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
+
+    const [workingDir, setWorkingDir] = createSignal('D:\\work')
+    const { state, tree } = makeState()
+    state.workingDir = workingDir
+    state.setWorkingDir = vi.fn((path: string) => setWorkingDir(path))
+    render(withPreferences(() => (
+      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
+    )))
+    await waitFor(() => expect(screen.getByTestId('directory-tree').getAttribute('data-root-path')).toBe('D:\\'))
+
+    fireEvent.click(screen.getByTestId('directory-selector-home'))
+
+    await waitFor(() => expect(screen.getByTestId('directory-tree').getAttribute('data-root-path')).toBe('C:\\'))
+    expect(tree.expandTreePath).toHaveBeenCalledWith('C:\\Users\\alice')
+  })
+
   it('sits between the hidden-files toggle and the refresh button', () => {
     renderSelector()
 

--- a/frontend/src/components/shell/DirectorySelector.test.tsx
+++ b/frontend/src/components/shell/DirectorySelector.test.tsx
@@ -65,6 +65,7 @@ afterEach(() => {
 
 function makeState() {
   const refreshTree = vi.fn()
+  const expandTreePath = vi.fn()
   return {
     state: {
       workerId: () => 'worker-1',
@@ -79,8 +80,10 @@ function makeState() {
       treeKey: () => 0,
       setTreeRef: vi.fn(),
       refreshTree,
+      expandTreePath,
     },
     refreshTree,
+    expandTreePath,
   }
 }
 
@@ -91,13 +94,13 @@ function makeState() {
  * it to watch the tree re-root. Omit it to keep `makeState`'s own `/repo`.
  */
 function renderSelector(workingDir?: string | (() => string)) {
-  const { state, tree, refreshTree } = makeState()
+  const { state, tree, refreshTree, expandTreePath } = makeState()
   if (workingDir !== undefined)
     state.workingDir = typeof workingDir === 'function' ? workingDir : () => workingDir
   const view = render(withPreferences(() => (
     <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
   )))
-  return { ...view, state, tree, refreshTree }
+  return { ...view, state, tree, refreshTree, expandTreePath }
 }
 
 describe('directorySelector', () => {
@@ -333,5 +336,63 @@ describe('directorySelector drive menu', () => {
 
     expect(refreshTree).toHaveBeenCalledOnce()
     await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalledTimes(2))
+  })
+})
+
+describe('directorySelector home button', () => {
+  it('selects the home directory and opens it', () => {
+    const { state, expandTreePath } = renderSelector()
+
+    fireEvent.click(screen.getByTestId('directory-selector-home'))
+
+    expect(state.setWorkingDir).toHaveBeenCalledWith('/home/alice')
+    expect(expandTreePath).toHaveBeenCalledWith('/home/alice')
+  })
+
+  // The selection must land FIRST. It can re-root the tree, and a new root
+  // replaces the whole expansion state, so the reverse order loses the
+  // expansion this button exists to produce.
+  it('selects before it expands', () => {
+    const calls: string[] = []
+    const { state, expandTreePath } = renderSelector()
+    vi.mocked(state.setWorkingDir).mockImplementation(() => {
+      calls.push('select')
+    })
+    expandTreePath.mockImplementation(() => {
+      calls.push('expand')
+    })
+
+    fireEvent.click(screen.getByTestId('directory-selector-home'))
+
+    expect(calls).toEqual(['select', 'expand'])
+  })
+
+  // A worker that has not reported yet has no home directory to go to, and
+  // selecting '' would clear the working directory instead.
+  it('is disabled, and does nothing, while the home directory is unknown', () => {
+    workerHome.mockReturnValue('')
+    const { state, expandTreePath } = renderSelector()
+
+    const button = screen.getByTestId('directory-selector-home')
+    expect(button).toBeDisabled()
+
+    fireEvent.click(button)
+
+    expect(state.setWorkingDir).not.toHaveBeenCalled()
+    expect(expandTreePath).not.toHaveBeenCalled()
+  })
+
+  it('sits between the hidden-files toggle and the refresh button', () => {
+    renderSelector()
+
+    const ids = screen.getAllByRole('button')
+      .map(b => b.getAttribute('data-testid'))
+      .filter((id): id is string => id !== null && id.startsWith('directory-selector-'))
+
+    expect(ids).toEqual([
+      'directory-selector-show-hidden-toggle',
+      'directory-selector-home',
+      'directory-selector-refresh',
+    ])
   })
 })

--- a/frontend/src/components/shell/DirectorySelector.test.tsx
+++ b/frontend/src/components/shell/DirectorySelector.test.tsx
@@ -84,10 +84,25 @@ function makeState() {
   }
 }
 
+/**
+ * Render the picker, and hand back everything a test in this file asserts on.
+ *
+ * `workingDir` takes a string or an accessor: one test drives a signal through
+ * it to watch the tree re-root. Omit it to keep `makeState`'s own `/repo`.
+ */
+function renderSelector(workingDir?: string | (() => string)) {
+  const { state, tree, refreshTree } = makeState()
+  if (workingDir !== undefined)
+    state.workingDir = typeof workingDir === 'function' ? workingDir : () => workingDir
+  const view = render(withPreferences(() => (
+    <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
+  )))
+  return { ...view, state, tree, refreshTree }
+}
+
 describe('directorySelector', () => {
   it('refreshFileTree invokes the current tree state refreshTree', () => {
-    const { state, tree, refreshTree } = makeState()
-    render(withPreferences(() => <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />))
+    const { refreshTree } = renderSelector()
 
     refreshFileTree()
 
@@ -95,8 +110,7 @@ describe('directorySelector', () => {
   })
 
   it('toggleHiddenFiles updates the visible button title through the registry callback', () => {
-    const { state, tree } = makeState()
-    render(withPreferences(() => <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />))
+    renderSelector()
 
     expect(screen.getByRole('button', { name: 'Hide hidden files' })).toBeInTheDocument()
 
@@ -106,35 +120,24 @@ describe('directorySelector', () => {
   })
 
   it('unregisters dialog ops on unmount', () => {
-    const { state, tree, refreshTree } = makeState()
-    const view = render(withPreferences(() => <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />))
+    const { unmount, refreshTree } = renderSelector()
 
-    view.unmount()
+    unmount()
     refreshFileTree()
 
     expect(refreshTree).not.toHaveBeenCalled()
   })
 
   it('disables git status decorations in the picker tree', () => {
-    const { state, tree } = makeState()
-    render(withPreferences(() => <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />))
+    renderSelector()
 
     expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-show-git-status', 'false')
   })
 })
 
 describe('directorySelector root derivation', () => {
-  function renderWith(workingDir: string) {
-    const { state, tree } = makeState()
-    state.workingDir = () => workingDir
-    render(withPreferences(() => (
-      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
-    )))
-    return state
-  }
-
   it('roots the tree at the filesystem root of the selected path', () => {
-    renderWith('/repo/sub')
+    renderSelector('/repo/sub')
 
     expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', '/')
   })
@@ -143,13 +146,13 @@ describe('directorySelector root derivation', () => {
     workerOs.mockReturnValue('windows')
     workerHome.mockReturnValue('D:\\Users\\alice')
 
-    renderWith('')
+    renderSelector('')
 
     expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', 'D:\\')
   })
 
   it('passes the worker home directory as the tree reveal path', () => {
-    renderWith('')
+    renderSelector('')
 
     expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-reveal-path', '/home/alice')
   })
@@ -161,12 +164,9 @@ describe('directorySelector root derivation', () => {
   it('re-roots the tree when the selection changes drive', async () => {
     workerOs.mockReturnValue('windows')
     workerHome.mockReturnValue('C:\\Users\\alice')
-    const { state, tree } = makeState()
     const [dir, setDir] = createSignal('C:\\a')
-    state.workingDir = dir
-    render(withPreferences(() => (
-      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
-    )))
+    // eslint-disable-next-line solid/reactivity -- renderSelector stores the accessor on the state object the component reads, which IS a tracked scope
+    renderSelector(dir)
 
     expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', 'C:\\')
 
@@ -178,7 +178,7 @@ describe('directorySelector root derivation', () => {
   // round trip would buy nothing. This is also what keeps WSL and Docker
   // workers out of the Windows path: both report `linux`.
   it('never asks a posix worker for its roots', () => {
-    renderWith('/repo')
+    renderSelector('/repo')
 
     expect(listFilesystemRoots).not.toHaveBeenCalled()
     expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', '/')
@@ -191,7 +191,7 @@ describe('directorySelector root derivation', () => {
     workerHome.mockReturnValue('')
     listFilesystemRoots.mockResolvedValue({ roots: ['E:\\', 'F:\\'] })
 
-    renderWith('')
+    renderSelector('')
 
     await waitFor(() => expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', 'E:\\'))
   })
@@ -200,29 +200,69 @@ describe('directorySelector root derivation', () => {
     workerOs.mockReturnValue('windows')
     workerHome.mockReturnValue('')
 
-    renderWith('')
+    renderSelector('')
 
     expect(screen.queryByTestId('directory-tree')).toBeNull()
     expect(screen.getByText('Loading drives…')).toBeInTheDocument()
   })
+
+  /**
+   * `flavorFromOs(undefined)` answers `'posix'`, and that answer now picks the
+   * tree's ROOT. A Windows worker whose info has not arrived would mount at
+   * `/`, issue a ListDirectory the worker refuses, and paint an error over the
+   * whole pane before re-rooting at `C:\`. "Unknown" has to be its own state.
+   */
+  it('waits rather than rooting at / while the worker os is unknown', () => {
+    workerOs.mockReturnValue(undefined)
+    workerHome.mockReturnValue('')
+
+    renderSelector('')
+
+    expect(screen.queryByTestId('directory-tree')).toBeNull()
+  })
+
+  // An unknown OS does not stop a root the PATH itself states. `filesystemRoot`
+  // sniffs the flavor, so a prefilled selection roots immediately either way.
+  it('still roots from the selection while the worker os is unknown', () => {
+    workerOs.mockReturnValue(undefined)
+    workerHome.mockReturnValue('')
+
+    renderSelector('C:\\proj\\app')
+
+    expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', 'C:\\')
+  })
+
+  it('roots a posix selection while the worker os is unknown', () => {
+    workerOs.mockReturnValue(undefined)
+    workerHome.mockReturnValue('')
+
+    renderSelector('/repo/sub')
+
+    expect(screen.getByTestId('directory-tree')).toHaveAttribute('data-root-path', '/')
+  })
+
+  // Without an onError the picker showed "Loading drives…" for a fetch that
+  // had already failed, and only the Refresh button escaped -- with nothing on
+  // screen saying to press it.
+  it('reports a failed drive listing instead of a permanent loading state', async () => {
+    workerOs.mockReturnValue('windows')
+    workerHome.mockReturnValue('')
+    listFilesystemRoots.mockRejectedValue(new Error('worker offline'))
+
+    renderSelector('')
+
+    await waitFor(() => expect(screen.getByTestId('directory-selector-no-root')).toHaveTextContent(/worker offline/))
+    expect(screen.queryByText('Loading drives…')).toBeNull()
+  })
 })
 
 describe('directorySelector drive menu', () => {
-  function renderPicker(workingDir = '') {
-    const { state, tree } = makeState()
-    state.workingDir = () => workingDir
-    render(withPreferences(() => (
-      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
-    )))
-    return state
-  }
-
   it('shows the drive selector for a windows worker with more than one root', async () => {
     workerOs.mockReturnValue('windows')
     workerHome.mockReturnValue('C:\\Users\\alice')
     listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
 
-    renderPicker()
+    renderSelector('')
 
     await waitFor(() => expect(screen.getByTestId('drive-selector-trigger')).toBeInTheDocument())
   })
@@ -232,7 +272,7 @@ describe('directorySelector drive menu', () => {
     workerHome.mockReturnValue('C:\\Users\\alice')
     listFilesystemRoots.mockResolvedValue({ roots: ['C:\\'] })
 
-    renderPicker()
+    renderSelector('')
 
     await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalled())
     expect(screen.queryByTestId('drive-selector-trigger')).toBeNull()
@@ -247,7 +287,7 @@ describe('directorySelector drive menu', () => {
     workerOs.mockReturnValue('linux')
     workerHome.mockReturnValue('/mnt/c/Users/alice')
 
-    renderPicker()
+    renderSelector('')
 
     await Promise.resolve()
     expect(screen.queryByTestId('drive-selector-trigger')).toBeNull()
@@ -259,7 +299,7 @@ describe('directorySelector drive menu', () => {
     workerHome.mockReturnValue('C:\\Users\\alice')
     listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
 
-    const state = renderPicker()
+    const { state } = renderSelector('')
     await waitFor(() => expect(screen.getByTestId('drive-option-d')).toBeInTheDocument())
 
     fireEvent.click(screen.getByTestId('drive-option-d'))
@@ -271,11 +311,7 @@ describe('directorySelector drive menu', () => {
     workerOs.mockReturnValue('windows')
     workerHome.mockReturnValue('C:\\Users\\alice')
     listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
-    const { state, tree, refreshTree } = makeState()
-    state.workingDir = () => ''
-    render(withPreferences(() => (
-      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
-    )))
+    const { refreshTree } = renderSelector('')
     await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalledTimes(1))
 
     refreshFileTree()
@@ -290,11 +326,7 @@ describe('directorySelector drive menu', () => {
     workerOs.mockReturnValue('windows')
     workerHome.mockReturnValue('C:\\Users\\alice')
     listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
-    const { state, tree, refreshTree } = makeState()
-    state.workingDir = () => ''
-    render(withPreferences(() => (
-      <DirectorySelector state={state as any} tree={tree as any} repoGitStore={createRepoGitStore()} />
-    )))
+    const { refreshTree } = renderSelector('')
     await waitFor(() => expect(listFilesystemRoots).toHaveBeenCalledTimes(1))
 
     fireEvent.click(screen.getByTestId('directory-selector-refresh'))

--- a/frontend/src/components/shell/DirectorySelector.tsx
+++ b/frontend/src/components/shell/DirectorySelector.tsx
@@ -3,7 +3,7 @@ import type { DirectoryTreeState } from '~/hooks/createDirectoryTreeState'
 import type { createRepoGitStore } from '~/stores/repoGit.store'
 import Eye from 'lucide-solid/icons/eye'
 import EyeOff from 'lucide-solid/icons/eye-off'
-import { createEffect, createMemo, onCleanup, Show } from 'solid-js'
+import { createEffect, createMemo, createSignal, onCleanup, Show } from 'solid-js'
 import { treeContainer, treeContainerFill } from '~/components/common/Dialog.css'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { LabeledField } from '~/components/common/LabeledField'
@@ -11,6 +11,7 @@ import { RefreshButton } from '~/components/common/RefreshButton'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { usePreferences } from '~/context/PreferencesContext'
 import { useFilesystemRoots } from '~/hooks/useFilesystemRoots'
+import { formatErrorMessage } from '~/lib/errors'
 import { registerDialogFileTreeOps } from '~/lib/fileTreeOps'
 import { filesystemRoot, flavorFromOs } from '~/lib/paths'
 import { shortcutHint } from '~/lib/shortcuts/display'
@@ -48,16 +49,30 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
 
   const workerId = () => props.state.workerId()
   const homeDir = () => workerInfoStore.getHomeDir(workerId())
-  const flavor = createMemo(() => flavorFromOs(workerInfoStore.getOs(workerId())))
+  // Undefined until the worker reports, NOT `flavorFromOs(undefined)`, which
+  // answers `'posix'`. That answer now picks the tree's ROOT, so a Windows
+  // worker whose info has not arrived would mount a tree at `/`, issue a
+  // ListDirectory the worker refuses, and paint an error over the whole pane
+  // before it re-roots at `C:\`. Five other call sites already treat unknown
+  // as its own state -- `workerPaths.ts` is the named helper.
+  const flavor = createMemo(() => {
+    const os = workerInfoStore.getOs(workerId())
+    return os ? flavorFromOs(os) : undefined
+  })
 
   // Windows only. `filesystemRoot` already knows a POSIX worker has exactly
   // one root, so the round trip would buy nothing there. Keying on the
   // REPORTED os is also what keeps WSL and Docker workers out: both report
   // `linux`, and both really do have a single `/`.
-  const drives = useFilesystemRoots(() => {
-    const id = workerId()
-    return id && flavor() === 'win32' ? { workerId: id } : null
-  })
+  const [drivesError, setDrivesError] = createSignal<string | null>(null)
+  const drives = useFilesystemRoots(
+    workerId,
+    () => flavor() === 'win32',
+    // Without this the picker shows "Loading drives…" for a fetch that already
+    // failed, and only the Refresh button escapes -- with nothing on screen
+    // saying to press it.
+    (err: unknown) => setDrivesError(formatErrorMessage(err, 'Failed to list drives')),
+  )
 
   /**
    * The tree's root: the filesystem root of whatever the picker points at.
@@ -69,20 +84,34 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
    *
    * The fallback chain is the selection, then the worker's home directory (a
    * "New workspace" started from a directory opens with NO selection), then
-   * what the worker reported. Undefined on Windows alone, and only until one
-   * of those answers.
+   * what the worker reported. Undefined until one of those answers.
+   *
+   * An unknown flavor does NOT stop the first two links: `filesystemRoot`
+   * sniffs the path itself, so a prefilled `C:\proj` still roots at `C:\` and
+   * `/repo/sub` at `/`. Only a worker with no selection AND no home directory
+   * waits, and then the placeholder below is the honest answer.
    */
   const treeRoot = createMemo(() => {
     const f = flavor()
     return filesystemRoot(props.state.workingDir(), f)
       ?? filesystemRoot(homeDir(), f)
-      ?? (f === 'posix' ? '/' : drives.roots()[0])
+      ?? (f === 'posix' ? '/' : f === 'win32' ? drives.roots()[0] : undefined)
   })
+
+  /**
+   * The root the drive menu shows, or undefined when there is no menu.
+   *
+   * Only when there is a CHOICE to make. A POSIX worker reports exactly one
+   * root, so this one rule hides the control on every platform with nothing
+   * to offer, and the layout needs no OS test of its own.
+   */
+  const driveMenuRoot = createMemo(() => (drives.roots().length > 1 ? treeRoot() : undefined))
 
   // Both refresh entry points do the same thing, so a user never ends up with
   // a re-listed tree beside a stale drive menu. `refresh` is a no-op while the
   // source is null, so a POSIX worker's Refresh costs nothing extra.
   const refreshAll = () => {
+    setDrivesError(null)
     props.tree.refreshTree()
     void drives.refresh()
   }
@@ -133,11 +162,7 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
             flavor={flavor()}
             onSubmit={props.state.setWorkingDir}
             leading={(
-              // Only when there is a choice to make. A POSIX worker reports
-              // exactly one root, so this one rule hides the control on every
-              // platform with nothing to offer, and the layout needs no OS test
-              // of its own.
-              <Show when={drives.roots().length > 1 && treeRoot()}>
+              <Show when={driveMenuRoot()}>
                 {root => (
                   <DriveSelector
                     value={root()}
@@ -150,7 +175,11 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
           />
           <Show
             when={treeRoot()}
-            fallback={<div class={`${treeContainerFill} ${emptyState}`}>Loading drives…</div>}
+            fallback={(
+              <div class={`${treeContainerFill} ${emptyState}`} data-testid="directory-selector-no-root">
+                {drivesError() ?? 'Loading drives…'}
+              </div>
+            )}
           >
             {root => (
               <DirectoryTree

--- a/frontend/src/components/shell/DirectorySelector.tsx
+++ b/frontend/src/components/shell/DirectorySelector.tsx
@@ -3,6 +3,7 @@ import type { DirectoryTreeState } from '~/hooks/createDirectoryTreeState'
 import type { createRepoGitStore } from '~/stores/repoGit.store'
 import Eye from 'lucide-solid/icons/eye'
 import EyeOff from 'lucide-solid/icons/eye-off'
+import House from 'lucide-solid/icons/house'
 import { createEffect, createMemo, createSignal, onCleanup, Show } from 'solid-js'
 import { treeContainer, treeContainerFill } from '~/components/common/Dialog.css'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
@@ -116,6 +117,23 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
     void drives.refresh()
   }
 
+  /**
+   * Select the home directory and open it.
+   *
+   * Two steps, in this order. The selection alone only reveals the directory,
+   * because the tree opens the ancestors of its reveal target and stops there.
+   * And the selection can re-root the tree -- a home directory on another
+   * Windows drive does exactly that -- which replaces the expansion state, so
+   * an expand written first would not survive.
+   */
+  const goHome = () => {
+    const home = homeDir()
+    if (!home)
+      return
+    props.state.setWorkingDir(home)
+    props.tree.expandTreePath(home)
+  }
+
   createEffect(() => {
     const unregister = registerDialogFileTreeOps({
       refresh: refreshAll,
@@ -138,6 +156,15 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
             state={showHiddenFiles() ? IconButtonState.Enabled : IconButtonState.Active}
             onClick={() => setShowHiddenFiles(prev => !prev)}
             data-testid="directory-selector-show-hidden-toggle"
+          />
+          <IconButton
+            icon={House}
+            iconSize="sm"
+            size="sm"
+            title="Go to home directory"
+            state={homeDir() ? IconButtonState.Enabled : IconButtonState.Disabled}
+            onClick={goHome}
+            data-testid="directory-selector-home"
           />
           <RefreshButton
             onClick={refreshAll}

--- a/frontend/src/components/shell/DirectorySelector.tsx
+++ b/frontend/src/components/shell/DirectorySelector.tsx
@@ -3,18 +3,20 @@ import type { DirectoryTreeState } from '~/hooks/createDirectoryTreeState'
 import type { createRepoGitStore } from '~/stores/repoGit.store'
 import Eye from 'lucide-solid/icons/eye'
 import EyeOff from 'lucide-solid/icons/eye-off'
-import { createEffect, onCleanup, Show } from 'solid-js'
+import { createEffect, createMemo, onCleanup, Show } from 'solid-js'
 import { treeContainer, treeContainerFill } from '~/components/common/Dialog.css'
 import { IconButton, IconButtonState } from '~/components/common/IconButton'
 import { LabeledField } from '~/components/common/LabeledField'
 import { RefreshButton } from '~/components/common/RefreshButton'
 import { DirectoryTree } from '~/components/tree/DirectoryTree'
 import { usePreferences } from '~/context/PreferencesContext'
+import { useFilesystemRoots } from '~/hooks/useFilesystemRoots'
 import { registerDialogFileTreeOps } from '~/lib/fileTreeOps'
-import { flavorFromOs } from '~/lib/paths'
+import { filesystemRoot, flavorFromOs } from '~/lib/paths'
 import { shortcutHint } from '~/lib/shortcuts/display'
 import { workerInfoStore } from '~/stores/workerInfo.store'
 import { emptyState } from '~/styles/shared.css'
+import { DriveSelector } from './DriveSelector'
 import { PathInput } from './PathInput'
 
 /**
@@ -44,9 +46,50 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
   const showHiddenFiles = prefs.directoryPickerShowHidden
   const setShowHiddenFiles = (next: (prev: boolean) => boolean) => prefs.setDirectoryPickerShowHidden(next(showHiddenFiles()))
 
+  const workerId = () => props.state.workerId()
+  const homeDir = () => workerInfoStore.getHomeDir(workerId())
+  const flavor = createMemo(() => flavorFromOs(workerInfoStore.getOs(workerId())))
+
+  // Windows only. `filesystemRoot` already knows a POSIX worker has exactly
+  // one root, so the round trip would buy nothing there. Keying on the
+  // REPORTED os is also what keeps WSL and Docker workers out: both report
+  // `linux`, and both really do have a single `/`.
+  const drives = useFilesystemRoots(() => {
+    const id = workerId()
+    return id && flavor() === 'win32' ? { workerId: id } : null
+  })
+
+  /**
+   * The tree's root: the filesystem root of whatever the picker points at.
+   *
+   * DERIVED, never stored. A signal holding "the current drive" would be a
+   * second statement of the same fact, and the two would disagree the moment a
+   * user typed another drive into the path box -- the box writes
+   * `workingDir`, and nothing would have written that signal.
+   *
+   * The fallback chain is the selection, then the worker's home directory (a
+   * "New workspace" started from a directory opens with NO selection), then
+   * what the worker reported. Undefined on Windows alone, and only until one
+   * of those answers.
+   */
+  const treeRoot = createMemo(() => {
+    const f = flavor()
+    return filesystemRoot(props.state.workingDir(), f)
+      ?? filesystemRoot(homeDir(), f)
+      ?? (f === 'posix' ? '/' : drives.roots()[0])
+  })
+
+  // Both refresh entry points do the same thing, so a user never ends up with
+  // a re-listed tree beside a stale drive menu. `refresh` is a no-op while the
+  // source is null, so a POSIX worker's Refresh costs nothing extra.
+  const refreshAll = () => {
+    props.tree.refreshTree()
+    void drives.refresh()
+  }
+
   createEffect(() => {
     const unregister = registerDialogFileTreeOps({
-      refresh: () => props.tree.refreshTree(),
+      refresh: refreshAll,
       toggleHiddenFiles: () => setShowHiddenFiles(prev => !prev),
     })
     onCleanup(unregister)
@@ -68,7 +111,7 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
             data-testid="directory-selector-show-hidden-toggle"
           />
           <RefreshButton
-            onClick={() => props.tree.refreshTree()}
+            onClick={refreshAll}
             title={shortcutHint('Refresh directory tree', 'app.refreshDirectoryTree')}
             data-testid="directory-selector-refresh"
           />
@@ -86,22 +129,45 @@ export const DirectorySelector: Component<DirectorySelectorProps> = (props) => {
         <div class={treeContainer}>
           <PathInput
             selectedPath={props.state.workingDir()}
-            homeDir={workerInfoStore.getHomeDir(props.state.workerId())}
-            flavor={flavorFromOs(workerInfoStore.getOs(props.state.workerId()))}
+            homeDir={homeDir()}
+            flavor={flavor()}
             onSubmit={props.state.setWorkingDir}
+            leading={(
+              // Only when there is a choice to make. A POSIX worker reports
+              // exactly one root, so this one rule hides the control on every
+              // platform with nothing to offer, and the layout needs no OS test
+              // of its own.
+              <Show when={drives.roots().length > 1 && treeRoot()}>
+                {root => (
+                  <DriveSelector
+                    value={root()}
+                    roots={drives.roots()}
+                    onSelect={props.state.setWorkingDir}
+                  />
+                )}
+              </Show>
+            )}
           />
-          <DirectoryTree
-            workerId={props.state.workerId()}
-            selectedPath={props.state.workingDir()}
-            onSelect={props.state.setWorkingDir}
-            rootPath="~"
-            homeDir={workerInfoStore.getHomeDir(props.state.workerId())}
-            flavor={flavorFromOs(workerInfoStore.getOs(props.state.workerId()))}
-            showHiddenFiles={showHiddenFiles()}
-            gitStatusStore={props.repoGitStore}
-            showGitStatus={false}
-            ref={props.tree.setTreeRef}
-          />
+          <Show
+            when={treeRoot()}
+            fallback={<div class={`${treeContainerFill} ${emptyState}`}>Loading drives…</div>}
+          >
+            {root => (
+              <DirectoryTree
+                workerId={props.state.workerId()}
+                selectedPath={props.state.workingDir()}
+                onSelect={props.state.setWorkingDir}
+                rootPath={root()}
+                revealPath={homeDir()}
+                homeDir={homeDir()}
+                flavor={flavor()}
+                showHiddenFiles={showHiddenFiles()}
+                gitStatusStore={props.repoGitStore}
+                showGitStatus={false}
+                ref={props.tree.setTreeRef}
+              />
+            )}
+          </Show>
         </div>
       </Show>
     </LabeledField>

--- a/frontend/src/components/shell/DriveSelector.css.ts
+++ b/frontend/src/components/shell/DriveSelector.css.ts
@@ -1,48 +1,28 @@
 import { style } from '@vanilla-extract/css'
+import { fieldTrigger } from '~/styles/shared.css'
 
-export const trigger = style({
-  display: 'flex',
-  alignItems: 'center',
+export const trigger = style([fieldTrigger, {
   gap: 'var(--space-1)',
   // Never shrinks: the input beside it takes the slack instead, so a long path
   // cannot push the drive off the row.
   flexShrink: 0,
   padding: 'var(--space-1) var(--space-2)',
-  fontSize: 'var(--text-7)',
-  lineHeight: 'var(--leading-normal)',
-  backgroundColor: 'var(--background)',
-  color: 'var(--foreground)',
-  border: '1px solid var(--input)',
-  borderRadius: 'var(--radius-medium)',
-  transition: 'border-color var(--transition-fast), box-shadow var(--transition-fast)',
-  selectors: {
-    '&:focus-visible': {
-      outline: 'none',
-      borderColor: 'var(--ring)',
-      boxShadow: '0 0 0 2px rgb(from var(--ring) r g b / 0.2)',
-    },
-  },
-})
-
-export const triggerIcon = style({
-  color: 'var(--muted-foreground)',
-  flexShrink: 0,
-})
+}])
 
 export const triggerValue = style({
   whiteSpace: 'nowrap',
 })
 
-export const triggerChevron = style({
-  color: 'var(--muted-foreground)',
-  flexShrink: 0,
-})
-
+// Only what differs from Oat's own `ot-dropdown [popover]` rule, which already
+// supplies the background, the border, the radius and `margin: 0`. Restating
+// them here would be four declarations that say what the layer below already
+// says, and an unlayered class outranks it -- so a change to the design system
+// would stop reaching this menu.
 export const menu = style({
-  margin: 0,
   minWidth: '10rem',
   padding: 'var(--space-1)',
-  backgroundColor: 'var(--background)',
-  border: '1px solid var(--border)',
-  borderRadius: 'var(--radius-medium)',
+  // Oat's default is `--shadow-small`. The sibling dropdown this menu sits
+  // beside (`AgentProviderSelector`) lifts it, and two menus in one dialog
+  // must not float at two different heights.
+  boxShadow: 'var(--shadow-medium)',
 })

--- a/frontend/src/components/shell/DriveSelector.css.ts
+++ b/frontend/src/components/shell/DriveSelector.css.ts
@@ -1,0 +1,48 @@
+import { style } from '@vanilla-extract/css'
+
+export const trigger = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--space-1)',
+  // Never shrinks: the input beside it takes the slack instead, so a long path
+  // cannot push the drive off the row.
+  flexShrink: 0,
+  padding: 'var(--space-1) var(--space-2)',
+  fontSize: 'var(--text-7)',
+  lineHeight: 'var(--leading-normal)',
+  backgroundColor: 'var(--background)',
+  color: 'var(--foreground)',
+  border: '1px solid var(--input)',
+  borderRadius: 'var(--radius-medium)',
+  transition: 'border-color var(--transition-fast), box-shadow var(--transition-fast)',
+  selectors: {
+    '&:focus-visible': {
+      outline: 'none',
+      borderColor: 'var(--ring)',
+      boxShadow: '0 0 0 2px rgb(from var(--ring) r g b / 0.2)',
+    },
+  },
+})
+
+export const triggerIcon = style({
+  color: 'var(--muted-foreground)',
+  flexShrink: 0,
+})
+
+export const triggerValue = style({
+  whiteSpace: 'nowrap',
+})
+
+export const triggerChevron = style({
+  color: 'var(--muted-foreground)',
+  flexShrink: 0,
+})
+
+export const menu = style({
+  margin: 0,
+  minWidth: '10rem',
+  padding: 'var(--space-1)',
+  backgroundColor: 'var(--background)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-medium)',
+})

--- a/frontend/src/components/shell/DriveSelector.test.tsx
+++ b/frontend/src/components/shell/DriveSelector.test.tsx
@@ -1,0 +1,111 @@
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DriveSelector } from './DriveSelector'
+
+afterEach(() => {
+  cleanup()
+})
+
+function renderSelector(
+  { value, roots, onSelect = vi.fn() }: { value: string, roots: string[], onSelect?: (root: string) => void },
+) {
+  const view = render(() => (
+    <DriveSelector value={value} roots={roots} onSelect={onSelect} />
+  ))
+  return { ...view, onSelect }
+}
+
+function openMenu() {
+  fireEvent.click(screen.getByTestId('drive-selector-trigger'))
+}
+
+/**
+ * The option rows, read by their ROLE ATTRIBUTE rather than through
+ * `getAllByRole`.
+ *
+ * jsdom does not implement the popover API, so the menu stays outside the
+ * accessibility tree and every role QUERY skips it. The attribute is what the
+ * component is responsible for, and it is what a real browser turns into the
+ * role, so asserting on it pins the same contract.
+ */
+function optionRows(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>('[role="menuitemradio"]')]
+}
+
+describe('driveSelector', () => {
+  it('shows the current root on the trigger', () => {
+    renderSelector({ value: 'D:\\', roots: ['C:\\', 'D:\\'] })
+
+    expect(screen.getByTestId('drive-selector-trigger')).toHaveTextContent('D:\\')
+  })
+
+  it('checks exactly the current root', () => {
+    renderSelector({ value: 'D:\\', roots: ['C:\\', 'D:\\'] })
+    openMenu()
+
+    const items = optionRows()
+    expect(items).toHaveLength(2)
+    expect(items.filter(el => el.getAttribute('aria-checked') === 'true')).toHaveLength(1)
+    expect(screen.getByTestId('drive-option-d')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  // Windows compares drive letters without regard to case, so a value spelled
+  // differently from the reported root is the SAME root, not a missing one.
+  it('matches the current root case-insensitively without duplicating it', () => {
+    renderSelector({ value: 'c:\\', roots: ['C:\\'] })
+    openMenu()
+
+    expect(optionRows()).toHaveLength(1)
+    expect(screen.getByTestId('drive-option-c')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  // Windows never enumerates a UNC share as a logical drive. Without the
+  // current value in the list, every row is unchecked and one stray click
+  // leaves the user with no way back to where they were.
+  it('leads with a root the worker did not report', () => {
+    renderSelector({ value: '\\\\srv\\share\\', roots: ['C:\\', 'D:\\'] })
+    openMenu()
+
+    const items = optionRows()
+    expect(items).toHaveLength(3)
+    expect(items[0]).toHaveTextContent('\\\\srv\\share\\')
+    expect(items[0]).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('calls onSelect with the chosen root', () => {
+    const { onSelect } = renderSelector({ value: 'C:\\', roots: ['C:\\', 'D:\\'] })
+    openMenu()
+
+    fireEvent.click(screen.getByTestId('drive-option-d'))
+
+    expect(onSelect).toHaveBeenCalledWith('D:\\')
+  })
+
+  // A native <select> opens the OS picker, which ignores the app's theme and
+  // typography. The project bans it outright; this pins that.
+  it('uses radio menu items, never a native select', () => {
+    const { container } = renderSelector({ value: 'C:\\', roots: ['C:\\', 'D:\\'] })
+    openMenu()
+
+    expect(container.querySelector('select')).toBeNull()
+    expect(optionRows()).toHaveLength(2)
+  })
+
+  // The trigger's own text is a bare drive letter, so without an explicit name
+  // a screen reader announces the current drive where the control's PURPOSE
+  // belongs.
+  it('names the trigger', () => {
+    renderSelector({ value: 'C:\\', roots: ['C:\\', 'D:\\'] })
+
+    expect(screen.getByRole('button', { name: 'Drive' })).toBeInTheDocument()
+  })
+
+  // A <menu> of radio items carries no name of its own either. jsdom keeps the
+  // popover out of the accessibility tree, so the attribute is what to assert.
+  it('names the menu', () => {
+    renderSelector({ value: 'C:\\', roots: ['C:\\', 'D:\\'] })
+    openMenu()
+
+    expect(screen.getByTestId('drive-selector-menu')).toHaveAttribute('aria-label', 'Drive')
+  })
+})

--- a/frontend/src/components/shell/DriveSelector.test.tsx
+++ b/frontend/src/components/shell/DriveSelector.test.tsx
@@ -94,7 +94,7 @@ describe('driveSelector', () => {
   // The trigger's own text is a bare drive letter, so without an explicit name
   // a screen reader announces the current drive where the control's PURPOSE
   // belongs.
-  it('names the trigger', () => {
+  it('gives the trigger an accessible name', () => {
     renderSelector({ value: 'C:\\', roots: ['C:\\', 'D:\\'] })
 
     expect(screen.getByRole('button', { name: 'Drive' })).toBeInTheDocument()
@@ -102,7 +102,7 @@ describe('driveSelector', () => {
 
   // A <menu> of radio items carries no name of its own either. jsdom keeps the
   // popover out of the accessibility tree, so the attribute is what to assert.
-  it('names the menu', () => {
+  it('gives the menu an accessible name', () => {
     renderSelector({ value: 'C:\\', roots: ['C:\\', 'D:\\'] })
     openMenu()
 

--- a/frontend/src/components/shell/DriveSelector.tsx
+++ b/frontend/src/components/shell/DriveSelector.tsx
@@ -4,6 +4,9 @@ import HardDrive from 'lucide-solid/icons/hard-drive'
 import { createMemo, For } from 'solid-js'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
+import { pathEq } from '~/lib/paths'
+import { slugify } from '~/lib/slug'
+import { fieldTriggerChevron } from '~/styles/shared.css'
 import * as styles from './DriveSelector.css'
 
 export interface DriveSelectorProps {
@@ -24,13 +27,17 @@ export interface DriveSelectorProps {
  * `linux`, and both really do have a single `/`.
  *
  * A `DropdownMenu` of radio items, never a native `<select>`. A drive list is
- * dynamic and unbounded -- mapped network drives and removable media come and
- * go -- so it is the second of the two shapes this project allows.
+ * dynamic and has no upper limit -- mapped network drives and removable media
+ * come and go -- so it is the second of the two shapes this project allows.
  */
 export const DriveSelector: Component<DriveSelectorProps> = (props) => {
-  // This renders for a Windows worker alone, so a case-insensitive comparison
-  // is the CORRECT one here, not a shortcut.
-  const sameRoot = (a: string, b: string) => a.toLowerCase() === b.toLowerCase()
+  // This renders for a Windows worker alone, so the win32 rule -- a
+  // case-insensitive comparison -- is the CORRECT one here, not a shortcut.
+  // Through `pathEq` so the one module that decides how two paths compare
+  // stays the only one that decides it: both sides already arrive with the
+  // trailing separator that makes a root a root, so there is nothing to
+  // normalize.
+  const sameRoot = (a: string, b: string) => pathEq(a, b, 'win32')
 
   const options = createMemo(() => {
     // The current root may not be in the reported list: Windows does not
@@ -43,8 +50,11 @@ export const DriveSelector: Component<DriveSelectorProps> = (props) => {
   })
 
   // A backslash and a colon are awkward to address in a selector, and the
-  // letter already identifies the drive.
-  const optionTestId = (root: string) => `drive-option-${root.replace(/[^a-z0-9]/gi, '').toLowerCase()}`
+  // letter already identifies the drive. `slugify`, not a second fold of its
+  // own: two folds mean two statements of which characters survive, and this
+  // one used to DELETE every separator, so `\\srv\a-b` and `\\srv\ab`
+  // collided on one id.
+  const optionTestId = (root: string) => `drive-option-${slugify(root)}`
 
   return (
     <DropdownMenu
@@ -64,9 +74,9 @@ export const DriveSelector: Component<DriveSelectorProps> = (props) => {
           onPointerDown={triggerProps.onPointerDown}
           onClick={triggerProps.onClick}
         >
-          <Icon icon={HardDrive} size="sm" class={styles.triggerIcon} />
+          <Icon icon={HardDrive} size="sm" class={fieldTriggerChevron} />
           <span class={styles.triggerValue}>{props.value}</span>
-          <ChevronDown size={16} class={styles.triggerChevron} />
+          <ChevronDown size={16} class={fieldTriggerChevron} />
         </button>
       )}
     >

--- a/frontend/src/components/shell/DriveSelector.tsx
+++ b/frontend/src/components/shell/DriveSelector.tsx
@@ -1,0 +1,86 @@
+import type { Component } from 'solid-js'
+import ChevronDown from 'lucide-solid/icons/chevron-down'
+import HardDrive from 'lucide-solid/icons/hard-drive'
+import { createMemo, For } from 'solid-js'
+import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
+import { Icon } from '~/components/common/Icon'
+import * as styles from './DriveSelector.css'
+
+export interface DriveSelectorProps {
+  /** The root the tree is currently on, e.g. `C:\` or `\\srv\share\`. */
+  value: string
+  /** The roots the worker reported. May not contain `value`. */
+  roots: readonly string[]
+  /** Called with the chosen root. The caller makes it the selected path. */
+  onSelect: (root: string) => void
+}
+
+/**
+ * The drive half of the directory picker's location bar, left of the path box.
+ *
+ * WINDOWS ONLY, and the CALLER decides that -- this component never asks about
+ * the OS. `DirectorySelector` shows it only when the worker's reported flavor
+ * is win32, which is also what excludes WSL and Docker workers: both report
+ * `linux`, and both really do have a single `/`.
+ *
+ * A `DropdownMenu` of radio items, never a native `<select>`. A drive list is
+ * dynamic and unbounded -- mapped network drives and removable media come and
+ * go -- so it is the second of the two shapes this project allows.
+ */
+export const DriveSelector: Component<DriveSelectorProps> = (props) => {
+  // This renders for a Windows worker alone, so a case-insensitive comparison
+  // is the CORRECT one here, not a shortcut.
+  const sameRoot = (a: string, b: string) => a.toLowerCase() === b.toLowerCase()
+
+  const options = createMemo(() => {
+    // The current root may not be in the reported list: Windows does not
+    // enumerate a UNC share as a logical drive, and a drive may be mapped
+    // after the fetch. Leading with it keeps the trigger's own value
+    // selectable; without it every row is unchecked and the current location
+    // becomes unreachable after one stray click.
+    const roots = props.roots
+    return roots.some(r => sameRoot(r, props.value)) ? [...roots] : [props.value, ...roots]
+  })
+
+  // A backslash and a colon are awkward to address in a selector, and the
+  // letter already identifies the drive.
+  const optionTestId = (root: string) => `drive-option-${root.replace(/[^a-z0-9]/gi, '').toLowerCase()}`
+
+  return (
+    <DropdownMenu
+      class={styles.menu}
+      // A <menu> of radio items carries no name of its own, and neither does
+      // the trigger: its text is a bare drive letter.
+      aria-label="Drive"
+      data-testid="drive-selector-menu"
+      trigger={triggerProps => (
+        <button
+          type="button"
+          class={styles.trigger}
+          aria-label="Drive"
+          aria-expanded={triggerProps['aria-expanded']}
+          data-testid="drive-selector-trigger"
+          ref={triggerProps.ref}
+          onPointerDown={triggerProps.onPointerDown}
+          onClick={triggerProps.onClick}
+        >
+          <Icon icon={HardDrive} size="sm" class={styles.triggerIcon} />
+          <span class={styles.triggerValue}>{props.value}</span>
+          <ChevronDown size={16} class={styles.triggerChevron} />
+        </button>
+      )}
+    >
+      <For each={options()}>
+        {root => (
+          <DropdownMenuCheckableItem
+            kind="radio"
+            label={root}
+            checked={sameRoot(root, props.value)}
+            data-testid={optionTestId(root)}
+            onSelect={() => props.onSelect(root)}
+          />
+        )}
+      </For>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/components/shell/NewAgentDialog.test.tsx
+++ b/frontend/src/components/shell/NewAgentDialog.test.tsx
@@ -33,7 +33,7 @@ vi.mock('~/api/workerRpc', () => ({
   getGitInfo: vi.fn(async () => ({})),
   getWorkerSystemInfo: vi.fn(async () => ({})),
   statFile: vi.fn(async () => ({})),
-  listDirectory: vi.fn(async () => ({ entries: [] })),
+  listDirectory: vi.fn(async () => ({ listings: [{ path: '', entries: [], truncated: false, totalEntries: 0 }] })),
   openAgent: vi.fn(async () => ({})),
 }))
 

--- a/frontend/src/components/shell/NewTerminalDialog.test.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.test.tsx
@@ -33,7 +33,7 @@ vi.mock('~/api/workerRpc', () => ({
   getWorkerSystemInfo: vi.fn(async () => ({})),
   listAvailableShells: vi.fn(async () => ({ shells: ['bash', 'zsh'], defaultShell: 'bash' })),
   statFile: vi.fn(async () => ({})),
-  listDirectory: vi.fn(async () => ({ entries: [] })),
+  listDirectory: vi.fn(async () => ({ listings: [{ path: '', entries: [], truncated: false, totalEntries: 0 }] })),
   openTerminal: vi.fn(async () => ({ terminalId: 'tid-1', title: 'Terminal 1' })),
 }))
 

--- a/frontend/src/components/shell/NewTerminalDialog.tsx
+++ b/frontend/src/components/shell/NewTerminalDialog.tsx
@@ -61,13 +61,9 @@ export const NewTerminalDialog: Component<NewTerminalDialogProps> = (props) => {
   })
   const tree = createDirectoryTreeState()
   const shellState = useAvailableShells(
-    () => {
-      const id = worker.workerId()
-      if (!id)
-        return null
-      return { workerId: id }
-    },
-    err => setError(formatErrorMessage(err, 'Failed to load shells')),
+    () => worker.workerId(),
+    () => true,
+    (err: unknown) => setError(formatErrorMessage(err, 'Failed to load shells')),
     // A later load withdraws the report the failed one wrote. Without this the
     // Refresh-shells button repopulates the menu and arms Create while the
     // banner still reads "Failed to load shells", which is the one state that

--- a/frontend/src/components/shell/PathInput.css.ts
+++ b/frontend/src/components/shell/PathInput.css.ts
@@ -3,6 +3,8 @@ import { globalStyle, style } from '@vanilla-extract/css'
 export const pathInput = style({
   display: 'flex',
   alignItems: 'center',
+  // Separates the leading slot (the Windows drive selector) from the input.
+  gap: 'var(--space-1)',
   padding: 'var(--space-1)',
   borderBottom: '1px solid var(--border)',
   flexShrink: 0,
@@ -14,6 +16,11 @@ export const pathInput = style({
 // of the input (provided by pathInput's padding).
 globalStyle(`${pathInput} input`, {
   marginBlockStart: 0,
+  // The row can hold a leading control, so the input takes the rest of it.
+  // `minWidth: 0` is what lets the input shrink rather than push that control
+  // off the row -- a flex item's default `min-width: auto` refuses to.
+  flex: 1,
+  minWidth: 0,
 })
 
 export const pathHint = style({

--- a/frontend/src/components/shell/PathInput.test.tsx
+++ b/frontend/src/components/shell/PathInput.test.tsx
@@ -9,7 +9,7 @@ import { PathInput } from './PathInput'
 function renderInput(props: {
   selectedPath: string
   homeDir: string
-  flavor: PathFlavor
+  flavor?: PathFlavor
   onSubmit: (path: string) => void
 }) {
   return render(() => (
@@ -90,6 +90,36 @@ describe('pathInput on a POSIX worker', () => {
     renderInput({ ...posixProps, onSubmit })
     fireEvent.input(pathInput(), { target: { value: '/opt/data' } })
     expect(screen.queryByTestId('path-flavor-hint')).toBeNull()
+  })
+})
+
+describe('pathInput before the worker reports its os', () => {
+  /**
+   * The flavor is undefined until the worker answers, and the hint is a
+   * comparison against it. "This looks like a Windows path but the worker
+   * expects POSIX paths" is a GUESS while the worker has not said which it
+   * expects -- and it is the wrong guess for a Windows worker, whose real
+   * `C:\` path would be flagged as a mistake.
+   */
+  it('shows no flavor hint while the flavor is unknown', () => {
+    renderInput({ selectedPath: '', homeDir: '', flavor: undefined, onSubmit: vi.fn() })
+
+    fireEvent.input(pathInput(), { target: { value: 'C:\\Users\\alice' } })
+    expect(screen.queryByTestId('path-flavor-hint')).toBeNull()
+
+    fireEvent.input(pathInput(), { target: { value: '/home/alice' } })
+    expect(screen.queryByTestId('path-flavor-hint')).toBeNull()
+  })
+
+  // The input still works: only the hint waits.
+  it('still submits a typed path while the flavor is unknown', () => {
+    const onSubmit = vi.fn()
+    renderInput({ selectedPath: '', homeDir: '', flavor: undefined, onSubmit })
+
+    fireEvent.input(pathInput(), { target: { value: '/opt/data' } })
+    fireEvent.keyDown(pathInput(), { key: 'Enter' })
+
+    expect(onSubmit).toHaveBeenCalledWith('/opt/data')
   })
 })
 

--- a/frontend/src/components/shell/PathInput.test.tsx
+++ b/frontend/src/components/shell/PathInput.test.tsx
@@ -145,3 +145,63 @@ describe('pathInput submission', () => {
     expect(onSubmit).not.toHaveBeenCalled()
   })
 })
+
+describe('pathInput leading slot', () => {
+  const base = { selectedPath: '/home/alice', homeDir: '/home/alice', flavor: 'posix' as const }
+
+  function renderWithSlot(leading?: unknown) {
+    return render(() => (
+      <PathInput
+        selectedPath={base.selectedPath}
+        homeDir={base.homeDir}
+        flavor={base.flavor}
+        onSubmit={() => {}}
+        leading={leading as never}
+      />
+    ))
+  }
+
+  it('renders the slot immediately before the input inside the row', () => {
+    renderWithSlot(<span data-testid="slot">C:\\</span>)
+
+    const input = screen.getByPlaceholderText('Enter path...')
+    const slot = screen.getByTestId('slot')
+    // A DOM reorder that put the drive to the RIGHT of the input would still
+    // look correct in a screenshot of a short path, so pin the order.
+    expect(slot.compareDocumentPosition(input) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(slot.parentElement).toBe(input.closest('div'))
+  })
+
+  it('renders no leading box when the slot is omitted', () => {
+    renderWithSlot(undefined)
+
+    expect(screen.queryByTestId('slot')).toBeNull()
+    expect(screen.getByPlaceholderText('Enter path...')).toBeInTheDocument()
+  })
+
+  /**
+   * The reason the slot lives inside this component rather than in a wrapper
+   * the caller builds: the hint belongs UNDER the whole row. A caller that
+   * wrapped the drive control and this input in a row of its own would trap
+   * the hint inside that row, beside the input.
+   */
+  it('keeps the flavor hint below the row, not inside it', async () => {
+    const view = render(() => (
+      <PathInput
+        selectedPath="/home/alice"
+        homeDir="/home/alice"
+        flavor="win32"
+        onSubmit={() => {}}
+        leading={<span data-testid="slot">C:\\</span>}
+      />
+    ))
+
+    const input = screen.getByPlaceholderText('Enter path...')
+    fireEvent.input(input, { target: { value: '/etc/hosts' } })
+
+    const hint = await screen.findByTestId('path-flavor-hint')
+    const row = screen.getByTestId('slot').parentElement!
+    expect(row.contains(hint)).toBe(false)
+    view.unmount()
+  })
+})

--- a/frontend/src/components/shell/PathInput.tsx
+++ b/frontend/src/components/shell/PathInput.tsx
@@ -10,8 +10,15 @@ export interface PathInputProps {
   selectedPath: string
   /** The worker's home directory, used to abbreviate and expand `~`. */
   homeDir?: string
-  /** The worker's path flavor, which decides what an absolute path looks like. */
-  flavor: PathFlavor
+  /**
+   * The worker's path flavor, which decides what an absolute path looks like.
+   *
+   * Undefined until the worker reports its OS. The tilde helpers already sniff
+   * the path when the flavor is absent; the mismatch hint below stays silent,
+   * because "this looks like a Windows path but the worker expects POSIX
+   * paths" is a guess whenever the worker has not said which it expects.
+   */
+  flavor?: PathFlavor
   /** Called with an expanded, worker-flavored path on Enter or on blur. */
   onSubmit: (path: string) => void
   /**
@@ -72,6 +79,8 @@ export const PathInput: Component<PathInputProps> = (props) => {
   }
 
   const flavorHint = createMemo(() => {
+    if (!props.flavor)
+      return null
     const raw = inputValue().trim()
     if (!raw || raw.startsWith('~'))
       return null

--- a/frontend/src/components/shell/PathInput.tsx
+++ b/frontend/src/components/shell/PathInput.tsx
@@ -1,4 +1,4 @@
-import type { Component } from 'solid-js'
+import type { Component, JSX } from 'solid-js'
 import type { PathFlavor } from '~/lib/paths'
 import { createEffect, createMemo, createSignal, Show } from 'solid-js'
 import { Tooltip } from '~/components/common/Tooltip'
@@ -14,6 +14,18 @@ export interface PathInputProps {
   flavor: PathFlavor
   /** Called with an expanded, worker-flavored path on Enter or on blur. */
   onSubmit: (path: string) => void
+  /**
+   * A control at the LEFT end of the path row, sharing its box: the picker's
+   * Windows drive selector.
+   *
+   * A SLOT, not the control. This component's job is one input, and a drive
+   * list needs a worker id, an RPC and the picker's own setter, none of which
+   * belongs here. The row's CHROME does belong here -- the padding, the bottom
+   * border, and the flavor hint below the row rather than beside the input --
+   * which is why the slot sits inside the box instead of the caller wrapping
+   * both in a row of its own.
+   */
+  leading?: JSX.Element
 }
 
 /**
@@ -76,6 +88,7 @@ export const PathInput: Component<PathInputProps> = (props) => {
   return (
     <>
       <div class={styles.pathInput}>
+        {props.leading}
         <Tooltip text={props.selectedPath} showWhen="clipped">
           <input
             type="text"

--- a/frontend/src/components/shell/useTabOperations.ts
+++ b/frontend/src/components/shell/useTabOperations.ts
@@ -847,11 +847,17 @@ export function useTabOperations(opts: UseTabOperationsOpts) {
     })
   }
 
-  // Reset file tree selection when active tab changes
+  // Reset file tree selection when active tab changes.
+  //
+  // No `'~'` fallback: this feeds the tree's `selectedPath`, which it compares
+  // against the absolute paths the worker reports. A tilde resolves only on
+  // the worker, so it matches no node and selects nothing -- an empty string
+  // says that with no pretence, and the tree then reveals its own
+  // `revealPath` instead.
   createEffect(() => {
     const _tab = activeTab()
     const ctx = getCurrentTabContext()
-    setFileTreePath(ctx.workingDir || '~')
+    setFileTreePath(ctx.workingDir)
   })
 
   /**

--- a/frontend/src/components/shell/useTerminalOperations.ts
+++ b/frontend/src/components/shell/useTerminalOperations.ts
@@ -69,12 +69,10 @@ export function useTerminalOperations(props: UseTerminalOperationsProps) {
   // Populates the tab-bar's "new terminal" dropdown. The hook re-fetches
   // on workerId change and skips while the source returns null (worker
   // still resolving).
-  const { shells: availableShells, defaultShell } = useAvailableShells(() => {
-    const ctx = props.getCurrentTabContext()
-    if (!ctx.workerId)
-      return null
-    return { workerId: ctx.workerId }
-  })
+  const { shells: availableShells, defaultShell } = useAvailableShells(
+    () => props.getCurrentTabContext().workerId,
+    () => true,
+  )
   // Dedup concurrent restartTerminal RPCs. Held Enter (autorepeat) would
   // otherwise fire one RPC per keystroke, and the backend rejects every
   // redundant call with FailedPrecondition while the first restart is

--- a/frontend/src/components/tree/DirectoryTree.download.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.download.test.tsx
@@ -42,11 +42,15 @@ const { DirectoryTree } = await import('./DirectoryTree')
 
 function setupTree() {
   listDirectoryImpl.mockResolvedValue({
-    entries: [
-      { path: '/repo/src', name: 'src', isDir: true, hidden: false, size: 0n, modTime: '2026-05-01T10:00:00Z' },
-      { path: '/repo/archive.zip', name: 'archive.zip', isDir: false, hidden: false, size: 1024n, modTime: '2026-05-01T10:00:00Z' },
-    ],
-    truncated: false,
+    listings: [{
+      path: '/repo',
+      entries: [
+        { path: '/repo/src', name: 'src', isDir: true, hidden: false, size: 0n, modTime: '2026-05-01T10:00:00Z' },
+        { path: '/repo/archive.zip', name: 'archive.zip', isDir: false, hidden: false, size: 1024n, modTime: '2026-05-01T10:00:00Z' },
+      ],
+      truncated: false,
+      totalEntries: 2,
+    }],
   })
 
   render(() => (

--- a/frontend/src/components/tree/DirectoryTree.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.test.tsx
@@ -3,7 +3,7 @@ import type { FileSortOrder } from '~/lib/fileSort'
 import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { PREFIX_DIRECTORY_TREE, sessionStorageSet } from '~/lib/browserStorage'
+import { PREFIX_DIRECTORY_TREE, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
 import { createRepoGitStore } from '~/stores/repoGit.store'
 import { DIRECTORY_TREE_STATE_VERSION, DirectoryTree } from './DirectoryTree'
 
@@ -31,6 +31,28 @@ function entry(root: string, name: string, overrides: EntryOverrides = {}) {
     hidden: overrides.hidden ?? false,
     size: overrides.size ?? 0n,
     modTime: overrides.modTime ?? '2026-01-01T00:00:00Z',
+  }
+}
+
+/**
+ * One directory's reply, in the shape ListDirectory answers with.
+ *
+ * `path` is left empty because nothing reads it on this path: a per-node load
+ * keys the cache by the NODE's path, and the tree re-keys a chain's first
+ * listing to the root it asked for. A chain test that needs real paths builds
+ * its own reply.
+ */
+function oneListing(
+  entries: ReturnType<typeof entry>[],
+  opts: { truncated?: boolean, totalEntries?: number } = {},
+) {
+  return {
+    listings: [{
+      path: '',
+      entries,
+      truncated: opts.truncated ?? false,
+      totalEntries: opts.totalEntries ?? 0,
+    }],
   }
 }
 
@@ -69,10 +91,7 @@ describe('directoryTree', () => {
    */
   it('keeps an unchanged row mounted when a refresh adds a sibling', async () => {
     const root = '/repo-reconcile'
-    listDirectory.mockResolvedValue({
-      entries: [entry(root, 'a.txt'), entry(root, 'b.txt')],
-      truncated: false,
-    })
+    listDirectory.mockResolvedValue(oneListing([entry(root, 'a.txt'), entry(root, 'b.txt')]))
 
     let handle!: DirectoryTreeHandle
     render(() => (
@@ -89,10 +108,7 @@ describe('directoryTree', () => {
     await waitFor(() => expect(rowFor('a.txt')).toBeTruthy())
     const before = rowFor('a.txt')!
 
-    listDirectory.mockResolvedValue({
-      entries: [entry(root, 'a.txt'), entry(root, 'b.txt'), entry(root, 'c.txt')],
-      truncated: false,
-    })
+    listDirectory.mockResolvedValue(oneListing([entry(root, 'a.txt'), entry(root, 'b.txt'), entry(root, 'c.txt')]))
     handle.refresh()
     await waitFor(() => expect(rowFor('c.txt')).toBeTruthy())
 
@@ -102,10 +118,7 @@ describe('directoryTree', () => {
 
   it('marks the selected row with data-active, the one marker the coarse-pointer kebab reveal keys on', async () => {
     const root = '/repo-active'
-    listDirectory.mockResolvedValue({
-      entries: [entry(root, 'a.txt'), entry(root, 'b.txt')],
-      truncated: false,
-    })
+    listDirectory.mockResolvedValue(oneListing([entry(root, 'a.txt'), entry(root, 'b.txt')]))
 
     render(() => (
       <DirectoryTree
@@ -163,7 +176,7 @@ describe('directoryTree sorting', () => {
   }
 
   beforeEach(() => {
-    listDirectory.mockResolvedValue({ entries, truncated: false })
+    listDirectory.mockResolvedValue(oneListing(entries))
   })
 
   it('defaults to directories first, then name ascending', async () => {
@@ -224,7 +237,7 @@ describe('directoryTree sorting', () => {
    * The whole payload is discarded and re-fetched instead.
    */
   it('discards an unversioned payload entirely', async () => {
-    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}${root}:files`, JSON.stringify({
+    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, JSON.stringify({
       expandedPaths: { [root]: true },
       childrenCache: {
         [root]: [{ path: `${root}/stale.txt`, displayName: 'stale.txt', isDir: false, hidden: false }],
@@ -244,7 +257,7 @@ describe('directoryTree sorting', () => {
    * build is discarded too -- forward and backward are the same question.
    */
   it('discards a payload stamped with a different version', async () => {
-    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}${root}:files`, JSON.stringify({
+    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, JSON.stringify({
       v: DIRECTORY_TREE_STATE_VERSION + 1,
       expandedPaths: { [root]: true },
       childrenCache: {
@@ -260,7 +273,7 @@ describe('directoryTree sorting', () => {
   })
 
   it('restores a payload at the current version without re-fetching', async () => {
-    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}${root}:files`, JSON.stringify({
+    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, JSON.stringify({
       v: DIRECTORY_TREE_STATE_VERSION,
       expandedPaths: { [root]: true },
       childrenCache: {
@@ -280,7 +293,7 @@ describe('directoryTree sorting', () => {
    * -- a hand edit, or a truncated write. That directory alone is dropped.
    */
   it('drops a malformed directory inside an otherwise current payload', async () => {
-    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}${root}:files`, JSON.stringify({
+    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, JSON.stringify({
       v: DIRECTORY_TREE_STATE_VERSION,
       expandedPaths: { [root]: true },
       childrenCache: {
@@ -301,7 +314,7 @@ describe('directoryTree sorting', () => {
    * the size of what is hidden rather than only that something is.
    */
   it('names how many entries the directory really held', async () => {
-    listDirectory.mockResolvedValue({ entries, truncated: true, totalEntries: 12043 })
+    listDirectory.mockResolvedValue(oneListing(entries, { truncated: true, totalEntries: 12043 }))
     const { container } = renderSorted({ key: 'name', direction: 'asc' })
     await waitFor(() => expect(container.textContent).toContain('listing truncated'))
     expect(container.textContent).toContain('5 of 12043 entries')
@@ -313,7 +326,7 @@ describe('directoryTree sorting', () => {
    * must still APPEAR, which a truthiness test on the count would have broken.
    */
   it('falls back to the open-ended count when the worker sends no total', async () => {
-    listDirectory.mockResolvedValue({ entries, truncated: true })
+    listDirectory.mockResolvedValue(oneListing(entries, { truncated: true }))
     const { container } = renderSorted({ key: 'name', direction: 'asc' })
     await waitFor(() => expect(container.textContent).toContain('listing truncated'))
     expect(container.textContent).toContain('5+ entries')
@@ -321,7 +334,7 @@ describe('directoryTree sorting', () => {
   })
 
   it('says the listing was truncated by name when sorting by something else', async () => {
-    listDirectory.mockResolvedValue({ entries, truncated: true })
+    listDirectory.mockResolvedValue(oneListing(entries, { truncated: true }))
     const { container, setSortOrder } = renderSorted({ key: 'name', direction: 'asc' })
     await waitFor(() => expect(container.textContent).toContain('listing truncated'))
 
@@ -360,7 +373,7 @@ describe('directoryTree root row info', () => {
   }
 
   it('stats the root once and shows its modified time', async () => {
-    listDirectory.mockResolvedValue({ entries: [entry(root, 'a.txt')], truncated: false })
+    listDirectory.mockResolvedValue(oneListing([entry(root, 'a.txt')]))
     statFile.mockResolvedValue({ info: { modTime: '2026-04-01T09:00:00Z' } })
 
     render(() => (
@@ -380,7 +393,7 @@ describe('directoryTree root row info', () => {
   })
 
   it('waits for enabled before stat-ing, then stats once it flips', async () => {
-    listDirectory.mockResolvedValue({ entries: [entry(root, 'a.txt')], truncated: false })
+    listDirectory.mockResolvedValue(oneListing([entry(root, 'a.txt')]))
     statFile.mockResolvedValue({ info: { modTime: '2026-04-01T09:00:00Z' } })
     const [enabled, setEnabled] = createSignal(false)
 
@@ -400,7 +413,7 @@ describe('directoryTree root row info', () => {
    * to a change of worker or root.
    */
   it('keeps the root modified time on screen across a refresh', async () => {
-    listDirectory.mockResolvedValue({ entries: [entry(root, 'a.txt')], truncated: false })
+    listDirectory.mockResolvedValue(oneListing([entry(root, 'a.txt')]))
     statFile.mockResolvedValueOnce({ info: { modTime: '2026-04-01T09:00:00Z' } })
 
     let handle!: DirectoryTreeHandle
@@ -427,7 +440,7 @@ describe('directoryTree root row info', () => {
   })
 
   it('omits the block when the root cannot be stat-ed', async () => {
-    listDirectory.mockResolvedValue({ entries: [entry(root, 'a.txt')], truncated: false })
+    listDirectory.mockResolvedValue(oneListing([entry(root, 'a.txt')]))
     statFile.mockRejectedValue(new Error('permission denied'))
 
     render(() => (
@@ -457,7 +470,7 @@ describe('directoryTree filtering', () => {
   ]
 
   beforeEach(() => {
-    listDirectory.mockResolvedValue({ entries, truncated: false })
+    listDirectory.mockResolvedValue(oneListing(entries))
   })
 
   function renderFiltered(props: { showHiddenFiles?: boolean, isVisible?: (path: string) => boolean }) {
@@ -520,5 +533,460 @@ describe('directoryTree filtering', () => {
     renderFiltered({ isVisible: () => false })
     await waitFor(() => expect(listDirectory).toHaveBeenCalled())
     expect(renderedNames()).not.toContain('visible.ts')
+  })
+})
+
+/**
+ * A worker that answers a chain request, honouring `fromRoot`.
+ *
+ * `dirs` maps a directory path to its entries. A request with `fromRoot`
+ * answers with every directory on the root-to-target chain that `dirs` knows
+ * about, outermost first, exactly as the worker does.
+ */
+function mockChain(dirs: Record<string, ReturnType<typeof entry>[]>, separator = '/') {
+  listDirectory.mockImplementation(async (_workerId: string, req: { path: string, fromRoot?: string }) => {
+    const chain: string[] = []
+    if (req.fromRoot) {
+      let cur = req.fromRoot
+      chain.push(cur)
+      const rest = req.path.slice(req.fromRoot.length).split(/[\\/]+/).filter(Boolean)
+      for (const part of rest) {
+        cur = cur.endsWith(separator) ? `${cur}${part}` : `${cur}${separator}${part}`
+        chain.push(cur)
+      }
+    }
+    else {
+      chain.push(req.path)
+    }
+    return {
+      listings: chain
+        .filter(path => dirs[path] !== undefined)
+        .map(path => ({ path, entries: dirs[path], truncated: false, totalEntries: dirs[path].length })),
+    }
+  })
+}
+
+function dirEntry(parent: string, name: string, separator = '/') {
+  return {
+    name,
+    path: parent.endsWith(separator) ? `${parent}${name}` : `${parent}${separator}${name}`,
+    isDir: true,
+    hidden: false,
+    size: 0n,
+    modTime: '2026-01-01T00:00:00Z',
+  }
+}
+
+function renderTree(props: Partial<Parameters<typeof DirectoryTree>[0]> & { rootPath: string }) {
+  return render(() => (
+    <DirectoryTree
+      workerId="w1"
+      gitStatusStore={gitStatusStore}
+      selectedPath=""
+      onSelect={() => {}}
+      {...props}
+    />
+  ))
+}
+
+describe('directoryTree reveal', () => {
+  const root = '/'
+
+  it('expands toward revealPath when nothing is selected', async () => {
+    mockChain({
+      '/': [dirEntry('/', 'home'), dirEntry('/', 'opt')],
+      '/home': [dirEntry('/home', 'alice')],
+      '/home/alice': [dirEntry('/home/alice', 'proj')],
+    })
+
+    renderTree({ rootPath: root, revealPath: '/home/alice' })
+
+    await waitFor(() => expect(rowFor('proj')).toBeTruthy())
+    expect(rowFor('home')).toBeTruthy()
+    expect(rowFor('alice')).toBeTruthy()
+  })
+
+  // The whole point of a separate prop: a revealed node is OPEN, never
+  // selected. Seeding the selection instead would arm the New workspace
+  // dialog's Create button with a directory the user never chose.
+  it('does not mark the revealed node selected', async () => {
+    mockChain({
+      '/': [dirEntry('/', 'home')],
+      '/home': [dirEntry('/home', 'alice')],
+      '/home/alice': [],
+    })
+
+    renderTree({ rootPath: root, revealPath: '/home/alice' })
+
+    await waitFor(() => expect(rowFor('alice')).toBeTruthy())
+    expect(document.querySelectorAll('[data-active="true"]')).toHaveLength(0)
+    expect(document.querySelector('[data-testid="tree-root-node"]')?.getAttribute('data-active')).toBe('false')
+  })
+
+  it('ignores revealPath once a path is selected', async () => {
+    mockChain({
+      '/': [dirEntry('/', 'home')],
+      '/home': [dirEntry('/home', 'alice')],
+      '/home/alice': [dirEntry('/home/alice', 'proj')],
+    })
+
+    renderTree({ rootPath: root, selectedPath: '/home', revealPath: '/home/alice' })
+
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+    expect(rowFor('home')?.getAttribute('data-active')).toBe('true')
+    // `/home` is expanded because it holds the selection, but nothing walked
+    // on to `/home/alice`'s own children.
+    await waitFor(() => expect(rowFor('alice')).toBeTruthy())
+    expect(rowFor('proj')).toBeUndefined()
+  })
+
+  it('ignores an empty revealPath', async () => {
+    mockChain({ '/': [dirEntry('/', 'home')] })
+
+    renderTree({ rootPath: root, revealPath: '' })
+
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+    expect(listDirectory).toHaveBeenCalledTimes(1)
+    expect(listDirectory.mock.calls[0][1]).toMatchObject({ path: '/' })
+    expect(listDirectory.mock.calls[0][1].fromRoot).toBeUndefined()
+  })
+})
+
+describe('directoryTree chain loading', () => {
+  it('fetches the whole root-to-reveal chain in one request', async () => {
+    mockChain({
+      '/': [dirEntry('/', 'home')],
+      '/home': [dirEntry('/home', 'alice')],
+      '/home/alice': [dirEntry('/home/alice', 'proj')],
+      '/home/alice/proj': [],
+    })
+
+    renderTree({ rootPath: '/', revealPath: '/home/alice/proj' })
+
+    await waitFor(() => expect(rowFor('proj')).toBeTruthy())
+    expect(listDirectory).toHaveBeenCalledTimes(1)
+    expect(listDirectory.mock.calls[0][1]).toMatchObject({ path: '/home/alice/proj', fromRoot: '/' })
+  })
+
+  it('does not re-request when every chain directory is cached', async () => {
+    mockChain({
+      '/': [dirEntry('/', 'home')],
+      '/home': [dirEntry('/home', 'alice')],
+      '/home/alice': [],
+    })
+
+    const { unmount } = renderTree({ rootPath: '/', revealPath: '/home/alice' })
+    await waitFor(() => expect(rowFor('alice')).toBeTruthy())
+    const afterFirst = listDirectory.mock.calls.length
+    unmount()
+
+    // A second mount restores from sessionStorage, so the chain is already
+    // known and nothing is fetched again.
+    renderTree({ rootPath: '/', revealPath: '/home/alice' })
+    await waitFor(() => expect(rowFor('alice')).toBeTruthy())
+    expect(listDirectory.mock.calls.length).toBe(afterFirst)
+  })
+
+  it('re-reveals in one round trip when the target moves to another branch', async () => {
+    mockChain({
+      '/': [dirEntry('/', 'home'), dirEntry('/', 'opt')],
+      '/home': [dirEntry('/home', 'alice')],
+      '/home/alice': [],
+      '/opt': [dirEntry('/opt', 'tools')],
+      '/opt/tools': [],
+    })
+
+    const [selected, setSelected] = createSignal('/home/alice')
+    render(() => (
+      <DirectoryTree
+        workerId="w1"
+        gitStatusStore={gitStatusStore}
+        rootPath="/"
+        selectedPath={selected()}
+        onSelect={() => {}}
+      />
+    ))
+    await waitFor(() => expect(rowFor('alice')).toBeTruthy())
+    const afterFirst = listDirectory.mock.calls.length
+
+    setSelected('/opt/tools')
+    await waitFor(() => expect(rowFor('tools')).toBeTruthy())
+    expect(listDirectory.mock.calls.length).toBe(afterFirst + 1)
+    expect(listDirectory.mock.calls.at(-1)?.[1]).toMatchObject({ path: '/opt/tools', fromRoot: '/' })
+  })
+
+  // A chain failure with the root on screen is not a tree failure: the
+  // per-node cascade still walks the user there one level at a time.
+  it('keeps the tree on screen when a chain request fails', async () => {
+    const dirs: Record<string, ReturnType<typeof entry>[]> = {
+      '/': [dirEntry('/', 'home')],
+      '/home': [dirEntry('/home', 'alice')],
+      '/home/alice': [],
+    }
+    listDirectory.mockImplementation(async (_w: string, req: { path: string, fromRoot?: string }) => {
+      if (req.fromRoot)
+        throw new Error('chain boom')
+      const entries = dirs[req.path] ?? []
+      return { listings: [{ path: req.path, entries, truncated: false, totalEntries: entries.length }] }
+    })
+
+    const [selected, setSelected] = createSignal('')
+    render(() => (
+      <DirectoryTree
+        workerId="w1"
+        gitStatusStore={gitStatusStore}
+        rootPath="/"
+        selectedPath={selected()}
+        onSelect={() => {}}
+      />
+    ))
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+
+    setSelected('/home/alice')
+    await waitFor(() => expect(rowFor('alice')).toBeTruthy())
+    expect(rowFor('home')).toBeTruthy()
+    expect(document.body.textContent).not.toContain('Failed to load directory')
+  })
+
+  it('does not blank the tree to Loading when the selection changes', async () => {
+    mockChain({
+      '/': [dirEntry('/', 'home')],
+      '/home': [dirEntry('/home', 'alice')],
+      '/home/alice': [],
+    })
+
+    const [selected, setSelected] = createSignal('')
+    render(() => (
+      <DirectoryTree
+        workerId="w1"
+        gitStatusStore={gitStatusStore}
+        rootPath="/"
+        selectedPath={selected()}
+        onSelect={() => {}}
+      />
+    ))
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+
+    setSelected('/home/alice')
+    // The tree-level loading state REPLACES every row, so its absence is what
+    // "the tree did not blank" means. A node's own inline spinner is a
+    // different element and is correct while its children arrive.
+    expect(document.querySelector('[data-testid="tree-root-node"]')).toBeTruthy()
+    expect(rowFor('home')).toBeTruthy()
+    await waitFor(() => expect(rowFor('alice')).toBeTruthy())
+  })
+
+  /**
+   * The worker canonicalizes what it lists, so a symlinked root answers under
+   * a different path. The root row's cache is keyed by `rootPath`, so the
+   * first listing is re-keyed to what was asked for -- and the effect must not
+   * then re-fetch forever because its own guard never matches.
+   */
+  it('re-keys the first listing when the worker canonicalizes the root', async () => {
+    listDirectory.mockResolvedValue({
+      listings: [{
+        path: '/private/tmp/ws',
+        entries: [dirEntry('/private/tmp/ws', 'src')],
+        truncated: false,
+        totalEntries: 1,
+      }],
+    })
+
+    renderTree({ rootPath: '/tmp/ws' })
+
+    await waitFor(() => expect(rowFor('src')).toBeTruthy())
+    // Settles instead of looping: the guard stops a repeat of the same
+    // (worker, root, target) request.
+    await waitFor(() => expect(listDirectory).toHaveBeenCalled())
+    expect(listDirectory.mock.calls.length).toBeLessThanOrEqual(2)
+  })
+
+  it('drops a file target from the chain', async () => {
+    mockChain({
+      '/': [dirEntry('/', 'home')],
+      '/home': [
+        dirEntry('/home', 'alice'),
+        { name: 'notes.txt', path: '/home/notes.txt', isDir: false, hidden: false, size: 4n, modTime: '2026-01-01T00:00:00Z' },
+      ],
+    })
+
+    const [selected, setSelected] = createSignal('')
+    render(() => (
+      <DirectoryTree
+        workerId="w1"
+        gitStatusStore={gitStatusStore}
+        showFiles
+        rootPath="/"
+        selectedPath={selected()}
+        onSelect={() => {}}
+      />
+    ))
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+
+    setSelected('/home/notes.txt')
+    await waitFor(() => expect(rowFor('notes.txt')).toBeTruthy())
+    const afterFirst = listDirectory.mock.calls.length
+
+    // Selecting the same file again asks for nothing: the tree knows it is a
+    // file, so the chain ends at its parent, which is already cached.
+    setSelected('')
+    setSelected('/home/notes.txt')
+    await waitFor(() => expect(rowFor('notes.txt')).toBeTruthy())
+    expect(listDirectory.mock.calls.length).toBe(afterFirst)
+  })
+})
+
+describe('directoryTree request de-duplication', () => {
+  /**
+   * The chain loader and the per-node cascade both react to the same reveal
+   * target, so on a selection change they ask for the same directories in the
+   * same tick. Without one in-flight registry between them, revealing a path
+   * costs one request per level again -- the exact cost the chain removes.
+   */
+  it('issues one request per directory when the chain and a node ask together', async () => {
+    const asked: string[] = []
+    listDirectory.mockImplementation(async (_w: string, req: { path: string, fromRoot?: string }) => {
+      asked.push(req.path)
+      const dirs: Record<string, ReturnType<typeof entry>[]> = {
+        '/': [dirEntry('/', 'home')],
+        '/home': [dirEntry('/home', 'alice')],
+        '/home/alice': [],
+      }
+      const chain = req.fromRoot ? ['/', '/home', '/home/alice'] : [req.path]
+      return {
+        listings: chain
+          .filter(path => dirs[path] !== undefined)
+          .map(path => ({ path, entries: dirs[path], truncated: false, totalEntries: dirs[path].length })),
+      }
+    })
+
+    const [selected, setSelected] = createSignal('')
+    render(() => (
+      <DirectoryTree
+        workerId="w1"
+        gitStatusStore={gitStatusStore}
+        rootPath="/"
+        selectedPath={selected()}
+        onSelect={() => {}}
+      />
+    ))
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+
+    // `/home` is on screen and unexpanded, so its node reacts to the same
+    // change the chain loader does.
+    setSelected('/home/alice')
+    await waitFor(() => expect(rowFor('alice')).toBeTruthy())
+
+    expect(asked.filter(p => p === '/home')).toHaveLength(0)
+    expect(asked.filter(p => p === '/home/alice')).toHaveLength(1)
+  })
+
+  /**
+   * The worker may answer with FEWER listings than the chain implies: both the
+   * listing cap and the payload budget drop levels from the deep end. The
+   * per-node cascade must then fetch what is missing, so a short chain costs
+   * the user nothing but a second round trip.
+   */
+  it('lets the cascade fetch a tail the worker truncated away', async () => {
+    const dirs: Record<string, ReturnType<typeof entry>[]> = {
+      '/': [dirEntry('/', 'home')],
+      '/home': [dirEntry('/home', 'alice')],
+      '/home/alice': [dirEntry('/home/alice', 'proj')],
+    }
+    listDirectory.mockImplementation(async (_w: string, req: { path: string, fromRoot?: string }) => {
+      // The chain answer stops two levels short of the target.
+      const chain = req.fromRoot ? ['/', '/home'] : [req.path]
+      return {
+        listings: chain
+          .filter(path => dirs[path] !== undefined)
+          .map(path => ({ path, entries: dirs[path], truncated: false, totalEntries: dirs[path].length })),
+      }
+    })
+
+    render(() => (
+      <DirectoryTree
+        workerId="w1"
+        gitStatusStore={gitStatusStore}
+        rootPath="/"
+        selectedPath=""
+        revealPath="/home/alice/proj"
+        onSelect={() => {}}
+      />
+    ))
+
+    // `/home/alice` was not in the truncated chain, so its node fetched it.
+    await waitFor(() => expect(rowFor('proj')).toBeTruthy())
+  })
+})
+
+describe('directoryTree at a filesystem root', () => {
+  it('labels a posix root row with the root itself', async () => {
+    mockChain({ '/': [dirEntry('/', 'home')] })
+
+    renderTree({ rootPath: '/', flavor: 'posix' })
+
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+    const rootRow = document.querySelector('[data-testid="tree-root-node"]')
+    expect(rootRow?.querySelector('[data-testid="tree-row-name"]')?.textContent).toBe('/')
+  })
+
+  // `basename('C:\\', 'win32')` is 'C:' -- the drive WITHOUT the separator
+  // that makes it a root, and not what the drive selector beside it reads.
+  it('labels a windows drive root with the trailing separator', async () => {
+    mockChain({ 'C:\\': [dirEntry('C:\\', 'Users', '\\')] }, '\\')
+
+    renderTree({ rootPath: 'C:\\', flavor: 'win32' })
+
+    await waitFor(() => expect(rowFor('Users')).toBeTruthy())
+    const rootRow = document.querySelector('[data-testid="tree-root-node"]')
+    expect(rootRow?.querySelector('[data-testid="tree-row-name"]')?.textContent).toBe('C:\\')
+  })
+
+  it('expands toward a windows revealPath', async () => {
+    mockChain({
+      'C:\\': [dirEntry('C:\\', 'Users', '\\')],
+      'C:\\Users': [dirEntry('C:\\Users', 'alice', '\\')],
+      'C:\\Users\\alice': [dirEntry('C:\\Users\\alice', 'proj', '\\')],
+    }, '\\')
+
+    renderTree({ rootPath: 'C:\\', flavor: 'win32', revealPath: 'C:\\Users\\alice' })
+
+    await waitFor(() => expect(rowFor('proj')).toBeTruthy())
+    expect(listDirectory).toHaveBeenCalledTimes(1)
+    expect(listDirectory.mock.calls[0][1]).toMatchObject({ path: 'C:\\Users\\alice', fromRoot: 'C:\\' })
+  })
+
+  it('keys sessionStorage on the worker as well as the root path', async () => {
+    mockChain({ 'C:\\': [dirEntry('C:\\', 'Users', '\\')] }, '\\')
+
+    renderTree({ rootPath: 'C:\\', flavor: 'win32' })
+
+    await waitFor(() => expect(rowFor('Users')).toBeTruthy())
+    expect(sessionStorageGet(`${PREFIX_DIRECTORY_TREE}w1:C:\\:dirs`)).toBeTruthy()
+  })
+
+  /**
+   * Two workers routinely share a root path -- every POSIX worker roots the
+   * picker at `/`. Without the worker in the key, the second one restores the
+   * first one's listing and then skips its own fetch.
+   */
+  it('does not serve one worker cached listing to another', async () => {
+    mockChain({ '/': [dirEntry('/', 'from-w1')] })
+    const { unmount } = renderTree({ rootPath: '/' })
+    await waitFor(() => expect(rowFor('from-w1')).toBeTruthy())
+    unmount()
+
+    mockChain({ '/': [dirEntry('/', 'from-w2')] })
+    render(() => (
+      <DirectoryTree
+        workerId="w2"
+        gitStatusStore={gitStatusStore}
+        rootPath="/"
+        selectedPath=""
+        onSelect={() => {}}
+      />
+    ))
+    await waitFor(() => expect(rowFor('from-w2')).toBeTruthy())
+    expect(rowFor('from-w1')).toBeUndefined()
   })
 })

--- a/frontend/src/components/tree/DirectoryTree.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.test.tsx
@@ -1363,3 +1363,73 @@ describe('directoryTree win32 separators', () => {
     await waitFor(() => expect(rowFor('Alice')).toBeTruthy())
   })
 })
+
+describe('directoryTree expandPath', () => {
+  const root = '/expand-handle'
+  const storeKey = `${PREFIX_DIRECTORY_TREE}w1:${root}:dirs`
+
+  /**
+   * The paths the tree holds open, sorted.
+   *
+   * Read from the persisted state, NOT from the rendered rows: a collapsed
+   * directory still renders its children into the DOM and hides them with a
+   * class, so `rowFor` finds a row that no user can see.
+   */
+  function expandedPaths(): string[] {
+    const stored = sessionStorageGet<{ expandedPaths?: Record<string, boolean> }>(storeKey)
+    return Object.keys(stored?.expandedPaths ?? {}).sort()
+  }
+
+  function mockTwoLevels() {
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string, fromRoot?: string }) => {
+      if (req.fromRoot) {
+        return {
+          listings: [
+            { path: root, entries: [dirEntry(root, 'home')], truncated: false, totalEntries: 1 },
+            { path: `${root}/home`, entries: [dirEntry(`${root}/home`, 'alice')], truncated: false, totalEntries: 1 },
+          ],
+        }
+      }
+      if (req.path === `${root}/home`)
+        return oneListing([dirEntry(`${root}/home`, 'alice')])
+      return oneListing([dirEntry(root, 'home')])
+    })
+  }
+
+  // The reveal effect opens every ANCESTOR of its target and stops there, so a
+  // selection alone never opens the directory it selected.
+  it('opens the node that the reveal leaves closed', async () => {
+    mockTwoLevels()
+    let handle!: DirectoryTreeHandle
+    const captureHandle = (h: DirectoryTreeHandle) => {
+      handle = h
+    }
+    renderTree({ rootPath: root, selectedPath: `${root}/home`, ref: captureHandle })
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+    await settle()
+    expect(expandedPaths()).toEqual([root])
+
+    handle.expandPath(`${root}/home`)
+    await settle()
+
+    expect(expandedPaths()).toEqual([root, `${root}/home`])
+  })
+
+  // An empty path names no node. The key would persist, and no chevron could
+  // ever collapse it again.
+  it('ignores an empty path instead of persisting a key for it', async () => {
+    mockTwoLevels()
+    let handle!: DirectoryTreeHandle
+    const captureHandle = (h: DirectoryTreeHandle) => {
+      handle = h
+    }
+    renderTree({ rootPath: root, ref: captureHandle })
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+    await settle()
+
+    handle.expandPath('')
+    await settle()
+
+    expect(expandedPaths()).toEqual([root])
+  })
+})

--- a/frontend/src/components/tree/DirectoryTree.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.test.tsx
@@ -1415,6 +1415,47 @@ describe('directoryTree expandPath', () => {
     expect(expandedPaths()).toEqual([root, `${root}/home`])
   })
 
+  /**
+   * The picker's Home button does exactly this pair, in this order.
+   *
+   * Selecting a home directory on another Windows drive re-roots the tree, and
+   * a new root REPLACES the expansion state wholesale. The write therefore has
+   * to land after that replacement, which it does because a signal write runs
+   * the whole update cycle before it returns.
+   */
+  it('survives a root change made in the same tick', async () => {
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string }) => {
+      if (req.path === 'C:\\')
+        return oneListing([dirEntry('C:\\', 'Users', '\\')])
+      return oneListing([dirEntry('D:\\', 'work', '\\')])
+    })
+    const [treeRoot, setTreeRoot] = createSignal('D:\\')
+    let handle!: DirectoryTreeHandle
+    const captureHandle = (h: DirectoryTreeHandle) => {
+      handle = h
+    }
+    render(() => (
+      <DirectoryTree
+        workerId="w1"
+        gitStatusStore={gitStatusStore}
+        rootPath={treeRoot()}
+        selectedPath=""
+        onSelect={() => {}}
+        ref={captureHandle}
+      />
+    ))
+    await waitFor(() => expect(rowFor('work')).toBeTruthy())
+
+    setTreeRoot('C:\\')
+    handle.expandPath('C:\\Users')
+    await settle()
+
+    const stored = sessionStorageGet<{ expandedPaths?: Record<string, boolean> }>(
+      `${PREFIX_DIRECTORY_TREE}w1:C:\\:dirs`,
+    )
+    expect(Object.keys(stored?.expandedPaths ?? {}).sort()).toEqual(['C:\\', 'C:\\Users'])
+  })
+
   // An empty path names no node. The key would persist, and no chevron could
   // ever collapse it again.
   it('ignores an empty path instead of persisting a key for it', async () => {
@@ -1431,5 +1472,192 @@ describe('directoryTree expandPath', () => {
     await settle()
 
     expect(expandedPaths()).toEqual([root])
+  })
+})
+
+describe('directoryTree keyboard navigation', () => {
+  const root = '/aria'
+
+  /**
+   * Two directories at the root, one of them holding a file.
+   *
+   * Both children are directories on purpose: the visible order is then a
+   * plain name sort, whatever the comparator does with files. `inner.txt`
+   * gives the walk a row that IS in the DOM while its parent is closed.
+   */
+  function mockTree() {
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string }) => {
+      if (req.path === `${root}/alpha`)
+        return oneListing([entry(`${root}/alpha`, 'inner.txt')])
+      if (req.path === `${root}/beta`)
+        return oneListing([])
+      return oneListing([dirEntry(root, 'alpha'), dirEntry(root, 'beta')])
+    })
+  }
+
+  function treeEl(): HTMLElement {
+    return document.querySelector('[role="tree"]') as HTMLElement
+  }
+
+  function rootRow(): HTMLElement {
+    return document.querySelector('[data-testid="tree-root-node"]') as HTMLElement
+  }
+
+  // Dispatched on the focused row, not on the container, so it travels the
+  // path a browser gives it and the delegation is under test too.
+  function press(key: string) {
+    fireEvent.keyDown(document.activeElement ?? treeEl(), { key })
+  }
+
+  async function renderReady(props: Record<string, unknown> = {}) {
+    mockTree()
+    renderTree({ rootPath: root, ...props })
+    await waitFor(() => expect(rowFor('alpha')).toBeTruthy())
+    await settle()
+  }
+
+  it('marks the tree, its rows and its groups', async () => {
+    await renderReady()
+
+    expect(treeEl()).toBeTruthy()
+    expect(rootRow().getAttribute('role')).toBe('treeitem')
+    expect(rootRow().getAttribute('aria-expanded')).toBe('true')
+    expect(rootRow().getAttribute('aria-level')).toBe('1')
+
+    expect(rowFor('alpha')!.getAttribute('role')).toBe('treeitem')
+    expect(rowFor('alpha')!.getAttribute('aria-expanded')).toBe('false')
+    expect(rowFor('alpha')!.getAttribute('aria-level')).toBe('2')
+    expect(document.querySelectorAll('[role="group"]').length).toBeGreaterThan(0)
+  })
+
+  // A row that can never open must say nothing about expansion, or a screen
+  // reader announces the file as a collapsed directory.
+  it('leaves aria-expanded off a file row', async () => {
+    await renderReady()
+    rootRow().focus()
+    press('ArrowDown')
+    press('ArrowRight')
+    await waitFor(() => expect(rowFor('inner.txt')).toBeTruthy())
+
+    expect(rowFor('inner.txt')!.hasAttribute('aria-expanded')).toBe(false)
+    expect(rowFor('inner.txt')!.getAttribute('aria-level')).toBe('3')
+  })
+
+  // A tree is ONE stop in the page's tab order.
+  it('holds exactly one tab stop, on the root until a row takes focus', async () => {
+    await renderReady()
+
+    let stops = document.querySelectorAll('[role="treeitem"][tabindex="0"]')
+    expect(stops).toHaveLength(1)
+    expect(stops[0]).toBe(rootRow())
+
+    rootRow().focus()
+    press('ArrowDown')
+
+    stops = document.querySelectorAll('[role="treeitem"][tabindex="0"]')
+    expect(stops).toHaveLength(1)
+    expect(stops[0]).toBe(rowFor('alpha'))
+  })
+
+  it('steps through the VISIBLE rows, not the rendered ones', async () => {
+    await renderReady()
+    rootRow().focus()
+
+    press('ArrowDown')
+    expect(document.activeElement).toBe(rowFor('alpha'))
+
+    // Open it and close it again, so its child stays RENDERED while hidden.
+    // That is the row a walk of the DOM would step into: it sits between
+    // `alpha` and `beta` there, and nowhere on screen.
+    press('ArrowRight')
+    await waitFor(() => expect(rowFor('inner.txt')).toBeTruthy())
+    press('ArrowLeft')
+    await waitFor(() => expect(rowFor('alpha')!.getAttribute('aria-expanded')).toBe('false'))
+    expect(rowFor('inner.txt')).toBeTruthy()
+
+    press('ArrowDown')
+    expect(document.activeElement).toBe(rowFor('beta'))
+
+    // The last row: the focus stays rather than wrapping.
+    press('ArrowDown')
+    expect(document.activeElement).toBe(rowFor('beta'))
+
+    press('ArrowUp')
+    expect(document.activeElement).toBe(rowFor('alpha'))
+  })
+
+  it('opens with ArrowRight, descends on the second press, and closes with ArrowLeft', async () => {
+    await renderReady()
+    rootRow().focus()
+    press('ArrowDown')
+
+    // The first press opens the directory and does NOT move the focus.
+    press('ArrowRight')
+    await waitFor(() => expect(rowFor('alpha')!.getAttribute('aria-expanded')).toBe('true'))
+    expect(document.activeElement).toBe(rowFor('alpha'))
+
+    // The listing lands after the expansion, so the child row is not there
+    // the moment the directory reports itself open.
+    await waitFor(() => expect(rowFor('inner.txt')).toBeTruthy())
+    press('ArrowRight')
+    expect(document.activeElement).toBe(rowFor('inner.txt'))
+
+    // A row that cannot close moves to its parent instead.
+    press('ArrowLeft')
+    expect(document.activeElement).toBe(rowFor('alpha'))
+
+    press('ArrowLeft')
+    expect(rowFor('alpha')!.getAttribute('aria-expanded')).toBe('false')
+    expect(document.activeElement).toBe(rowFor('alpha'))
+  })
+
+  it('jumps to the first and last visible rows with Home and End', async () => {
+    await renderReady()
+    rootRow().focus()
+
+    press('End')
+    expect(document.activeElement).toBe(rowFor('beta'))
+
+    press('Home')
+    expect(document.activeElement).toBe(rootRow())
+  })
+
+  it('activates the focused row on Enter, exactly as a click does', async () => {
+    const onSelect = vi.fn()
+    await renderReady({ onSelect })
+    rootRow().focus()
+    press('ArrowDown')
+
+    press('Enter')
+
+    // A click both selects and toggles, so Enter must do both too. It awaits
+    // the listing before it selects, so this cannot be a synchronous check.
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith(`${root}/alpha`))
+    expect(rowFor('alpha')!.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  // The tab stop cannot name a row that is no longer on screen, or the tree
+  // drops out of the tab order entirely.
+  it('returns the tab stop to the root when the focused row is collapsed away', async () => {
+    let handle!: DirectoryTreeHandle
+    const captureHandle = (h: DirectoryTreeHandle) => {
+      handle = h
+    }
+    await renderReady({ ref: captureHandle })
+    rootRow().focus()
+    press('ArrowDown')
+    press('ArrowRight')
+    await waitFor(() => expect(rowFor('inner.txt')).toBeTruthy())
+    press('ArrowRight')
+    expect(document.activeElement).toBe(rowFor('inner.txt'))
+
+    // Collapse All, which is the one way to close the directory under the
+    // focused row: ArrowLeft would move to the parent before it closed it.
+    handle.collapseAll()
+    await settle()
+
+    const stops = document.querySelectorAll('[role="treeitem"][tabindex="0"]')
+    expect(stops).toHaveLength(1)
+    expect(stops[0]).toBe(rootRow())
   })
 })

--- a/frontend/src/components/tree/DirectoryTree.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.test.tsx
@@ -3,7 +3,7 @@ import type { FileSortOrder } from '~/lib/fileSort'
 import { fireEvent, render, waitFor } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { PREFIX_DIRECTORY_TREE, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
+import { PREFIX_DIRECTORY_TREE, sessionStorageClearForTests, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
 import { createRepoGitStore } from '~/stores/repoGit.store'
 import { DIRECTORY_TREE_STATE_VERSION, DirectoryTree } from './DirectoryTree'
 
@@ -56,6 +56,18 @@ function oneListing(
   }
 }
 
+/**
+ * Drain the microtask queue a few times.
+ *
+ * An effect that re-fires on its own asynchronous write needs one turn per
+ * iteration, so a loop shows up within a handful of them. Not a timer: a
+ * fixed delay would make the test slower AND weaker.
+ */
+async function settle(turns = 10): Promise<void> {
+  for (let i = 0; i < turns; i++)
+    await Promise.resolve()
+}
+
 function rowFor(name: string): Element | undefined {
   return [...document.querySelectorAll('[data-testid="tree-row"]')]
     .find(el => el.querySelector('[data-testid="tree-row-name"]')?.textContent === name)
@@ -75,7 +87,7 @@ beforeEach(() => {
   listDirectory.mockReset()
   statFile.mockReset()
   statFile.mockResolvedValue({ info: { modTime: '2026-01-01T00:00:00Z' } })
-  sessionStorage.clear()
+  sessionStorageClearForTests()
 })
 
 describe('directoryTree', () => {
@@ -795,10 +807,70 @@ describe('directoryTree chain loading', () => {
     renderTree({ rootPath: '/tmp/ws' })
 
     await waitFor(() => expect(rowFor('src')).toBeTruthy())
-    // Settles instead of looping: the guard stops a repeat of the same
-    // (worker, root, target) request.
-    await waitFor(() => expect(listDirectory).toHaveBeenCalled())
-    expect(listDirectory.mock.calls.length).toBeLessThanOrEqual(2)
+    // Settles instead of looping: the re-keyed listing satisfies the cache
+    // guard, so the effect's next run finds the chain already loaded.
+    await settle()
+    expect(listDirectory).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The same canonicalization, one level DEEPER -- where re-keying cannot
+   * help.
+   *
+   * Only the FIRST listing is re-keyed, because the entries of a deeper one
+   * carry the worker's own spelling and the tree's nodes are built from those.
+   * So `/tmp/ws/src` is a directory this chain named and the cache never
+   * receives: its guard misses forever. This effect subscribes to the cache it
+   * writes, so without `lastChainKey` its own write would re-run it, and the
+   * tree would issue the same request for as long as it stayed mounted.
+   */
+  it('does not re-fetch in a loop when the worker answers under paths the chain never named', async () => {
+    listDirectory.mockResolvedValue({
+      listings: [
+        { path: '/private/tmp/ws', entries: [dirEntry('/private/tmp/ws', 'src')], truncated: false, totalEntries: 1 },
+        { path: '/private/tmp/ws/src', entries: [], truncated: false, totalEntries: 0 },
+      ],
+    })
+
+    renderTree({ rootPath: '/tmp/ws', revealPath: '/tmp/ws/src' })
+
+    await waitFor(() => expect(rowFor('src')).toBeTruthy())
+    await settle()
+    expect(listDirectory).toHaveBeenCalledTimes(1)
+    expect(listDirectory.mock.calls[0][1]).toMatchObject({ path: '/tmp/ws/src', fromRoot: '/tmp/ws' })
+  })
+
+  /**
+   * The chain key describes the request whose result the cache holds, so it
+   * must not outlive that cache.
+   *
+   * `showFiles` is part of the sessionStorage key and NOT part of the chain
+   * key, so toggling it replaces the whole cache while `(worker, root,
+   * target)` stays the same. A guard that remembered the old request would
+   * suppress the one fetch that refills the emptied tree, and the picker would
+   * sit blank for the rest of the session.
+   */
+  it('re-fetches after a cache reset the chain key cannot see', async () => {
+    mockChain({ '/': [dirEntry('/', 'home')] })
+
+    const [showFiles, setShowFiles] = createSignal(false)
+    render(() => (
+      <DirectoryTree
+        workerId="w1"
+        gitStatusStore={gitStatusStore}
+        rootPath="/"
+        selectedPath=""
+        showFiles={showFiles()}
+        onSelect={() => {}}
+      />
+    ))
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
+
+    setShowFiles(true)
+
+    await waitFor(() => expect(listDirectory).toHaveBeenCalledTimes(2))
+    expect(listDirectory.mock.calls[1][1]).toMatchObject({ path: '/', dirsOnly: false })
+    await waitFor(() => expect(rowFor('home')).toBeTruthy())
   })
 
   it('drops a file target from the chain', async () => {

--- a/frontend/src/components/tree/DirectoryTree.test.tsx
+++ b/frontend/src/components/tree/DirectoryTree.test.tsx
@@ -5,7 +5,8 @@ import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PREFIX_DIRECTORY_TREE, sessionStorageClearForTests, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
 import { createRepoGitStore } from '~/stores/repoGit.store'
-import { DIRECTORY_TREE_STATE_VERSION, DirectoryTree } from './DirectoryTree'
+import { DirectoryTree } from './DirectoryTree'
+import { DIRECTORY_TREE_STATE_VERSION } from './directoryTreeState'
 
 const gitStatusStore = createRepoGitStore()
 
@@ -249,7 +250,7 @@ describe('directoryTree sorting', () => {
    * The whole payload is discarded and re-fetched instead.
    */
   it('discards an unversioned payload entirely', async () => {
-    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, JSON.stringify({
+    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, ({
       expandedPaths: { [root]: true },
       childrenCache: {
         [root]: [{ path: `${root}/stale.txt`, displayName: 'stale.txt', isDir: false, hidden: false }],
@@ -269,7 +270,7 @@ describe('directoryTree sorting', () => {
    * build is discarded too -- forward and backward are the same question.
    */
   it('discards a payload stamped with a different version', async () => {
-    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, JSON.stringify({
+    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, ({
       v: DIRECTORY_TREE_STATE_VERSION + 1,
       expandedPaths: { [root]: true },
       childrenCache: {
@@ -285,7 +286,7 @@ describe('directoryTree sorting', () => {
   })
 
   it('restores a payload at the current version without re-fetching', async () => {
-    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, JSON.stringify({
+    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, ({
       v: DIRECTORY_TREE_STATE_VERSION,
       expandedPaths: { [root]: true },
       childrenCache: {
@@ -305,7 +306,7 @@ describe('directoryTree sorting', () => {
    * -- a hand edit, or a truncated write. That directory alone is dropped.
    */
   it('drops a malformed directory inside an otherwise current payload', async () => {
-    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, JSON.stringify({
+    sessionStorageSet(`${PREFIX_DIRECTORY_TREE}w1:${root}:files`, ({
       v: DIRECTORY_TREE_STATE_VERSION,
       expandedPaths: { [root]: true },
       childrenCache: {
@@ -325,7 +326,7 @@ describe('directoryTree sorting', () => {
    * The worker reports what the directory really held, so the notice can name
    * the size of what is hidden rather than only that something is.
    */
-  it('names how many entries the directory really held', async () => {
+  it('gives how many entries the directory really held', async () => {
     listDirectory.mockResolvedValue(oneListing(entries, { truncated: true, totalEntries: 12043 }))
     const { container } = renderSorted({ key: 'name', direction: 'asc' })
     await waitFor(() => expect(container.textContent).toContain('listing truncated'))
@@ -819,12 +820,12 @@ describe('directoryTree chain loading', () => {
    *
    * Only the FIRST listing is re-keyed, because the entries of a deeper one
    * carry the worker's own spelling and the tree's nodes are built from those.
-   * So `/tmp/ws/src` is a directory this chain named and the cache never
+   * So `/tmp/ws/src` is a directory this chain listed and the cache never
    * receives: its guard misses forever. This effect subscribes to the cache it
    * writes, so without `lastChainKey` its own write would re-run it, and the
    * tree would issue the same request for as long as it stayed mounted.
    */
-  it('does not re-fetch in a loop when the worker answers under paths the chain never named', async () => {
+  it('does not re-fetch in a loop when the worker answers under paths the chain never listed', async () => {
     listDirectory.mockResolvedValue({
       listings: [
         { path: '/private/tmp/ws', entries: [dirEntry('/private/tmp/ws', 'src')], truncated: false, totalEntries: 1 },
@@ -1060,5 +1061,305 @@ describe('directoryTree at a filesystem root', () => {
     ))
     await waitFor(() => expect(rowFor('from-w2')).toBeTruthy())
     expect(rowFor('from-w1')).toBeUndefined()
+  })
+})
+
+describe('directoryTree canonicalized chain', () => {
+  /**
+   * The worker canonicalizes what it lists, and a symlink BELOW the root
+   * changes the level count with it (`/tmp/ws` is two levels under `/`,
+   * `/private/tmp/ws` is three), so no pairing by index recovers the caller's
+   * spelling. The chain effect re-keys the ROOT listing alone, and the middle
+   * listings land under keys no node reads.
+   *
+   * The tree must still reach the target -- the per-node cascade re-lists each
+   * such level under the path it asked for. This pins that recovery, so a
+   * later change to the re-key cannot silently lose it.
+   */
+  it('still reveals the target when the worker answers under canonicalized paths', async () => {
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string, fromRoot?: string }) => {
+      if (req.fromRoot) {
+        // The chain answers entirely under `/private/...`, so only the root
+        // listing lands on a key the tree holds.
+        return {
+          listings: [
+            { path: '/', entries: [dirEntry('/', 'tmp')], truncated: false, totalEntries: 1 },
+            { path: '/private', entries: [dirEntry('/private', 'tmp')], truncated: false, totalEntries: 1 },
+            { path: '/private/tmp', entries: [dirEntry('/private/tmp', 'ws')], truncated: false, totalEntries: 1 },
+          ],
+        }
+      }
+      // The per-node cascade asks for the path it holds, and gets it.
+      const perPath: Record<string, ReturnType<typeof dirEntry>[]> = {
+        '/tmp': [dirEntry('/tmp', 'ws')],
+        '/tmp/ws': [dirEntry('/tmp/ws', 'src')],
+      }
+      return {
+        listings: [{ path: req.path, entries: perPath[req.path] ?? [], truncated: false, totalEntries: 0 }],
+      }
+    })
+
+    renderTree({ rootPath: '/', revealPath: '/tmp/ws' })
+
+    // `tmp` comes from the re-keyed root listing; `ws` can only come from the
+    // cascade re-listing `/tmp` under the spelling the tree actually holds.
+    await waitFor(() => expect(rowFor('ws')).toBeTruthy())
+    expect(rowFor('tmp')).toBeTruthy()
+  })
+})
+
+describe('directoryTree refresh', () => {
+  /**
+   * The refresh path used to call the RPC directly, so it carried neither the
+   * worker guard nor the in-flight claim. Two workers routinely share a root
+   * path -- every POSIX worker roots the picker at `/` -- so a refresh answer
+   * that landed after the tree moved to another worker wrote the previous
+   * worker's listing into the new worker's tree, with no error and nothing on
+   * screen to say the rows belonged to another machine.
+   */
+  it('drops a refresh response that lands after the tree switched worker', async () => {
+    let releaseW1: ((v: unknown) => void) | undefined
+    listDirectory.mockImplementation(async (workerId: string) => {
+      if (workerId === 'w2')
+        return { listings: [{ path: '/', entries: [dirEntry('/', 'from-w2')], truncated: false, totalEntries: 1 }] }
+      if (releaseW1) {
+        await new Promise((resolve) => {
+          releaseW1 = resolve
+        })
+      }
+      return { listings: [{ path: '/', entries: [dirEntry('/', 'from-w1')], truncated: false, totalEntries: 1 }] }
+    })
+
+    const [workerId, setWorkerId] = createSignal('w1')
+    let handle: DirectoryTreeHandle | undefined
+    const captureHandle = (h: DirectoryTreeHandle) => {
+      handle = h
+    }
+    render(() => (
+      <DirectoryTree
+        workerId={workerId()}
+        gitStatusStore={gitStatusStore}
+        rootPath="/"
+        selectedPath=""
+        onSelect={() => {}}
+        ref={captureHandle}
+      />
+    ))
+    await waitFor(() => expect(rowFor('from-w1')).toBeTruthy())
+
+    // The next w1 request hangs until this test releases it.
+    releaseW1 = () => {}
+    handle!.refresh()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    setWorkerId('w2')
+    await waitFor(() => expect(rowFor('from-w2')).toBeTruthy())
+
+    releaseW1?.(undefined)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(rowFor('from-w1')).toBeUndefined()
+    expect(rowFor('from-w2')).toBeTruthy()
+  })
+})
+
+describe('directoryTree unreadable directories', () => {
+  function nodeError(): string | undefined {
+    return document.querySelector('[data-testid="tree-node-error"]')?.textContent ?? undefined
+  }
+
+  /**
+   * The tree has ONE error slot and it belongs to the first load, when there
+   * is nothing on screen at all. So a directory the user clicked and could not
+   * read used to refuse to open and say nothing at all about why.
+   */
+  it('shows why a directory would not open', async () => {
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string }) => {
+      if (req.path === '/')
+        return { listings: [{ path: '/', entries: [dirEntry('/', 'blocked')], truncated: false, totalEntries: 1 }] }
+      throw new Error('permission denied')
+    })
+
+    renderTree({ rootPath: '/' })
+    await waitFor(() => expect(rowFor('blocked')).toBeTruthy())
+
+    fireEvent.click(rowFor('blocked')!)
+
+    await waitFor(() => expect(nodeError()).toMatch(/permission denied/))
+  })
+
+  // The worker names the directory its CHAIN stopped at, and why. That one
+  // never reaches the client as a rejection -- the request succeeded.
+  it('shows the reason the worker reported for a chain it cut short', async () => {
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string, fromRoot?: string }) => {
+      if (req.fromRoot) {
+        return {
+          listings: [{ path: '/', entries: [dirEntry('/', 'blocked')], truncated: false, totalEntries: 1 }],
+          unreadable: { path: '/blocked', reason: 'permission denied' },
+        }
+      }
+      // The per-node cascade asks the same directory and is refused too --
+      // which is why the chain reported it in the first place.
+      throw new Error('permission denied')
+    })
+
+    renderTree({ rootPath: '/', revealPath: '/blocked/inner' })
+
+    await waitFor(() => expect(nodeError()).toMatch(/permission denied/))
+  })
+
+  // A node whose listing failed stays COLLAPSED, so nothing re-lists it and a
+  // refresh cannot clear its reason by arriving with data. Refresh clears the
+  // reasons itself -- it means "everything you know is stale" -- which also
+  // lifts the "do not ask again" mark, so the next click retries.
+  it('clears the reason on refresh, and the next click retries', async () => {
+    let fail = true
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string }) => {
+      if (req.path === '/')
+        return { listings: [{ path: '/', entries: [dirEntry('/', 'blocked')], truncated: false, totalEntries: 1 }] }
+      if (fail)
+        throw new Error('permission denied')
+      return { listings: [{ path: '/blocked', entries: [dirEntry('/blocked', 'inner')], truncated: false, totalEntries: 1 }] }
+    })
+
+    let handle: DirectoryTreeHandle | undefined
+    const captureHandle = (h: DirectoryTreeHandle) => {
+      handle = h
+    }
+    renderTree({ rootPath: '/', ref: captureHandle })
+    await waitFor(() => expect(rowFor('blocked')).toBeTruthy())
+    fireEvent.click(rowFor('blocked')!)
+    await waitFor(() => expect(nodeError()).toMatch(/permission denied/))
+
+    fail = false
+    handle!.refresh()
+    await waitFor(() => expect(nodeError()).toBeUndefined())
+
+    fireEvent.click(rowFor('blocked')!)
+
+    await waitFor(() => expect(rowFor('inner')).toBeTruthy())
+    expect(nodeError()).toBeUndefined()
+  })
+
+  // The counterpart: a listing that arrives on its own clears the reason too,
+  // so a stale message never sits over a directory that lists perfectly well.
+  it('clears the reason when the directory lists on a later click', async () => {
+    let fail = true
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string }) => {
+      if (req.path === '/')
+        return { listings: [{ path: '/', entries: [dirEntry('/', 'blocked')], truncated: false, totalEntries: 1 }] }
+      if (fail) {
+        fail = false
+        throw new Error('permission denied')
+      }
+      return { listings: [{ path: '/blocked', entries: [dirEntry('/blocked', 'inner')], truncated: false, totalEntries: 1 }] }
+    })
+
+    renderTree({ rootPath: '/' })
+    await waitFor(() => expect(rowFor('blocked')).toBeTruthy())
+    fireEvent.click(rowFor('blocked')!)
+    await waitFor(() => expect(nodeError()).toMatch(/permission denied/))
+
+    fireEvent.click(rowFor('blocked')!)
+
+    await waitFor(() => expect(rowFor('inner')).toBeTruthy())
+    expect(nodeError()).toBeUndefined()
+  })
+})
+
+describe('directoryTree failure handling', () => {
+  /**
+   * A directory the caller cannot read fails every time it is asked, and a
+   * tree rooted at `/` puts several of those in front of every user
+   * (`/root`, `/lost+found`). Marking the node expanded anyway satisfied the
+   * "expanded but the cache is missing" effect forever, and that effect reads
+   * `loading()` -- so each failure re-armed it. The browser then sent one
+   * ListDirectory per round trip for as long as the picker was open.
+   */
+  it('does not expand or re-request a directory whose listing failed', async () => {
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string }) => {
+      if (req.path === '/')
+        return { listings: [{ path: '/', entries: [dirEntry('/', 'blocked')], truncated: false, totalEntries: 1 }] }
+      throw new Error('permission denied')
+    })
+
+    renderTree({ rootPath: '/' })
+    await waitFor(() => expect(rowFor('blocked')).toBeTruthy())
+
+    fireEvent.click(rowFor('blocked')!)
+    await waitFor(() => expect(listDirectory.mock.calls.some(c => c[1].path === '/blocked')).toBe(true))
+
+    const afterClick = listDirectory.mock.calls.length
+    // Several macrotasks: a loop driven by the effect would issue one request
+    // per settled promise, so any growth at all is the defect.
+    for (let i = 0; i < 5; i++)
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(listDirectory.mock.calls.length).toBe(afterClick)
+  })
+
+  // Refresh is the user's own "try again", so it must re-arm a node the
+  // failure above shut off. Without this the only way back is to reopen the
+  // dialog.
+  it('re-requests a failed directory after a refresh', async () => {
+    listDirectory.mockImplementation(async (_workerId: string, req: { path: string }) => {
+      if (req.path === '/')
+        return { listings: [{ path: '/', entries: [dirEntry('/', 'blocked')], truncated: false, totalEntries: 1 }] }
+      throw new Error('permission denied')
+    })
+
+    let handle: DirectoryTreeHandle | undefined
+    const captureHandle = (h: DirectoryTreeHandle) => {
+      handle = h
+    }
+    renderTree({ rootPath: '/', ref: captureHandle })
+    await waitFor(() => expect(rowFor('blocked')).toBeTruthy())
+    fireEvent.click(rowFor('blocked')!)
+    await waitFor(() => expect(listDirectory.mock.calls.some(c => c[1].path === '/blocked')).toBe(true))
+    const afterClick = listDirectory.mock.calls.length
+
+    handle!.refresh()
+    await waitFor(() => expect(listDirectory.mock.calls.length).toBeGreaterThan(afterClick))
+  })
+})
+
+describe('directoryTree win32 separators', () => {
+  /**
+   * `PathInput` submits whatever the user typed, so a win32 selection reaches
+   * the tree spelled `C:/Users/alice` while the worker's own listings spell it
+   * `C:\Users\alice`. `relativeUnder` requires one separator on both sides, so
+   * an un-normalized comparison answered "not under" and collapsed the whole
+   * reveal: no chain request, no node expanded, no row selected.
+   */
+  it('reveals a target typed with forward slashes on a win32 tree', async () => {
+    mockChain({
+      'C:\\': [dirEntry('C:\\', 'Users', '\\')],
+      'C:\\Users': [dirEntry('C:\\Users', 'alice', '\\')],
+      'C:\\Users\\alice': [dirEntry('C:\\Users\\alice', 'proj', '\\')],
+    }, '\\')
+
+    renderTree({ rootPath: 'C:\\', flavor: 'win32', revealPath: 'C:/Users/alice' })
+
+    // `alice` is the discriminator: it renders only once `C:\Users` expands,
+    // which needs the reveal target to compare as a descendant of it. Without
+    // the normalization the chain collapses to the root alone, so the request
+    // carries no from_root and `C:\Users` is never listed.
+    await waitFor(() => expect(rowFor('alice')).toBeTruthy())
+    expect(listDirectory.mock.calls[0][1].fromRoot).toBe('C:\\')
+  })
+
+  // The worker reports a name in its own case; a typed path need not match it.
+  // A `===` comparison then treats a node the tree already holds as one it has
+  // never seen.
+  it('matches a target whose case differs from the worker listing', async () => {
+    mockChain({
+      'C:\\': [dirEntry('C:\\', 'Users', '\\')],
+      'C:\\Users': [dirEntry('C:\\Users', 'Alice', '\\')],
+      'C:\\Users\\Alice': [dirEntry('C:\\Users\\Alice', 'proj', '\\')],
+    }, '\\')
+
+    renderTree({ rootPath: 'C:\\', flavor: 'win32', revealPath: 'c:\\users\\alice' })
+
+    await waitFor(() => expect(rowFor('Alice')).toBeTruthy())
   })
 })

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -1,4 +1,5 @@
 import type { Accessor, Component } from 'solid-js'
+import type { DirectoryListing } from '~/generated/proto/leapmux/v1/file_pb'
 import type { FileSortFields, FileSortKey, FileSortOrder } from '~/lib/fileSort'
 import type { PathFlavor } from '~/lib/paths'
 import type { createRepoGitStore, DiffStats } from '~/stores/repoGit.store'
@@ -17,7 +18,7 @@ import { PREFIX_DIRECTORY_TREE, sessionStorageGet, sessionStorageSet } from '~/l
 import { createStableContext } from '~/lib/createStableContext'
 import { formatErrorMessage } from '~/lib/errors'
 import { DEFAULT_FILE_SORT_ORDER, makeFileComparator } from '~/lib/fileSort'
-import { basename, detectFlavor, relativeUnder } from '~/lib/paths'
+import { basename, detectFlavor, filesystemRoot, relativeUnder, sep, split } from '~/lib/paths'
 import { prefersReducedMotion } from '~/lib/prefersReducedMotion'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
 import { emptyState } from '~/styles/shared.css'
@@ -38,7 +39,30 @@ export interface DirectoryTreeProps {
   onFileOpen?: (path: string) => void
   onMention?: (path: string) => void
   onOpenTerminal?: (dirPath: string) => void
-  rootPath?: string
+  /**
+   * The tree's root row. REQUIRED, and an absolute path.
+   *
+   * There is deliberately no `'~'` default. A tilde resolves only on the
+   * WORKER, so nothing here can reason about it: `basename('~')` is `'~'`,
+   * `isAbsolute('~')` is false, and `relativeUnder(abs, '~')` is null -- which
+   * silently changes what "Copy relative path" answers and what counts as a
+   * descendant. A caller whose own root is not known yet renders nothing
+   * instead of passing a placeholder.
+   */
+  rootPath: string
+  /**
+   * Where to walk the tree open when NOTHING is selected.
+   *
+   * The picker opens on the filesystem root so a user can reach anywhere, and
+   * "New workspace" started from a directory opens with no selection at all.
+   * Without this the first thing that user sees is `/`, with their home
+   * directory several clicks away. Ignored the moment `selectedPath` is
+   * non-empty, so it never fights the user's own choice.
+   *
+   * EXPANSION ONLY. Selection is `selectedPath`, and nothing else reads this,
+   * so a revealed node is open but never selected.
+   */
+  revealPath?: string
   homeDir?: string
   /**
    * Path flavor for the worker this tree is rendering. Defaults to a
@@ -135,6 +159,12 @@ interface TreeContextValue {
   workerId: string
   showFiles: boolean
   rootPath: string
+  /**
+   * The path the tree walks itself open toward: the user's selection when
+   * there is one, else `revealPath`. ONE accessor, so no node restates the
+   * precedence and the chain loader and the per-node cascade share one input.
+   */
+  revealTarget: () => string
   homeDir?: string
   flavor: () => PathFlavor
   scrollContainer?: HTMLDivElement
@@ -155,6 +185,16 @@ interface TreeContextValue {
   setNodeExpanded: (path: string, expanded: boolean) => void
   getChildren: (path: string) => TreeNodeData[] | undefined
   setChildren: (path: string, data: TreeNodeData[], truncated: boolean, totalEntries: number) => void
+  /**
+   * Fetch and cache one directory's children, unless a request that will
+   * supply them is already in flight -- in which case await that one.
+   *
+   * The de-duplication is the point. The chain loader and the per-node cascade
+   * both react to the same reveal target, so on a selection change they would
+   * otherwise ask for the same directories at the same moment. Never rejects:
+   * a listing that fails leaves the node collapsed, exactly as before.
+   */
+  ensureChildren: (path: string) => Promise<void>
   isTruncated: (path: string) => boolean
 }
 
@@ -287,19 +327,18 @@ function visibleSortedChildren(
 // File listing
 // -------------------------------------------------------------------------
 
-// No sort here: the cache holds the worker's order (directories first, then
-// name), and the display order is applied when the rows render, so changing the
-// sort reorders what is already on screen instead of re-fetching every
-// expanded directory.
-async function loadChildren(
-  workerId: string,
-  dirPath: string,
-  showFiles: boolean,
-): Promise<{ entries: TreeNodeData[], truncated: boolean, totalEntries: number }> {
-  const resp = await workerRpc.listDirectory(workerId, { workerId, path: dirPath, maxDepth: 5, dirsOnly: !showFiles })
+/** One directory's listing, as the tree caches it. */
+interface DirectoryListingData {
+  path: string
+  entries: TreeNodeData[]
+  truncated: boolean
+  totalEntries: number
+}
 
+function toListingData(listing: DirectoryListing): DirectoryListingData {
   return {
-    entries: resp.entries.map(entry => ({
+    path: listing.path,
+    entries: listing.entries.map(entry => ({
       path: entry.path,
       displayName: entry.name,
       isDir: entry.isDir,
@@ -310,11 +349,86 @@ async function loadChildren(
       size: Number(entry.size ?? 0n),
       modTime: entry.modTime,
     })),
-    truncated: resp.truncated,
+    truncated: listing.truncated,
     // `?? 0` for a worker that predates the field: the notice then falls back
     // to "N+ entries" rather than claiming a total of zero.
-    totalEntries: resp.totalEntries ?? 0,
+    totalEntries: listing.totalEntries ?? 0,
   }
+}
+
+/**
+ * List one directory, or -- when `fromRoot` is given -- every directory from
+ * `fromRoot` down to `dirPath`, outermost first.
+ *
+ * The chain form is what lets a tree rooted at the FILESYSTEM ROOT reveal a
+ * deep selection without one round trip per level. Rooted at `/` and revealing
+ * `/home/alice/proj`, the per-node cascade issued four sequential requests,
+ * because each level can only ask once the previous level's listing mounted
+ * it. One request now answers all four.
+ *
+ * No sort here: the cache holds the worker's order (directories first, then
+ * name), and the display order is applied when the rows render, so changing the
+ * sort reorders what is already on screen instead of re-fetching every
+ * expanded directory.
+ */
+async function loadListings(
+  workerId: string,
+  dirPath: string,
+  showFiles: boolean,
+  fromRoot?: string,
+): Promise<DirectoryListingData[]> {
+  const resp = await workerRpc.listDirectory(workerId, {
+    workerId,
+    path: dirPath,
+    maxDepth: 5,
+    dirsOnly: !showFiles,
+    ...(fromRoot ? { fromRoot } : {}),
+  })
+  return resp.listings.map(toListingData)
+}
+
+/** The single-directory form every per-node caller uses. */
+async function loadChildren(
+  workerId: string,
+  dirPath: string,
+  showFiles: boolean,
+): Promise<DirectoryListingData> {
+  const [only] = await loadListings(workerId, dirPath, showFiles)
+  // A worker that answers a single-directory request with NO listing committed
+  // a protocol violation, not "the directory is empty" -- an empty directory
+  // answers with one listing whose `entries` is empty. Throw rather than cache
+  // a phantom listing, which the "already loaded" guard would then honour for
+  // the rest of the session.
+  if (!only)
+    throw new Error(`ListDirectory returned no listing for ${dirPath}`)
+  return only
+}
+
+/**
+ * Every directory from `root` down to `target`, outermost first, or `[root]`
+ * when the target is not under the root.
+ *
+ * `split` rather than a scan for separators, because on win32 the VOLUME is one
+ * leading segment: a hand-rolled walk over the separator would emit `C:` as an
+ * ancestor, and `C:` names the current directory on drive C, not its root.
+ *
+ * The accumulator is spelled out rather than built with `join`, which strips a
+ * trailing separator from every element but the last -- and a POSIX root IS
+ * that separator, so `join(['/', 'home'])` answers `'home'`. The win32 root
+ * survives that, which is the kind of half-working that hides inside a helper.
+ */
+function ancestorChain(root: string, target: string, flavor: PathFlavor): string[] {
+  const rel = target ? relativeUnder(target, root, flavor) : null
+  if (!rel)
+    return [root]
+  const separator = sep(flavor)
+  const chain = [root]
+  let cur = root
+  for (const part of split(rel, flavor)) {
+    cur = cur.endsWith(separator) ? `${cur}${part}` : `${cur}${separator}${part}`
+    chain.push(cur)
+  }
+  return chain
 }
 
 /**
@@ -439,11 +553,13 @@ const TreeNode: Component<{
       return
     setLoading(true)
     try {
-      const result = await loadChildren(tree.workerId, props.node.path, tree.showFiles)
-      tree.setChildren(props.node.path, result.entries, result.truncated, result.totalEntries)
-    }
-    catch {
-      // ignore load errors
+      // Through the tree, not straight to the RPC: the chain loader claims
+      // every directory it is about to fetch, so a node revealed by the same
+      // selection change AWAITS that one request instead of racing it with a
+      // request of its own. Without that, revealing a path the tree already
+      // has on screen costs one request per level again -- the exact cost the
+      // chain exists to remove.
+      await tree.ensureChildren(props.node.path)
     }
     finally {
       setLoading(false)
@@ -468,14 +584,23 @@ const TreeNode: Component<{
     }
   }
 
-  // Auto-expand when selectedPath changes to a descendant of this node.
+  // Auto-expand when the reveal target moves under this node. The target is
+  // the user's selection when there is one and `revealPath` when there is not
+  // -- see `DirectoryTreeProps.revealPath`.
+  //
+  // The tree-level chain effect normally caches every ancestor before these
+  // nodes mount, so this takes the `loaded()` branch below and expands with no
+  // round trip. It stays the fallback for a chain request that failed, and it
+  // owns the deepest-node scroll, which the scroll-on-select effect further
+  // down does not cover: that one returns early for a collapsed directory, and
+  // the reveal target is never auto-expanded by its own node.
   createEffect(on(
-    () => props.selectedPath,
-    (selected) => {
+    () => tree.revealTarget(),
+    (target) => {
       if (!props.node.isDir)
         return
       const flavor = tree.flavor()
-      if (!isDescendantPath(selected, props.node.path, flavor))
+      if (!isDescendantPath(target, props.node.path, flavor))
         return
 
       if (!loaded()) {
@@ -484,7 +609,7 @@ const TreeNode: Component<{
           // Scroll into view for the deepest auto-expanded node.
           // Only scroll if this is the closest ancestor (children will handle deeper).
           const hasMatchingChild = children().some(
-            c => c.isDir && (isDescendantPath(selected, c.path, flavor) || selected === c.path),
+            c => c.isDir && (isDescendantPath(target, c.path, flavor) || target === c.path),
           )
           if (!hasMatchingChild) {
             scrollIntoViewIfNeeded()
@@ -696,7 +821,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     props.ref?.({
       collapseAll: () => {
         setState(produce((s) => {
-          const rp = props.rootPath ?? '~'
+          const rp = props.rootPath
           for (const key of Object.keys(s.expandedPaths)) {
             if (key !== rp)
               delete s.expandedPaths[key]
@@ -707,7 +832,12 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     })
   })
 
-  const storageKey = () => `${PREFIX_DIRECTORY_TREE}${props.rootPath ?? '~'}:${props.showFiles ? 'files' : 'dirs'}`
+  // The workerId is part of the key because two workers routinely share a root
+  // path -- every POSIX worker roots the picker at `/`. Without it the restore
+  // below hydrates worker A's listing for worker B, and the load effect then
+  // skips its fetch because the cache is populated, so the picker shows the
+  // wrong machine's directories with no way to tell.
+  const storageKey = () => `${PREFIX_DIRECTORY_TREE}${props.workerId}:${props.rootPath}:${props.showFiles ? 'files' : 'dirs'}`
 
   // Restore state from sessionStorage when rootPath changes
   createEffect(() => {
@@ -725,7 +855,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     catch { /* ignore corrupt data */ }
     // Default: root is expanded
     setState({
-      expandedPaths: { [props.rootPath ?? '~']: true },
+      expandedPaths: { [props.rootPath]: true },
       childrenCache: {},
       truncatedDirs: {},
     })
@@ -792,13 +922,76 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     })
   }
 
+  /**
+   * Write a whole root-to-target chain in ONE reactive pass.
+   *
+   * Per listing it does exactly what `setChildrenInStore` does, by calling it:
+   * the same unchanged-content fast path, the same keyed reconcile, the same
+   * truncation bookkeeping. The difference is the single `batch`. Separate
+   * calls would invalidate `children()`, every node's git decorations and the
+   * whole `<For>` once per level, and the passes in between would render a
+   * tree whose ancestors are loaded and whose descendants are not.
+   */
+  const setListingsInStore = (listings: readonly DirectoryListingData[]) => {
+    batch(() => {
+      for (const listing of listings)
+        setChildrenInStore(listing.path, listing.entries, listing.truncated, listing.totalEntries)
+    })
+  }
+
+  /**
+   * Directories with a listing request already in flight, and the request that
+   * will supply each of them.
+   *
+   * A plain Map, NOT reactive: it says what is happening right now, and a node
+   * that re-rendered because of it would learn nothing it does not already
+   * learn from the cache. The chain loader claims every directory it is about
+   * to fetch BEFORE it awaits, so a per-node load that starts in the same tick
+   * finds the claim and awaits it.
+   */
+  const inFlight = new Map<string, Promise<void>>()
+
+  /** Register one promise as the pending listing for each of `paths`. */
+  const claimInFlight = (paths: readonly string[], work: Promise<void>) => {
+    const settled = work.finally(() => {
+      for (const path of paths) {
+        if (inFlight.get(path) === settled)
+          inFlight.delete(path)
+      }
+    })
+    for (const path of paths)
+      inFlight.set(path, settled)
+    return settled
+  }
+
+  const ensureChildren = (path: string): Promise<void> => {
+    const pending = inFlight.get(path)
+    if (pending)
+      return pending
+    const work = loadChildren(props.workerId, path, props.showFiles ?? false)
+      // eslint-disable-next-line solid/reactivity -- async promise callback; setChildrenInStore reads state as a current-value check, not a subscription
+      .then((result) => {
+        setChildrenInStore(path, result.entries, result.truncated, result.totalEntries)
+      })
+      .catch(() => { /* a failed listing leaves the node collapsed */ })
+    return claimInFlight([path], work)
+  }
+
   const workerFlavor = createMemo<PathFlavor>(() =>
     props.flavor ?? detectFlavor(props.homeDir || props.rootPath || ''))
 
-  const rootPath = () => props.rootPath ?? '~'
+  const rootPath = () => props.rootPath
+  const revealTarget = () => props.selectedPath || props.revealPath || ''
   const rootDisplayName = () => {
     const rp = rootPath()
-    return basename(rp, workerFlavor()) || rp
+    const flavor = workerFlavor()
+    // A FILESYSTEM ROOT has no basename worth showing: `basename('/')` is ''
+    // and `basename('C:\\')` is 'C:' -- the drive without the separator that
+    // makes it a root, and not what a drive selector beside it reads. Label
+    // the root with itself.
+    if (filesystemRoot(rp, flavor) === rp)
+      return rp
+    return basename(rp, flavor) || rp
   }
 
   // Root children derived from the centralized cache, filtered and sorted the
@@ -857,37 +1050,110 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     },
   ))
 
-  // Load root children when workerId or rootPath changes
+  /**
+   * The chain, minus a target the tree already knows is a FILE.
+   *
+   * A file has no listing, so keeping it would leave the "everything cached"
+   * guard permanently false and fire a request on every click of that file.
+   * Before its parent's listing arrives the tree knows nothing about it, so
+   * the file survives exactly one request and drops out afterwards. The worker
+   * ends the chain at the parent as well, so this is belt and braces.
+   */
+  const revealChain = (root: string, target: string, flavor: PathFlavor): string[] => {
+    const chain = ancestorChain(root, target, flavor)
+    if (chain.length < 2)
+      return chain
+    const parent = chain[chain.length - 2]
+    const known = getChildren(parent)?.find(c => c.path === target)
+    return known && !known.isDir ? chain.slice(0, -1) : chain
+  }
+
+  /**
+   * The last chain request this tree issued, as workerId + root + target.
+   *
+   * NOT reactive, and deliberately not derived from the cache. The worker
+   * CANONICALIZES what it lists, so a symlinked ancestor comes back under a
+   * path the chain never named -- the cache guard below then misses forever,
+   * and this effect reads `childrenCache`, so it would re-fetch every time its
+   * own write landed. This key makes that loop impossible rather than leaving
+   * it to the unchanged-content fast path to damp.
+   */
+  let lastChainKey = ''
+
+  // Load the root listing and, when the tree has somewhere to reveal, every
+  // listing between the root and it -- in ONE request.
+  //
+  // This is what makes a root of `/` affordable. Revealing `/home/alice/proj`
+  // through the per-node cascade alone costs four SEQUENTIAL requests, because
+  // each level can only ask once the previous level's listing mounted it.
   createEffect(() => {
     const workerId = props.workerId
-    const root = props.rootPath ?? '~'
+    const root = props.rootPath
+    const target = revealTarget()
     if (!workerId)
       return
     if (props.enabled === false)
       return
 
-    // If we already have cached children (from sessionStorage or previous
-    // load), skip fetching — this eliminates flicker on tab switches.
-    if (getChildren(root) !== undefined)
+    const chain = revealChain(root, target, workerFlavor())
+    // Skip only when EVERY directory on the chain is cached (from
+    // sessionStorage or a previous load), which also removes the flicker on a
+    // tab switch. The old guard tested the root alone, which sufficed while
+    // the root was all this effect fetched; a cached root beside an uncached
+    // ancestor is now the normal state right after a path is typed.
+    if (chain.every(p => getChildren(p) !== undefined))
       return
 
+    const chainKey = JSON.stringify([workerId, root, target])
+    if (chainKey === lastChainKey)
+      return
+    lastChainKey = chainKey
+
+    // The loading and error UI belongs to the FIRST load, when the tree has
+    // nothing to show. A reveal that runs with the root already on screen is
+    // silent -- the same rule the refresh path below states -- so changing the
+    // selection never blanks the tree, and a failed chain never paints an
+    // error over a working one. The per-node cascade still walks the user
+    // there one level at a time when this request fails.
+    const initialRootCached = getChildren(root) !== undefined
+    const chained = chain.length > 1
     const version = ++loadVersion
-    setLoading(true)
-    setError(null)
-    loadChildren(workerId, root, props.showFiles ?? false)
+    if (!initialRootCached) {
+      setLoading(true)
+      setError(null)
+    }
+    const work = loadListings(workerId, chained ? target : root, props.showFiles ?? false, chained ? root : undefined)
       // eslint-disable-next-line solid/reactivity -- async promise callback; setChildrenInStore reads state as a current-value check, not a subscription
-      .then((result) => {
+      .then((listings) => {
         if (version !== loadVersion)
           return
-        setChildrenInStore(root, result.entries, result.truncated, result.totalEntries)
-        setLoading(false)
+        if (listings.length === 0)
+          throw new Error(`ListDirectory returned no listings for ${root}`)
+        // Re-key the FIRST listing to the root we asked for. The worker
+        // canonicalizes what it lists, so a root that is a symlink answers
+        // under a different path -- `/tmp/ws` as `/private/tmp/ws` on macOS --
+        // and the root row's cache is keyed by `props.rootPath`. Deeper
+        // listings keep the worker's spelling, because that is what the
+        // entries' own paths, and therefore the tree's nodes, are built from.
+        setListingsInStore([{ ...listings[0], path: root }, ...listings.slice(1)])
+        if (!initialRootCached)
+          setLoading(false)
       })
       .catch((err) => {
         if (version !== loadVersion)
           return
-        setError(formatErrorMessage(err, 'Failed to load directory'))
-        setLoading(false)
+        // Let the next run retry: the failure was this request's, not this
+        // (workerId, root, target)'s.
+        lastChainKey = ''
+        if (!initialRootCached) {
+          setError(formatErrorMessage(err, 'Failed to load directory'))
+          setLoading(false)
+        }
       })
+    // Claimed AFTER the promise exists but BEFORE anything awaits it, so a
+    // node mounted by this same reveal finds the claim rather than issuing its
+    // own request for a directory this response already carries.
+    claimInFlight(chain, work)
   })
 
   // Auto-refresh tree when an agent turn ends.
@@ -907,7 +1173,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
       if (prev === undefined)
         return
       const workerId = props.workerId
-      const root = props.rootPath ?? '~'
+      const root = props.rootPath
       if (!workerId)
         return
       loadChildren(workerId, root, props.showFiles ?? false)
@@ -929,6 +1195,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     get workerId() { return props.workerId },
     get showFiles() { return props.showFiles ?? false },
     get rootPath() { return rootPath() },
+    revealTarget,
     get homeDir() { return props.homeDir },
     flavor: workerFlavor,
     get scrollContainer() { return treeRef },
@@ -947,6 +1214,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     setNodeExpanded,
     getChildren,
     setChildren: setChildrenInStore,
+    ensureChildren,
     isTruncated,
   }
 

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -192,6 +192,29 @@ interface TreeContextValue {
    */
   refetchChildren: (path: string) => Promise<void>
   isTruncated: (path: string) => boolean
+  /**
+   * The one row that holds a tab stop.
+   *
+   * A tree is ONE stop in the page's tab order, so every row carries
+   * `tabindex="-1"` except this one. It follows the last focused row, and
+   * falls back to the selection, then to the root, when that row goes away
+   * with the directory that held it.
+   */
+  tabStopPath: () => string
+  /** Move the tab stop, and the DOM focus, to one row. */
+  focusRow: (path: string) => void
+  /** Record the row the browser just focused, so the tab stop follows it. */
+  noteRowFocus: (path: string) => void
+  /** Register a row's element, or forget it with `undefined`. */
+  registerRow: (path: string, el: HTMLElement | undefined) => void
+}
+
+/** One row of {@link visibleRows}: what the keyboard pattern needs, and no more. */
+interface VisibleRow {
+  path: string
+  isDir: boolean
+  /** The directory that renders this row, or undefined for the root row. */
+  parent: string | undefined
 }
 
 const TreeContext = createStableContext<TreeContextValue>('tree/DirectoryTree')
@@ -281,6 +304,8 @@ const TreeNode: Component<{
     tree.comparator(),
   ))
   const loaded = () => tree.getChildren(props.node.path) !== undefined
+  // The registry outlives this row, so the row takes its entry with it.
+  onCleanup(() => tree.registerRow(props.node.path, undefined))
 
   const doScroll = () => {
     const container = tree.scrollContainer
@@ -496,6 +521,7 @@ const TreeNode: Component<{
         ref={(el) => {
           nodeRef = el
           setNodeEl(el)
+          tree.registerRow(props.node.path, el)
         }}
         class={styles.node}
         classList={{ [styles.nodeSelected]: isSelected() }}
@@ -505,6 +531,15 @@ const TreeNode: Component<{
         data-active={isSelected() ? 'true' : 'false'}
         style={{ 'padding-left': indent() }}
         data-testid="tree-row"
+        role="treeitem"
+        // Omitted for a file. `aria-expanded` on a row that can never open
+        // announces it as a directory that happens to be closed.
+        aria-expanded={props.node.isDir ? expanded() : undefined}
+        aria-selected={isSelected()}
+        // The root row is level 1, so a depth-0 child is level 2.
+        aria-level={props.depth + 2}
+        tabIndex={tree.tabStopPath() === props.node.path ? 0 : -1}
+        onFocus={() => tree.noteRowFocus(props.node.path)}
         onClick={toggle}
       >
         <Show
@@ -568,7 +603,7 @@ const TreeNode: Component<{
       </Show>
       <Show when={loaded()}>
         <div ref={childrenRef} class={styles.childrenWrapper} classList={{ [styles.childrenWrapperExpanded]: expanded() && !loading() }}>
-          <div class={styles.childrenInner}>
+          <div class={styles.childrenInner} role="group">
             <For each={children()}>
               {child => (
                 <TreeNode
@@ -851,6 +886,148 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     return visibleSortedChildren(all, showHidden(), props.isVisible, comparator())
   })
 
+  // -------------------------------------------------------------------------
+  // Keyboard navigation — the WAI-ARIA tree pattern
+  // -------------------------------------------------------------------------
+
+  /**
+   * Every row the user can see, in the order the tree renders them.
+   *
+   * NOT the DOM order. A collapsed directory still renders its children and
+   * hides them with `visibility: hidden`, so a walk of the DOM would step into
+   * rows that are not on screen. This walk stops at a directory the store
+   * calls closed, and it filters and sorts each level exactly as the render
+   * does, so the two orders cannot drift.
+   */
+  const visibleRows = createMemo<VisibleRow[]>(() => {
+    const rp = rootPath()
+    const rows: VisibleRow[] = [{ path: rp, isDir: true, parent: undefined }]
+    const hidden = showHidden()
+    const visible = props.isVisible
+    const compare = comparator()
+    const walk = (parent: string) => {
+      const all = getChildren(parent)
+      if (!all)
+        return
+      for (const child of visibleSortedChildren(all, hidden, visible, compare)) {
+        rows.push({ path: child.path, isDir: child.isDir, parent })
+        if (child.isDir && isNodeExpanded(child.path))
+          walk(child.path)
+      }
+    }
+    // Unconditional, because the root row renders its children whatever the
+    // store holds for it. It is open by definition.
+    walk(rp)
+    return rows
+  })
+
+  const rowEls = new Map<string, HTMLElement>()
+  const registerRow = (path: string, el: HTMLElement | undefined) => {
+    if (el)
+      rowEls.set(path, el)
+    else
+      rowEls.delete(path)
+  }
+
+  const [focusedPath, setFocusedPath] = createSignal('')
+  const tabStopPath = createMemo(() => {
+    const rows = visibleRows()
+    const onScreen = (path: string) => !!path && rows.some(r => r.path === path)
+    if (onScreen(focusedPath()))
+      return focusedPath()
+    if (onScreen(props.selectedPath))
+      return props.selectedPath
+    return rootPath()
+  })
+
+  const focusRow = (path: string) => {
+    setFocusedPath(path)
+    // `isConnected` covers a row replaced between the walk and this call.
+    // Focus on a detached element does nothing at all, and says nothing.
+    const el = rowEls.get(path)
+    if (el?.isConnected)
+      el.focus()
+  }
+
+  // The root row has no chevron and cannot close, so it reports open whatever
+  // the store says about it.
+  const rowIsOpen = (row: VisibleRow) => row.path === rootPath() || isNodeExpanded(row.path)
+
+  const onTreeKeyDown = (e: KeyboardEvent) => {
+    const rows = visibleRows()
+    const index = rows.findIndex(r => r.path === tabStopPath())
+    if (index < 0)
+      return
+    const row = rows[index]
+    switch (e.key) {
+      case 'ArrowDown':
+        if (index + 1 < rows.length) {
+          e.preventDefault()
+          focusRow(rows[index + 1].path)
+        }
+        break
+      case 'ArrowUp':
+        if (index > 0) {
+          e.preventDefault()
+          focusRow(rows[index - 1].path)
+        }
+        break
+      case 'ArrowRight': {
+        if (!row.isDir)
+          break
+        e.preventDefault()
+        if (!rowIsOpen(row)) {
+          setNodeExpanded(row.path, true)
+          break
+        }
+        // Open already, so the key means "go inside". The first child is the
+        // next row by construction: the walk emits it immediately after.
+        const first = rows[index + 1]
+        if (first?.parent === row.path)
+          focusRow(first.path)
+        break
+      }
+      case 'ArrowLeft':
+        e.preventDefault()
+        if (row.isDir && rowIsOpen(row) && row.path !== rootPath()) {
+          setNodeExpanded(row.path, false)
+          break
+        }
+        if (row.parent)
+          focusRow(row.parent)
+        break
+      case 'Home':
+        e.preventDefault()
+        focusRow(rows[0].path)
+        break
+      case 'End':
+        e.preventDefault()
+        focusRow(rows[rows.length - 1].path)
+        break
+      case 'Enter':
+      case ' ': {
+        e.preventDefault()
+        // The row's OWN click handler, never a copy of it. A click selects and
+        // toggles together, and the two input methods must not drift apart.
+        const el = rowEls.get(row.path)
+        if (el?.isConnected)
+          el.click()
+        break
+      }
+    }
+  }
+
+  // The root row's element, registered under the CURRENT root. `rootPath` can
+  // change under a mounted tree, and a ref callback fires once per element.
+  createEffect(() => {
+    const el = rootNodeEl()
+    const rp = rootPath()
+    if (!el)
+      return
+    registerRow(rp, el)
+    onCleanup(() => registerRow(rp, undefined))
+  })
+
   /**
    * The root row's own modification time, for its three-dot menu.
    *
@@ -963,6 +1140,10 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     ensureChildren,
     refetchChildren,
     isTruncated,
+    tabStopPath,
+    focusRow,
+    noteRowFocus: (path: string) => setFocusedPath(path),
+    registerRow,
   }
 
   return (
@@ -970,7 +1151,15 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
       <div class={styles.container}>
         <div class={styles.tree} ref={treeRef}>
           <Switch fallback={(
-            <div class={styles.treeInner}>
+            // One key handler for the whole tree, because a tree is ONE tab
+            // stop: the row that holds it is the row the keys act on, and it
+            // is reachable from here without a listener on every row.
+            <div
+              class={styles.treeInner}
+              role="tree"
+              aria-label="Directory tree"
+              onKeyDown={onTreeKeyDown}
+            >
               {/* Root directory row */}
               <div
                 ref={setRootNodeEl}
@@ -979,6 +1168,14 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
                 data-active={props.selectedPath === rootPath() ? 'true' : 'false'}
                 style={{ 'padding-left': '8px' }}
                 data-testid="tree-root-node"
+                role="treeitem"
+                // Always open: this row has no chevron, and it renders its
+                // children whenever it has them.
+                aria-expanded={true}
+                aria-selected={props.selectedPath === rootPath()}
+                aria-level={1}
+                tabIndex={tabStopPath() === rootPath() ? 0 : -1}
+                onFocus={() => setFocusedPath(rootPath())}
                 onClick={() => props.onSelect(rootPath())}
               >
                 <Icon icon={FolderOpen} size="sm" class={styles.folderIcon} />
@@ -998,7 +1195,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
               </div>
               <Show when={rootChildren() !== undefined}>
                 <div class={`${styles.childrenWrapper} ${styles.childrenWrapperExpanded}`}>
-                  <div class={styles.childrenInner}>
+                  <div class={styles.childrenInner} role="group">
                     <Show
                       when={rootChildren()!.length > 0}
                       fallback={<div class={emptyState}>{props.isVisible ? 'No changes' : 'Empty directory'}</div>}

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -18,7 +18,7 @@ import { PREFIX_DIRECTORY_TREE, sessionStorageGet, sessionStorageSet } from '~/l
 import { createStableContext } from '~/lib/createStableContext'
 import { formatErrorMessage } from '~/lib/errors'
 import { DEFAULT_FILE_SORT_ORDER, makeFileComparator } from '~/lib/fileSort'
-import { basename, detectFlavor, filesystemRoot, relativeUnder, sep, split } from '~/lib/paths'
+import { basename, detectFlavor, filesystemRoot, join, relativeUnder, split } from '~/lib/paths'
 import { prefersReducedMotion } from '~/lib/prefersReducedMotion'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
 import { emptyState } from '~/styles/shared.css'
@@ -411,21 +411,15 @@ async function loadChildren(
  * `split` rather than a scan for separators, because on win32 the VOLUME is one
  * leading segment: a hand-rolled walk over the separator would emit `C:` as an
  * ancestor, and `C:` names the current directory on drive C, not its root.
- *
- * The accumulator is spelled out rather than built with `join`, which strips a
- * trailing separator from every element but the last -- and a POSIX root IS
- * that separator, so `join(['/', 'home'])` answers `'home'`. The win32 root
- * survives that, which is the kind of half-working that hides inside a helper.
  */
 function ancestorChain(root: string, target: string, flavor: PathFlavor): string[] {
   const rel = target ? relativeUnder(target, root, flavor) : null
   if (!rel)
     return [root]
-  const separator = sep(flavor)
   const chain = [root]
   let cur = root
   for (const part of split(rel, flavor)) {
-    cur = cur.endsWith(separator) ? `${cur}${part}` : `${cur}${separator}${part}`
+    cur = join([cur, part], flavor)
     chain.push(cur)
   }
   return chain

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -1,6 +1,7 @@
 import type { Accessor, Component } from 'solid-js'
-import type { DirectoryListing } from '~/generated/proto/leapmux/v1/file_pb'
-import type { FileSortFields, FileSortKey, FileSortOrder } from '~/lib/fileSort'
+import type { DirectoryListingData } from './directoryListings'
+import type { DirectoryTreeStateJSON, TreeNodeData } from './directoryTreeState'
+import type { FileSortOrder } from '~/lib/fileSort'
 import type { PathFlavor } from '~/lib/paths'
 import type { createRepoGitStore, DiffStats } from '~/stores/repoGit.store'
 import ChevronRight from 'lucide-solid/icons/chevron-right'
@@ -16,13 +17,23 @@ import { Icon } from '~/components/common/Icon'
 import { StartupSpinner } from '~/components/common/StartupPanel'
 import { PREFIX_DIRECTORY_TREE, sessionStorageGet, sessionStorageSet } from '~/lib/browserStorage'
 import { createStableContext } from '~/lib/createStableContext'
-import { formatErrorMessage } from '~/lib/errors'
 import { DEFAULT_FILE_SORT_ORDER, makeFileComparator } from '~/lib/fileSort'
-import { basename, detectFlavor, filesystemRoot, join, relativeUnder, split } from '~/lib/paths'
+import { basename, detectFlavor, isFilesystemRoot } from '~/lib/paths'
 import { prefersReducedMotion } from '~/lib/prefersReducedMotion'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
-import { emptyState } from '~/styles/shared.css'
+import { emptyState, warningText } from '~/styles/shared.css'
+import { createDirectoryListings } from './directoryListings'
 import * as styles from './DirectoryTree.css'
+import {
+  deserializeState,
+  formatTruncationNotice,
+  isDescendantPath,
+  samePath,
+  sameTreeEntries,
+  serializeState,
+  TREE_SORT_FIELDS,
+  visibleSortedChildren,
+} from './directoryTreeState'
 import { getGitFileIconClass, RowLabelWithStats } from './gitStatusUtils'
 import { menuTrigger, sidebarActions } from './sidebarActions.css'
 
@@ -106,51 +117,6 @@ export interface DirectoryTreeProps {
   ref?: (handle: DirectoryTreeHandle) => void
 }
 
-interface TreeNodeData {
-  path: string
-  displayName: string
-  isDir: boolean
-  hidden: boolean
-  /**
-   * Bytes, from the listing's stat. For a DIRECTORY this is the inode's own
-   * size, which says nothing about its contents — nothing displays or sorts on
-   * it (see `makeFileComparator` and `FileActionsMenu`'s `showSize`).
-   */
-  size: number
-  /** RFC3339 UTC, from the listing's stat. */
-  modTime: string
-}
-
-/** The fields the sort comparator reads off a tree node. */
-const TREE_SORT_FIELDS: FileSortFields<TreeNodeData> = {
-  name: node => node.displayName,
-  isDir: node => node.isDir,
-  size: node => node.size,
-  modTime: node => node.modTime || undefined,
-}
-
-// Content equality for the children cache; see setChildrenInStore.
-function sameTreeEntries(a: readonly TreeNodeData[], b: readonly TreeNodeData[]): boolean {
-  if (a === b)
-    return true
-  if (a.length !== b.length)
-    return false
-  for (let i = 0; i < a.length; i++) {
-    const x = a[i]
-    const y = b[i]
-    // size and modTime are part of the comparison because the tree SORTS and
-    // DISPLAYS them: without them, a file whose contents changed but whose
-    // name did not would keep its stale size in the three-dot menu and its
-    // stale position under a size or modified sort. It does cost fast-path
-    // hits that the pre-sort tree never lost -- see setChildrenInStore.
-    if (x.path !== y.path || x.displayName !== y.displayName || x.isDir !== y.isDir
-      || x.hidden !== y.hidden || x.size !== y.size || x.modTime !== y.modTime) {
-      return false
-    }
-  }
-  return true
-}
-
 // -------------------------------------------------------------------------
 // Tree context — bundles stable, tree-wide values to avoid prop drilling
 // -------------------------------------------------------------------------
@@ -175,6 +141,15 @@ interface TreeContextValue {
   comparator: () => (a: TreeNodeData, b: TreeNodeData) => number
   /** The inline notice for a directory the worker truncated, bound to the current sort. */
   truncationNotice: (path: string, shown: number) => string
+  /**
+   * Why a directory would not list, or undefined when it listed.
+   *
+   * The one surface for a per-node listing failure. The tree's own error slot
+   * belongs to the FIRST load, when there is nothing on screen at all, so
+   * without this a directory the caller cannot read simply refused to open
+   * and said nothing.
+   */
+  unreadableReason: (path: string) => string | undefined
   isVisible: () => ((path: string) => boolean) | undefined
   refreshVersion: () => number
   onSelect: (path: string) => void
@@ -195,6 +170,14 @@ interface TreeContextValue {
    * a listing that fails leaves the node collapsed, exactly as before.
    */
   ensureChildren: (path: string) => Promise<void>
+  /**
+   * Fetch one directory's children again, whatever is already in flight.
+   *
+   * The refresh path, and only that: a user who presses Refresh has said the
+   * cached answer is stale, so awaiting a claim made before that would return
+   * exactly the answer they rejected.
+   */
+  refetchChildren: (path: string) => Promise<void>
   isTruncated: (path: string) => boolean
 }
 
@@ -205,224 +188,6 @@ function useTree(): TreeContextValue {
   if (!ctx)
     throw new Error('useTree must be used within a TreeContext.Provider')
   return ctx
-}
-
-// -------------------------------------------------------------------------
-// Serialization helpers for sessionStorage
-// -------------------------------------------------------------------------
-
-/**
- * Schema version for the persisted tree state.
- *
- * Bump this whenever the SHAPE of anything in the payload changes -- a field
- * added to or removed from `TreeNodeData`, or a change to how the two path maps
- * are keyed. The next load then discards the whole payload and re-fetches,
- * instead of hydrating a shape the current code misreads.
- *
- * A version, not a per-field probe: the probe this replaced tested two of
- * `TreeNodeData`'s six fields and could not reach `expandedPaths` or
- * `truncatedDirs` at all, so the next field added here would have needed
- * someone to remember to extend it. Same mechanism as
- * `STORED_ROW_HEIGHTS_VERSION` in the chat's row-height cache.
- *
- * 1: entries carry `size` and `modTime`, so the sidebar can sort by them.
- */
-export const DIRECTORY_TREE_STATE_VERSION = 1
-
-interface DirectoryTreeStateJSON {
-  v?: number
-  expandedPaths: Record<string, boolean>
-  childrenCache: Record<string, TreeNodeData[]>
-  truncatedDirs?: Record<string, number>
-}
-
-function serializeState(
-  expandedPaths: Record<string, boolean>,
-  childrenCache: Record<string, TreeNodeData[]>,
-  truncatedDirs: Record<string, number>,
-): string {
-  return JSON.stringify({ v: DIRECTORY_TREE_STATE_VERSION, expandedPaths, childrenCache, truncatedDirs })
-}
-
-/**
- * Restores the persisted tree state, or null when the payload is unusable.
- *
- * A version mismatch discards EVERYTHING, expansion included. That costs a
- * collapsed tree once per bump, and it buys the one rule that covers every key
- * in the payload: a partial restore would have to prove, for each surviving
- * key, that the old shape still reads correctly under the new code.
- */
-function deserializeState(raw: string): { expandedPaths: Record<string, boolean>, childrenCache: Record<string, TreeNodeData[]>, truncatedDirs: Record<string, number> } | null {
-  try {
-    const json: DirectoryTreeStateJSON = JSON.parse(raw)
-    if (!json || typeof json !== 'object' || json.v !== DIRECTORY_TREE_STATE_VERSION)
-      return null
-    return {
-      expandedPaths: json.expandedPaths ?? {},
-      // Still filtered, for a payload that is the right VERSION but corrupt --
-      // a hand edit, or a truncated write. The version answers "is this shape
-      // current"; this answers "is this value well formed".
-      childrenCache: wellFormedCachedChildren(json.childrenCache),
-      truncatedDirs: json.truncatedDirs ?? {},
-    }
-  }
-  catch {
-    return null
-  }
-}
-
-/** Drops any cached directory whose entries are not a well-formed array. */
-function wellFormedCachedChildren(cache: Record<string, TreeNodeData[]> | undefined): Record<string, TreeNodeData[]> {
-  const usable: Record<string, TreeNodeData[]> = {}
-  for (const [path, entries] of Object.entries(cache ?? {})) {
-    if (!Array.isArray(entries))
-      continue
-    if (entries.every(e => typeof e?.path === 'string' && typeof e?.displayName === 'string'))
-      usable[path] = entries
-  }
-  return usable
-}
-
-// -------------------------------------------------------------------------
-// Visibility helpers
-// -------------------------------------------------------------------------
-
-function isDescendantPath(child: string, parent: string, flavor: PathFlavor): boolean {
-  const rel = relativeUnder(child, parent, flavor)
-  return rel !== null && rel !== ''
-}
-
-/**
- * The inline row shown under a directory the worker truncated.
- *
- * The worker sorts by name and cuts at its entry limit BEFORE stat-ing, so a
- * sort by anything else orders only the entries that survived that cut. The
- * notice names the window, so the user does not read a partial answer as a
- * complete one.
- */
-function formatTruncationNotice(shown: number, total: number, sortKey: FileSortKey): string {
-  // The worker reports what the directory really held, so the notice names the
-  // size of what is hidden instead of only that something is. `total` is 0 for
-  // a listing restored from a cache written before the worker sent it.
-  const count = total > shown ? `${shown} of ${total} entries` : `${shown}+ entries`
-  return sortKey === 'name'
-    ? `${count}, listing truncated`
-    : `${count}, truncated by name before sorting`
-}
-
-/** The rows one directory renders: hidden/git filters first, then the sort. */
-function visibleSortedChildren(
-  all: readonly TreeNodeData[],
-  showHidden: boolean,
-  isVisible: ((path: string) => boolean) | undefined,
-  comparator: (a: TreeNodeData, b: TreeNodeData) => number,
-): TreeNodeData[] {
-  const filtered = showHidden && !isVisible
-    ? all
-    : all.filter(c => (showHidden || !c.hidden) && (!isVisible || isVisible(c.path)))
-  return filtered.toSorted(comparator)
-}
-
-// -------------------------------------------------------------------------
-// File listing
-// -------------------------------------------------------------------------
-
-/** One directory's listing, as the tree caches it. */
-interface DirectoryListingData {
-  path: string
-  entries: TreeNodeData[]
-  truncated: boolean
-  totalEntries: number
-}
-
-function toListingData(listing: DirectoryListing): DirectoryListingData {
-  return {
-    path: listing.path,
-    entries: listing.entries.map(entry => ({
-      path: entry.path,
-      displayName: entry.name,
-      isDir: entry.isDir,
-      hidden: entry.hidden,
-      // `size` is a protobuf int64, so the wire type is bigint. File sizes stay
-      // far below Number.MAX_SAFE_INTEGER, and JSON.stringify -- which the
-      // sessionStorage cache runs on this value -- throws on a bigint.
-      size: Number(entry.size ?? 0n),
-      modTime: entry.modTime,
-    })),
-    truncated: listing.truncated,
-    // `?? 0` for a worker that predates the field: the notice then falls back
-    // to "N+ entries" rather than claiming a total of zero.
-    totalEntries: listing.totalEntries ?? 0,
-  }
-}
-
-/**
- * List one directory, or -- when `fromRoot` is given -- every directory from
- * `fromRoot` down to `dirPath`, outermost first.
- *
- * The chain form is what lets a tree rooted at the FILESYSTEM ROOT reveal a
- * deep selection without one round trip per level. Rooted at `/` and revealing
- * `/home/alice/proj`, the per-node cascade issued four sequential requests,
- * because each level can only ask once the previous level's listing mounted
- * it. One request now answers all four.
- *
- * No sort here: the cache holds the worker's order (directories first, then
- * name), and the display order is applied when the rows render, so changing the
- * sort reorders what is already on screen instead of re-fetching every
- * expanded directory.
- */
-async function loadListings(
-  workerId: string,
-  dirPath: string,
-  showFiles: boolean,
-  fromRoot?: string,
-): Promise<DirectoryListingData[]> {
-  const resp = await workerRpc.listDirectory(workerId, {
-    workerId,
-    path: dirPath,
-    maxDepth: 5,
-    dirsOnly: !showFiles,
-    ...(fromRoot ? { fromRoot } : {}),
-  })
-  return resp.listings.map(toListingData)
-}
-
-/** The single-directory form every per-node caller uses. */
-async function loadChildren(
-  workerId: string,
-  dirPath: string,
-  showFiles: boolean,
-): Promise<DirectoryListingData> {
-  const [only] = await loadListings(workerId, dirPath, showFiles)
-  // A worker that answers a single-directory request with NO listing committed
-  // a protocol violation, not "the directory is empty" -- an empty directory
-  // answers with one listing whose `entries` is empty. Throw rather than cache
-  // a phantom listing, which the "already loaded" guard would then honour for
-  // the rest of the session.
-  if (!only)
-    throw new Error(`ListDirectory returned no listing for ${dirPath}`)
-  return only
-}
-
-/**
- * Every directory from `root` down to `target`, outermost first, or `[root]`
- * when the target is not under the root.
- *
- * `split` rather than a scan for separators, because on win32 the VOLUME is one
- * leading segment: a hand-rolled walk over the separator would emit `C:` as an
- * ancestor, and `C:` names the current directory on drive C, not its root.
- */
-function ancestorChain(root: string, target: string, flavor: PathFlavor): string[] {
-  const rel = target ? relativeUnder(target, root, flavor) : null
-  if (!rel)
-    return [root]
-  const chain = [root]
-  let cur = root
-  for (const part of split(rel, flavor)) {
-    cur = join([cur, part], flavor)
-    chain.push(cur)
-  }
-  return chain
 }
 
 /**
@@ -542,9 +307,19 @@ const TreeNode: Component<{
     childrenRef.addEventListener('transitionend', onEnd)
   }
 
-  const doLoad = async () => {
-    if (loaded() || loading())
-      return
+  // Loads this node's children, and reports whether they arrived.
+  //
+  // The ANSWER is what stops a failure from spinning. A directory the caller
+  // cannot read -- and a tree rooted at `/` puts several in front of every
+  // user -- fails every time it is asked. Expanding it anyway leaves the
+  // "expanded but the cache is missing" effect below permanently satisfied,
+  // and that effect reads `loading()`, so each failure re-triggers it: one
+  // ListDirectory per round trip, for as long as the tree is on screen.
+  const doLoad = async (): Promise<boolean> => {
+    if (loaded())
+      return true
+    if (loading())
+      return false
     setLoading(true)
     try {
       // Through the tree, not straight to the RPC: the chain loader claims
@@ -554,11 +329,20 @@ const TreeNode: Component<{
       // has on screen costs one request per level again -- the exact cost the
       // chain exists to remove.
       await tree.ensureChildren(props.node.path)
+      return loaded()
     }
     finally {
       setLoading(false)
     }
   }
+
+  // Why this node's listing would not load, or undefined when it loaded.
+  //
+  // Read from the tree's store rather than held in a local signal: the reason
+  // is also what the row RENDERS, and one statement of it means the "do not
+  // ask again" mark and the message on screen cannot disagree. A refresh
+  // clears it, which is the user's own "try again".
+  const loadError = () => tree.unreadableReason(props.node.path)
 
   const toggle = async () => {
     if (!props.node.isDir) {
@@ -566,8 +350,11 @@ const TreeNode: Component<{
       tree.onFileOpen?.(props.node.path)
       return
     }
-    await doLoad()
-    const willExpand = !expanded()
+    const ok = await doLoad()
+    // A directory that would not list does not expand: expanding it arms the
+    // re-fetch effect against a request that fails every time. Collapsing is
+    // always allowed, so this gates the OPEN direction alone.
+    const willExpand = !expanded() && ok
 
     // Set expanded state before onSelect so that the scroll-on-select
     // effect sees the correct state and skips scrolling on collapse.
@@ -598,12 +385,17 @@ const TreeNode: Component<{
         return
 
       if (!loaded()) {
-        doLoad().then(() => { // eslint-disable-line solid/reactivity -- one-shot async load
+        doLoad().then((ok) => { // eslint-disable-line solid/reactivity -- one-shot async load
+          // A listing that failed leaves the node collapsed. Expanding it
+          // would arm the re-fetch effect below against a request that fails
+          // every time -- see `doLoad`.
+          if (!ok)
+            return
           tree.setNodeExpanded(props.node.path, true)
           // Scroll into view for the deepest auto-expanded node.
           // Only scroll if this is the closest ancestor (children will handle deeper).
           const hasMatchingChild = children().some(
-            c => c.isDir && (isDescendantPath(target, c.path, flavor) || target === c.path),
+            c => c.isDir && (isDescendantPath(target, c.path, flavor) || samePath(target, c.path, flavor)),
           )
           if (!hasMatchingChild) {
             scrollIntoViewIfNeeded()
@@ -616,10 +408,12 @@ const TreeNode: Component<{
     },
   ))
 
-  // Re-fetch when expanded but cache is missing (e.g. after sessionStorage restore).
+  // Re-fetch when expanded but cache is missing (e.g. after sessionStorage
+  // restore). Never after a failure: this effect reads `loading()`, so a
+  // directory that cannot be read would re-arm it on every rejection.
   createEffect(() => {
-    if (props.node.isDir && expanded() && !loaded() && !loading()) {
-      doLoad()
+    if (props.node.isDir && expanded() && !loaded() && !loading() && !loadError()) {
+      void doLoad()
     }
   })
 
@@ -631,11 +425,14 @@ const TreeNode: Component<{
         return
       if (!props.node.isDir || !expanded())
         return
-      loadChildren(tree.workerId, props.node.path, tree.showFiles)
-        .then((result) => { // eslint-disable-line solid/reactivity -- one-shot async refresh
-          tree.setChildren(props.node.path, result.entries, result.truncated, result.totalEntries)
-        })
-        .catch(() => { /* ignore refresh errors */ })
+      // Through the tree, not straight to the RPC, so the refresh carries the
+      // worker guard: an answer that lands after the tree moved to another
+      // worker must not write the previous worker's listing into it.
+      //
+      // `refetchChildren`, never `ensureChildren`: a pending claim's answer is
+      // the one the user just called stale, so the de-duplicating form would
+      // swallow the refresh entirely.
+      void tree.refetchChildren(props.node.path)
     },
   ))
 
@@ -738,6 +535,24 @@ const TreeNode: Component<{
           Loading...
         </div>
       </Show>
+      {/*
+        Beside the loading row, NOT inside the children block below: a listing
+        that failed leaves the node collapsed, so a reason rendered among the
+        children it does not have would never be seen. This is the one surface
+        for a per-node failure -- the tree's own error slot belongs to the
+        first load, when nothing is on screen at all.
+      */}
+      <Show when={!loading() && loadError()}>
+        {reason => (
+          <div
+            class={`${styles.emptyInline} ${warningText}`}
+            style={{ 'padding-left': `${8 + (props.depth + 1) * 16}px` }}
+            data-testid="tree-node-error"
+          >
+            {reason()}
+          </div>
+        )}
+      </Show>
       <Show when={loaded()}>
         <div ref={childrenRef} class={styles.childrenWrapper} classList={{ [styles.childrenWrapperExpanded]: expanded() && !loading() }}>
           <div class={styles.childrenInner}>
@@ -768,9 +583,6 @@ const TreeNode: Component<{
 }
 
 export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
-  const [loading, setLoading] = createSignal(false)
-  const [error, setError] = createSignal<string | null>(null)
-  let loadVersion = 0
   let treeRef!: HTMLDivElement
   // The root row element, for its right-click / long-press menu.
   const [rootNodeEl, setRootNodeEl] = createContextMenuAnchor()
@@ -801,10 +613,22 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     expandedPaths: Record<string, boolean>
     childrenCache: Record<string, TreeNodeData[]>
     truncatedDirs: Record<string, number>
+    /**
+     * Why a directory would not list, by path.
+     *
+     * Deliberately NOT in the persisted payload. It describes the last
+     * ATTEMPT, not the cached contents, and a reason restored from a previous
+     * session would sit on a row that lists perfectly well now. It is also the
+     * "do not ask again" mark: the re-fetch effect skips a path that has one,
+     * so a directory the caller cannot read is asked about once per Refresh
+     * rather than once per round trip.
+     */
+    unreadableDirs: Record<string, string>
   }>({
     expandedPaths: {},
     childrenCache: {},
     truncatedDirs: {},
+    unreadableDirs: {},
   })
 
   const [refreshVersion, setRefreshVersion] = createSignal(0)
@@ -833,35 +657,15 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   // wrong machine's directories with no way to tell.
   const storageKey = () => `${PREFIX_DIRECTORY_TREE}${props.workerId}:${props.rootPath}:${props.showFiles ? 'files' : 'dirs'}`
 
-  /**
-   * The last chain request this tree issued, as workerId + root + target.
-   *
-   * NOT reactive, and deliberately not derived from the cache. The worker
-   * CANONICALIZES what it lists, so a symlinked ancestor comes back under a
-   * path the chain never named -- the chain effect's cache guard then misses
-   * forever, and that effect reads `childrenCache`, so it would re-fetch every
-   * time its own write landed. This key makes that loop impossible rather than
-   * leaving it to the unchanged-content fast path to damp.
-   *
-   * It describes the request whose result the CURRENT cache holds, so the
-   * effect below clears it whenever it replaces that cache.
-   */
-  let lastChainKey = ''
-
   // Restore state from sessionStorage when rootPath changes
   createEffect(() => {
     const key = storageKey()
-    // The cache is about to be replaced wholesale, so the key no longer
-    // describes it. Leaving it set would suppress the one fetch that refills
-    // an emptied tree -- the guard exists to stop this effect's own writes
-    // from re-triggering it, not to outlive the cache it speaks for.
-    lastChainKey = ''
     try {
-      const stored = sessionStorageGet<string>(key)
+      const stored = sessionStorageGet<DirectoryTreeStateJSON>(key)
       if (stored) {
         const restored = deserializeState(stored)
         if (restored) {
-          setState(restored)
+          setState({ ...restored, unreadableDirs: {} })
           return
         }
       }
@@ -872,6 +676,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
       expandedPaths: { [props.rootPath]: true },
       childrenCache: {},
       truncatedDirs: {},
+      unreadableDirs: {},
     })
   })
 
@@ -900,10 +705,23 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   // PRESENCE means truncated, not truthiness: the stored value is a count, and
   // a worker that does not report one stores 0. Testing the number would make
   // the notice vanish for exactly that case.
+  /** Why this directory would not list, or undefined when it listed. */
+  const unreadableReason = (path: string): string | undefined => state.unreadableDirs[path]
+  const setUnreadable = (path: string, reason: string | undefined) => {
+    if (state.unreadableDirs[path] === reason)
+      return
+    setState('unreadableDirs', produce((u: Record<string, string>) => {
+      if (reason === undefined)
+        delete u[path]
+      else
+        u[path] = reason
+    }))
+  }
+
   const isTruncated = (path: string): boolean => state.truncatedDirs[path] !== undefined
   /** How many entries the worker saw before it cut; 0 when it did not say. */
   const truncatedTotal = (path: string): number => state.truncatedDirs[path] ?? 0
-  // Every turn-end fans out into one loadChildren per expanded TreeNode.
+  // Every turn-end fans out into one listing request per expanded TreeNode.
   // Most subtrees haven't changed between turns, so skip the setState when
   // data and truncation match the cache — otherwise Solid would invalidate
   // children(), per-node gitIcon/diffStats, prefixIndex (walks every file ×
@@ -914,6 +732,9 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     // Compares the stored value INCLUDING its absence, so both "was it cut"
     // and "how much is missing" are covered: an unchanged listing whose total
     // moved (files added past the cut) still refreshes the notice.
+    // A listing that arrived clears the reason: whatever stopped it before,
+    // it does not stop it now.
+    setUnreadable(path, undefined)
     const truncationUnchanged = state.truncatedDirs[path] === (truncated ? totalEntries : undefined)
     if (truncationUnchanged && existing && sameTreeEntries(existing, data))
       return
@@ -953,49 +774,31 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     })
   }
 
-  /**
-   * Directories with a listing request already in flight, and the request that
-   * will supply each of them.
-   *
-   * A plain Map, NOT reactive: it says what is happening right now, and a node
-   * that re-rendered because of it would learn nothing it does not already
-   * learn from the cache. The chain loader claims every directory it is about
-   * to fetch BEFORE it awaits, so a per-node load that starts in the same tick
-   * finds the claim and awaits it.
-   */
-  const inFlight = new Map<string, Promise<void>>()
-
-  /** Register one promise as the pending listing for each of `paths`. */
-  const claimInFlight = (paths: readonly string[], work: Promise<void>) => {
-    const settled = work.finally(() => {
-      for (const path of paths) {
-        if (inFlight.get(path) === settled)
-          inFlight.delete(path)
-      }
-    })
-    for (const path of paths)
-      inFlight.set(path, settled)
-    return settled
-  }
-
-  const ensureChildren = (path: string): Promise<void> => {
-    const pending = inFlight.get(path)
-    if (pending)
-      return pending
-    const work = loadChildren(props.workerId, path, props.showFiles ?? false)
-      // eslint-disable-next-line solid/reactivity -- async promise callback; setChildrenInStore reads state as a current-value check, not a subscription
-      .then((result) => {
-        setChildrenInStore(path, result.entries, result.truncated, result.totalEntries)
-      })
-      .catch(() => { /* a failed listing leaves the node collapsed */ })
-    return claimInFlight([path], work)
-  }
-
   const workerFlavor = createMemo<PathFlavor>(() =>
     props.flavor ?? detectFlavor(props.homeDir || props.rootPath || ''))
 
   const rootPath = () => props.rootPath
   const revealTarget = () => props.selectedPath || props.revealPath || ''
+  // Everything about WHEN to ask the worker, and for what, lives in the
+  // loader. This component owns the store it writes into, and the rows.
+  const listings = createDirectoryListings({
+    workerId: () => props.workerId,
+    rootPath: () => props.rootPath,
+    showFiles: () => props.showFiles ?? false,
+    flavor: () => workerFlavor(),
+    enabled: () => props.enabled !== false,
+    // The key of the cache the loader speaks for. When it changes the store is
+    // replaced wholesale, so every claim and the chain guard go with it -- see
+    // `DirectoryListingsOptions.cacheKey`.
+    cacheKey: storageKey,
+    revealTarget,
+    getChildren,
+    setChildren: setChildrenInStore,
+    setListings: setListingsInStore,
+    setUnreadable,
+  })
+  const { ensureChildren, refetchChildren, loading, error } = listings
+
   const rootDisplayName = () => {
     const rp = rootPath()
     const flavor = workerFlavor()
@@ -1003,7 +806,11 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     // and `basename('C:\\')` is 'C:' -- the drive without the separator that
     // makes it a root, and not what a drive selector beside it reads. Label
     // the root with itself.
-    if (filesystemRoot(rp, flavor) === rp)
+    //
+    // `isFilesystemRoot`, not a comparison against `filesystemRoot`'s output:
+    // a root arrives spelled several ways (`C:/` as well as `C:\`), and only
+    // one of them equals that output.
+    if (isFilesystemRoot(rp, flavor))
       return rp
     return basename(rp, flavor) || rp
   }
@@ -1064,100 +871,6 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     },
   ))
 
-  /**
-   * The chain, minus a target the tree already knows is a FILE.
-   *
-   * A file has no listing, so keeping it would leave the "everything cached"
-   * guard permanently false and fire a request on every click of that file.
-   * Before its parent's listing arrives the tree knows nothing about it, so
-   * the file survives exactly one request and drops out afterwards. The worker
-   * ends the chain at the parent as well, so this is belt and braces.
-   */
-  const revealChain = (root: string, target: string, flavor: PathFlavor): string[] => {
-    const chain = ancestorChain(root, target, flavor)
-    if (chain.length < 2)
-      return chain
-    const parent = chain[chain.length - 2]
-    const known = getChildren(parent)?.find(c => c.path === target)
-    return known && !known.isDir ? chain.slice(0, -1) : chain
-  }
-
-  // Load the root listing and, when the tree has somewhere to reveal, every
-  // listing between the root and it -- in ONE request.
-  //
-  // This is what makes a root of `/` affordable. Revealing `/home/alice/proj`
-  // through the per-node cascade alone costs four SEQUENTIAL requests, because
-  // each level can only ask once the previous level's listing mounted it.
-  createEffect(() => {
-    const workerId = props.workerId
-    const root = props.rootPath
-    const target = revealTarget()
-    if (!workerId)
-      return
-    if (props.enabled === false)
-      return
-
-    const chain = revealChain(root, target, workerFlavor())
-    // Skip only when EVERY directory on the chain is cached (from
-    // sessionStorage or a previous load), which also removes the flicker on a
-    // tab switch. The old guard tested the root alone, which sufficed while
-    // the root was all this effect fetched; a cached root beside an uncached
-    // ancestor is now the normal state right after a path is typed.
-    if (chain.every(p => getChildren(p) !== undefined))
-      return
-
-    const chainKey = JSON.stringify([workerId, root, target])
-    if (chainKey === lastChainKey)
-      return
-    lastChainKey = chainKey
-
-    // The loading and error UI belongs to the FIRST load, when the tree has
-    // nothing to show. A reveal that runs with the root already on screen is
-    // silent -- the same rule the refresh path below states -- so changing the
-    // selection never blanks the tree, and a failed chain never paints an
-    // error over a working one. The per-node cascade still walks the user
-    // there one level at a time when this request fails.
-    const initialRootCached = getChildren(root) !== undefined
-    const chained = chain.length > 1
-    const version = ++loadVersion
-    if (!initialRootCached) {
-      setLoading(true)
-      setError(null)
-    }
-    const work = loadListings(workerId, chained ? target : root, props.showFiles ?? false, chained ? root : undefined)
-      // eslint-disable-next-line solid/reactivity -- async promise callback; setChildrenInStore reads state as a current-value check, not a subscription
-      .then((listings) => {
-        if (version !== loadVersion)
-          return
-        if (listings.length === 0)
-          throw new Error(`ListDirectory returned no listings for ${root}`)
-        // Re-key the FIRST listing to the root we asked for. The worker
-        // canonicalizes what it lists, so a root that is a symlink answers
-        // under a different path -- `/tmp/ws` as `/private/tmp/ws` on macOS --
-        // and the root row's cache is keyed by `props.rootPath`. Deeper
-        // listings keep the worker's spelling, because that is what the
-        // entries' own paths, and therefore the tree's nodes, are built from.
-        setListingsInStore([{ ...listings[0], path: root }, ...listings.slice(1)])
-        if (!initialRootCached)
-          setLoading(false)
-      })
-      .catch((err) => {
-        if (version !== loadVersion)
-          return
-        // Let the next run retry: the failure was this request's, not this
-        // (workerId, root, target)'s.
-        lastChainKey = ''
-        if (!initialRootCached) {
-          setError(formatErrorMessage(err, 'Failed to load directory'))
-          setLoading(false)
-        }
-      })
-    // Claimed AFTER the promise exists but BEFORE anything awaits it, so a
-    // node mounted by this same reveal finds the claim rather than issuing its
-    // own request for a directory this response already carries.
-    claimInFlight(chain, work)
-  })
-
   // Auto-refresh tree when an agent turn ends.
   createEffect(on(
     () => props.turnEndTrigger,
@@ -1174,16 +887,27 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     (_, prev) => {
       if (prev === undefined)
         return
+      // Refresh is "everything you know is stale", and that covers what the
+      // tree knows about a directory it could NOT read. A node whose listing
+      // failed stays collapsed, so nothing re-lists it and its reason would
+      // otherwise sit on the row for the rest of the session. Clearing it also
+      // lifts the "do not ask again" mark, so the next click on that row
+      // retries rather than showing the old message again.
+      // `produce`, not `setState('unreadableDirs', {})`: a store write MERGES
+      // the object it is given, so an empty one changes nothing at all.
+      setState('unreadableDirs', produce((u: Record<string, string>) => {
+        for (const path of Object.keys(u))
+          delete u[path]
+      }))
+
       const workerId = props.workerId
       const root = props.rootPath
       if (!workerId)
         return
-      loadChildren(workerId, root, props.showFiles ?? false)
-        // eslint-disable-next-line solid/reactivity -- async promise callback; setChildrenInStore reads state as a current-value check, not a subscription
-        .then((result) => {
-          setChildrenInStore(root, result.entries, result.truncated, result.totalEntries)
-        })
-        .catch(() => { /* ignore refresh errors */ })
+      // Same form as the per-node refresh above, and for the same two
+      // reasons: the worker guard, and a refresh that must ask again rather
+      // than await a claim it has just declared stale.
+      void refetchChildren(root)
     },
   ))
 
@@ -1204,6 +928,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     get showHiddenFiles() { return showHidden() },
     comparator,
     truncationNotice,
+    unreadableReason,
     gitStatusStore: () => props.gitStatusStore,
     get showGitStatus() { return props.showGitStatus !== false },
     isVisible: () => props.isVisible,
@@ -1217,6 +942,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     getChildren,
     setChildren: setChildrenInStore,
     ensureChildren,
+    refetchChildren,
     isTruncated,
   }
 

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -40,6 +40,19 @@ import { menuTrigger, sidebarActions } from './sidebarActions.css'
 export interface DirectoryTreeHandle {
   collapseAll: () => void
   refresh: () => void
+  /**
+   * Open the node at `path` itself.
+   *
+   * The reveal effect opens every ANCESTOR of the reveal target and stops
+   * there: its `isDescendantPath` test is strict, so the target's own node
+   * never expands. A caller that means "go to this directory and show what is
+   * inside it" takes this second step.
+   *
+   * Call it AFTER the write that selects `path`. That write can re-root the
+   * tree, a new root replaces the whole expansion state, and the reverse order
+   * therefore loses the expansion.
+   */
+  expandPath: (path: string) => void
 }
 
 export interface DirectoryTreeProps {
@@ -634,22 +647,6 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   const [refreshVersion, setRefreshVersion] = createSignal(0)
   const triggerRefresh = () => setRefreshVersion(v => v + 1)
 
-  // Expose imperative handle via ref callback.
-  createEffect(() => {
-    props.ref?.({
-      collapseAll: () => {
-        setState(produce((s) => {
-          const rp = props.rootPath
-          for (const key of Object.keys(s.expandedPaths)) {
-            if (key !== rp)
-              delete s.expandedPaths[key]
-          }
-        }))
-      },
-      refresh: triggerRefresh,
-    })
-  })
-
   // The workerId is part of the key because two workers routinely share a root
   // path -- every POSIX worker roots the picker at `/`. Without it the restore
   // below hydrates worker A's listing for worker B, and the load effect then
@@ -700,6 +697,28 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
       }
     }))
   }
+
+  // Expose imperative handle via ref callback.
+  createEffect(() => {
+    props.ref?.({
+      collapseAll: () => {
+        setState(produce((s) => {
+          const rp = props.rootPath
+          for (const key of Object.keys(s.expandedPaths)) {
+            if (key !== rp)
+              delete s.expandedPaths[key]
+          }
+        }))
+      },
+      refresh: triggerRefresh,
+      // An empty path names no node. Writing one would persist a key that
+      // matches nothing and that no chevron can ever collapse again.
+      expandPath: (path: string) => {
+        if (path)
+          setNodeExpanded(path, true)
+      },
+    })
+  })
 
   const getChildren = (path: string): TreeNodeData[] | undefined => state.childrenCache[path]
   // PRESENCE means truncated, not truthiness: the stored value is a count, and

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -839,9 +839,29 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   // wrong machine's directories with no way to tell.
   const storageKey = () => `${PREFIX_DIRECTORY_TREE}${props.workerId}:${props.rootPath}:${props.showFiles ? 'files' : 'dirs'}`
 
+  /**
+   * The last chain request this tree issued, as workerId + root + target.
+   *
+   * NOT reactive, and deliberately not derived from the cache. The worker
+   * CANONICALIZES what it lists, so a symlinked ancestor comes back under a
+   * path the chain never named -- the chain effect's cache guard then misses
+   * forever, and that effect reads `childrenCache`, so it would re-fetch every
+   * time its own write landed. This key makes that loop impossible rather than
+   * leaving it to the unchanged-content fast path to damp.
+   *
+   * It describes the request whose result the CURRENT cache holds, so the
+   * effect below clears it whenever it replaces that cache.
+   */
+  let lastChainKey = ''
+
   // Restore state from sessionStorage when rootPath changes
   createEffect(() => {
     const key = storageKey()
+    // The cache is about to be replaced wholesale, so the key no longer
+    // describes it. Leaving it set would suppress the one fetch that refills
+    // an emptied tree -- the guard exists to stop this effect's own writes
+    // from re-triggering it, not to outlive the cache it speaks for.
+    lastChainKey = ''
     try {
       const stored = sessionStorageGet<string>(key)
       if (stored) {
@@ -1067,18 +1087,6 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
     const known = getChildren(parent)?.find(c => c.path === target)
     return known && !known.isDir ? chain.slice(0, -1) : chain
   }
-
-  /**
-   * The last chain request this tree issued, as workerId + root + target.
-   *
-   * NOT reactive, and deliberately not derived from the cache. The worker
-   * CANONICALIZES what it lists, so a symlinked ancestor comes back under a
-   * path the chain never named -- the cache guard below then misses forever,
-   * and this effect reads `childrenCache`, so it would re-fetch every time its
-   * own write landed. This key makes that loop impossible rather than leaving
-   * it to the unchanged-content fast path to damp.
-   */
-  let lastChainKey = ''
 
   // Load the root listing and, when the tree has somewhere to reveal, every
   // listing between the root and it -- in ONE request.

--- a/frontend/src/components/tree/FilesSection.test.tsx
+++ b/frontend/src/components/tree/FilesSection.test.tsx
@@ -9,7 +9,7 @@ import { DEFAULT_FILE_SORT_ORDER } from '~/lib/fileSort'
 import { FilesSection, FilesSectionHeaderActions } from './FilesSection'
 
 vi.mock('~/api/workerRpc', () => ({
-  listDirectory: vi.fn(async () => ({ entries: [], truncated: false })),
+  listDirectory: vi.fn(async () => ({ listings: [{ path: '', entries: [], truncated: false, totalEntries: 0 }] })),
   statFile: vi.fn(async () => ({ info: { modTime: '2026-01-01T00:00:00Z' } })),
   channelManager: { subscribe: () => () => {} },
 }))

--- a/frontend/src/components/tree/FilesSection.test.tsx
+++ b/frontend/src/components/tree/FilesSection.test.tsx
@@ -335,3 +335,52 @@ describe('filesSectionHeaderActions', () => {
     expect(screen.getByTestId('files-sort-direction-asc').getAttribute('aria-checked')).toBe('true')
   })
 })
+
+describe('filesSection tree root', () => {
+  function rootRowName(): string | undefined {
+    return document
+      .querySelector('[data-testid="tree-root-node"] [data-testid="tree-row-name"]')
+      ?.textContent ?? undefined
+  }
+
+  function renderWithDirs(workingDir: string, homeDir: string) {
+    return render(() => (
+      <FilesSection
+        workerId={WORKER_ID}
+        workingDir={workingDir}
+        homeDir={homeDir}
+        flavor="posix"
+        fileTreePath=""
+        onFileSelect={() => {}}
+        gitStatusStore={fakeGitStore([])}
+        hasActiveFileTab={false}
+      />
+    ))
+  }
+
+  // The root ROW's label is the observable statement of the tree's root.
+  it('roots the tree at the working directory', async () => {
+    renderWithDirs('/repo', '/home/alice')
+    await waitFor(() => expect(rootRowName()).toBe('repo'))
+  })
+
+  /**
+   * A tab mounts from the CRDT before its working directory arrives. The tree
+   * used to receive the literal `'~'` in that window, which `DirectoryTree`
+   * documents as forbidden: a tilde resolves only on the worker, so
+   * `filesystemRoot('~')` is undefined, `relativeUnder(abs, '~')` is null, and
+   * the reveal, the auto-expand and "Copy relative path" all quietly stop
+   * working against a root that names nothing on disk.
+   */
+  it('falls back to the worker home directory, never to a tilde', async () => {
+    renderWithDirs('', '/home/alice')
+    await waitFor(() => expect(rootRowName()).toBe('alice'))
+  })
+
+  it('renders no tree at all while neither directory is known', async () => {
+    renderWithDirs('', '')
+    // A tick, so this cannot pass merely because the tree has not painted yet.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(document.querySelector('[data-testid="tree-root-node"]')).toBeNull()
+  })
+})

--- a/frontend/src/components/tree/FilesSection.tsx
+++ b/frontend/src/components/tree/FilesSection.tsx
@@ -187,6 +187,18 @@ export const FilesSection: Component<FilesSectionProps> = (props) => {
   // FilterTabBar's other call site already generates its own for that reason.
   const filterPanelId = createUniqueId()
   const [flatListMode, setFlatListMode] = createSignal(false)
+  /**
+   * The tree's root row.
+   *
+   * `DirectoryTreeProps.rootPath` is REQUIRED and must be an absolute path --
+   * a placeholder `'~'` resolves only on the worker, so nothing in the browser
+   * can reason about it. A tab mounts from the CRDT before its working
+   * directory arrives, so this falls back to the worker's home directory,
+   * which the tab is about to root at anyway. Empty until one of the two
+   * answers, and the tree renders nothing in that window.
+   */
+  const treeRoot = createMemo(() => props.workingDir || props.homeDir)
+
   // Both preferences are scoped to (workerId, workingDir), so the key changes
   // whenever the active tab does. createPersistedSignal owns the two rules that
   // go with that: re-read on a key change, and never write on mount.
@@ -257,13 +269,13 @@ export const FilesSection: Component<FilesSectionProps> = (props) => {
   const gitErrorHint = () => props.gitStatusStore.focusedState()?.errorHint || undefined
 
   return (
-    // `data-working-dir` carries the RESOLVED dir, unlike the tree below, which
-    // falls back to `~` so it can render something while the dir is still
-    // hydrating. E2E needs the distinction: several actions (opening a terminal
-    // from the tab bar) read the active tab's dir synchronously on click and
-    // take a one-shot degraded branch when it is empty, so a spec must be able
-    // to wait for the real thing rather than for a placeholder that is already
-    // on screen.
+    // `data-working-dir` carries the tab's own dir, which is empty until the
+    // tab hydrates -- unlike the tree below, which roots at the worker's home
+    // directory in that window. E2E needs the distinction: several actions
+    // (opening a terminal from the tab bar) read the active tab's dir
+    // synchronously on click and take a one-shot degraded branch when it is
+    // empty, so a spec must be able to wait for the real thing rather than for
+    // a tree that is already on screen.
     <div class={styles.wrapper} data-working-dir={props.workingDir}>
       <Show when={gitErrorHint()}>
         <div class={`${warningText} ${styles.gitErrorHint}`} data-testid="files-git-error-hint">
@@ -292,25 +304,29 @@ export const FilesSection: Component<FilesSectionProps> = (props) => {
           when={isFiltered() && flatListMode()}
           fallback={(
             <div class={styles.treeContent}>
-              <DirectoryTree
-                workerId={props.workerId}
-                showFiles
-                selectedPath={props.fileTreePath}
-                onSelect={props.onFileSelect}
-                onFileOpen={path => props.onFileOpen?.(path, activeFilter())}
-                onMention={props.onMention}
-                onOpenTerminal={props.onOpenTerminal}
-                rootPath={props.workingDir || '~'}
-                homeDir={props.homeDir}
-                flavor={props.flavor}
-                gitStatusStore={props.gitStatusStore}
-                isVisible={isVisible()}
-                showHiddenFiles={showHiddenFiles()}
-                sortOrder={sortOrder()}
-                turnEndTrigger={props.turnEndTrigger}
-                enabled={props.enabled}
-                ref={(h) => { treeHandle = h }}
-              />
+              <Show when={treeRoot()}>
+                {root => (
+                  <DirectoryTree
+                    workerId={props.workerId}
+                    showFiles
+                    selectedPath={props.fileTreePath}
+                    onSelect={props.onFileSelect}
+                    onFileOpen={path => props.onFileOpen?.(path, activeFilter())}
+                    onMention={props.onMention}
+                    onOpenTerminal={props.onOpenTerminal}
+                    rootPath={root()}
+                    homeDir={props.homeDir}
+                    flavor={props.flavor}
+                    gitStatusStore={props.gitStatusStore}
+                    isVisible={isVisible()}
+                    showHiddenFiles={showHiddenFiles()}
+                    sortOrder={sortOrder()}
+                    turnEndTrigger={props.turnEndTrigger}
+                    enabled={props.enabled}
+                    ref={(h) => { treeHandle = h }}
+                  />
+                )}
+              </Show>
             </div>
           )}
         >

--- a/frontend/src/components/tree/directoryListings.test.ts
+++ b/frontend/src/components/tree/directoryListings.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ancestorChain, loadChildren, loadListings } from './directoryListings'
+
+const listDirectory = vi.fn()
+vi.mock('~/api/workerRpc', () => ({
+  listDirectory: (...args: unknown[]) => listDirectory(...args),
+}))
+
+beforeEach(() => {
+  listDirectory.mockReset()
+})
+
+function listing(path: string, names: string[] = []) {
+  return {
+    path,
+    entries: names.map(name => ({
+      name,
+      path: `${path}/${name}`,
+      isDir: false,
+      hidden: false,
+      size: 0n,
+      modTime: '2026-01-01T00:00:00Z',
+    })),
+    truncated: false,
+    totalEntries: names.length,
+  }
+}
+
+describe('ancestorChain', () => {
+  it('walks from the root down to the target, outermost first', () => {
+    expect(ancestorChain('/', '/home/alice/proj', 'posix'))
+      .toEqual(['/', '/home', '/home/alice', '/home/alice/proj'])
+  })
+
+  it('answers the root alone when the target is not under it', () => {
+    expect(ancestorChain('/a', '/b/c', 'posix')).toEqual(['/a'])
+  })
+
+  it('answers the root alone for an empty target', () => {
+    expect(ancestorChain('/a', '', 'posix')).toEqual(['/a'])
+  })
+
+  it('answers the root alone when the target IS the root', () => {
+    expect(ancestorChain('/a', '/a', 'posix')).toEqual(['/a'])
+  })
+
+  /**
+   * `split` rather than a scan for separators, because on win32 the VOLUME is
+   * one leading segment. A hand-rolled walk over the separator would emit `C:`
+   * as an ancestor, and `C:` identifies the current directory on drive C, not
+   * its root.
+   */
+  it('never emits a bare drive letter as an ancestor on win32', () => {
+    const chain = ancestorChain('C:\\', 'C:\\Users\\alice', 'win32')
+    expect(chain).toEqual(['C:\\', 'C:\\Users', 'C:\\Users\\alice'])
+    expect(chain).not.toContain('C:')
+  })
+
+  // The target reaches the tree in whatever spelling the user typed, so the
+  // walk has to normalize before it compares.
+  it('accepts a win32 target typed with forward slashes', () => {
+    expect(ancestorChain('C:\\', 'C:/Users/alice', 'win32'))
+      .toEqual(['C:\\', 'C:\\Users', 'C:\\Users\\alice'])
+  })
+
+  it('walks a UNC share root', () => {
+    expect(ancestorChain('\\\\srv\\share\\', '\\\\srv\\share\\a\\b', 'win32'))
+      .toEqual(['\\\\srv\\share\\', '\\\\srv\\share\\a', '\\\\srv\\share\\a\\b'])
+  })
+})
+
+describe('loadListings', () => {
+  it('asks for one directory when no root is given', async () => {
+    listDirectory.mockResolvedValue({ listings: [listing('/a', ['x'])] })
+
+    const resp = await loadListings('w1', '/a', true)
+
+    expect(listDirectory.mock.calls[0][1]).toMatchObject({ path: '/a', dirsOnly: false })
+    expect(listDirectory.mock.calls[0][1].fromRoot).toBeUndefined()
+    expect(resp.listings.map(l => l.path)).toEqual(['/a'])
+  })
+
+  it('sends from_root for a chain, and dirs_only when files are hidden', async () => {
+    listDirectory.mockResolvedValue({ listings: [listing('/'), listing('/a')] })
+
+    const resp = await loadListings('w1', '/a', false, '/')
+
+    expect(listDirectory.mock.calls[0][1]).toMatchObject({ path: '/a', fromRoot: '/', dirsOnly: true })
+    expect(resp.listings.map(l => l.path)).toEqual(['/', '/a'])
+  })
+
+  // The worker names the directory its chain stopped at, and why. A chain that
+  // completed carries nothing, so a tree cannot render a stale reason.
+  it('carries the unreadable directory through, and omits it when absent', async () => {
+    listDirectory.mockResolvedValueOnce({
+      listings: [listing('/')],
+      unreadable: { path: '/blocked', reason: 'permission denied' },
+    })
+    expect((await loadListings('w1', '/blocked/x', false, '/')).unreadable)
+      .toEqual({ path: '/blocked', reason: 'permission denied' })
+
+    listDirectory.mockResolvedValueOnce({ listings: [listing('/')] })
+    expect((await loadListings('w1', '/', false)).unreadable).toBeUndefined()
+  })
+
+  // `size` arrives as a bigint on the wire, and the sessionStorage cache runs
+  // JSON.stringify over this value -- which throws on a bigint.
+  it('converts the wire bigint size to a number', async () => {
+    listDirectory.mockResolvedValue({
+      listings: [{ ...listing('/a'), entries: [{ name: 'x', path: '/a/x', isDir: false, hidden: false, size: 42n, modTime: '' }] }],
+    })
+
+    const [only] = (await loadListings('w1', '/a', true)).listings
+
+    expect(only.entries[0].size).toBe(42)
+    expect(() => JSON.stringify(only)).not.toThrow()
+  })
+})
+
+describe('loadChildren', () => {
+  it('answers the single listing the worker sent', async () => {
+    listDirectory.mockResolvedValue({ listings: [listing('/a', ['x', 'y'])] })
+
+    expect((await loadChildren('w1', '/a', true)).entries.map(e => e.displayName)).toEqual(['x', 'y'])
+  })
+
+  it('answers an empty directory as a listing with no entries', async () => {
+    listDirectory.mockResolvedValue({ listings: [listing('/a')] })
+
+    const only = await loadChildren('w1', '/a', true)
+
+    expect(only.entries).toEqual([])
+    expect(only.truncated).toBe(false)
+  })
+
+  /**
+   * A worker that answers a single-directory request with NO listing committed
+   * a protocol violation, not "the directory is empty" -- an empty directory
+   * answers with one listing whose `entries` is empty. Throwing beats caching a
+   * phantom listing, which the "already loaded" guard would then honour for
+   * the rest of the session.
+   */
+  it('throws rather than caching a phantom listing', async () => {
+    listDirectory.mockResolvedValue({ listings: [] })
+
+    await expect(loadChildren('w1', '/a', true)).rejects.toThrow(/no listing for \/a/)
+  })
+})

--- a/frontend/src/components/tree/directoryListings.ts
+++ b/frontend/src/components/tree/directoryListings.ts
@@ -1,0 +1,425 @@
+import type { Accessor } from 'solid-js'
+import type { TreeNodeData } from './directoryTreeState'
+import type { DirectoryListing } from '~/generated/proto/leapmux/v1/file_pb'
+import type { PathFlavor } from '~/lib/paths'
+import { createEffect, createSignal, on } from 'solid-js'
+import * as workerRpc from '~/api/workerRpc'
+import { formatErrorMessage } from '~/lib/errors'
+import { join, normalizeSeparators, relativeUnder, split } from '~/lib/paths'
+import { samePath } from './directoryTreeState'
+
+// -------------------------------------------------------------------------
+// File listing
+// -------------------------------------------------------------------------
+
+/** One directory's listing, as the tree caches it. */
+export interface DirectoryListingData {
+  path: string
+  entries: TreeNodeData[]
+  truncated: boolean
+  totalEntries: number
+}
+
+function toListingData(listing: DirectoryListing): DirectoryListingData {
+  return {
+    path: listing.path,
+    entries: listing.entries.map(entry => ({
+      path: entry.path,
+      displayName: entry.name,
+      isDir: entry.isDir,
+      hidden: entry.hidden,
+      // `size` is a protobuf int64, so the wire type is bigint. File sizes stay
+      // far below Number.MAX_SAFE_INTEGER, and JSON.stringify -- which the
+      // sessionStorage cache runs on this value -- throws on a bigint.
+      size: Number(entry.size ?? 0n),
+      modTime: entry.modTime,
+    })),
+    truncated: listing.truncated,
+    totalEntries: listing.totalEntries,
+  }
+}
+
+/**
+ * One ListDirectory answer: the listings, and the directory a READ failure
+ * stopped the chain at.
+ *
+ * `unreadable` is absent when the chain is complete AND when a cap cut it: a
+ * listing count and a payload budget are not failures, and the caller lists
+ * the rest itself. So a reason here always has a row to sit on.
+ */
+interface ChainResult {
+  listings: DirectoryListingData[]
+  unreadable?: { path: string, reason: string }
+}
+
+/**
+ * List one directory, or -- when `fromRoot` is given -- every directory from
+ * `fromRoot` down to `dirPath`, outermost first.
+ *
+ * The chain form is what lets a tree rooted at the FILESYSTEM ROOT reveal a
+ * deep selection without one round trip per level. Rooted at `/` and revealing
+ * `/home/alice/proj`, the per-node cascade issued four sequential requests,
+ * because each level can only ask once the previous level's listing mounted
+ * it. One request now answers all four.
+ *
+ * No sort here: the cache holds the worker's order (directories first, then
+ * name), and the display order is applied when the rows render, so changing the
+ * sort reorders what is already on screen instead of re-fetching every
+ * expanded directory.
+ */
+export async function loadListings(
+  workerId: string,
+  dirPath: string,
+  showFiles: boolean,
+  fromRoot?: string,
+): Promise<ChainResult> {
+  const resp = await workerRpc.listDirectory(workerId, {
+    workerId,
+    path: dirPath,
+    maxDepth: 5,
+    dirsOnly: !showFiles,
+    ...(fromRoot ? { fromRoot } : {}),
+  })
+  return {
+    listings: resp.listings.map(toListingData),
+    unreadable: resp.unreadable && { path: resp.unreadable.path, reason: resp.unreadable.reason },
+  }
+}
+
+/** The single-directory form every per-node caller uses. */
+export async function loadChildren(
+  workerId: string,
+  dirPath: string,
+  showFiles: boolean,
+): Promise<DirectoryListingData> {
+  const [only] = (await loadListings(workerId, dirPath, showFiles)).listings
+  // A worker that answers a single-directory request with NO listing committed
+  // a protocol violation, not "the directory is empty" -- an empty directory
+  // answers with one listing whose `entries` is empty. Throw rather than cache
+  // a phantom listing, which the "already loaded" guard would then honour for
+  // the rest of the session.
+  if (!only)
+    throw new Error(`ListDirectory returned no listing for ${dirPath}`)
+  return only
+}
+
+/**
+ * Every directory from `root` down to `target`, outermost first, or `[root]`
+ * when the target is not under the root.
+ *
+ * `split` rather than a scan for separators, because on win32 the VOLUME is one
+ * leading segment: a hand-rolled walk over the separator would emit `C:` as an
+ * ancestor, and `C:` identifies the current directory on drive C, not its
+ * root.
+ *
+ * Both inputs are normalized first, for the reason `isDescendantPath` states:
+ * a target the user typed as `C:/Users/alice` is under a root spelled `C:\`,
+ * and an un-normalized comparison says it is not.
+ */
+export function ancestorChain(root: string, target: string, flavor: PathFlavor): string[] {
+  const rel = target ? relativeUnder(normalizeSeparators(target, flavor), normalizeSeparators(root, flavor), flavor) : null
+  if (!rel)
+    return [root]
+  const chain = [root]
+  let cur = root
+  for (const part of split(rel, flavor)) {
+    cur = join([cur, part], flavor)
+    chain.push(cur)
+  }
+  return chain
+}
+
+/** What {@link createDirectoryListings} reads from the tree, and writes back. */
+export interface DirectoryListingsOptions {
+  workerId: Accessor<string>
+  rootPath: Accessor<string>
+  showFiles: Accessor<boolean>
+  flavor: Accessor<PathFlavor>
+  /** False suspends the loader entirely: a hidden tree asks for nothing. */
+  enabled: Accessor<boolean>
+  /**
+   * The key of the cache this loader speaks for.
+   *
+   * When it changes, the caller replaces the whole store, so every claim and
+   * the chain guard go with it: both describe the cache that just went away,
+   * and neither can be rebuilt from the new one. The loader watches this
+   * itself, rather than taking a `reset()` the caller must remember to call,
+   * because the ORDER matters -- the drop has to happen before the chain
+   * effect reads the new cache.
+   */
+  cacheKey: Accessor<string>
+  /** The path the tree walks itself open toward. Drives the chain request. */
+  revealTarget: Accessor<string>
+  getChildren: (path: string) => TreeNodeData[] | undefined
+  /** Write one directory's children. */
+  setChildren: (path: string, entries: TreeNodeData[], truncated: boolean, totalEntries: number) => void
+  /** Write a whole chain in ONE reactive pass. */
+  setListings: (listings: readonly DirectoryListingData[]) => void
+  /** Record, or clear, why a directory would not list. */
+  setUnreadable: (path: string, reason: string | undefined) => void
+}
+
+export interface DirectoryListings {
+  /** True only for the FIRST load, when the tree has nothing to show. */
+  loading: Accessor<boolean>
+  /** Set only when that first load failed, for the same reason. */
+  error: Accessor<string | null>
+  ensureChildren: (path: string) => Promise<void>
+  refetchChildren: (path: string) => Promise<void>
+}
+
+/**
+ * The tree's listing loader: what it asks the worker for, and when.
+ *
+ * Split from the component because none of it renders. It owns the in-flight
+ * registry, the chain request and the guard that keeps that request from
+ * re-firing on its own write; the component owns the store it writes into and
+ * every row it draws.
+ *
+ * `loading` and `error` come back OUT because the tree renders them, and
+ * because only the loader knows which load is the first one -- the one with
+ * nothing on screen behind it, and therefore the only one whose failure is
+ * worth a full-pane error.
+ */
+export function createDirectoryListings(opts: DirectoryListingsOptions): DirectoryListings {
+  const [loading, setLoading] = createSignal(false)
+  const [error, setError] = createSignal<string | null>(null)
+  let loadVersion = 0
+
+  /**
+   * Directories with a listing request already in flight, and the request that
+   * will supply each of them.
+   *
+   * A plain Map, NOT reactive: it records the requests in flight right now,
+   * and a node that re-rendered because of it would learn nothing it does not
+   * already learn from the cache. The chain loader claims every directory it is about
+   * to fetch BEFORE it awaits, so a per-node load that starts in the same tick
+   * finds the claim and awaits it.
+   */
+  const inFlight = new Map<string, Promise<void>>()
+
+  /** Register one promise as the pending listing for each of `paths`. */
+  const claimInFlight = (paths: readonly string[], work: Promise<void>) => {
+    const settled = work.finally(() => {
+      for (const path of paths) {
+        if (inFlight.get(path) === settled)
+          inFlight.delete(path)
+      }
+    })
+    for (const path of paths)
+      inFlight.set(path, settled)
+    return settled
+  }
+
+  /**
+   * Drop every claim, because the answers they promise no longer belong to
+   * this tree.
+   *
+   * The store is replaced wholesale when the worker or the root changes, and
+   * `inFlight` must go with it. Two workers routinely share a path -- every
+   * POSIX worker roots the picker at `/` and reveals `/home` -- so a claim
+   * left behind is one a node of the NEXT worker awaits, and it resolves with
+   * the previous worker's listing.
+   */
+  const clearInFlight = () => inFlight.clear()
+
+  /**
+   * The last chain request this tree issued, as workerId + root + target.
+   *
+   * NOT reactive, and deliberately not derived from the cache. The worker
+   * CANONICALIZES what it lists, so a symlinked ancestor comes back under a
+   * path the chain never listed -- the chain effect's cache guard then misses
+   * forever, and that effect reads `childrenCache`, so it would re-fetch every
+   * time its own write landed. This key makes that loop impossible rather than
+   * leaving it to the unchanged-content fast path to damp.
+   *
+   * It describes the request whose result the CURRENT cache holds, so the
+   * effect below clears it whenever it replaces that cache.
+   */
+  let lastChainKey = ''
+
+  /**
+   * List one directory and cache it, whatever is already in flight for it.
+   *
+   * The worker is CAPTURED, not read again in the callback: the props can move
+   * to another worker while the request is open, and two workers routinely
+   * share a path -- every POSIX worker roots the picker at `/`. Without the
+   * guard the answer lands in the next worker's tree, which then shows one
+   * machine's directories labelled as another's.
+   */
+  const refetchChildren = (path: string): Promise<void> => {
+    const workerId = opts.workerId()
+    const showFiles = opts.showFiles()
+    const work = loadChildren(workerId, path, showFiles)
+
+      .then((result) => {
+        if (workerId !== opts.workerId())
+          return
+        opts.setChildren(path, result.entries, result.truncated, result.totalEntries)
+      })
+
+      .catch((err) => {
+        // A failed listing leaves the node collapsed, and now says why. This
+        // is the only surface for it: the tree's one error slot belongs to the
+        // FIRST load, so a per-node failure used to disappear entirely.
+        if (workerId === opts.workerId())
+          opts.setUnreadable(path, formatErrorMessage(err, 'cannot be read'))
+      })
+    return claimInFlight([path], work)
+  }
+
+  const ensureChildren = async (path: string): Promise<void> => {
+    const pending = inFlight.get(path)
+    if (pending) {
+      await pending
+      // A claim is a HINT, not a guarantee. The chain loader claims every
+      // directory it asks about, and the worker may answer with fewer
+      // listings -- it caps the chain by count and by payload budget, and it
+      // stops at a level it cannot read. Re-check, and ask for what the
+      // response did not carry.
+      if (opts.getChildren(path) !== undefined)
+        return
+      // Through `ensureChildren` again, not `refetchChildren`: two nodes that
+      // awaited the same claim must not each start a request. The claim above
+      // is already deleted by the time any awaiter resumes, so this recurses
+      // exactly once.
+      return ensureChildren(path)
+    }
+    return refetchChildren(path)
+  }
+
+  // BEFORE the chain effect below, so on a cacheKey change this runs first and
+  // that effect reads a loader with nothing stale in it. Solid runs effects in
+  // creation order, so the position of this call is the guarantee.
+  createEffect(on(opts.cacheKey, () => {
+    clearInFlight()
+    lastChainKey = ''
+  }))
+
+  /**
+   * The chain, minus a target the tree already knows is a FILE.
+   *
+   * A file has no listing, so keeping it would leave the "everything cached"
+   * guard permanently false and fire a request on every click of that file.
+   * Before its parent's listing arrives the tree knows nothing about it, so
+   * the file survives exactly one request and drops out afterwards. The worker
+   * ends the chain at the parent as well, so this guard is a second, redundant
+   * one -- but it is the one that removes the REQUEST, which the worker's own
+   * rule cannot do.
+   */
+  const revealChain = (root: string, target: string, flavor: PathFlavor): string[] => {
+    const chain = ancestorChain(root, target, flavor)
+    if (chain.length < 2)
+      return chain
+    const parent = chain[chain.length - 2]
+    const known = opts.getChildren(parent)?.find(c => samePath(c.path, target, flavor))
+    return known && !known.isDir ? chain.slice(0, -1) : chain
+  }
+
+  // Load the root listing and, when the tree has somewhere to reveal, every
+  // listing between the root and it -- in ONE request.
+  //
+  // This is what makes a root of `/` affordable. Revealing `/home/alice/proj`
+  // through the per-node cascade alone costs four SEQUENTIAL requests, because
+  // each level can only ask once the previous level's listing mounted it.
+  createEffect(() => {
+    const workerId = opts.workerId()
+    const root = opts.rootPath()
+    const target = opts.revealTarget()
+    if (!workerId)
+      return
+    if (!opts.enabled())
+      return
+
+    const chain = revealChain(root, target, opts.flavor())
+    // Skip only when EVERY directory on the chain is cached (from
+    // sessionStorage or a previous load), which also removes the flicker on a
+    // tab switch. The old guard tested the root alone, which sufficed while
+    // the root was all this effect fetched; a cached root beside an uncached
+    // ancestor is now the normal state right after a path is typed.
+    if (chain.every(p => opts.getChildren(p) !== undefined))
+      return
+
+    const chainKey = JSON.stringify([workerId, root, target])
+    if (chainKey === lastChainKey)
+      return
+    lastChainKey = chainKey
+
+    // The loading and error UI belongs to the FIRST load, when the tree has
+    // nothing to show. A reveal that runs with the root already on screen is
+    // silent -- the same rule the refresh path below states -- so changing the
+    // selection never blanks the tree, and a failed chain never paints an
+    // error over a working one. The per-node cascade still walks the user
+    // there one level at a time when this request fails.
+    const initialRootCached = opts.getChildren(root) !== undefined
+    const chained = chain.length > 1
+    const version = ++loadVersion
+    if (initialRootCached) {
+      // This run supersedes any pending one, and it has content on screen, so
+      // it will never lower `loading` itself. Lower it here instead: without
+      // this, a run that started with the root uncached raises `loading`, this
+      // run invalidates it by `loadVersion`, and nobody ever lowers it -- the
+      // whole tree stays behind "Loading..." for the life of the component.
+      setLoading(false)
+    }
+    else {
+      setLoading(true)
+      setError(null)
+    }
+    // The chain's OWN deepest element, not the raw target. `revealChain` drops
+    // a target it already knows is a file, and sending the file anyway makes
+    // the worker repeat that rule -- two implementations of one decision.
+    const deepest = chain[chain.length - 1]
+    const work = loadListings(workerId, deepest, opts.showFiles(), chained ? root : undefined)
+
+      .then((resp) => {
+        if (version !== loadVersion)
+          return
+        const { listings } = resp
+        if (listings.length === 0)
+          throw new Error(`ListDirectory returned no listings for ${root}`)
+        // Re-key the FIRST listing to the root we asked for. The worker
+        // canonicalizes what it lists, so a root that is a symlink answers
+        // under a different path -- `/tmp/ws` as `/private/tmp/ws` on macOS --
+        // and the root row's cache is keyed by `opts.rootPath()`. Deeper
+        // listings keep the worker's spelling, because that is what the
+        // entries' own paths, and therefore the tree's nodes, are built from.
+        //
+        // This repairs the ROOT key alone, and it cannot do more. When the
+        // worker canonicalizes a level BELOW the root, the level count changes
+        // with it -- `/tmp/ws` is two levels under `/` and `/private/tmp/ws`
+        // is three -- so no pairing by index recovers the caller's spelling.
+        // Those middle listings then land under keys no node reads, the
+        // "everything cached" guard above stays false, and `lastChainKey`
+        // is what stops the effect re-firing on its own write. The tree still
+        // reaches the target: the per-node cascade re-lists each such level
+        // under the path it asked for, at one round trip per level. The chain
+        // is an optimization, and this is the case where it does not apply.
+        opts.setListings([{ ...listings[0], path: root }, ...listings.slice(1)])
+        // The worker names the directory its chain stopped at, and why. Set it
+        // AFTER the listings, because writing a listing clears the reason for
+        // that path and the unreadable one carries no listing.
+        if (resp.unreadable)
+          opts.setUnreadable(resp.unreadable.path, resp.unreadable.reason)
+        if (!initialRootCached)
+          setLoading(false)
+      })
+      .catch((err) => {
+        if (version !== loadVersion)
+          return
+        // Let the next run retry: the failure was this request's, not this
+        // (workerId, root, target)'s.
+        lastChainKey = ''
+        if (!initialRootCached) {
+          setError(formatErrorMessage(err, 'Failed to load directory'))
+          setLoading(false)
+        }
+      })
+    // Claimed AFTER the promise exists but BEFORE anything awaits it, so a
+    // node mounted by this same reveal finds the claim rather than issuing its
+    // own request for a directory this response already carries.
+    claimInFlight(chain, work)
+  })
+
+  return { loading, error, ensureChildren, refetchChildren }
+}

--- a/frontend/src/components/tree/directoryTreeState.test.ts
+++ b/frontend/src/components/tree/directoryTreeState.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import {
+  deserializeState,
+  DIRECTORY_TREE_STATE_VERSION,
+  formatTruncationNotice,
+  isDescendantPath,
+  samePath,
+  sameTreeEntries,
+  serializeState,
+  visibleSortedChildren,
+} from './directoryTreeState'
+
+function node(path: string, over: Partial<{ displayName: string, isDir: boolean, hidden: boolean, size: number, modTime: string }> = {}) {
+  return {
+    path,
+    displayName: over.displayName ?? path.split('/').pop()!,
+    isDir: over.isDir ?? false,
+    hidden: over.hidden ?? false,
+    size: over.size ?? 0,
+    modTime: over.modTime ?? '2026-01-01T00:00:00Z',
+  }
+}
+
+describe('isDescendantPath', () => {
+  it('accepts a path strictly under the parent', () => {
+    expect(isDescendantPath('/a/b', '/a', 'posix')).toBe(true)
+    expect(isDescendantPath('/a/b/c', '/a', 'posix')).toBe(true)
+  })
+
+  // A node never counts as its own descendant: the reveal effect uses this to
+  // decide what to auto-expand, and a node must not expand itself.
+  it('refuses the parent itself and a sibling', () => {
+    expect(isDescendantPath('/a', '/a', 'posix')).toBe(false)
+    expect(isDescendantPath('/ab', '/a', 'posix')).toBe(false)
+  })
+
+  /**
+   * `PathInput` submits whatever the user typed, so a win32 selection reaches
+   * the tree spelled `C:/Users/alice` while the worker's listings spell it
+   * `C:\Users\alice`. An un-normalized comparison answers "not under", which
+   * collapses the whole reveal.
+   */
+  it('normalizes separators and case on win32', () => {
+    expect(isDescendantPath('C:/Users/alice', 'C:\\Users', 'win32')).toBe(true)
+    expect(isDescendantPath('c:\\users\\alice', 'C:\\Users', 'win32')).toBe(true)
+  })
+
+  // `\` is a legal character in a POSIX file name, so it is NOT a separator
+  // there and `a\b` is one component.
+  it('does not treat a backslash as a separator on posix', () => {
+    expect(isDescendantPath('/a\\b', '/a', 'posix')).toBe(false)
+  })
+})
+
+describe('samePath', () => {
+  it('matches across win32 separator and case spellings', () => {
+    expect(samePath('C:/Users', 'C:\\users', 'win32')).toBe(true)
+  })
+
+  it('is byte-exact on posix', () => {
+    expect(samePath('/A', '/a', 'posix')).toBe(false)
+    expect(samePath('/a', '/a', 'posix')).toBe(true)
+  })
+})
+
+describe('sameTreeEntries', () => {
+  it('reports identical content as unchanged', () => {
+    expect(sameTreeEntries([node('/a/x')], [node('/a/x')])).toBe(true)
+    expect(sameTreeEntries([], [])).toBe(true)
+  })
+
+  // size and modTime are in the comparison because the tree SORTS and DISPLAYS
+  // them: a file whose contents changed but whose name did not would otherwise
+  // keep its stale size and its stale position under a size sort.
+  it('reports a changed size or modTime as changed', () => {
+    expect(sameTreeEntries([node('/a/x', { size: 1 })], [node('/a/x', { size: 2 })])).toBe(false)
+    expect(sameTreeEntries(
+      [node('/a/x', { modTime: '2026-01-01T00:00:00Z' })],
+      [node('/a/x', { modTime: '2026-02-01T00:00:00Z' })],
+    )).toBe(false)
+  })
+
+  it('reports a different length or a different path as changed', () => {
+    expect(sameTreeEntries([node('/a/x')], [node('/a/x'), node('/a/y')])).toBe(false)
+    expect(sameTreeEntries([node('/a/x')], [node('/a/y')])).toBe(false)
+  })
+})
+
+describe('serializeState and deserializeState', () => {
+  const state = {
+    expandedPaths: { '/a': true },
+    childrenCache: { '/a': [node('/a/x')] },
+    truncatedDirs: { '/a': 300 },
+  }
+
+  it('round-trips a payload at the current version', () => {
+    expect(deserializeState(serializeState(state.expandedPaths, state.childrenCache, state.truncatedDirs)))
+      .toEqual(state)
+  })
+
+  // A version mismatch discards EVERYTHING, expansion included: a partial
+  // restore would have to prove, per key, that the old shape still reads
+  // correctly under the new code.
+  it('discards a payload stamped with another version', () => {
+    const stored = serializeState(state.expandedPaths, state.childrenCache, state.truncatedDirs)
+    expect(deserializeState({ ...stored, v: DIRECTORY_TREE_STATE_VERSION + 1 })).toBeNull()
+    expect(deserializeState({ ...stored, v: undefined })).toBeNull()
+    expect(deserializeState(undefined)).toBeNull()
+  })
+
+  // The version answers "is this shape current"; this answers "is this value
+  // well formed" -- for a hand edit, or a truncated write.
+  it('drops a malformed directory but keeps the rest', () => {
+    const restored = deserializeState({
+      v: DIRECTORY_TREE_STATE_VERSION,
+      expandedPaths: { '/a': true },
+      childrenCache: { '/a': [node('/a/x')], '/bad': 'nope' as never, '/partial': [{ path: '/p' } as never] },
+      truncatedDirs: {},
+    })
+    expect(Object.keys(restored!.childrenCache)).toEqual(['/a'])
+  })
+})
+
+describe('formatTruncationNotice', () => {
+  // The worker reports what the directory really held, so the notice gives the
+  // size of what is hidden rather than only that something is.
+  it('gives the real total when the worker sent one', () => {
+    expect(formatTruncationNotice(256, 300, 'name')).toBe('256 of 300 entries, listing truncated')
+  })
+
+  // `total` is 0 for a listing restored from a cache written before the worker
+  // sent it, so the notice falls back rather than claiming a total of zero.
+  it('falls back to N+ when the total is unknown', () => {
+    expect(formatTruncationNotice(256, 0, 'name')).toBe('256+ entries, listing truncated')
+  })
+
+  // The worker cuts BY NAME before stat-ing, so any other sort orders only
+  // what survived that cut. The notice has to say so.
+  it('says the cut came first for a non-name sort', () => {
+    expect(formatTruncationNotice(256, 300, 'size')).toBe('256 of 300 entries, truncated by name before sorting')
+  })
+})
+
+describe('visibleSortedChildren', () => {
+  const byName = (a: { displayName: string }, b: { displayName: string }) => a.displayName.localeCompare(b.displayName)
+  const all = [node('/a/c'), node('/a/.hidden'), node('/a/b')]
+
+  it('drops hidden entries and sorts the rest', () => {
+    expect(visibleSortedChildren([node('/a/c'), node('/a/.h', { hidden: true }), node('/a/b')], false, undefined, byName)
+      .map(n => n.displayName)).toEqual(['b', 'c'])
+  })
+
+  it('keeps hidden entries when asked', () => {
+    expect(visibleSortedChildren(all, true, undefined, byName)).toHaveLength(3)
+  })
+
+  // The git filter runs even when hidden files are shown, so a filtered tree
+  // does not quietly widen when the user toggles hidden files on.
+  it('applies the visibility filter even with hidden shown', () => {
+    const visible = (p: string) => p !== '/a/c'
+    expect(visibleSortedChildren(all, true, visible, byName).map(n => n.path)).not.toContain('/a/c')
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [node('/a/c'), node('/a/b')]
+    visibleSortedChildren(input, true, undefined, byName)
+    expect(input.map(n => n.displayName)).toEqual(['c', 'b'])
+  })
+})

--- a/frontend/src/components/tree/directoryTreeState.ts
+++ b/frontend/src/components/tree/directoryTreeState.ts
@@ -1,0 +1,193 @@
+import type { FileSortFields, FileSortKey } from '~/lib/fileSort'
+import type { PathFlavor } from '~/lib/paths'
+import { normalizeSeparators, pathEq, relativeUnder } from '~/lib/paths'
+
+// The tree's own state: the row it caches, the schema it persists, and the
+// pure predicates its rendering asks. None of this reads a store or a prop, so
+// it is testable without mounting a component -- which is why it lives beside
+// `DirectoryTree` rather than inside it.
+
+export interface TreeNodeData {
+  path: string
+  displayName: string
+  isDir: boolean
+  hidden: boolean
+  /**
+   * Bytes, from the listing's stat. For a DIRECTORY this is the inode's own
+   * size, which says nothing about its contents — nothing displays or sorts on
+   * it (see `makeFileComparator` and `FileActionsMenu`'s `showSize`).
+   */
+  size: number
+  /** RFC3339 UTC, from the listing's stat. */
+  modTime: string
+}
+
+/** The fields the sort comparator reads off a tree node. */
+export const TREE_SORT_FIELDS: FileSortFields<TreeNodeData> = {
+  name: node => node.displayName,
+  isDir: node => node.isDir,
+  size: node => node.size,
+  modTime: node => node.modTime || undefined,
+}
+
+// Content equality for the children cache; see setChildrenInStore.
+export function sameTreeEntries(a: readonly TreeNodeData[], b: readonly TreeNodeData[]): boolean {
+  if (a === b)
+    return true
+  if (a.length !== b.length)
+    return false
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]
+    const y = b[i]
+    // size and modTime are part of the comparison because the tree SORTS and
+    // DISPLAYS them: without them, a file whose contents changed but whose
+    // name did not would keep its stale size in the three-dot menu and its
+    // stale position under a size or modified sort. It does cost fast-path
+    // hits that the pre-sort tree never lost -- see setChildrenInStore.
+    if (x.path !== y.path || x.displayName !== y.displayName || x.isDir !== y.isDir
+      || x.hidden !== y.hidden || x.size !== y.size || x.modTime !== y.modTime) {
+      return false
+    }
+  }
+  return true
+}
+
+// -------------------------------------------------------------------------
+// Serialization helpers for sessionStorage
+// -------------------------------------------------------------------------
+
+/**
+ * Schema version for the persisted tree state.
+ *
+ * Bump this whenever the SHAPE of anything in the payload changes -- a field
+ * added to or removed from `TreeNodeData`, or a change to how the two path maps
+ * are keyed. The next load then discards the whole payload and re-fetches,
+ * instead of hydrating a shape the current code misreads.
+ *
+ * A version, not a per-field probe: the probe this replaced tested two of
+ * `TreeNodeData`'s six fields and could not reach `expandedPaths` or
+ * `truncatedDirs` at all, so the next field added here would have needed
+ * someone to remember to extend it. Same mechanism as
+ * `STORED_ROW_HEIGHTS_VERSION` in the chat's row-height cache.
+ *
+ * 1: entries carry `size` and `modTime`, so the sidebar can sort by them.
+ */
+export const DIRECTORY_TREE_STATE_VERSION = 1
+
+export interface DirectoryTreeStateJSON {
+  v?: number
+  expandedPaths: Record<string, boolean>
+  childrenCache: Record<string, TreeNodeData[]>
+  truncatedDirs?: Record<string, number>
+}
+
+/**
+ * The stored shape, as an OBJECT.
+ *
+ * Not a string: `sessionStorageSet` serializes whatever it is handed, so a
+ * pre-stringified payload is stringified a second time -- once to build it,
+ * once to escape every quotation mark of it inside the wrapper. This effect
+ * runs on every store write, and a `/`-rooted tree caches many more directory
+ * listings than a home-rooted one did.
+ */
+export function serializeState(
+  expandedPaths: Record<string, boolean>,
+  childrenCache: Record<string, TreeNodeData[]>,
+  truncatedDirs: Record<string, number>,
+): DirectoryTreeStateJSON {
+  return { v: DIRECTORY_TREE_STATE_VERSION, expandedPaths, childrenCache, truncatedDirs }
+}
+
+/**
+ * Restores the persisted tree state, or null when the payload is unusable.
+ *
+ * A version mismatch discards EVERYTHING, expansion included. That costs a
+ * collapsed tree once per bump, and it buys the one rule that covers every key
+ * in the payload: a partial restore would have to prove, for each surviving
+ * key, that the old shape still reads correctly under the new code.
+ */
+export function deserializeState(json: DirectoryTreeStateJSON | undefined): { expandedPaths: Record<string, boolean>, childrenCache: Record<string, TreeNodeData[]>, truncatedDirs: Record<string, number> } | null {
+  try {
+    if (!json || typeof json !== 'object' || json.v !== DIRECTORY_TREE_STATE_VERSION)
+      return null
+    return {
+      expandedPaths: json.expandedPaths ?? {},
+      // Still filtered, for a payload that is the right VERSION but corrupt --
+      // a hand edit, or a truncated write. The version answers "is this shape
+      // current"; this answers "is this value well formed".
+      childrenCache: wellFormedCachedChildren(json.childrenCache),
+      truncatedDirs: json.truncatedDirs ?? {},
+    }
+  }
+  catch {
+    return null
+  }
+}
+
+/** Drops any cached directory whose entries are not a well-formed array. */
+export function wellFormedCachedChildren(cache: Record<string, TreeNodeData[]> | undefined): Record<string, TreeNodeData[]> {
+  const usable: Record<string, TreeNodeData[]> = {}
+  for (const [path, entries] of Object.entries(cache ?? {})) {
+    if (!Array.isArray(entries))
+      continue
+    if (entries.every(e => typeof e?.path === 'string' && typeof e?.displayName === 'string'))
+      usable[path] = entries
+  }
+  return usable
+}
+
+// -------------------------------------------------------------------------
+// Visibility helpers
+// -------------------------------------------------------------------------
+
+// `relativeUnder` requires both inputs to already use the flavor's separator,
+// and nothing upstream guarantees that: `PathInput` submits whatever the user
+// typed, so a win32 selection reaches the tree spelled `C:/Users/alice` while
+// the worker's own listings spell it `C:\Users\alice`. Comparing the two
+// answers "not under", which collapses the whole reveal -- no chain request,
+// no node expanded, no row selected. Normalize at the comparison, the way
+// `relativizePath` already does.
+export function isDescendantPath(child: string, parent: string, flavor: PathFlavor): boolean {
+  const rel = relativeUnder(normalizeSeparators(child, flavor), normalizeSeparators(parent, flavor), flavor)
+  return rel !== null && rel !== ''
+}
+
+// Whether two paths address the same node, under the same normalization.
+//
+// `===` is wrong on win32 twice over: the worker's listing spells a name in
+// its own case, and a typed path can use either separator. A node the tree
+// already holds then looks like one it has never seen.
+export function samePath(a: string, b: string, flavor: PathFlavor): boolean {
+  return pathEq(normalizeSeparators(a, flavor), normalizeSeparators(b, flavor), flavor)
+}
+
+/**
+ * The inline row shown under a directory the worker truncated.
+ *
+ * The worker sorts by name and cuts at its entry limit BEFORE stat-ing, so a
+ * sort by anything else orders only the entries that survived that cut. The
+ * notice states the window, so the user does not read a partial answer as a
+ * complete one.
+ */
+export function formatTruncationNotice(shown: number, total: number, sortKey: FileSortKey): string {
+  // The worker reports what the directory really held, so the notice gives the
+  // size of what is hidden instead of only that something is. `total` is 0 for
+  // a listing restored from a cache written before the worker sent it.
+  const count = total > shown ? `${shown} of ${total} entries` : `${shown}+ entries`
+  return sortKey === 'name'
+    ? `${count}, listing truncated`
+    : `${count}, truncated by name before sorting`
+}
+
+/** The rows one directory renders: hidden/git filters first, then the sort. */
+export function visibleSortedChildren(
+  all: readonly TreeNodeData[],
+  showHidden: boolean,
+  isVisible: ((path: string) => boolean) | undefined,
+  comparator: (a: TreeNodeData, b: TreeNodeData) => number,
+): TreeNodeData[] {
+  const filtered = showHidden && !isVisible
+    ? all
+    : all.filter(c => (showHidden || !c.hidden) && (!isVisible || isVisible(c.path)))
+  return filtered.toSorted(comparator)
+}

--- a/frontend/src/components/tree/gitVisibility.test.ts
+++ b/frontend/src/components/tree/gitVisibility.test.ts
@@ -130,6 +130,17 @@ describe('computeGitVisibility', () => {
     const { paths } = computeGitVisibility([entry('src/main.ts')], 'C:\\repo', 'win32')
     expect(paths.has('C:\\repo\\src\\main.ts')).toBe(true)
   })
+
+  /**
+   * A repo checked out AT the filesystem root. `join` used to strip the root
+   * away, so every path here came out relative -- `src/main.ts` instead of
+   * `/src/main.ts` -- and matched no node the tree renders, which hides the
+   * whole repository behind a git filter.
+   */
+  it('builds absolute paths when the root is the filesystem root', () => {
+    const { paths } = computeGitVisibility([entry('src/main.ts')], '/', unix)
+    expect(paths).toEqual(new Set(['/', '/src', '/src/main.ts']))
+  })
 })
 
 describe('flatEntryOpenTarget', () => {
@@ -137,6 +148,10 @@ describe('flatEntryOpenTarget', () => {
 
   it('resolves a file entry against the repo root', () => {
     expect(flatEntryOpenTarget({ path: 'src/main.ts', isDir: false }, '/repo', unix)).toBe('/repo/src/main.ts')
+  })
+
+  it('resolves against the filesystem root without losing the leading separator', () => {
+    expect(flatEntryOpenTarget({ path: 'src/main.ts', isDir: false }, '/', unix)).toBe('/src/main.ts')
   })
 
   it('refuses an untracked-directory entry', () => {

--- a/frontend/src/components/workspace/BranchContextMenu.tsx
+++ b/frontend/src/components/workspace/BranchContextMenu.tsx
@@ -89,9 +89,9 @@ export const BranchContextMenu: Component<BranchContextMenuProps> = (props) => {
   // nobody opened. Both hooks keep their cached answer once the menu closes and
   // re-fetch only on a workerId change, so re-opening the same row is free.
   const [menuOpen, setMenuOpen] = createSignal(false)
-  const listSource = () => menuOpen() && props.workerId ? { workerId: props.workerId } : null
-  const { providers } = useAvailableProviders(listSource)
-  const { shells, defaultShell } = useAvailableShells(listSource)
+  const listWorkerId = () => props.workerId
+  const { providers } = useAvailableProviders(listWorkerId, menuOpen)
+  const { shells, defaultShell } = useAvailableShells(listWorkerId, menuOpen)
 
   /** One change item. The three differ only in their mode. */
   const changeItem = (mode: ChangeBranchMode) => (

--- a/frontend/src/components/workspace/ChangeBranchDialog.tsx
+++ b/frontend/src/components/workspace/ChangeBranchDialog.tsx
@@ -143,13 +143,9 @@ export const ChangeBranchDialog: Component<ChangeBranchDialogProps> = (props) =>
   createEffect(on(worktreeTabType, () => title.regenerateIfPristine(), { defer: true }))
 
   const shellState = useAvailableShells(
-    () => {
-      if (gitMode.gitMode() === GitMode.CreateWorktree && worktreeTabType() === TabType.TERMINAL) {
-        return { workerId: props.workerId }
-      }
-      return null
-    },
-    err => log.warn('Failed to list shells', err),
+    () => props.workerId,
+    () => gitMode.gitMode() === GitMode.CreateWorktree && worktreeTabType() === TabType.TERMINAL,
+    (err: unknown) => log.warn('Failed to list shells', err),
   )
   const { shell } = shellState
 

--- a/frontend/src/components/workspace/RepoContextMenu.tsx
+++ b/frontend/src/components/workspace/RepoContextMenu.tsx
@@ -48,10 +48,10 @@ const CheckoutActions: Component<{
   // Fetched only while the menu is open, like the branch row's. One of these
   // mounts per repository row of every workspace, so a mount-time fetch would
   // scan every Worker in the fleet to fill menus nobody opened.
-  const listSource = () =>
-    props.menuOpen() && props.checkout.workerId ? { workerId: props.checkout.workerId } : null
-  const { providers } = useAvailableProviders(listSource)
-  const { shells, defaultShell } = useAvailableShells(listSource)
+  const listWorkerId = () => props.checkout.workerId
+  const menuOpen = () => props.menuOpen()
+  const { providers } = useAvailableProviders(listWorkerId, menuOpen)
+  const { shells, defaultShell } = useAvailableShells(listWorkerId, menuOpen)
 
   return (
     <>

--- a/frontend/src/components/workspace/RepositoryTargetMenu.tsx
+++ b/frontend/src/components/workspace/RepositoryTargetMenu.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'solid-js'
 import { createMemo, For, Show } from 'solid-js'
 import { SubMenu } from '~/components/common/SubMenu'
+import { slugify } from '~/lib/slug'
 import { menuSectionHeader } from '~/styles/shared.css'
 
 export interface RepositoryTargetMenuProps<T> {
@@ -19,22 +20,6 @@ export interface RepositoryTargetMenuProps<T> {
    * only case that renders a submenu at all.
    */
   testIdPrefix: string
-}
-
-/**
- * A label reduced to something addressable: lowercase, and every run of
- * non-alphanumerics folded to one hyphen. Repository labels carry spaces,
- * dots, slashes and a middle dot, none of which belong in a selector.
- *
- * The fold is LOSSY, which is why {@link targetSlugs} below never trusts it
- * alone: `worker · a/b` and `worker-a-b` both reduce to `worker-a-b`, `foo_bar`
- * and `foo-bar` both reduce to `foo-bar`, and a label with no ASCII
- * alphanumerics at all reduces to the empty string.
- */
-function slugify(label: string): string {
-  // No `i` flag: `.toLowerCase()` already ran, and on a NEGATED class the flag
-  // would stop `[^a-z0-9]` from excluding uppercase letters.
-  return label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 }
 
 /**

--- a/frontend/src/hooks/createDirectoryTreeState.test.ts
+++ b/frontend/src/hooks/createDirectoryTreeState.test.ts
@@ -5,10 +5,14 @@ import { describe, expect, it, vi } from 'vitest'
 import { createDirectoryTreeState } from '~/hooks/createDirectoryTreeState'
 import { flush } from '~/test-support/async'
 
-function makeHandle(): DirectoryTreeHandle & { refresh: Mock<() => void> } {
+function makeHandle(): DirectoryTreeHandle & {
+  refresh: Mock<() => void>
+  expandPath: Mock<(path: string) => void>
+} {
   return {
     collapseAll: vi.fn<() => void>(),
     refresh: vi.fn<() => void>(),
+    expandPath: vi.fn<(path: string) => void>(),
   }
 }
 
@@ -85,6 +89,39 @@ describe('createDirectoryTreeState', () => {
       state.refreshTree()
       expect(first.refresh).not.toHaveBeenCalled()
       expect(second.refresh).toHaveBeenCalledTimes(1)
+      dispose()
+    })
+  })
+
+  it('expandTreePath forwards the path to the handle', () => {
+    createRoot((dispose) => {
+      const state = createDirectoryTreeState()
+      const handle = makeHandle()
+      state.setTreeRef(handle)
+      state.expandTreePath('/home/alice')
+      expect(handle.expandPath).toHaveBeenCalledExactlyOnceWith('/home/alice')
+      dispose()
+    })
+  })
+
+  // The picker calls this from a click handler, which can run before the tree
+  // mounts and hands its handle over.
+  it('expandTreePath is a no-op while no tree handle is set', () => {
+    createRoot((dispose) => {
+      const state = createDirectoryTreeState()
+      expect(() => state.expandTreePath('/home/alice')).not.toThrow()
+      dispose()
+    })
+  })
+
+  // Unlike refreshTree, this does NOT bump treeKey: opening one directory
+  // invalidates no branch or worktree list.
+  it('expandTreePath leaves treeKey alone', () => {
+    createRoot((dispose) => {
+      const state = createDirectoryTreeState()
+      state.setTreeRef(makeHandle())
+      state.expandTreePath('/home/alice')
+      expect(state.treeKey()).toBe(0)
       dispose()
     })
   })

--- a/frontend/src/hooks/createDirectoryTreeState.ts
+++ b/frontend/src/hooks/createDirectoryTreeState.ts
@@ -22,7 +22,12 @@ export function createDirectoryTreeState() {
     treeHandle?.refresh()
     setTreeKey(k => k + 1)
   }
-  return { treeKey, setTreeRef, refreshTree }
+  // Forwarded rather than re-implemented: the expansion state lives in the
+  // tree's own store, and this hook holds the handle that reaches it.
+  const expandTreePath = (path: string) => {
+    treeHandle?.expandPath(path)
+  }
+  return { treeKey, setTreeRef, refreshTree, expandTreePath }
 }
 
 export type DirectoryTreeState = ReturnType<typeof createDirectoryTreeState>

--- a/frontend/src/hooks/createWorkerScopedList.ts
+++ b/frontend/src/hooks/createWorkerScopedList.ts
@@ -8,8 +8,27 @@ export interface WorkerScopedArgs {
 }
 
 export interface CreateWorkerScopedListOpts<Args extends WorkerScopedArgs, Resp> {
-  /** The fetch args, or null to skip. A null source keeps the cached list. */
-  source: Accessor<Args | null>
+  /**
+   * Which worker this list is about, ALWAYS -- never null to mean "not now".
+   *
+   * The worker is tracked separately from the fetch gate on purpose. A source
+   * that answered null for "do not fetch yet" also hid WHICH worker the
+   * caller was on, so a caller whose gate happened to close on the same tick
+   * the worker changed kept serving the previous worker's answer. Splitting
+   * the two makes that impossible: the clear follows the worker, and the gate
+   * decides only whether to ask.
+   *
+   * Empty means "no worker yet"; nothing is fetched and nothing is cleared.
+   */
+  workerId: Accessor<string>
+  /**
+   * Whether to fetch NOW. A gate that closes keeps the cached list, so a
+   * caller that ties it to "the menu is open" re-opens with no round trip.
+   * Defaults to always.
+   */
+  enabled?: Accessor<boolean>
+  /** The rest of the fetch args, read untracked when a fetch starts. */
+  args: Accessor<Omit<Args, 'workerId'>>
   fetch: (args: Args, signal: AbortSignal) => Promise<Resp>
   /** Store the answer. Runs only on success. */
   applySuccess: (resp: Resp, args: Args) => void
@@ -21,10 +40,13 @@ export interface CreateWorkerScopedListOpts<Args extends WorkerScopedArgs, Resp>
 export interface WorkerScopedList {
   loading: Accessor<boolean>
   /**
-   * Re-run the fetch for the current source. The source-driven effect fires on
+   * Re-run the fetch for the current worker. The worker-driven effect fires on
    * a workerId TRANSITION only, so a transient failure on the current worker
    * would otherwise leave the caller with no list and no way back. No-op while
-   * the source returns null.
+   * there is no worker.
+   *
+   * Deliberately NOT gated by `enabled`: it is the caller's own explicit
+   * retry, and a Refresh button must work whatever the gate says.
    */
   refresh: () => Promise<void>
 }
@@ -40,30 +62,42 @@ export interface WorkerScopedList {
  * has a comment in both explaining a past bug, and a fix to one would not have
  * reached the other.
  *
- * Three properties this owns, and no caller restates:
+ * Four properties this owns, and no caller restates:
  *
  *   - The sentinel advances ONLY on success, so a failed fetch lets the next
  *     tick with the same workerId retry rather than short-circuit on a stale
  *     value. Stamping it before the fetch locks the caller out of recovering
  *     from a transient failure until the user switches workers and back.
- *   - It tracks the workerId SCALAR, not the source accessor. Caller closures
+ *   - It tracks the workerId SCALAR, not an args accessor. Caller closures
  *     build a fresh args object every tick, so tracking the accessor re-fires
  *     the effect on identity churn that changes nothing.
  *   - It clears BEFORE the fetch, so the previous worker's answer can never be
  *     offered for the new one during the window the fetch is in flight.
+ *   - It clears on EVERY worker change, including one where the gate is shut.
+ *     The gate and the worker are separate inputs for exactly this reason: a
+ *     caller whose gate closes on the same tick the worker changes -- the
+ *     directory picker's drive list does, because the gate is "the worker runs
+ *     Windows" -- would otherwise keep offering the previous worker's answer
+ *     for the new one, with no transition left to clear it.
  */
 export function createWorkerScopedList<Args extends WorkerScopedArgs, Resp>(
   opts: CreateWorkerScopedListOpts<Args, Resp>,
 ): WorkerScopedList {
+  // The worker whose answer is on screen. Advances ONLY on success.
   let lastLoadedWorkerId = ''
+  // The worker a fetch is open for. Cleared on both outcomes, so a failure
+  // leaves the next tick free to retry the same worker.
+  let requestedWorkerId = ''
 
   const fetcher = createGuardedFetch<Args, Resp>({
     fetch: opts.fetch,
     applySuccess: (resp, args) => {
       opts.applySuccess(resp, args)
       lastLoadedWorkerId = args.workerId
+      requestedWorkerId = ''
     },
     onError: (err) => {
+      requestedWorkerId = ''
       opts.onError?.(err)
       opts.clear()
     },
@@ -76,30 +110,45 @@ export function createWorkerScopedList<Args extends WorkerScopedArgs, Resp>(
   // already excludes the `void` branch, so this states the arm that applies.
   const run = fetcher.run as (args: Args | null) => Promise<void>
 
-  const workerIdFromSource = (): string | null => opts.source()?.workerId ?? null
-  createEffect(on(workerIdFromSource, (workerId) => {
-    if (!workerId)
-      return
-    if (workerId === lastLoadedWorkerId)
-      return
-    opts.clear()
-    // The `on()` already subscribes through `workerIdFromSource`; read the rest
-    // of the args untracked.
-    const args = untrack<Args | null>(opts.source)
-    if (args === null)
-      return
-    void run(args)
-  }))
+  const argsFor = (workerId: string): Args =>
+    ({ ...untrack(opts.args), workerId }) as Args
+
+  // ONE effect over both inputs. Two effects would each see a fetch the other
+  // had just started but not yet finished -- the success sentinel advances on
+  // success alone -- and would issue it twice.
+  createEffect(on(
+    [opts.workerId, () => opts.enabled?.() ?? true],
+    ([workerId, enabled]) => {
+      // BEFORE the gate, and before any decision to fetch. An answer belongs
+      // to the worker it came from, so the moment the worker is a different
+      // one that answer must go -- whether or not this new worker is one we
+      // may ask about, and whether or not it is a worker at all.
+      if (lastLoadedWorkerId !== '' && workerId !== lastLoadedWorkerId) {
+        opts.clear()
+        lastLoadedWorkerId = ''
+      }
+      if (!workerId || !enabled)
+        return
+      // Already answered, or already asked. `requestedWorkerId` is what stops
+      // the double fetch: the sentinel above cannot, because it waits for the
+      // response this run is about to await.
+      if (workerId === lastLoadedWorkerId || workerId === requestedWorkerId)
+        return
+      requestedWorkerId = workerId
+      void run(argsFor(workerId))
+    },
+  ))
 
   const refresh = async (): Promise<void> => {
-    const args = untrack<Args | null>(opts.source)
-    if (args === null)
+    const workerId = untrack(opts.workerId)
+    if (!workerId)
       return
-    // `lastLoadedWorkerId` is deliberately NOT cleared here. The source-driven
+    requestedWorkerId = workerId
+    // `lastLoadedWorkerId` is deliberately NOT cleared here. The worker-driven
     // effect consults it on a workerId TRANSITION only, so a manual refresh
     // against the current worker just re-fetches and re-stamps it on success --
     // or leaves it untouched on failure, which preserves the retry rule above.
-    await run(args)
+    await run(argsFor(workerId))
   }
 
   return { loading: fetcher.loading, refresh }

--- a/frontend/src/hooks/useAvailableProviders.test.ts
+++ b/frontend/src/hooks/useAvailableProviders.test.ts
@@ -25,11 +25,10 @@ beforeEach(() => {
 })
 
 describe('useAvailableProviders', () => {
-  it('does not fetch while the source returns null', async () => {
+  it('does not fetch while there is no worker', async () => {
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source] = createSignal<{ workerId: string } | null>(null)
-        const hook = useAvailableProviders(source)
+        const hook = useAvailableProviders(() => '', () => true)
         await flush()
         expect(listAvailableProviders).not.toHaveBeenCalled()
         expect(hook.loading()).toBe(false)
@@ -40,13 +39,13 @@ describe('useAvailableProviders', () => {
     })
   })
 
-  it('fetches once the source returns args and populates the list', async () => {
+  it('fetches once a worker arrives and populates the list', async () => {
     listAvailableProviders.mockResolvedValueOnce(providersResp([AgentProvider.CLAUDE_CODE, AgentProvider.CODEX]))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workerId: string } | null>(null)
-        const hook = useAvailableProviders(source)
-        setSource({ workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableProviders(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(listAvailableProviders).toHaveBeenCalledTimes(1)
         expect(listAvailableProviders.mock.calls[0][0]).toBe('A')
@@ -65,9 +64,9 @@ describe('useAvailableProviders', () => {
     listAvailableProviders.mockResolvedValueOnce(providersResp([]))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workerId: string } | null>(null)
-        const hook = useAvailableProviders(source)
-        setSource({ workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableProviders(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(hook.providers()).toEqual([])
         dispose()
@@ -76,25 +75,46 @@ describe('useAvailableProviders', () => {
     })
   })
 
-  it('latches: source flipping null and back does not re-fetch and keeps the list', async () => {
+  it('latches: the gate closing and re-opening does not re-fetch and keeps the list', async () => {
     listAvailableProviders.mockResolvedValueOnce(providersResp([AgentProvider.CLAUDE_CODE]))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workerId: string } | null>(null)
-        const hook = useAvailableProviders(source)
-        setSource({ workerId: 'A' })
+        const [open, setOpen] = createSignal(true)
+        const hook = useAvailableProviders(() => 'A', open)
         await flush()
         expect(listAvailableProviders).toHaveBeenCalledTimes(1)
 
         // The branch menu closes: the gate drops but the answer stays, so
         // re-opening the same row costs no round trip.
-        setSource(null)
+        setOpen(false)
         await flush()
         expect(hook.providers()).toEqual([AgentProvider.CLAUDE_CODE])
         expect(listAvailableProviders).toHaveBeenCalledTimes(1)
 
-        setSource({ workerId: 'A' })
+        setOpen(true)
         await flush()
+        expect(listAvailableProviders).toHaveBeenCalledTimes(1)
+        dispose()
+        done()
+      })
+    })
+  })
+
+  // The defect the workerId/gate split exists to remove. A gate keyed on a
+  // property OF the worker closes on the same tick the worker changes, so a
+  // source that folded the two together had no transition left to clear on.
+  it('clears on a worker change even when the gate shuts at the same moment', async () => {
+    listAvailableProviders.mockResolvedValueOnce(providersResp([AgentProvider.CLAUDE_CODE]))
+    await new Promise<void>((done) => {
+      createRoot(async (dispose) => {
+        const [workerId, setWorkerId] = createSignal('A')
+        const hook = useAvailableProviders(workerId, () => workerId() === 'A')
+        await flush()
+        expect(hook.providers()).toEqual([AgentProvider.CLAUDE_CODE])
+
+        setWorkerId('B')
+        await flush()
+        expect(hook.providers()).toBeUndefined()
         expect(listAvailableProviders).toHaveBeenCalledTimes(1)
         dispose()
         done()
@@ -109,16 +129,16 @@ describe('useAvailableProviders', () => {
       .mockImplementationOnce(() => second.promise)
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workerId: string } | null>(null)
-        const hook = useAvailableProviders(source)
-        setSource({ workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableProviders(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(hook.providers()).toEqual([AgentProvider.CLAUDE_CODE])
 
         // Worker B may not have A's providers, so the stale list must go
         // before the new answer lands -- otherwise the menu offers a provider
         // this machine cannot run.
-        setSource({ workerId: 'B' })
+        setWorkerId('B')
         await flush()
         expect(hook.providers()).toBeUndefined()
         expect(hook.loading()).toBe(true)
@@ -133,17 +153,15 @@ describe('useAvailableProviders', () => {
     })
   })
 
-  it('source identity churn with a stable workerId does not refire the fetch', async () => {
+  // The hook takes the workerId as a plain string accessor, so there is no
+  // object for a caller to reallocate. What can still re-evaluate is the gate,
+  // and a gate that answers the same value must not re-issue the RPC.
+  it('re-evaluating the gate to the same value does not refire the fetch', async () => {
     listAvailableProviders.mockResolvedValueOnce(providersResp([AgentProvider.CLAUDE_CODE]))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
         const [tick, setTick] = createSignal(0)
-        // A fresh object on every read, exactly as a real caller builds one.
-        const source = () => {
-          tick()
-          return { workerId: 'A' }
-        }
-        useAvailableProviders(source)
+        useAvailableProviders(() => 'A', () => tick() >= 0)
         await flush()
         expect(listAvailableProviders).toHaveBeenCalledTimes(1)
         setTick(1)
@@ -162,9 +180,9 @@ describe('useAvailableProviders', () => {
       .mockResolvedValueOnce(providersResp([AgentProvider.CODEX]))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workerId: string } | null>(null)
-        const hook = useAvailableProviders(source, onError)
-        setSource({ workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableProviders(workerId, () => true, onError)
+        setWorkerId('A')
         await flush()
         expect(onError).toHaveBeenCalledTimes(1)
         expect(hook.providers()).toBeUndefined()
@@ -182,14 +200,31 @@ describe('useAvailableProviders', () => {
     })
   })
 
-  it('refresh is a no-op while the source is null', async () => {
+  it('refresh is a no-op while there is no worker', async () => {
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source] = createSignal<{ workerId: string } | null>(null)
-        const hook = useAvailableProviders(source)
+        const hook = useAvailableProviders(() => '', () => true)
         await hook.refresh()
         await flush()
         expect(listAvailableProviders).not.toHaveBeenCalled()
+        dispose()
+        done()
+      })
+    })
+  })
+
+  // `refresh` is the caller's own retry, so a shut gate must not veto it.
+  it('refresh fetches even while the gate is shut', async () => {
+    listAvailableProviders.mockResolvedValueOnce(providersResp([AgentProvider.CODEX]))
+    await new Promise<void>((done) => {
+      createRoot(async (dispose) => {
+        const hook = useAvailableProviders(() => 'A', () => false)
+        await flush()
+        expect(listAvailableProviders).not.toHaveBeenCalled()
+
+        await hook.refresh()
+        await flush()
+        expect(hook.providers()).toEqual([AgentProvider.CODEX])
         dispose()
         done()
       })
@@ -201,9 +236,9 @@ describe('useAvailableProviders', () => {
     listAvailableProviders.mockImplementationOnce(() => d.promise)
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workerId: string } | null>(null)
-        const hook = useAvailableProviders(source)
-        setSource({ workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableProviders(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(hook.loading()).toBe(true)
         d.resolve(providersResp([AgentProvider.CLAUDE_CODE]))

--- a/frontend/src/hooks/useAvailableProviders.ts
+++ b/frontend/src/hooks/useAvailableProviders.ts
@@ -1,5 +1,6 @@
 import type { Accessor } from 'solid-js'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
+import type { WorkerScopedArgs } from '~/hooks/createWorkerScopedList'
 import { createSignal } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { createWorkerScopedList } from '~/hooks/createWorkerScopedList'
@@ -18,10 +19,10 @@ export interface UseAvailableProvidersResult {
   providers: Accessor<AgentProvider[] | undefined>
   loading: Accessor<boolean>
   /**
-   * Re-run the fetch for the current source. The source-driven effect fires on
+   * Re-run the fetch for the current worker. The worker-driven effect fires on
    * a workerId TRANSITION only, so a transient failure on the current worker
-   * would otherwise leave the caller with no list and no way back. No-op while
-   * the source returns null.
+   * would otherwise leave the caller with no list and no way back. Runs
+   * whatever `enabled` says; no-op while there is no worker.
    */
   refresh: () => Promise<void>
 }
@@ -31,11 +32,12 @@ export interface UseAvailableProvidersResult {
  * that asks about ONE stated worker on demand.
  *
  * The sibling of {@link import('./useAvailableShells').useAvailableShells}, and
- * deliberately the same shape: `source` returns the fetch args or `null` to
- * skip, the hook fetches on the first non-null value and re-fetches only when
- * the workerId changes, and a null source keeps the cached list rather than
- * clearing it — so a caller that ties the source to "the menu is open"
- * re-opens without a second round trip.
+ * deliberately the same shape: `workerId` says which worker and `enabled` says
+ * whether to ask, the hook fetches the first time the gate is open for a worker
+ * and re-fetches only when the workerId changes, and a closed gate keeps the
+ * cached list rather than clearing it — so a caller that ties the gate to "the
+ * menu is open" re-opens without a second round trip. A WORKER change clears
+ * whatever the gate says.
  *
  * `useAgentOperations.loadAvailableProviders` is NOT this hook and does not use
  * it. That one scans for whichever worker the ACTIVE TAB is on, and it carries
@@ -45,15 +47,18 @@ export interface UseAvailableProvidersResult {
  * machine the current tab happens to sit on.
  */
 export function useAvailableProviders(
-  source: Accessor<UseAvailableProvidersArgs | null>,
+  workerId: Accessor<string>,
+  enabled: Accessor<boolean>,
   onError?: (err: unknown) => void,
 ): UseAvailableProvidersResult {
   const [providers, setProviders] = createSignal<AgentProvider[] | undefined>(undefined)
 
   // Every rule about WHEN to fetch, when to retry and when to clear lives in
   // `createWorkerScopedList`. This hook keeps only the payload it stores.
-  const list = createWorkerScopedList<UseAvailableProvidersArgs, Awaited<ReturnType<typeof workerRpc.listAvailableProviders>>>({
-    source,
+  const list = createWorkerScopedList<WorkerScopedArgs, Awaited<ReturnType<typeof workerRpc.listAvailableProviders>>>({
+    workerId,
+    enabled,
+    args: () => ({}),
     fetch: (args, signal) => workerRpc.listAvailableProviders(args.workerId, { signal }),
     applySuccess: resp => setProviders([...resp.providers]),
     // The previous worker's list is not an answer for this one, and

--- a/frontend/src/hooks/useAvailableShells.test.ts
+++ b/frontend/src/hooks/useAvailableShells.test.ts
@@ -25,11 +25,11 @@ beforeEach(() => {
 })
 
 describe('useAvailableShells', () => {
-  it('does not fetch while the source returns null', async () => {
+  it('does not fetch while there is no worker', async () => {
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, _setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
+        const [workerId, _setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true)
         await flush()
         expect(listAvailableShells).not.toHaveBeenCalled()
         expect(hook.loading()).toBe(false)
@@ -41,16 +41,16 @@ describe('useAvailableShells', () => {
     })
   })
 
-  it('fetches once the source returns args, populates shells, and uses the server default', async () => {
+  it('fetches once a worker arrives, populates shells, and uses the server default', async () => {
     listAvailableShells.mockResolvedValueOnce(shellsResp(['/bin/zsh', '/bin/bash'], '/bin/zsh'))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(listAvailableShells).toHaveBeenCalledTimes(1)
-        expect(listAvailableShells.mock.calls[0]).toEqual(['A', { workspaceId: 'w', workerId: 'A' }])
+        expect(listAvailableShells.mock.calls[0]).toEqual(['A', { workerId: 'A' }])
         expect(hook.shells()).toEqual(['/bin/zsh', '/bin/bash'])
         expect(hook.defaultShell()).toBe('/bin/zsh')
         expect(hook.shell()).toBe('/bin/zsh')
@@ -65,9 +65,9 @@ describe('useAvailableShells', () => {
     listAvailableShells.mockResolvedValueOnce(shellsResp(['/bin/fish', '/bin/zsh'], ''))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(hook.defaultShell()).toBe('/bin/fish')
         dispose()
@@ -80,9 +80,9 @@ describe('useAvailableShells', () => {
     listAvailableShells.mockResolvedValueOnce(shellsResp([], ''))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(hook.defaultShell()).toBe('')
         expect(hook.shell()).toBe('')
@@ -92,26 +92,25 @@ describe('useAvailableShells', () => {
     })
   })
 
-  it('latches: source flipping null → null doesn\'t re-fetch and keeps shells', async () => {
+  it('latches: the gate closing and re-opening does not re-fetch and keeps shells', async () => {
     listAvailableShells.mockResolvedValueOnce(shellsResp(['/bin/zsh'], '/bin/zsh'))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [open, setOpen] = createSignal(true)
+        const hook = useAvailableShells(() => 'A', open)
         await flush()
         expect(listAvailableShells).toHaveBeenCalledTimes(1)
 
         // Caller drops the gate. Cached shells must survive the toggle.
-        setSource(null)
+        setOpen(false)
         await flush()
         expect(hook.shells()).toEqual(['/bin/zsh'])
         expect(listAvailableShells).toHaveBeenCalledTimes(1)
 
-        // Re-toggle for the same worker. Still no refetch -- this is
-        // the regression guard for the ChangeBranchDialog "fires once
-        // even after Open-as toggles" case.
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        // Re-toggle for the same worker. Still no refetch -- this is the
+        // regression guard for the ChangeBranchDialog "fires once even after
+        // Open-as toggles" case.
+        setOpen(true)
         await flush()
         expect(listAvailableShells).toHaveBeenCalledTimes(1)
         dispose()
@@ -120,15 +119,34 @@ describe('useAvailableShells', () => {
     })
   })
 
+  // Losing the worker is not the same as closing the gate: there is no worker
+  // whose answer this could be, so the list must go.
+  it('clears when the worker goes away', async () => {
+    listAvailableShells.mockResolvedValueOnce(shellsResp(['/bin/zsh'], '/bin/zsh'))
+    await new Promise<void>((done) => {
+      createRoot(async (dispose) => {
+        const [workerId, setWorkerId] = createSignal('A')
+        const hook = useAvailableShells(workerId, () => true)
+        await flush()
+        expect(hook.shells()).toEqual(['/bin/zsh'])
+
+        setWorkerId('')
+        await flush()
+        expect(hook.shells()).toEqual([])
+        dispose()
+        done()
+      })
+    })
+  })
   it('re-fetches when workerId changes and resets any prior user override', async () => {
     listAvailableShells
       .mockResolvedValueOnce(shellsResp(['/bin/zsh', '/bin/bash'], '/bin/zsh'))
       .mockResolvedValueOnce(shellsResp(['/usr/bin/pwsh'], '/usr/bin/pwsh'))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true)
+        setWorkerId('A')
         await flush()
 
         // User overrides to /bin/bash.
@@ -137,7 +155,7 @@ describe('useAvailableShells', () => {
 
         // User picks a different worker. The override must clear so
         // we don't send a shell path that doesn't exist on worker B.
-        setSource({ workspaceId: 'w', workerId: 'B' })
+        setWorkerId('B')
         await flush()
         expect(listAvailableShells).toHaveBeenCalledTimes(2)
         expect(hook.shells()).toEqual(['/usr/bin/pwsh'])
@@ -152,9 +170,9 @@ describe('useAvailableShells', () => {
     listAvailableShells.mockResolvedValueOnce(shellsResp(['/bin/zsh', '/bin/bash'], '/bin/zsh'))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(hook.shell()).toBe('/bin/zsh')
 
@@ -174,9 +192,9 @@ describe('useAvailableShells', () => {
     listAvailableShells.mockImplementationOnce(() => d.promise)
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(hook.loading()).toBe(true)
         d.resolve(shellsResp(['/bin/zsh'], '/bin/zsh'))
@@ -188,31 +206,25 @@ describe('useAvailableShells', () => {
     })
   })
 
-  it('source identity churn with stable workerId does not refire the fetch', async () => {
-    // Real callers build a fresh args object on every reactive read
-    // (`{ workspaceId, workerId }`). Tracking the source accessor by
-    // reference would refire the effect on every upstream tick — a
-    // `workspaceId` change, or merely a re-read that allocates a new
-    // object — even though the workerId, the only field that gates the
-    // fetch, is unchanged. The hook tracks `source()?.workerId` instead,
-    // so identity churn upstream stays a memo no-op.
-    listAvailableShells.mockResolvedValueOnce(shellsResp(['/bin/zsh'], '/bin/zsh'))
+  // The hook takes the workerId as a plain string accessor, so identity churn
+  // upstream cannot reach it: there is no object to reallocate. What CAN still
+  // re-evaluate is the gate, and a gate that answers the same value must not
+  // re-issue the RPC.
+  it('re-evaluating the gate to the same value does not refire the fetch', async () => {
+    listAvailableShells.mockResolvedValue(shellsResp(['/bin/zsh'], '/bin/zsh'))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [workspaceId, setWorkspaceId] = createSignal('w')
-        const source = () => ({ workspaceId: workspaceId(), workerId: 'A' })
-        useAvailableShells(source)
+        const [tick, setTick] = createSignal(0)
+        const enabled = () => tick() >= 0
+        useAvailableShells(() => 'A', enabled)
         await flush()
         expect(listAvailableShells).toHaveBeenCalledTimes(1)
 
-        // workspaceId change: source returns a fresh object identity, but the
-        // workerId field is unchanged. No refetch.
-        setWorkspaceId('w2')
+        setTick(1)
         await flush()
         expect(listAvailableShells).toHaveBeenCalledTimes(1)
 
-        // And a third churn for good measure.
-        setWorkspaceId('w3')
+        setTick(2)
         await flush()
         expect(listAvailableShells).toHaveBeenCalledTimes(1)
         dispose()
@@ -220,15 +232,14 @@ describe('useAvailableShells', () => {
       })
     })
   })
-
   it('on RPC failure: invokes onError, clears shells, and turns loading off', async () => {
     const onError = vi.fn()
     listAvailableShells.mockRejectedValueOnce(new Error('worker offline'))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source, onError)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true, onError)
+        setWorkerId('A')
         await flush()
         expect(onError).toHaveBeenCalledTimes(1)
         expect((onError.mock.calls[0][0] as Error).message).toBe('worker offline')
@@ -252,15 +263,15 @@ describe('useAvailableShells', () => {
       .mockImplementationOnce(() => d.promise)
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true)
+        setWorkerId('A')
         await flush()
         expect(hook.shells()).toEqual(['/bin/zsh'])
         expect(hook.shell()).toBe('/bin/zsh')
 
         // Switch workers — the new worker's fetch is in flight.
-        setSource({ workspaceId: 'w', workerId: 'B' })
+        setWorkerId('B')
         await flush()
         // While the new fetch is pending, the OLD worker's shell must
         // not be reported — otherwise downstream gates would accept it.
@@ -292,10 +303,7 @@ describe('useAvailableShells', () => {
       .mockResolvedValueOnce(shellsResp(['/bin/zsh'], '/bin/zsh'))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source] = createSignal<{ workspaceId: string, workerId: string } | null>(
-          { workspaceId: 'w', workerId: 'A' },
-        )
-        const hook = useAvailableShells(source, onError)
+        const hook = useAvailableShells(() => 'A', () => true, onError)
         await flush()
         expect(onError).toHaveBeenCalledTimes(1)
         expect(hook.shells()).toEqual([])
@@ -311,14 +319,90 @@ describe('useAvailableShells', () => {
     })
   })
 
-  it('refresh() is a no-op when the source returns null (the gate said don\'t fetch)', async () => {
+  it('refresh() is a no-op when there is no worker', async () => {
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source)
+        const hook = useAvailableShells(() => '', () => true)
         await hook.refresh()
         await flush()
         expect(listAvailableShells).not.toHaveBeenCalled()
+        dispose()
+        done()
+      })
+    })
+  })
+
+  // `refresh` is the caller's own retry -- the Refresh button and its
+  // shortcut -- so it must work whatever the gate says. A gate that answers
+  // "do not fetch on your own" is not a refusal to answer a direct request.
+  it('refresh() fetches even while the gate is shut', async () => {
+    listAvailableShells.mockResolvedValueOnce(shellsResp(['/bin/zsh'], '/bin/zsh'))
+    await new Promise<void>((done) => {
+      createRoot(async (dispose) => {
+        const hook = useAvailableShells(() => 'A', () => false)
+        await flush()
+        expect(listAvailableShells).not.toHaveBeenCalled()
+
+        await hook.refresh()
+        await flush()
+        expect(listAvailableShells).toHaveBeenCalledTimes(1)
+        expect(hook.shells()).toEqual(['/bin/zsh'])
+        dispose()
+        done()
+      })
+    })
+  })
+
+  // The defect this split exists to remove. A gate keyed on a property OF the
+  // worker -- "this one runs Windows", "this one is in worktree mode" --
+  // closes on the same tick the worker changes, so a source that folded the
+  // two together had no transition left to clear on, and the previous
+  // worker's shells stayed on offer for the new one.
+  it('clears on a worker change even when the gate shuts at the same moment', async () => {
+    listAvailableShells.mockResolvedValueOnce(shellsResp(['/bin/zsh'], '/bin/zsh'))
+    await new Promise<void>((done) => {
+      createRoot(async (dispose) => {
+        const [workerId, setWorkerId] = createSignal('A')
+        const hook = useAvailableShells(workerId, () => workerId() === 'A')
+        await flush()
+        expect(hook.shells()).toEqual(['/bin/zsh'])
+
+        setWorkerId('B')
+        await flush()
+        expect(hook.shells()).toEqual([])
+        expect(hook.shell()).toBe('')
+        expect(listAvailableShells).toHaveBeenCalledTimes(1)
+        dispose()
+        done()
+      })
+    })
+  })
+
+  // The other half of the same rule: a gate that OPENS without a worker
+  // change is the moment the fetch becomes due, and the worker-change effect
+  // will not fire again for it.
+  it('fetches when the gate opens for a worker it has not loaded', async () => {
+    listAvailableShells.mockResolvedValueOnce(shellsResp(['/bin/zsh'], '/bin/zsh'))
+    await new Promise<void>((done) => {
+      createRoot(async (dispose) => {
+        const [open, setOpen] = createSignal(false)
+        const hook = useAvailableShells(() => 'A', open)
+        await flush()
+        expect(listAvailableShells).not.toHaveBeenCalled()
+
+        setOpen(true)
+        await flush()
+        expect(listAvailableShells).toHaveBeenCalledTimes(1)
+        expect(hook.shells()).toEqual(['/bin/zsh'])
+
+        // Closing keeps the cached list, so re-opening the same worker's menu
+        // costs no second round trip.
+        setOpen(false)
+        await flush()
+        expect(hook.shells()).toEqual(['/bin/zsh'])
+        setOpen(true)
+        await flush()
+        expect(listAvailableShells).toHaveBeenCalledTimes(1)
         dispose()
         done()
       })
@@ -337,9 +421,9 @@ describe('useAvailableShells', () => {
       .mockResolvedValueOnce(shellsResp(['/bin/zsh'], '/bin/zsh'))
     await new Promise<void>((done) => {
       createRoot(async (dispose) => {
-        const [source, setSource] = createSignal<{ workspaceId: string, workerId: string } | null>(null)
-        const hook = useAvailableShells(source, onError)
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        const [workerId, setWorkerId] = createSignal('')
+        const hook = useAvailableShells(workerId, () => true, onError)
+        setWorkerId('A')
         await flush()
         expect(onError).toHaveBeenCalledTimes(1)
         expect(hook.shells()).toEqual([])
@@ -348,9 +432,9 @@ describe('useAvailableShells', () => {
         // the simplest model of "toggle the mode that gates the source
         // and toggle back" without involving a worker swap. The retry
         // must fire and succeed.
-        setSource(null)
+        setWorkerId('')
         await flush()
-        setSource({ workspaceId: 'w', workerId: 'A' })
+        setWorkerId('A')
         await flush()
         expect(listAvailableShells).toHaveBeenCalledTimes(2)
         expect(hook.shells()).toEqual(['/bin/zsh'])

--- a/frontend/src/hooks/useAvailableShells.ts
+++ b/frontend/src/hooks/useAvailableShells.ts
@@ -1,4 +1,5 @@
 import type { Accessor } from 'solid-js'
+import type { WorkerScopedArgs } from '~/hooks/createWorkerScopedList'
 import { createSignal } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { createWorkerScopedList } from '~/hooks/createWorkerScopedList'
@@ -16,12 +17,12 @@ interface UseAvailableShellsResult {
   setShell: (v: string | null) => void
   loading: Accessor<boolean>
   /**
-   * Manual retry hook for the current source. The worker-change effect
+   * Manual retry hook for the current worker. The worker-change effect
    * only fires on a workerId transition, so a transient failure on the
    * current worker would otherwise leave the dialog stuck with an empty
    * shell list and no recovery path until the user picked a different
-   * worker. Refresh re-runs the fetch against the current source; no-op
-   * when the source is null (the gate said "don't fetch yet").
+   * worker. Refresh re-runs the fetch against the current worker, whatever
+   * `enabled` says; no-op when there is no worker.
    */
   refresh: () => Promise<void>
 }
@@ -35,12 +36,12 @@ interface UseAvailableShellsResult {
  * route while a resource is loading, flashing blank under any dialog
  * that reads it during initial fetch.
  *
- * - `source` returns the fetch args or `null` to skip. The hook fetches
- *   the first time `source` returns a non-null value and re-fetches on
- *   `workerId` change. While `source` returns null, the cached shells
- *   remain in place so a caller that gates the source on a mode toggle
- *   (e.g. show shell list only in worktree-terminal mode) doesn't
- *   re-issue the RPC when re-toggling.
+ * - `workerId` says WHICH worker; `enabled` says whether to ask. The hook
+ *   fetches the first time `enabled` is true for a worker and re-fetches on
+ *   `workerId` change. While `enabled` is false the cached shells remain in
+ *   place, so a caller that gates on a mode toggle (e.g. show the shell list
+ *   only in worktree-terminal mode) doesn't re-issue the RPC when
+ *   re-toggling -- but a WORKER change still clears, whatever the gate says.
  * - `defaultShell` returns the server-reported default, falling back to
  *   the first shell in the list, falling back to ''.
  * - The user override resets whenever `workerId` changes, so picking a
@@ -53,7 +54,8 @@ interface UseAvailableShellsResult {
  *   the banner still says the load failed. `onLoaded` is that withdrawal.
  */
 export function useAvailableShells(
-  source: Accessor<UseAvailableShellsArgs | null>,
+  workerId: Accessor<string>,
+  enabled: Accessor<boolean>,
   onError?: (err: unknown) => void,
   onLoaded?: () => void,
 ): UseAvailableShellsResult {
@@ -64,8 +66,10 @@ export function useAvailableShells(
   // Every rule about WHEN to fetch, when to retry and when to clear lives in
   // `createWorkerScopedList`. This hook keeps only the state it stores: the
   // server default beside the list, and the user's explicit override.
-  const list = createWorkerScopedList<UseAvailableShellsArgs, Awaited<ReturnType<typeof workerRpc.listAvailableShells>>>({
-    source,
+  const list = createWorkerScopedList<WorkerScopedArgs, Awaited<ReturnType<typeof workerRpc.listAvailableShells>>>({
+    workerId,
+    enabled,
+    args: () => ({}),
     fetch: args => workerRpc.listAvailableShells(args.workerId, args),
     applySuccess: (resp) => {
       setShells(resp.shells)

--- a/frontend/src/hooks/useFilesystemRoots.test.ts
+++ b/frontend/src/hooks/useFilesystemRoots.test.ts
@@ -1,0 +1,76 @@
+import type { UseFilesystemRootsArgs } from './useFilesystemRoots'
+import { createRoot, createSignal } from 'solid-js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFilesystemRoots } from './useFilesystemRoots'
+
+const listFilesystemRoots = vi.fn()
+vi.mock('~/api/workerRpc', () => ({
+  listFilesystemRoots: (...args: unknown[]) => listFilesystemRoots(...args),
+}))
+
+beforeEach(() => {
+  listFilesystemRoots.mockReset()
+})
+
+/** Flush the microtask queue so the hook's fetch settles. */
+function tick() {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe('useFilesystemRoots', () => {
+  it('exposes the roots the worker reported', async () => {
+    listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
+
+    await createRoot(async (dispose) => {
+      const { roots } = useFilesystemRoots(() => ({ workerId: 'w1' }))
+      await tick()
+      expect(roots()).toEqual(['C:\\', 'D:\\'])
+      expect(listFilesystemRoots).toHaveBeenCalledWith('w1')
+      dispose()
+    })
+  })
+
+  // The caller hides its drive menu on an empty list, which is the correct
+  // reading of "this worker has not told us what it has".
+  it('answers an empty list after a failed fetch', async () => {
+    listFilesystemRoots.mockRejectedValue(new Error('offline'))
+    const onError = vi.fn()
+
+    await createRoot(async (dispose) => {
+      const { roots } = useFilesystemRoots(() => ({ workerId: 'w1' }), onError)
+      await tick()
+      expect(roots()).toEqual([])
+      expect(onError).toHaveBeenCalled()
+      dispose()
+    })
+  })
+
+  // A POSIX caller passes null: one root is already known, so the round trip
+  // would buy nothing.
+  it('does not fetch while the source is null', async () => {
+    await createRoot(async (dispose) => {
+      const [args] = createSignal<UseFilesystemRootsArgs | null>(null)
+      const { roots } = useFilesystemRoots(args)
+      await tick()
+      expect(listFilesystemRoots).not.toHaveBeenCalled()
+      expect(roots()).toEqual([])
+      dispose()
+    })
+  })
+
+  it('fetches once the source becomes non-null', async () => {
+    listFilesystemRoots.mockResolvedValue({ roots: ['C:\\'] })
+
+    await createRoot(async (dispose) => {
+      const [args, setArgs] = createSignal<UseFilesystemRootsArgs | null>(null)
+      const { roots } = useFilesystemRoots(args)
+      await tick()
+
+      setArgs({ workerId: 'w1' })
+      await tick()
+
+      expect(roots()).toEqual(['C:\\'])
+      dispose()
+    })
+  })
+})

--- a/frontend/src/hooks/useFilesystemRoots.test.ts
+++ b/frontend/src/hooks/useFilesystemRoots.test.ts
@@ -1,4 +1,3 @@
-import type { UseFilesystemRootsArgs } from './useFilesystemRoots'
 import { createRoot, createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useFilesystemRoots } from './useFilesystemRoots'
@@ -22,7 +21,7 @@ describe('useFilesystemRoots', () => {
     listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
 
     await createRoot(async (dispose) => {
-      const { roots } = useFilesystemRoots(() => ({ workerId: 'w1' }))
+      const { roots } = useFilesystemRoots(() => 'w1', () => true)
       await tick()
       expect(roots()).toEqual(['C:\\', 'D:\\'])
       expect(listFilesystemRoots).toHaveBeenCalledWith('w1')
@@ -37,7 +36,7 @@ describe('useFilesystemRoots', () => {
     const onError = vi.fn()
 
     await createRoot(async (dispose) => {
-      const { roots } = useFilesystemRoots(() => ({ workerId: 'w1' }), onError)
+      const { roots } = useFilesystemRoots(() => 'w1', () => true, onError)
       await tick()
       expect(roots()).toEqual([])
       expect(onError).toHaveBeenCalled()
@@ -45,12 +44,11 @@ describe('useFilesystemRoots', () => {
     })
   })
 
-  // A POSIX caller passes null: one root is already known, so the round trip
-  // would buy nothing.
-  it('does not fetch while the source is null', async () => {
+  // A POSIX caller shuts the gate: one root is already known, so the round
+  // trip would buy nothing.
+  it('does not fetch while the gate is shut', async () => {
     await createRoot(async (dispose) => {
-      const [args] = createSignal<UseFilesystemRootsArgs | null>(null)
-      const { roots } = useFilesystemRoots(args)
+      const { roots } = useFilesystemRoots(() => 'w1', () => false)
       await tick()
       expect(listFilesystemRoots).not.toHaveBeenCalled()
       expect(roots()).toEqual([])
@@ -58,17 +56,117 @@ describe('useFilesystemRoots', () => {
     })
   })
 
-  it('fetches once the source becomes non-null', async () => {
+  it('does not fetch while there is no worker', async () => {
+    await createRoot(async (dispose) => {
+      const { roots } = useFilesystemRoots(() => '', () => true)
+      await tick()
+      expect(listFilesystemRoots).not.toHaveBeenCalled()
+      expect(roots()).toEqual([])
+      dispose()
+    })
+  })
+
+  it('fetches once the gate opens', async () => {
     listFilesystemRoots.mockResolvedValue({ roots: ['C:\\'] })
 
     await createRoot(async (dispose) => {
-      const [args, setArgs] = createSignal<UseFilesystemRootsArgs | null>(null)
-      const { roots } = useFilesystemRoots(args)
+      const [open, setOpen] = createSignal(false)
+      const { roots } = useFilesystemRoots(() => 'w1', open)
+      await tick()
+      expect(listFilesystemRoots).not.toHaveBeenCalled()
+
+      setOpen(true)
       await tick()
 
-      setArgs({ workerId: 'w1' })
+      expect(roots()).toEqual(['C:\\'])
+      dispose()
+    })
+  })
+
+  /**
+   * The defect the workerId/gate split exists to remove.
+   *
+   * The picker's gate IS a property of the worker -- "this one runs Windows"
+   * -- so it closes on the same tick the worker changes. A source that folded
+   * the two together had no transition left to clear on, and the picker went
+   * on offering worker A's `C:\` and `D:\` for a Linux worker B. Choosing one
+   * then set the working directory to a path that does not exist there.
+   */
+  it('clears the previous worker drives when the new worker shuts the gate', async () => {
+    listFilesystemRoots.mockResolvedValue({ roots: ['C:\\', 'D:\\'] })
+
+    await createRoot(async (dispose) => {
+      const [workerId, setWorkerId] = createSignal('win-1')
+      const { roots } = useFilesystemRoots(workerId, () => workerId() === 'win-1')
+      await tick()
+      expect(roots()).toEqual(['C:\\', 'D:\\'])
+
+      setWorkerId('linux-1')
       await tick()
 
+      expect(roots()).toEqual([])
+      expect(listFilesystemRoots).toHaveBeenCalledTimes(1)
+      dispose()
+    })
+  })
+
+  it('clears and re-fetches when the worker changes with the gate open', async () => {
+    listFilesystemRoots
+      .mockResolvedValueOnce({ roots: ['C:\\'] })
+      .mockResolvedValueOnce({ roots: ['E:\\', 'F:\\'] })
+
+    await createRoot(async (dispose) => {
+      const [workerId, setWorkerId] = createSignal('w1')
+      const { roots } = useFilesystemRoots(workerId, () => true)
+      await tick()
+      expect(roots()).toEqual(['C:\\'])
+
+      setWorkerId('w2')
+      await tick()
+
+      expect(roots()).toEqual(['E:\\', 'F:\\'])
+      expect(listFilesystemRoots).toHaveBeenCalledTimes(2)
+      dispose()
+    })
+  })
+
+  // The picker's Refresh button and its shortcut both route here. Without it a
+  // transient failure would leave the drive menu empty until the user picked
+  // another worker and came back.
+  it('re-fetches on refresh and replaces the list', async () => {
+    listFilesystemRoots
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce({ roots: ['C:\\', 'D:\\'] })
+
+    await createRoot(async (dispose) => {
+      const { roots, refresh } = useFilesystemRoots(() => 'w1', () => true)
+      await tick()
+      expect(roots()).toEqual([])
+
+      await refresh()
+      await tick()
+
+      expect(roots()).toEqual(['C:\\', 'D:\\'])
+      expect(listFilesystemRoots).toHaveBeenCalledTimes(2)
+      dispose()
+    })
+  })
+
+  it('reports loading across one fetch', async () => {
+    let resolveFetch: ((v: { roots: string[] }) => void) | undefined
+    listFilesystemRoots.mockImplementation(() => new Promise((r) => {
+      resolveFetch = r
+    }))
+
+    await createRoot(async (dispose) => {
+      const { loading, roots } = useFilesystemRoots(() => 'w1', () => true)
+      await tick()
+      expect(loading()).toBe(true)
+
+      resolveFetch?.({ roots: ['C:\\'] })
+      await tick()
+
+      expect(loading()).toBe(false)
       expect(roots()).toEqual(['C:\\'])
       dispose()
     })

--- a/frontend/src/hooks/useFilesystemRoots.ts
+++ b/frontend/src/hooks/useFilesystemRoots.ts
@@ -1,0 +1,55 @@
+import type { Accessor } from 'solid-js'
+import { createSignal } from 'solid-js'
+import * as workerRpc from '~/api/workerRpc'
+import { createWorkerScopedList } from '~/hooks/createWorkerScopedList'
+
+export interface UseFilesystemRootsArgs {
+  workerId: string
+}
+
+interface UseFilesystemRootsResult {
+  /** The roots the worker reported, or `[]` before one answers. */
+  roots: Accessor<string[]>
+  loading: Accessor<boolean>
+  /**
+   * Manual retry for the current source. The worker-change effect fires on a
+   * workerId transition alone, so a transient failure would otherwise leave
+   * the caller with no list until the user picked another worker.
+   */
+  refresh: () => Promise<void>
+}
+
+/**
+ * Reactive wrapper around the `listFilesystemRoots` worker RPC.
+ *
+ * Plain signals plus an effect rather than `createResource`, for the reason
+ * `useAvailableShells` states: the router's Suspense boundary unmounts the
+ * whole route while a resource loads, flashing blank under any dialog that
+ * reads it during the first fetch.
+ *
+ * `source` returns the fetch args, or `null` to skip. A POSIX caller passes
+ * null: `filesystemRoot` already knows that a POSIX worker has exactly one
+ * root, so the round trip would buy nothing.
+ *
+ * Every rule about when to fetch, when to retry and when to clear lives in
+ * {@link createWorkerScopedList}. This hook keeps only the list it stores.
+ */
+export function useFilesystemRoots(
+  source: Accessor<UseFilesystemRootsArgs | null>,
+  onError?: (err: unknown) => void,
+): UseFilesystemRootsResult {
+  const [roots, setRoots] = createSignal<string[]>([])
+
+  const list = createWorkerScopedList<UseFilesystemRootsArgs, Awaited<ReturnType<typeof workerRpc.listFilesystemRoots>>>({
+    source,
+    fetch: args => workerRpc.listFilesystemRoots(args.workerId),
+    applySuccess: resp => setRoots(resp.roots),
+    // Cleared with the worker, so one worker's drives are never offered for
+    // another. A caller that shows a drive menu hides it again in that window,
+    // which is correct: it does not yet know what the new worker has.
+    clear: () => setRoots([]),
+    onError,
+  })
+
+  return { roots, loading: list.loading, refresh: list.refresh }
+}

--- a/frontend/src/hooks/useFilesystemRoots.ts
+++ b/frontend/src/hooks/useFilesystemRoots.ts
@@ -1,18 +1,15 @@
 import type { Accessor } from 'solid-js'
+import type { WorkerScopedArgs } from '~/hooks/createWorkerScopedList'
 import { createSignal } from 'solid-js'
 import * as workerRpc from '~/api/workerRpc'
 import { createWorkerScopedList } from '~/hooks/createWorkerScopedList'
-
-export interface UseFilesystemRootsArgs {
-  workerId: string
-}
 
 interface UseFilesystemRootsResult {
   /** The roots the worker reported, or `[]` before one answers. */
   roots: Accessor<string[]>
   loading: Accessor<boolean>
   /**
-   * Manual retry for the current source. The worker-change effect fires on a
+   * Manual retry for the current worker. The worker-change effect fires on a
    * workerId transition alone, so a transient failure would otherwise leave
    * the caller with no list until the user picked another worker.
    */
@@ -27,21 +24,26 @@ interface UseFilesystemRootsResult {
  * whole route while a resource loads, flashing blank under any dialog that
  * reads it during the first fetch.
  *
- * `source` returns the fetch args, or `null` to skip. A POSIX caller passes
- * null: `filesystemRoot` already knows that a POSIX worker has exactly one
- * root, so the round trip would buy nothing.
+ * `workerId` says WHICH worker; `enabled` says whether to ask. A POSIX caller
+ * passes `enabled: false`: `filesystemRoot` already knows that a POSIX worker
+ * has exactly one root, so the round trip would buy nothing. The two are
+ * separate so that a switch to a POSIX worker still CLEARS the previous
+ * worker's drives -- see {@link createWorkerScopedList}.
  *
  * Every rule about when to fetch, when to retry and when to clear lives in
- * {@link createWorkerScopedList}. This hook keeps only the list it stores.
+ * that helper. This hook keeps only the list it stores.
  */
 export function useFilesystemRoots(
-  source: Accessor<UseFilesystemRootsArgs | null>,
+  workerId: Accessor<string>,
+  enabled: Accessor<boolean>,
   onError?: (err: unknown) => void,
 ): UseFilesystemRootsResult {
   const [roots, setRoots] = createSignal<string[]>([])
 
-  const list = createWorkerScopedList<UseFilesystemRootsArgs, Awaited<ReturnType<typeof workerRpc.listFilesystemRoots>>>({
-    source,
+  const list = createWorkerScopedList<WorkerScopedArgs, Awaited<ReturnType<typeof workerRpc.listFilesystemRoots>>>({
+    workerId,
+    enabled,
+    args: () => ({}),
     fetch: args => workerRpc.listFilesystemRoots(args.workerId),
     applySuccess: resp => setRoots(resp.roots),
     // Cleared with the worker, so one worker's drives are never offered for

--- a/frontend/src/lib/paths.test.ts
+++ b/frontend/src/lib/paths.test.ts
@@ -120,6 +120,30 @@ describe('join', () => {
   it('drops empty and consecutive separators', () => {
     expect(join(['/home/', '/alice/', '/proj'], 'posix')).toBe('/home/alice/proj')
   })
+
+  /**
+   * A POSIX root is nothing but a separator, so stripping the trailing one
+   * empties it. Without the root prefix the result came out RELATIVE, and a
+   * tree rooted at `/` built every git path wrong.
+   */
+  it('keeps the leading separator when the first fragment is a posix root', () => {
+    expect(join(['/', 'home'], 'posix')).toBe('/home')
+    expect(join(['/', 'home', 'alice'], 'posix')).toBe('/home/alice')
+    expect(join(['/', '/home/', 'alice'], 'posix')).toBe('/home/alice')
+  })
+
+  it('answers the root itself when there is nothing to append', () => {
+    expect(join(['/'], 'posix')).toBe('/')
+    expect(join(['/', ''], 'posix')).toBe('/')
+  })
+
+  // The same shape on win32: `\foo` is rooted but volume-less. `C:\` is NOT
+  // this case -- it strips to `C:`, which still names the drive, which is why
+  // the defect only ever showed on POSIX.
+  it('keeps the leading separator for a volume-less win32 root', () => {
+    expect(join(['\\', 'foo'], 'win32')).toBe('\\foo')
+    expect(join(['C:\\', 'Users', 'alice'], 'win32')).toBe('C:\\Users\\alice')
+  })
 })
 
 describe('parentDirectory', () => {
@@ -241,6 +265,14 @@ describe('untildify', () => {
 
   it('is a no-op when homeDir is missing', () => {
     expect(untildify('~/proj')).toBe('~/proj')
+  })
+
+  // A home directory at the filesystem root goes through `join`'s root case.
+  // Without it this answered `proj` -- a RELATIVE path where the caller needs
+  // an absolute one.
+  it('expands against a home directory that is the filesystem root', () => {
+    expect(untildify('~/proj', '/', 'posix')).toBe('/proj')
+    expect(untildify('~', '/', 'posix')).toBe('/')
   })
 })
 

--- a/frontend/src/lib/paths.test.ts
+++ b/frontend/src/lib/paths.test.ts
@@ -6,8 +6,11 @@ import {
   filesystemRoot,
   flavorFromOs,
   isAbsolute,
+  isFilesystemRoot,
   join,
+  normalizeSeparators,
   parentDirectory,
+  pathEq,
   relativeUnder,
   relativizePath,
   split,
@@ -138,7 +141,7 @@ describe('join', () => {
   })
 
   // The same shape on win32: `\foo` is rooted but volume-less. `C:\` is NOT
-  // this case -- it strips to `C:`, which still names the drive, which is why
+  // this case -- it strips to `C:`, which still identifies the drive, which is why
   // the defect only ever showed on POSIX.
   it('keeps the leading separator for a volume-less win32 root', () => {
     expect(join(['\\', 'foo'], 'win32')).toBe('\\foo')
@@ -354,6 +357,101 @@ describe('relativeUnder', () => {
 
   it('returns null when the win32 volume differs', () => {
     expect(relativeUnder('D:\\data', 'C:\\data', 'win32')).toBeNull()
+  })
+
+  // One trailing separator was stripped, not every one, so a base spelled
+  // `/a//` built the prefix `/a//` and matched none of its own descendants.
+  it('strips every trailing separator on the base, not only one', () => {
+    expect(relativeUnder('/a/b', '/a//', 'posix')).toBe('b')
+    expect(relativeUnder('/a/b', '/a///', 'posix')).toBe('b')
+    expect(relativeUnder('/a/b', '//', 'posix')).toBe('a/b')
+    expect(relativeUnder('C:\\Users\\alice', 'C:\\Users\\\\', 'win32')).toBe('alice')
+  })
+
+  // A base of nothing but separators trims to '', and comparing against ''
+  // reported EVERY path as the base itself -- including the drive-relative
+  // `C:`, which identifies the current directory on drive C and not the
+  // drive's root.
+  it('does not treat a drive-relative path as the drive root', () => {
+    expect(relativeUnder('C:', 'C:\\', 'win32')).toBeNull()
+    expect(relativeUnder('C:', 'C:', 'win32')).toBe('')
+  })
+
+  it('returns null for an empty path', () => {
+    expect(relativeUnder('', '/', 'posix')).toBeNull()
+    expect(relativeUnder('', '', 'posix')).toBeNull()
+  })
+})
+
+describe('pathEq', () => {
+  it('compares byte-exactly on posix', () => {
+    expect(pathEq('/A', '/a', 'posix')).toBe(false)
+    expect(pathEq('/a', '/a', 'posix')).toBe(true)
+  })
+
+  it('compares case-insensitively on win32', () => {
+    expect(pathEq('C:\\Users', 'c:\\users', 'win32')).toBe(true)
+    expect(pathEq('C:\\Users', 'C:\\Other', 'win32')).toBe(false)
+  })
+
+  // Text, not paths: it neither cleans nor normalizes separators, which is
+  // why a caller that wants "the same directory" must normalize first.
+  it('does not normalize separators', () => {
+    expect(pathEq('C:/Users', 'C:\\Users', 'win32')).toBe(false)
+  })
+})
+
+describe('isFilesystemRoot', () => {
+  it('accepts a posix root however many separators it carries', () => {
+    expect(isFilesystemRoot('/', 'posix')).toBe(true)
+    expect(isFilesystemRoot('//', 'posix')).toBe(true)
+    expect(isFilesystemRoot('///', 'posix')).toBe(true)
+  })
+
+  it('accepts a win32 drive root in either separator', () => {
+    expect(isFilesystemRoot('C:\\', 'win32')).toBe(true)
+    expect(isFilesystemRoot('C:/', 'win32')).toBe(true)
+  })
+
+  // A UNC share root arrives with and without its trailing separator; both
+  // are the same root, so both must answer true.
+  it('accepts a UNC share root with or without a trailing separator', () => {
+    expect(isFilesystemRoot('\\\\srv\\share\\', 'win32')).toBe(true)
+    expect(isFilesystemRoot('\\\\srv\\share', 'win32')).toBe(true)
+  })
+
+  it('refuses anything under a root', () => {
+    expect(isFilesystemRoot('/home', 'posix')).toBe(false)
+    expect(isFilesystemRoot('C:\\Users', 'win32')).toBe(false)
+    expect(isFilesystemRoot('\\\\srv\\share\\x', 'win32')).toBe(false)
+  })
+
+  // `C:` is drive-relative -- the current directory on drive C, not its root.
+  it('refuses a drive-relative path and a relative path', () => {
+    expect(isFilesystemRoot('C:', 'win32')).toBe(false)
+    expect(isFilesystemRoot('proj/src', 'posix')).toBe(false)
+    expect(isFilesystemRoot('', 'posix')).toBe(false)
+  })
+
+  // A win32 path that is rooted but volume-less lands on whichever drive the
+  // worker's current directory is on, so the browser cannot call it a root.
+  it('refuses a volume-less win32 root', () => {
+    expect(isFilesystemRoot('\\', 'win32')).toBe(false)
+  })
+})
+
+describe('normalizeSeparators', () => {
+  it('rewrites forward slashes on win32', () => {
+    expect(normalizeSeparators('C:/Users/alice', 'win32')).toBe('C:\\Users\\alice')
+    expect(normalizeSeparators('C:\\Users\\alice', 'win32')).toBe('C:\\Users\\alice')
+  })
+
+  // `\` is a legal character in a POSIX file name, so `weird\name` is ONE
+  // component. Rewriting it made that file compare equal to a directory
+  // `weird/name` that may also exist.
+  it('keeps a backslash on posix, where it is a legal file-name character', () => {
+    expect(normalizeSeparators('/a/weird\\name', 'posix')).toBe('/a/weird\\name')
+    expect(normalizeSeparators('/a/b', 'posix')).toBe('/a/b')
   })
 })
 

--- a/frontend/src/lib/paths.test.ts
+++ b/frontend/src/lib/paths.test.ts
@@ -3,6 +3,7 @@ import {
   basename,
   detectFlavor,
   extname,
+  filesystemRoot,
   flavorFromOs,
   isAbsolute,
   join,
@@ -243,6 +244,47 @@ describe('untildify', () => {
   })
 })
 
+describe('filesystemRoot', () => {
+  it('returns / for any absolute posix path', () => {
+    expect(filesystemRoot('/', 'posix')).toBe('/')
+    expect(filesystemRoot('/etc/hosts', 'posix')).toBe('/')
+    expect(filesystemRoot('/a/b/', 'posix')).toBe('/')
+  })
+
+  it('returns undefined for a relative posix path', () => {
+    expect(filesystemRoot('proj/src', 'posix')).toBeUndefined()
+    expect(filesystemRoot('', 'posix')).toBeUndefined()
+  })
+
+  it('returns the drive root with the native separator on win32', () => {
+    expect(filesystemRoot('C:\\Users\\alice', 'win32')).toBe('C:\\')
+    expect(filesystemRoot('C:/Users/alice', 'win32')).toBe('C:\\')
+  })
+
+  it('is idempotent on a drive root', () => {
+    expect(filesystemRoot('C:\\', 'win32')).toBe('C:\\')
+    expect(filesystemRoot('C:/', 'win32')).toBe('C:\\')
+  })
+
+  it('returns the share root for a UNC path', () => {
+    expect(filesystemRoot('\\\\srv\\share\\x', 'win32')).toBe('\\\\srv\\share\\')
+    expect(filesystemRoot('\\\\srv\\share\\', 'win32')).toBe('\\\\srv\\share\\')
+  })
+
+  // Which drive a volume-less rooted path lands on is the worker's current
+  // directory, so the browser must not guess one.
+  it('returns undefined for a win32 path with no volume', () => {
+    expect(filesystemRoot('\\rooted', 'win32')).toBeUndefined()
+    expect(filesystemRoot('/rooted', 'win32')).toBeUndefined()
+    expect(filesystemRoot('proj\\src', 'win32')).toBeUndefined()
+  })
+
+  it('sniffs the flavor when none is given', () => {
+    expect(filesystemRoot('C:\\x')).toBe('C:\\')
+    expect(filesystemRoot('/x')).toBe('/')
+  })
+})
+
 describe('relativeUnder', () => {
   it('returns empty string when the paths are equal on posix', () => {
     expect(relativeUnder('/home/alice', '/home/alice', 'posix')).toBe('')
@@ -261,6 +303,16 @@ describe('relativeUnder', () => {
   it('distinguishes similarly-named siblings (no partial-match leakage)', () => {
     // "alice-fork" starts with "alice" but is not under it.
     expect(relativeUnder('/home/alice-fork', '/home/alice', 'posix')).toBeNull()
+  })
+
+  // A filesystem root IS a trailing separator, so without this every path
+  // under a root answered null and a tree rooted at `/` found no descendants.
+  it('treats a trailing separator on the base as a root', () => {
+    expect(relativeUnder('/a/b', '/', 'posix')).toBe('a/b')
+    expect(relativeUnder('/', '/', 'posix')).toBe('')
+    expect(relativeUnder('C:\\Users', 'C:\\', 'win32')).toBe('Users')
+    expect(relativeUnder('C:\\', 'C:\\', 'win32')).toBe('')
+    expect(relativeUnder('\\\\srv\\share\\x', '\\\\srv\\share\\', 'win32')).toBe('x')
   })
 
   it('compares case-insensitively on win32', () => {
@@ -308,5 +360,39 @@ describe('relativizePath', () => {
 
   it('falls back to absolute when roots differ on win32', () => {
     expect(relativizePath('D:\\data\\a.txt', 'C:\\proj')).toBe('D:\\data\\a.txt')
+  })
+})
+
+describe('relativizePath from a filesystem root', () => {
+  // The picker's tree is rooted at `/` now. Without the root guard the direct
+  // relative answer wins and "Copy relative path" reads `home/alice/proj/a.ts`.
+  it('prefers the tilde form when the base is the filesystem root', () => {
+    expect(relativizePath('/home/alice/proj/a.ts', '/', '/home/alice')).toBe('~/proj/a.ts')
+  })
+
+  it('falls back to the absolute path when the tilde does not apply', () => {
+    expect(relativizePath('/opt/data', '/', '/home/alice')).toBe('/opt/data')
+  })
+
+  it('still answers . for the root itself', () => {
+    expect(relativizePath('/', '/')).toBe('.')
+    expect(relativizePath('C:\\', 'C:\\')).toBe('.')
+  })
+
+  it('prefers the tilde form from a win32 drive root', () => {
+    expect(relativizePath('C:\\Users\\alice\\p', 'C:\\', 'C:\\Users\\alice')).toBe('~\\p')
+  })
+
+  // Regression guard for rewriting rootsMatch on top of filesystemRoot.
+  it('still compares win32 volumes case-insensitively', () => {
+    expect(relativizePath('C:\\proj\\src', 'c:\\PROJ')).toBe('src')
+  })
+
+  // rootsMatch is reached through relativizePath. Its rewrite must keep
+  // answering false when only ONE side has a root, or a `../` chain would be
+  // offered between an absolute path and a relative base.
+  it('offers no relative chain between an absolute path and a relative base', () => {
+    expect(relativizePath('/opt/data', 'rel/base')).toBe('/opt/data')
+    expect(relativizePath('C:\\opt\\data', 'rel\\base', undefined, 'win32')).toBe('C:\\opt\\data')
   })
 })

--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -15,6 +15,16 @@ function isSep(ch: string): boolean {
   return ch === '\\' || ch === '/'
 }
 
+// Remove every trailing separator. One spelling for a strip that four callers
+// need, so a base directory reduces the same way wherever it enters.
+//
+// Both separators, whatever the flavor: a win32 path reaches this file spelled
+// with `/` (a user types `C:/Users`), and a base that keeps one trailing
+// separator is a base that matches none of its own descendants.
+function stripTrailingSep(p: string): string {
+  return p.replace(TRAILING_SEP_RE, '')
+}
+
 // Parse a \\server\share prefix. Returns the normalized `\\server\share`
 // volume and the remainder, or null if the input isn't a well-formed UNC.
 function parseUncHead(p: string): { volume: string, rest: string } | null {
@@ -102,8 +112,8 @@ export function isAbsolute(p: string, flavor?: PathFlavor): boolean {
  *   filesystemRoot('\\rooted', 'win32')          -> undefined
  *
  * The answer always ENDS IN the flavor's separator, because that is what a
- * worker's ListDirectory needs. `C:` alone names the current directory on
- * drive C, not the drive's root, which is also why `isAbsolute('C:')` is
+ * worker's ListDirectory needs. `C:` alone identifies the current directory
+ * on drive C, not the drive's root, which is also why `isAbsolute('C:')` is
  * correctly false.
  *
  * A win32 path that is rooted but volume-less (`\foo`, `/foo`) answers
@@ -118,6 +128,41 @@ export function filesystemRoot(p: string, flavor?: PathFlavor): string | undefin
     return p.startsWith('/') ? '/' : undefined
   const volume = extractVolume(p)
   return volume ? `${volume}${sep(f)}` : undefined
+}
+
+/**
+ * Whether `p` IS a filesystem root, whatever spelling it arrives in.
+ *
+ *   isFilesystemRoot('/', 'posix')                 -> true
+ *   isFilesystemRoot('//', 'posix')                -> true
+ *   isFilesystemRoot('C:/', 'win32')               -> true
+ *   isFilesystemRoot('\\\\srv\\share', 'win32')      -> true
+ *   isFilesystemRoot('C:', 'win32')                -> false
+ *   isFilesystemRoot('/home', 'posix')             -> false
+ *
+ * A root arrives spelled several ways -- `/` and `//`, `C:\` and `C:/`,
+ * `\\srv\share` with and without its trailing separator -- and a caller that
+ * compares against `filesystemRoot`'s own output recognizes only one of them.
+ * A caller that compares against `filesystemRoot`'s own output recognizes
+ * only one of them. Counting COMPONENTS recognizes all of them, because
+ * `split` drops the empty ones: `//` and `C:/` hold nothing beyond their own
+ * root, and `/home` holds one thing more. That matters at both call sites:
+ * the tree labels its root row with itself, and "Copy relative path" refuses
+ * a root as a base.
+ *
+ * `C:` stays false. It is drive-relative -- it identifies the current
+ * directory on drive C, not the drive's root -- and `filesystemRoot` already
+ * answers undefined for it, which is also why `isAbsolute('C:')` is correctly
+ * false.
+ */
+export function isFilesystemRoot(p: string, flavor?: PathFlavor): boolean {
+  if (!p)
+    return false
+  const f = flavorOf(p, flavor)
+  const root = filesystemRoot(p, f)
+  if (root === undefined)
+    return false
+  return split(p, f).length === split(root, f).length
 }
 
 // Split a path into non-empty components. On Win32 the volume (`C:` or
@@ -158,15 +203,16 @@ export function join(parts: string[], flavor?: PathFlavor): string {
   // but the last -- which empties a root and drops it, so `join(['/', 'home'])`
   // answered `'home'`. Every path built from a POSIX root then came out
   // RELATIVE, which is how a tree rooted at `/` lost its git decorations.
-  // Win32 hides the defect: `C:\` strips to `C:`, which still names the drive.
-  const rooted = filtered[0].replace(TRAILING_SEP_RE, '') === ''
+  // Win32 hides the defect: `C:\` strips to `C:`, which still identifies the
+  // drive.
+  const rooted = stripTrailingSep(filtered[0]) === ''
   const out: string[] = []
   for (let i = rooted ? 1 : 0; i < filtered.length; i++) {
     let piece = filtered[i]
     if (i > 0)
       piece = piece.replace(LEADING_SEP_RE, '')
     if (i < filtered.length - 1)
-      piece = piece.replace(TRAILING_SEP_RE, '')
+      piece = stripTrailingSep(piece)
     if (piece !== '')
       out.push(piece)
   }
@@ -236,10 +282,22 @@ export function basename(p: string, flavor?: PathFlavor): string {
   return parts.length === 0 ? '' : parts[parts.length - 1]
 }
 
-function normalizeSeparators(p: string, flavor: PathFlavor): string {
-  return flavor === 'win32'
-    ? p.replace(FWD_SLASH_G, '\\')
-    : p.replace(BACK_SLASH_G, '/')
+/**
+ * Rewrite `p` with the flavor's own separator, where the flavor HAS a second
+ * one.
+ *
+ * Win32 accepts both `/` and `\`, so a path a user typed as `C:/Users` and the
+ * same path a worker reported as `C:\Users` must reduce to one spelling before
+ * any comparison.
+ *
+ * POSIX returns `p` unchanged, and that is the RULE, not a shortcut. `\` is a
+ * legal character in a POSIX file name, so `a\b` is ONE component, and a
+ * rewrite to `a/b` makes it compare equal to the directory `a/b`. Use
+ * `toPosixSeparators` where the target really is `/`: git reports its paths
+ * that way whatever the host OS.
+ */
+export function normalizeSeparators(p: string, flavor: PathFlavor): string {
+  return flavor === 'win32' ? p.replace(FWD_SLASH_G, '\\') : p
 }
 
 // Convert any flavor's separators to posix `/`. Useful for comparing against
@@ -248,8 +306,15 @@ export function toPosixSeparators(p: string): string {
   return p.replace(BACK_SLASH_G, '/')
 }
 
-// Case-insensitive on win32, byte-exact on posix.
-function pathEq(a: string, b: string, flavor: PathFlavor): boolean {
+// Compare two path TEXTS under the flavor's case rules: case-insensitive on
+// win32, byte-exact on posix.
+//
+// Text, not paths: it neither cleans nor normalizes separators, and callers
+// apply it to a whole path, to one segment, and to a prefix slice. A caller
+// that wants "the same directory" must normalize first. Deliberately NOT
+// named `samePath`, because Go's `pathutil.SamePath` cleans both inputs and
+// the shared name would mean two different things across the two languages.
+export function pathEq(a: string, b: string, flavor: PathFlavor): boolean {
   return flavor === 'win32'
     ? a.toLowerCase() === b.toLowerCase()
     : a === b
@@ -264,11 +329,23 @@ function pathEq(a: string, b: string, flavor: PathFlavor): boolean {
 // that, every path under a root answered null -- so a tree rooted at `/` found
 // none of its own descendants.
 export function relativeUnder(abs: string, base: string, flavor: PathFlavor): string | null {
+  if (!abs)
+    return null
+  // A relative path is under no absolute base. The strip below is what makes
+  // this necessary: it turns `C:\` into `C:`, and the equality test would then
+  // report the drive-RELATIVE `C:` -- the current directory on drive C -- as
+  // the drive's root. Every other spelling survives the strip unchanged.
+  if (isAbsolute(base, flavor) && !isAbsolute(abs, flavor))
+    return null
   const s = sep(flavor)
-  const trimmed = base.endsWith(s) ? base.slice(0, -1) : base
+  const trimmed = stripTrailingSep(base)
   if (pathEq(abs, base, flavor) || pathEq(abs, trimmed, flavor))
     return ''
+  // A root trims to '' (or to the bare volume), so the prefix IS the root.
+  // `abs` may spell that root with more separators than `base` did.
   const prefix = `${trimmed}${s}`
+  if (pathEq(abs, prefix, flavor))
+    return ''
   if (pathEq(abs.slice(0, prefix.length), prefix, flavor))
     return abs.slice(prefix.length)
   return null
@@ -280,9 +357,9 @@ export function tildify(absPath: string, homeDir?: string, flavor?: PathFlavor):
   if (!homeDir)
     return absPath
   const f = flavorOf(absPath, flavor)
-  const homeTrimmed = homeDir.replace(TRAILING_SEP_RE, '')
-  const homeNorm = f === 'win32' ? normalizeSeparators(homeTrimmed, f) : homeTrimmed
-  const absNorm = f === 'win32' ? normalizeSeparators(absPath, f) : absPath
+  const homeTrimmed = stripTrailingSep(homeDir)
+  const homeNorm = normalizeSeparators(homeTrimmed, f)
+  const absNorm = normalizeSeparators(absPath, f)
   const rem = relativeUnder(absNorm, homeNorm, f)
   if (rem === '')
     return '~'
@@ -320,17 +397,25 @@ export function relativizePath(
   const f = flavorOf(absPath, flavor)
   const s = sep(f)
 
-  const wdTrimmed = workingDir.replace(TRAILING_SEP_RE, '')
-  const absNorm = f === 'win32' ? normalizeSeparators(absPath, f) : absPath
-  const wdNorm = f === 'win32' ? normalizeSeparators(wdTrimmed, f) : wdTrimmed
+  const wdTrimmed = stripTrailingSep(workingDir)
+  const absNorm = normalizeSeparators(absPath, f)
+  const wdNorm = normalizeSeparators(wdTrimmed, f)
 
   // A FILESYSTEM ROOT is a base in name only. Every absolute path is under it,
   // so the direct-relative answer below is just the path with its root sliced
   // off -- one character shorter and no more readable. The directory picker's
   // tree is rooted at `/` (or `C:\`), so without this "Copy relative path" on
-  // `~/proj/a.ts` answers `home/alice/proj/a.ts`. Let the `..` and tilde
-  // candidates compete instead.
-  const baseIsRoot = filesystemRoot(workingDir, f) === normalizeSeparators(workingDir, f)
+  // `~/proj/a.ts` answers `home/alice/proj/a.ts`.
+  //
+  // Only the TILDE candidate competes after this. The `..` candidate cannot:
+  // `wdTrimmed` reduces a root to '' (or to the bare volume `C:`), so
+  // `rootsMatch` compares an undefined root and answers false. That is the
+  // correct outcome -- for a root base the `..` chain is empty, so it would
+  // rebuild the same one-character-shorter answer this guard just refused --
+  // and a caller outside the home directory therefore gets the ABSOLUTE path.
+  // `FileActionsMenu` hides "Copy relative path" for a root base rather than
+  // offer a second item that copies what "Copy path" already copies.
+  const baseIsRoot = isFilesystemRoot(workingDir, f)
 
   const rem = relativeUnder(absNorm, wdNorm, f)
   if (rem === '')

--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -152,8 +152,16 @@ export function join(parts: string[], flavor?: PathFlavor): string {
     return ''
   const f = flavorOf(filtered[0], flavor)
   const s = sep(f)
+  // A first element that is NOTHING BUT separators is a filesystem root: `/`,
+  // and win32's volume-less `\`. It becomes a prefix rather than an element,
+  // because the loop below strips the trailing separator from every element
+  // but the last -- which empties a root and drops it, so `join(['/', 'home'])`
+  // answered `'home'`. Every path built from a POSIX root then came out
+  // RELATIVE, which is how a tree rooted at `/` lost its git decorations.
+  // Win32 hides the defect: `C:\` strips to `C:`, which still names the drive.
+  const rooted = filtered[0].replace(TRAILING_SEP_RE, '') === ''
   const out: string[] = []
-  for (let i = 0; i < filtered.length; i++) {
+  for (let i = rooted ? 1 : 0; i < filtered.length; i++) {
     let piece = filtered[i]
     if (i > 0)
       piece = piece.replace(LEADING_SEP_RE, '')
@@ -162,12 +170,11 @@ export function join(parts: string[], flavor?: PathFlavor): string {
     if (piece !== '')
       out.push(piece)
   }
-  if (out.length === 0)
-    return ''
   let joined = out.join(s)
   if (f === 'win32')
     joined = joined.replace(FWD_SLASH_G, '\\')
-  return joined
+  // One separator, never two: the root supplies it, so the elements must not.
+  return rooted ? `${s}${joined}` : joined
 }
 
 // Parent directory of `p`. For a root, returns the root itself.

--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -34,6 +34,15 @@ function parseUncHead(p: string): { volume: string, rest: string } | null {
   return { volume: `\\\\${server}\\${p.slice(shareStart, i)}`, rest: p.slice(i) }
 }
 
+// The win32 volume of `p` (`C:` or `\\server\share`), WITHOUT a trailing
+// separator, or '' when the path has none. Private on purpose: a volume alone
+// is not a directory, and `filesystemRoot` is the answer callers want.
+function extractVolume(p: string): string {
+  if (DRIVE_LETTER_RE.test(p))
+    return p.slice(0, 2)
+  return parseUncHead(p)?.volume ?? ''
+}
+
 export function detectFlavor(p: string): PathFlavor {
   if (!p)
     return 'posix'
@@ -81,6 +90,34 @@ export function isAbsolute(p: string, flavor?: PathFlavor): boolean {
   if (f === 'win32')
     return p.startsWith('\\') || p.startsWith('/') || DRIVE_LETTER_RE.test(p)
   return p.startsWith('/')
+}
+
+/**
+ * The filesystem root `p` lives under, or undefined when `p` is not absolute.
+ *
+ *   filesystemRoot('/etc/hosts', 'posix')        -> '/'
+ *   filesystemRoot('C:/Users/a', 'win32')        -> 'C:\\'
+ *   filesystemRoot('\\\\srv\\share\\x', 'win32') -> '\\\\srv\\share\\'
+ *   filesystemRoot('proj/src', 'posix')          -> undefined
+ *   filesystemRoot('\\rooted', 'win32')          -> undefined
+ *
+ * The answer always ENDS IN the flavor's separator, because that is what a
+ * worker's ListDirectory needs. `C:` alone names the current directory on
+ * drive C, not the drive's root, which is also why `isAbsolute('C:')` is
+ * correctly false.
+ *
+ * A win32 path that is rooted but volume-less (`\foo`, `/foo`) answers
+ * undefined: which drive it lands on is the worker's current directory, and
+ * the browser cannot know it. Callers fall back.
+ */
+export function filesystemRoot(p: string, flavor?: PathFlavor): string | undefined {
+  if (!p)
+    return undefined
+  const f = flavorOf(p, flavor)
+  if (f === 'posix')
+    return p.startsWith('/') ? '/' : undefined
+  const volume = extractVolume(p)
+  return volume ? `${volume}${sep(f)}` : undefined
 }
 
 // Split a path into non-empty components. On Win32 the volume (`C:` or
@@ -212,12 +249,19 @@ function pathEq(a: string, b: string, flavor: PathFlavor): boolean {
 }
 
 // Returns '' when abs === base, the slice after `base + sep` when abs is
-// strictly under base, or null otherwise. `base` must have no trailing sep;
-// both inputs must already use the flavor's separator.
+// strictly under base, or null otherwise. Both inputs must already use the
+// flavor's separator.
+//
+// A TRAILING SEPARATOR on `base` is tolerated and stripped, because a
+// filesystem root is nothing but one (`/`, `C:\`, `\\srv\share\`). Without
+// that, every path under a root answered null -- so a tree rooted at `/` found
+// none of its own descendants.
 export function relativeUnder(abs: string, base: string, flavor: PathFlavor): string | null {
-  if (pathEq(abs, base, flavor))
+  const s = sep(flavor)
+  const trimmed = base.endsWith(s) ? base.slice(0, -1) : base
+  if (pathEq(abs, base, flavor) || pathEq(abs, trimmed, flavor))
     return ''
-  const prefix = `${base}${sep(flavor)}`
+  const prefix = `${trimmed}${s}`
   if (pathEq(abs.slice(0, prefix.length), prefix, flavor))
     return abs.slice(prefix.length)
   return null
@@ -273,10 +317,18 @@ export function relativizePath(
   const absNorm = f === 'win32' ? normalizeSeparators(absPath, f) : absPath
   const wdNorm = f === 'win32' ? normalizeSeparators(wdTrimmed, f) : wdTrimmed
 
+  // A FILESYSTEM ROOT is a base in name only. Every absolute path is under it,
+  // so the direct-relative answer below is just the path with its root sliced
+  // off -- one character shorter and no more readable. The directory picker's
+  // tree is rooted at `/` (or `C:\`), so without this "Copy relative path" on
+  // `~/proj/a.ts` answers `home/alice/proj/a.ts`. Let the `..` and tilde
+  // candidates compete instead.
+  const baseIsRoot = filesystemRoot(workingDir, f) === normalizeSeparators(workingDir, f)
+
   const rem = relativeUnder(absNorm, wdNorm, f)
   if (rem === '')
     return '.'
-  if (rem !== null)
+  if (rem !== null && !baseIsRoot)
     return rem
 
   let best = absNorm
@@ -297,16 +349,13 @@ export function relativizePath(
   return best
 }
 
+// Whether two paths hang off the SAME root: the same drive or UNC share on
+// win32, and both-absolute-or-both-relative on posix. Built on
+// `filesystemRoot` so "what root does this path have" is stated once.
 function rootsMatch(a: string, b: string, flavor: PathFlavor): boolean {
-  if (flavor === 'posix')
-    return a.startsWith('/') === b.startsWith('/')
-  const volA = extractVolume(a)
-  const volB = extractVolume(b)
-  return volA.toLowerCase() === volB.toLowerCase()
-}
-
-function extractVolume(p: string): string {
-  if (DRIVE_LETTER_RE.test(p))
-    return p.slice(0, 2)
-  return parseUncHead(p)?.volume ?? ''
+  const rootA = filesystemRoot(a, flavor)
+  const rootB = filesystemRoot(b, flavor)
+  if (rootA === undefined || rootB === undefined)
+    return rootA === rootB
+  return pathEq(rootA, rootB, flavor)
 }

--- a/frontend/src/lib/slug.test.ts
+++ b/frontend/src/lib/slug.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { slugify } from './slug'
+
+describe('slugify', () => {
+  it('reduces a windows drive root to its letter', () => {
+    expect(slugify('C:\\')).toBe('c')
+    expect(slugify('D:/')).toBe('d')
+  })
+
+  // The fold that a delete-every-separator rule got wrong: both of these
+  // reduced to `srvab`, so one drive menu offered two rows with one test id.
+  it('keeps a UNC server and share apart', () => {
+    expect(slugify('\\\\srv\\a-b')).toBe('srv-a-b')
+    expect(slugify('\\\\srv\\ab')).toBe('srv-ab')
+  })
+
+  it('folds a run of non-alphanumerics to one hyphen and trims the ends', () => {
+    expect(slugify('worker · a/b')).toBe('worker-a-b')
+    expect(slugify('  Leading and trailing  ')).toBe('leading-and-trailing')
+  })
+
+  // Lossy by design, which is why a caller that needs uniqueness resolves the
+  // collision itself.
+  it('answers the empty string for a label with no alphanumerics', () => {
+    expect(slugify('· / ·')).toBe('')
+    expect(slugify('')).toBe('')
+  })
+})

--- a/frontend/src/lib/slug.ts
+++ b/frontend/src/lib/slug.ts
@@ -1,0 +1,19 @@
+/**
+ * A label reduced to something addressable: lowercase, and every run of
+ * non-alphanumerics folded to one hyphen.
+ *
+ * The labels that reach this carry spaces, dots, slashes, colons, backslashes
+ * and a middle dot, none of which belong in a selector. A Windows drive root
+ * (`C:\`) reduces to its letter; a UNC root (`\\srv\share`) to `srv-share`.
+ *
+ * The fold is LOSSY: `worker · a/b` and `worker-a-b` both reduce to
+ * `worker-a-b`, `foo_bar` and `foo-bar` both reduce to `foo-bar`, and a label
+ * with no ASCII alphanumerics at all reduces to the empty string. A caller that
+ * needs a UNIQUE id must resolve a collision itself -- see `targetSlugs` in
+ * `~/components/workspace/RepositoryTargetMenu`.
+ */
+export function slugify(label: string): string {
+  // No `i` flag: `.toLowerCase()` already ran, and on a NEGATED class the flag
+  // would stop `[^a-z0-9]` from excluding uppercase letters.
+  return label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}

--- a/frontend/src/styles/shared.css.ts
+++ b/frontend/src/styles/shared.css.ts
@@ -28,6 +28,47 @@ export const controlReset = style({
 })
 
 /**
+ * The surface every FIELD TRIGGER shares: a button that sits where a form
+ * control would and opens a menu.
+ *
+ * Three carry it -- the directory picker's drive selector, the new-agent
+ * dialog's provider selector, and Preferences' phone-band section picker --
+ * and the repo's own conventions name the last two together as the shape to
+ * follow. Two of them render in the same dialog, so a divergence in the
+ * border, the radius or the focus ring is visible side by side. The `menu`
+ * rule already diverged once between them.
+ *
+ * ONLY what all three share. A call site composes this and adds its own
+ * padding, gap, width and alignment, which is why the base sets none of them:
+ * no call site overrides a property this declares, so the composition needs no
+ * ordering rule to be correct.
+ */
+export const fieldTrigger = style({
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: 'var(--text-7)',
+  lineHeight: 'var(--leading-normal)',
+  backgroundColor: 'var(--background)',
+  color: 'var(--foreground)',
+  border: '1px solid var(--input)',
+  borderRadius: 'var(--radius-medium)',
+  transition: 'border-color var(--transition-fast), box-shadow var(--transition-fast)',
+  selectors: {
+    '&:focus-visible': {
+      outline: 'none',
+      borderColor: 'var(--ring)',
+      boxShadow: '0 0 0 2px rgb(from var(--ring) r g b / 0.2)',
+    },
+  },
+})
+
+/** The chevron that marks a {@link fieldTrigger} as opening something. */
+export const fieldTriggerChevron = style({
+  color: 'var(--muted-foreground)',
+  flexShrink: 0,
+})
+
+/**
  * The small muted button that opens something: the composer's status-bar chips
  * (branch, model, effort, mode) and the info cluster beside them (the
  * context-usage trigger, the copy buttons inside its card).

--- a/frontend/tests/e2e/004-registration.spec.ts
+++ b/frontend/tests/e2e/004-registration.spec.ts
@@ -55,7 +55,8 @@ test.describe('Worker Registration', () => {
     const refreshBtn = page.getByLabel('Refresh directory tree')
     const refreshIcon = refreshBtn.locator('svg')
 
-    // Click a directory node in the tree (the root node)
+    // Click a directory node in the tree (the root node, which is the
+    // filesystem root -- the picker no longer roots at the home directory).
     await page.getByTestId('tree-root-node').click()
 
     // The refresh button's icon should NOT have a spinning animation

--- a/frontend/tests/e2e/065-directory-tree.spec.ts
+++ b/frontend/tests/e2e/065-directory-tree.spec.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import path, { join } from 'node:path'
 import { expect, test } from './fixtures'
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI, openAgentViaAPI } from './helpers/api'
-import { clickTreeContextItem, loginViaToken, openTreeContextMenu, openWorkspace, treeRow, treeRowNames } from './helpers/ui'
+import { clickTreeContextItem, loginViaToken, openTreeContextMenu, openWorkspace, treeRow, treeRowNames, waitForFilesSortOrder } from './helpers/ui'
 
 const frontendDir = path.resolve(import.meta.dirname, '../..')
 const ABSOLUTE_PATH_RE = /^\//
@@ -359,7 +359,7 @@ test.describe('DirectoryTree', () => {
   })
 
   test('sort menu reorders the tree and the choice survives a reload', async ({ page, leapmuxServer }) => {
-    const { hubUrl, adminToken, workerId } = leapmuxServer
+    const { hubUrl, adminToken, adminUserId, workerId } = leapmuxServer
     // A directory whose size order differs from its name order, so an
     // assertion on the row order cannot pass with the sort key ignored.
     const sortDir = join(tmpdir(), `leapmux-e2e-sortdir-${Date.now()}`)
@@ -385,6 +385,10 @@ test.describe('DirectoryTree', () => {
       await expect(names).toHaveText(['apple.txt', 'cherry.txt', 'banana.txt'])
 
       await page.keyboard.press('Escape')
+      // The choice is on screen well before it is on disk: it goes through a
+      // coalescing write-behind queue, and reloading without waiting drops it
+      // every time. Assert the state the reload depends on, not a delay.
+      await waitForFilesSortOrder(page, adminUserId, workerId, { key: 'size', direction: 'desc' })
       await page.reload()
       await expect(names).toHaveText(['apple.txt', 'cherry.txt', 'banana.txt'])
     }

--- a/frontend/tests/e2e/199-directory-picker-root.spec.ts
+++ b/frontend/tests/e2e/199-directory-picker-root.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from './fixtures'
+import { loginViaUI } from './helpers/ui'
+import { openNewWorkspaceDialog } from './helpers/worktree'
+
+/**
+ * The directory picker is rooted at the FILESYSTEM ROOT, not the home
+ * directory.
+ *
+ * The picker used to root at the literal `~`, which the Worker expanded, so
+ * nothing outside the home directory could be reached by clicking. These tests
+ * cover the two halves of the change: the root is now reachable, and the home
+ * directory is still one glance away rather than several clicks down.
+ *
+ * The CI Worker runs Linux, so the Windows drive selector gets no coverage
+ * here. `DriveSelector.test.tsx` and `DirectorySelector.test.tsx` carry it.
+ */
+test.describe('Directory picker root', () => {
+  test('roots the tree at the filesystem root', async ({ page }) => {
+    await loginViaUI(page)
+    await openNewWorkspaceDialog(page)
+
+    const rootNode = page.locator('[data-testid="tree-root-node"]:visible')
+    await expect(rootNode).toBeVisible()
+    await expect(rootNode.locator('[data-testid="tree-row-name"]')).toHaveText('/')
+  })
+
+  test('can browse to a directory outside the home directory', async ({ page }) => {
+    await loginViaUI(page)
+    await openNewWorkspaceDialog(page)
+
+    await expect(page.locator('[data-testid="tree-root-node"]:visible')).toBeVisible()
+
+    // `/tmp` exists on every POSIX host the suite runs on and is never under
+    // `$HOME`, so reaching it by clicking is exactly what the old root made
+    // impossible.
+    const tmpRow = page.locator('[data-testid="tree-row"]:visible')
+      .filter({ has: page.locator('[data-testid="tree-row-name"]', { hasText: /^(private|tmp)$/ }) })
+      .first()
+    await expect(tmpRow).toBeVisible()
+    await tmpRow.click()
+
+    // Selecting it writes the working directory, which the path box shows as
+    // an absolute path -- it is not under home, so it cannot tildify.
+    const pathBox = page.getByPlaceholder('Enter path...')
+    await expect(pathBox).toHaveValue(/^\/(private|tmp)/)
+  })
+
+  test('reveals the home directory without a click', async ({ page }) => {
+    await loginViaUI(page)
+    await openNewWorkspaceDialog(page)
+
+    await expect(page.locator('[data-testid="tree-root-node"]:visible')).toBeVisible()
+
+    // The dialog opens with no selection, so the tree walks itself open toward
+    // the Worker's home directory. Its own row is visible with zero clicks,
+    // and nothing is selected: `revealPath` expands, it never selects.
+    const homeRow = page.locator('[data-testid="tree-row"]:visible')
+      .filter({ has: page.locator('[data-testid="tree-row-name"]', { hasText: /^(home|Users|root)$/ }) })
+      .first()
+    await expect(homeRow).toBeVisible()
+    await expect(page.locator('[data-testid="tree-row"][data-active="true"]:visible')).toHaveCount(0)
+  })
+})

--- a/frontend/tests/e2e/199-directory-picker-root.spec.ts
+++ b/frontend/tests/e2e/199-directory-picker-root.spec.ts
@@ -33,8 +33,14 @@ test.describe('Directory picker root', () => {
     // `/tmp` exists on every POSIX host the suite runs on and is never under
     // `$HOME`, so reaching it by clicking is exactly what the old root made
     // impossible.
+    //
+    // The label may carry more than one segment. The tree asks for
+    // `max_depth: 5`, and the worker merges a directory holding exactly one
+    // child into its parent's row, so `/tmp` with a single subdirectory
+    // renders as `tmp/<child>`. Match the leading segment, not the whole
+    // label.
     const tmpRow = page.locator('[data-testid="tree-row"]:visible')
-      .filter({ has: page.locator('[data-testid="tree-row-name"]', { hasText: /^(private|tmp)$/ }) })
+      .filter({ has: page.locator('[data-testid="tree-row-name"]', { hasText: /^(private|tmp)(\/|$)/ }) })
       .first()
     await expect(tmpRow).toBeVisible()
     await tmpRow.click()
@@ -54,8 +60,11 @@ test.describe('Directory picker root', () => {
     // The dialog opens with no selection, so the tree walks itself open toward
     // the Worker's home directory. Its own row is visible with zero clicks,
     // and nothing is selected: `revealPath` expands, it never selects.
+    //
+    // The leading segment only, for the merge reason the test above states: a
+    // single-user host renders `/home` as `home/<user>` in one row.
     const homeRow = page.locator('[data-testid="tree-row"]:visible')
-      .filter({ has: page.locator('[data-testid="tree-row-name"]', { hasText: /^(home|Users|root)$/ }) })
+      .filter({ has: page.locator('[data-testid="tree-row-name"]', { hasText: /^(home|Users|root)(\/|$)/ }) })
       .first()
     await expect(homeRow).toBeVisible()
     await expect(page.locator('[data-testid="tree-row"][data-active="true"]:visible')).toHaveCount(0)

--- a/frontend/tests/e2e/199-directory-picker-root.spec.ts
+++ b/frontend/tests/e2e/199-directory-picker-root.spec.ts
@@ -84,11 +84,12 @@ test.describe('Directory picker root', () => {
     // box tildifies a path under the home directory, and the home directory
     // itself is the shortest such path.
     await expect(page.getByPlaceholder('Enter path...')).toHaveValue(/^(~|\/(home|Users|root)\/)/)
-    await expect(page.locator('[data-testid="tree-row"][data-active="true"]:visible')).toHaveCount(1)
+    const homeRow = page.locator('[data-testid="tree-row"][data-active="true"]:visible')
+    await expect(homeRow).toHaveCount(1)
 
-    // That the button also OPENS the directory is asserted in
-    // `DirectoryTree.test.tsx`, against the tree's expansion state. Here it
-    // would need the Worker's home directory to hold a child, which no CI host
-    // guarantees.
+    // The button OPENS the directory as well as selecting it. The row states
+    // that itself, so this needs no child under the Worker's home directory --
+    // which no CI host guarantees.
+    await expect(homeRow).toHaveAttribute('aria-expanded', 'true')
   })
 })

--- a/frontend/tests/e2e/199-directory-picker-root.spec.ts
+++ b/frontend/tests/e2e/199-directory-picker-root.spec.ts
@@ -69,4 +69,26 @@ test.describe('Directory picker root', () => {
     await expect(homeRow).toBeVisible()
     await expect(page.locator('[data-testid="tree-row"][data-active="true"]:visible')).toHaveCount(0)
   })
+
+  test('the home button selects the home directory', async ({ page }) => {
+    await loginViaUI(page)
+    await openNewWorkspaceDialog(page)
+
+    await expect(page.locator('[data-testid="tree-root-node"]:visible')).toBeVisible()
+    // The dialog opens unarmed -- the test above states why.
+    await expect(page.locator('[data-testid="tree-row"][data-active="true"]:visible')).toHaveCount(0)
+
+    await page.locator('[data-testid="directory-selector-home"]:visible').click()
+
+    // The button SELECTS, unlike the reveal that opened the dialog. The path
+    // box tildifies a path under the home directory, and the home directory
+    // itself is the shortest such path.
+    await expect(page.getByPlaceholder('Enter path...')).toHaveValue(/^(~|\/(home|Users|root)\/)/)
+    await expect(page.locator('[data-testid="tree-row"][data-active="true"]:visible')).toHaveCount(1)
+
+    // That the button also OPENS the directory is asserted in
+    // `DirectoryTree.test.tsx`, against the tree's expansion state. Here it
+    // would need the Worker's home directory to hold a child, which no CI host
+    // guarantees.
+  })
 })

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -1,10 +1,11 @@
 import type { Locator, Page } from '@playwright/test'
+import type { FileSortOrder } from '../../../src/lib/fileSort'
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import process from 'node:process'
 
 import { expect } from '@playwright/test'
-import { accountStorageKey, getTtlForKey, KEY_BROWSER_PREFS, PREFIX_EDITOR_DRAFT } from '../../../src/lib/browserStorage'
+import { accountStorageKey, getTtlForKey, KEY_BROWSER_PREFS, PREFIX_EDITOR_DRAFT, PREFIX_FILES_SORT_ORDER } from '../../../src/lib/browserStorage'
 import { readEntry, storageKeys, writeEntry } from './storage'
 
 /** Check if a locator is visible, returning false on timeout or error. */
@@ -1344,6 +1345,41 @@ export async function waitForEditorDraft(page: Page, userId: string, text: strin
     }
     return false
   }, `the editor draft "${text}" must be persisted before the reload`).toBe(true)
+}
+
+/**
+ * Wait until the Files section's sort choice has actually reached storage.
+ *
+ * The preference travels through the same coalescing write-behind queue the
+ * editor draft does, so a reload issued in the moments after the click drops
+ * it. `App`'s `pagehide` flush narrows that window and cannot close it: the
+ * flush awaits the connection before it opens a transaction, so the write
+ * lands at least a microtask after the handler returns. A click followed
+ * immediately by a reload loses the write EVERY time, not sometimes.
+ *
+ * The key carries the tab's working directory, which the Worker canonicalizes
+ * (`/var/...` becomes `/private/var/...` on macOS), so this matches on the
+ * `(prefix, workerId)` head and on the stored value instead. One agent per
+ * spec is what makes that unambiguous.
+ */
+export async function waitForFilesSortOrder(
+  page: Page,
+  userId: string,
+  workerId: string,
+  expected: FileSortOrder,
+) {
+  const prefix = accountStorageKey(userId, `${PREFIX_FILES_SORT_ORDER}${workerId}:`)
+  await expect.poll(async () => {
+    for (const key of await storageKeys(page)) {
+      if (!key.startsWith(prefix))
+        continue
+      const row = await readEntry(page, key)
+      const stored = row?.v as { key?: unknown, direction?: unknown } | undefined
+      if (stored?.key === expected.key && stored?.direction === expected.direction)
+        return true
+    }
+    return false
+  }, `the sort order ${expected.key}/${expected.direction} must be persisted before the reload`).toBe(true)
 }
 
 /**

--- a/proto/leapmux/v1/file.proto
+++ b/proto/leapmux/v1/file.proto
@@ -28,6 +28,28 @@ message ListDirectoryResponse {
   // deepest levels. A short chain is a valid answer, never an error -- the
   // caller already knows how to list the remaining levels one at a time.
   repeated DirectoryListing listings = 1;
+  // Set when the chain stopped because a directory could not be READ, rather
+  // than because a cap cut it. See UnreadableDirectory.
+  UnreadableDirectory unreadable = 2;
+}
+
+// The directory a chain stopped at, when it stopped because that directory
+// could not be read.
+//
+// Absent when the chain is complete, and absent when a cap cut it -- a listing
+// count and a payload budget are not failures, and the caller lists the rest
+// itself. Present only for the one directory whose read failed, so a tree can
+// say WHY a row will not open instead of refusing to open it in silence.
+//
+// The OUTERMOST directory is not reported here. Its failure is the request's
+// failure, and the request answers with an error instead.
+message UnreadableDirectory {
+  string path = 1;
+  // Why the read failed, for a person to read. A short fixed phrase --
+  // "permission denied", "no such directory" -- never the operating system's
+  // own message, which carries paths and errno spellings that no caller needs
+  // and that differ per platform. Do not branch on it.
+  string reason = 2;
 }
 
 // One directory's listing. The single-directory answer is a chain of length
@@ -48,7 +70,7 @@ message ReadFileRequest {
   string worker_id = 1;
   string path = 2;
   int64 offset = 3;
-  int64 limit = 4; // Max bytes; 0 = default (64KB)
+  int64 limit = 4; // Max bytes; 0 = default (60KB)
   // When true and the file size exceeds the read window
   // (offset + effective limit), the server returns an empty content
   // payload with the file's total_size populated, skipping the actual
@@ -99,8 +121,8 @@ message ListFilesystemRootsResponse {
   // Plain strings, and deliberately no label and no drive type. A volume LABEL
   // costs GetVolumeInformationW, which does I/O against the volume and is the
   // documented way to block for the SMB timeout on a disconnected mapped
-  // drive. That would turn a bitmask read into an unbounded wait, for a string
-  // no caller needs.
+  // drive. That would turn a bitmask read into a wait with no limit, for a
+  // string no caller needs.
   repeated string roots = 1;
 }
 

--- a/proto/leapmux/v1/file.proto
+++ b/proto/leapmux/v1/file.proto
@@ -6,9 +6,34 @@ message ListDirectoryRequest {
   string path = 2;
   int32 max_depth = 3; // When > 0, merge single-child directories server-side up to this depth
   bool dirs_only = 4; // When true, exclude non-directory entries before applying the entry limit
+  // When set, the response carries one listing per directory from from_root
+  // down to path, outermost first, instead of path alone. Lets a tree reveal a
+  // deep selection in one round trip instead of one per level.
+  //
+  // Must be path itself or an ancestor of it; anything else is
+  // InvalidArgument. Both are canonicalized before that test, so a symlinked
+  // ancestor is accepted. When path is not a directory the chain ends at its
+  // parent, so revealing a FILE costs one request too.
+  //
+  // Empty lists path alone, and a non-directory path is then an error.
+  string from_root = 5;
 }
 
 message ListDirectoryResponse {
+  // One per listed directory, outermost first. Exactly one when the request
+  // set no from_root.
+  //
+  // The worker may return FEWER than the request implies: the chain is capped
+  // by a listing count and by the channel's payload budget, and both drop the
+  // deepest levels. A short chain is a valid answer, never an error -- the
+  // caller already knows how to list the remaining levels one at a time.
+  repeated DirectoryListing listings = 1;
+}
+
+// One directory's listing. The single-directory answer is a chain of length
+// one, so there is no second shape for it and the fields below have one
+// spelling that cannot drift.
+message DirectoryListing {
   string path = 1;
   repeated FileInfo entries = 2;
   bool truncated = 3;
@@ -51,6 +76,32 @@ message StatFileRequest {
 
 message StatFileResponse {
   FileInfo info = 1;
+}
+
+// ListFilesystemRoots enumerates the roots of the worker's own filesystem, so
+// a browser can pick a starting node without guessing what "the top" is on
+// that host. POSIX answers ["/"]; Windows answers the drive roots that
+// currently carry a volume, e.g. ["C:\\", "D:\\"].
+//
+// It takes no arguments for the reason GetWorkerSystemInfoRequest does: it
+// asks about the MACHINE, not about a path, and the channel already identifies
+// the worker.
+message ListFilesystemRootsRequest {}
+
+message ListFilesystemRootsResponse {
+  // Absolute, in the spelling the worker's own filepath accepts as a
+  // directory: with a trailing separator ("/", "C:\\"), never a bare "C:",
+  // which filepath.IsAbs rejects and Clean reads as drive-relative.
+  //
+  // Ascending by drive letter, so an unchanged machine answers the same list
+  // twice and a drive menu built from it does not reshuffle.
+  //
+  // Plain strings, and deliberately no label and no drive type. A volume LABEL
+  // costs GetVolumeInformationW, which does I/O against the volume and is the
+  // documented way to block for the SMB timeout on a disconnected mapped
+  // drive. That would turn a bitmask read into an unbounded wait, for a string
+  // no caller needs.
+  repeated string roots = 1;
 }
 
 message FileInfo {

--- a/site/content/docs/using/control-cli.md
+++ b/site/content/docs/using/control-cli.md
@@ -540,11 +540,26 @@ These groups inspect a Worker's filesystem and git state read-only. The Worker i
 
 | Command | Key flags | Output |
 | --- | --- | --- |
-| `file list` | `--path <dir>` (required), `--max-depth N`, `--dirs-only` | `{path, truncated, entries}` |
+| `file list` | `--path <dir>` (required), `--max-depth N`, `--dirs-only`, `--from-root <dir>` | `{listings}` |
 | `file read` | `--path <file>` (required), `--offset N`, `--limit N` | `{path, total_size, content}` |
 | `file stat` | `--path <path>` (required) | Stat info |
+| `file roots` | none beyond the entity selectors | `{roots}` |
 
 `file read --limit 0` means the default 64 KB cap.
+
+`file list` answers a LIST of directory listings, one per entry, each
+`{path, entries, truncated, total_entries}`. Without `--from-root` that list
+holds exactly one entry, for `--path`. With `--from-root` it holds one entry
+per directory from that ancestor down to `--path`, outermost first, so a
+caller reads a whole branch in one request. `--from-root` must be `--path`
+itself or an ancestor of it. The Worker may answer with fewer entries than the
+depth implies, because the chain is capped by a listing count and by the
+message-size budget; both drop the deepest levels.
+
+`file roots` reports the Worker's own filesystem roots: `["/"]` on a POSIX
+host, and the drive roots that carry a volume (`"C:\\"`, `"D:\\"`) on
+Windows. A WSL or Docker Worker runs a Linux binary, so it reports `["/"]`
+like any other Linux host.
 
 ### `git`
 

--- a/site/content/docs/using/control-cli.md
+++ b/site/content/docs/using/control-cli.md
@@ -545,7 +545,7 @@ These groups inspect a Worker's filesystem and git state read-only. The Worker i
 | `file stat` | `--path <path>` (required) | Stat info |
 | `file roots` | none beyond the entity selectors | `{roots}` |
 
-`file read --limit 0` means the default 64 KB cap.
+`file read --limit 0` means the default 60 KB cap.
 
 `file list` answers a LIST of directory listings, one per entry, each
 `{path, entries, truncated, total_entries}`. Without `--from-root` that list


### PR DESCRIPTION
## Motivation

- The New workspace, New agent and New terminal dialogs share one
  directory picker. The picker hard-coded its tree root to the literal
  `~`, which the worker expanded. A user could not reach anything
  outside the home directory by clicking.
- A Windows worker was worse. Nothing enumerated the drives, so another
  drive was unreachable entirely.
- Three latent path defects blocked the change, in both languages. A
  filesystem root is nothing but the separator that a boundary test
  appends, so `relativeUnder(abs, '/')` answered null, the Go
  `HasPathPrefix(path, "/")` refused the worker's own chain requests,
  and `join(['/', 'home'])` answered the RELATIVE path `home`.

## Modifications

### The worker and the wire

- Add `ListFilesystemRoots`, an owner-gated inner RPC under
  `SCOPE_FILE_READ`. POSIX answers `/`. Windows enumerates the mounted
  drive letters through `GetLogicalDrives`, with a `GetDriveTypeW`
  filter that drops `DRIVE_NO_ROOT_DIR` alone. The filter fails open,
  because a listed drive that later fails to list is better than a real
  drive that the picker hides.
- Put the OS seam in `pathutil`, beside `NormalizeNative`, which already
  builds the `C:\` spelling that the RPC returns. The drive bit math and
  the `DRIVE_*` filter live in an untagged file, so both run under test
  on a host that has no drives.
- Give `ListDirectory` a `from_root`. The worker then answers every
  listing from an ancestor down to `path` in one response. A root at `/`
  otherwise costs one round trip for each level.
- **Breaking:** replace the flat response fields with
  `repeated DirectoryListing listings`. The single-directory answer is a
  chain of length one, so the four listing fields have no second
  spelling that can drift. The control CLI's `file list` JSON changes
  shape with it.
- Add `UnreadableDirectory`, set only when a READ failure cuts the chain
  -- never for a cap, which is not a failure. The reason is a fixed
  phrase, never the operating system's own message.
- Limit the chain twice: a count of 64 listings, and the channel's
  payload budget measured with `proto.Size`. Both limits shorten the
  chain from its deep end, never from its root, so the caller always
  gets a usable prefix.
- Add `file roots` to the control CLI. Shape the `file list` output by
  hand, so `omitempty` stops dropping `truncated` and `total_entries`
  from every listing that has neither.

### The picker

- Derive the tree root from the selected path, then the worker's home
  directory, then the first reported root. No stored "current drive" can
  then disagree with the path box.
- Add `DriveSelector`, a drive menu left of the path box, for a Windows
  worker that reports more than one root. WSL and Docker workers report
  `linux`, so the reported OS excludes them and no container detection
  is needed.
- Add a Home button between the hidden-files toggle and Refresh. It
  selects the home directory and opens it. Rooting at `/` puts the home
  directory several rows down, and a selection alone would not open it:
  the tree opens the ANCESTORS of its reveal target and stops there. The
  button is disabled while the worker reports no home directory, where
  selecting the empty path would clear the working directory instead.
- Add `DirectoryTree.revealPath`, which walks the tree open toward the
  home directory without marking it selected. A New workspace dialog
  opens unarmed, because a seeded selection would arm Create with a
  directory that nobody chose.
- Render the unreadable reason on the row. The tree's own error slot
  belongs to the first load. Refresh clears the reasons, and the next
  click retries.
- Key the sessionStorage cache and the in-flight registry by worker id.
  Two workers share a root path routinely, so a pending listing could
  otherwise write one worker's files into another worker's tree.
- Give `FilesSection` a real root: the working directory, then the
  worker's home. It renders nothing until one of them is known. It
  passed the literal `~` that `DirectoryTree` documents as forbidden.
- Hide "Copy relative path" for a root base, where it returned the
  absolute path -- byte for byte what "Copy path" already copies.

### Accessibility

- Give the tree the ARIA tree pattern: `role="tree"`, `role="treeitem"`
  and `role="group"`, with `aria-expanded`, `aria-selected` and
  `aria-level` on each row. A file omits `aria-expanded`, because a row
  that can never open would otherwise announce as a directory that is
  closed.
- Give it ONE tab stop and the key contract that goes with the pattern.
  Up and Down step through the rows, Right opens a directory and then
  descends into it, Left closes it and then ascends, Home and End jump
  to the two ends, and Enter or Space activates the row. The tree was
  reachable by mouse alone before this: its rows were plain divs with a
  click handler, and nothing in the component handled a key.
- Step through the VISIBLE rows. A closed directory that was loaded once
  still renders its children and hides them with `visibility: hidden`,
  so the DOM order holds rows that are nowhere on screen. The walk
  filters and sorts each level exactly as the render does.

### The shared path helpers

- Carry a separator-only first element of `join` as a PREFIX, not as an
  element, so the elements still join with exactly one separator.
- Compare the cleaned strings for equality first in `HasPathPrefix`, and
  append the boundary separator only when the prefix does not end in
  one.
- Normalize the separators and the case before every comparison. Keep
  the backslash intact on POSIX, where it is a legal file-name
  character.
- Add `filesystemRoot` and `isFilesystemRoot`, which recognize a root in
  every spelling: a POSIX root, a drive root and a UNC share.

### Structure

- Split `DirectoryTree.tsx` into `directoryTreeState.ts` (the row, the
  persisted schema, the pure predicates) and `directoryListings.ts` (the
  fetch path, the in-flight registry, the chain request). Each carries
  its own tests.
- **Breaking:** split `createWorkerScopedList`'s source into `workerId`
  and `enabled`. A gate keyed on a property OF the worker closes on the
  same tick that the worker changes, so the old shape had no transition
  left to clear on. `useAvailableShells` and `useAvailableProviders`
  move to the new signature, with their call sites.
- Add `DirectoryTreeHandle.expandPath`, which opens one node and ignores
  an empty path, and forward it through `createDirectoryTreeState` as
  `expandTreePath`. Publish the handle below `setNodeExpanded`, so it
  forwards to that one writer rather than restating the store write.
- Extract `fieldTrigger` and `fieldTriggerChevron` into the shared
  styles. Three dropdown triggers restated ten identical declarations,
  and their `menu` rules had already drifted.
- Extract `slugify` into `~/lib/slug`. The drive menu's own fold deleted
  every separator, so two different UNC shares collided on one test id.
- Add an E2E spec for the rooted picker and its Home button, unit suites
  for both new tree modules and for the new path helpers, and Go tests
  for the chain, the roots and the repaired prefix test.

## Result

- The picker opens at the POSIX root, or at the current drive root on
  Windows. You reach any readable directory by clicking.
- The Home button returns to the home directory in one click and opens
  it, so the wider root costs nothing on the common path. On Windows it
  also re-roots the tree and the drive menu when the home directory
  lives on another drive.
- The tree is operable from the keyboard, and a screen reader announces
  it as a tree rather than as a stack of unlabelled boxes.
- A Windows worker that reports more than one drive gains a drive menu.
  Choosing a drive re-roots the tree, and typing a path on another drive
  does the same.
- A deep reveal costs one round trip, not one for each level.
- A directory that the worker cannot read states the reason on its own
  row, instead of staying silently collapsed and re-listing forever.
- The sidebar Files section keeps its own root, which is the active
  tab's working directory.
