### PR TITLE
feat(links): Confirm an untrusted link before it opens

### DIFF
--- a/frontend/src/api/platformBridge.test.ts
+++ b/frontend/src/api/platformBridge.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { clearMocks, mockIPC, mockWindows } from '@tauri-apps/api/mocks'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { desktopFetch, observeWindowMode, parseDesktopBehaviorRefusals, parseLaunchVisibility, parseRelayClosePayload, platformBridge, readClipboardImage, restoreWindowGeometry, windowExitFullscreen } from './platformBridge'
+import { desktopFetch, observeWindowMode, openExternalUrl, parseDesktopBehaviorRefusals, parseLaunchVisibility, parseRelayClosePayload, platformBridge, readClipboardImage, restoreWindowGeometry, windowExitFullscreen } from './platformBridge'
 
 // isMac() in ~/lib/shortcuts/platform caches the UA-detected platform on
 // first call, so flipping navigator.userAgent between tests doesn't actually
@@ -12,6 +12,11 @@ vi.mock('~/lib/shortcuts/platform', () => ({
   isMac: isMacMock,
   getPlatform: () => (isMacMock() ? 'mac' : 'linux'),
 }))
+
+// Only `openExternalUrl` reaches a toast from this module, and its contract is
+// the MESSAGE it reports -- not oat's DOM, which jsdom has no host for.
+const showWarnToastWithLoggedCause = vi.hoisted(() => vi.fn())
+vi.mock('~/components/common/Toast', () => ({ showWarnToastWithLoggedCause }))
 
 describe('desktopFetch', () => {
   beforeEach(() => {
@@ -897,5 +902,95 @@ describe('parseRelayClosePayload', () => {
 
   it('does not treat a truthy-but-non-true wasClean as clean', () => {
     expect(parseRelayClosePayload({ wasClean: 1 }).wasClean).toBe(false)
+  })
+})
+
+describe('openExternalUrl', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    showWarnToastWithLoggedCause.mockClear()
+    // jsdom's window.open is a stub that logs "not implemented"; replace it so
+    // the browser branch is observable and quiet.
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    openSpy.mockRestore()
+    clearMocks()
+    delete (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+  })
+
+  it('opens a new tab with no opener in the browser build', async () => {
+    await openExternalUrl('https://example.test/path')
+
+    expect(openSpy).toHaveBeenCalledWith('https://example.test/path', '_blank', 'noopener,noreferrer')
+  })
+
+  it('routes to the opener plugin under the desktop shell', async () => {
+    (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {}
+    const invoked: { cmd: string, args: unknown }[] = []
+    mockIPC((cmd, args) => {
+      invoked.push({ cmd, args })
+      return null
+    })
+
+    await openExternalUrl('https://example.test/path')
+
+    // The same command the opener plugin's own click listener runs for an
+    // `<a target="_blank">`, which is the whole reason no capability changes.
+    expect(invoked.map(i => i.cmd)).toContain('plugin:opener|open_url')
+    // And never the browser branch: window.open returns null in the webview.
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it('reports a refused open instead of rejecting', async () => {
+    (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {}
+    mockIPC(() => {
+      throw new Error('opener.open_url not allowed. Command not found')
+    })
+
+    // Must not reject: the caller fires this from an event handler with no
+    // error sink, and a rejection there becomes "Something went wrong".
+    await expect(openExternalUrl('https://example.test/')).resolves.toBeUndefined()
+    expect(showWarnToastWithLoggedCause).toHaveBeenCalledWith('Could not open the link', expect.any(Error))
+  })
+
+  it.each([
+    ['mailto:someone@example.test'],
+    ['tel:+15550100'],
+  ])('hands %s to the opener too, matching the plugin scope', async (url) => {
+    // This gateway mirrors `allow-default-urls`, which is wider than the
+    // TERMINAL policy: `classifyUntrustedLink` refuses both of these before a
+    // click ever reaches here, and a first-party `mailto:` link must still work.
+    (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {}
+    const invoked: string[] = []
+    mockIPC((cmd) => {
+      invoked.push(cmd)
+      return null
+    })
+
+    await openExternalUrl(url)
+
+    expect(invoked).toContain('plugin:opener|open_url')
+  })
+
+  it.each([
+    ['file:///etc/passwd'],
+    ['javascript:alert(1)'],
+    ['vscode://file/etc/passwd'],
+    ['not a url at all'],
+  ])('refuses %s without reaching either backend', async (url) => {
+    (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {}
+    const invoked: string[] = []
+    mockIPC((cmd) => {
+      invoked.push(cmd)
+      return null
+    })
+
+    await openExternalUrl(url)
+
+    expect(invoked).toEqual([])
+    expect(openSpy).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/api/platformBridge.ts
+++ b/frontend/src/api/platformBridge.ts
@@ -1,5 +1,6 @@
 import type { BuildInfo } from '~/lib/buildEnv'
 import type { TrailingDebounced } from '~/lib/debounce'
+import { showWarnToastWithLoggedCause } from '~/components/common/Toast'
 import {
   LAUNCH_VISIBILITY_HIDDEN,
   LAUNCH_VISIBILITY_MINIMIZED,
@@ -791,6 +792,62 @@ export async function revealInFileManager(path: string): Promise<void> {
 }
 
 /**
+ * The schemes `openExternalUrl` will hand to the operating system.
+ *
+ * The same four the opener plugin's own `allow-default-urls` scope permits, so
+ * this gateway refuses in the webview what the Rust side would refuse anyway --
+ * with a log line that names the URL, instead of a rejected command.
+ */
+const EXTERNAL_URL_PROTOCOLS: readonly string[] = ['http:', 'https:', 'mailto:', 'tel:']
+
+/**
+ * Open a URL outside the app: the OS default browser under the desktop shell,
+ * a new tab in the browser build.
+ *
+ * The desktop branch invokes the opener plugin, which is the same
+ * `plugin:opener|open_url` command that plugin's injected click listener runs
+ * for an `<a target="_blank">`. That listener is why a link in the chat
+ * transcript reaches the browser, and it keys on a real anchor element in the
+ * click's composed path -- so a caller that HAS no anchor (xterm draws a link
+ * in its own link layer and dispatches from JavaScript) can only take this
+ * route.
+ *
+ * It reports rather than rejects. A caller fires this from an event handler
+ * with no error sink, and a rejection there reaches the global sink as
+ * "Something went wrong", which tells the user nothing.
+ */
+export async function openExternalUrl(url: string): Promise<void> {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  }
+  catch {
+    log.warn('refused to open a URL that does not parse', { url })
+    return
+  }
+  if (!EXTERNAL_URL_PROTOCOLS.includes(parsed.protocol)) {
+    log.warn('refused to open a URL outside the allowed schemes', { url })
+    return
+  }
+
+  if (!isTauriApp()) {
+    // `noopener` also makes the opened tab's `window.opener` null, so the
+    // destination cannot navigate this page. It is why the return value is
+    // ignored: `window.open` returns null WHENEVER `noopener` is set, so null
+    // says nothing about whether the tab opened and cannot report a refusal.
+    window.open(url, '_blank', 'noopener,noreferrer')
+    return
+  }
+  try {
+    const { openUrl } = await loadTauriOpener()
+    await openUrl(url)
+  }
+  catch (err) {
+    showWarnToastWithLoggedCause('Could not open the link', err)
+  }
+}
+
+/**
  * Push the resolved Desktop preferences into the shell.
  *
  * It REJECTS rather than swallowing, unlike `tauriFireAndForget`, because two
@@ -879,6 +936,7 @@ export const platformBridge = {
   fileSaveCommit,
   fileSaveAbort,
   revealInFileManager,
+  openExternalUrl,
   async connectSolo(): Promise<void> {
     await tauriInvoke('connect_solo')
     await refreshRuntimeState()

--- a/frontend/src/components/chat/results/imageResult.tsx
+++ b/frontend/src/components/chat/results/imageResult.tsx
@@ -4,6 +4,7 @@ import type { ImageResultSource, ImageSkipReason } from '~/lib/imageBlocks'
 import { createMemo, createSignal, For, Show } from 'solid-js'
 import { imageRenderInfo, imageSkipPlaceholder } from '~/lib/imageBlocks'
 import { sniffImageDimensionsFromDataUrl } from '~/lib/imageDimensions'
+import { UNTRUSTED_LINK_ATTRIBUTE } from '~/lib/untrustedLinkClicks'
 import { TOOL_IMAGE_MAX_HEIGHT_PX, toolImage, toolImageButton, toolImageRow, toolInputSummary } from '../toolStyles.css'
 
 /**
@@ -180,6 +181,7 @@ function ImageResultPlaceholder(props: {
               target="_blank"
               rel="noopener noreferrer nofollow"
               referrerpolicy="no-referrer"
+              {...{ [UNTRUSTED_LINK_ATTRIBUTE]: '' }}
             >
               open ↗
             </a>

--- a/frontend/src/components/chat/results/webSearchResults.test.tsx
+++ b/frontend/src/components/chat/results/webSearchResults.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
+import { UNTRUSTED_LINK_ATTRIBUTE } from '~/lib/untrustedLinkClicks'
 import { clippedText } from '~/styles/shared.css'
 import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
 import { classSelector } from '~/test-support/composedClass'
@@ -26,6 +27,15 @@ describe('webSearchResultsBody', () => {
   it('puts each link on the shared tool meta row', () => {
     const { container } = renderResults()
     expect(container.querySelector(classSelector(toolMetaRow))).toBeTruthy()
+  })
+
+  // A search-result title and its address are two different strangers' words,
+  // so the click has to reach the same prompt a terminal hyperlink takes.
+  // `src/test-support/untrustedAnchorsAreMarked.test.ts` guards the whole set
+  // from the source; this pins what actually reaches the DOM.
+  it('marks the link untrusted', () => {
+    const { container } = renderResults()
+    expect(container.querySelector(`a[${UNTRUSTED_LINK_ATTRIBUTE}]`)).toBeTruthy()
   })
 
   it('renders the link title and its domain', () => {

--- a/frontend/src/components/chat/results/webSearchResults.tsx
+++ b/frontend/src/components/chat/results/webSearchResults.tsx
@@ -5,6 +5,7 @@ import { For, Show } from 'solid-js'
 import { Tooltip } from '~/components/common/Tooltip'
 import { cachedInnerHtml } from '~/lib/htmlFragmentCache'
 import { pluralize } from '~/lib/plural'
+import { UNTRUSTED_LINK_ATTRIBUTE } from '~/lib/untrustedLinkClicks'
 import { extractDomain } from '~/lib/url'
 import { clippedText } from '~/styles/shared.css'
 import { getToolResultExpanded, renderMarkdownForContext } from '../messageRenderers'
@@ -54,7 +55,9 @@ export function WebSearchResultsBody(props: {
                     this panel, so the tooltip is the only route to the rest. */}
                 <Tooltip text={link.title} showWhen="clipped">
                   <span class={clippedText}>
-                    <a href={link.url} target="_blank" rel="noopener noreferrer nofollow">{link.title}</a>
+                    {/* The title comes from a search result, so the text and
+                        the address are two different strangers' words. */}
+                    <a href={link.url} target="_blank" rel="noopener noreferrer nofollow" {...{ [UNTRUSTED_LINK_ATTRIBUTE]: '' }}>{link.title}</a>
                   </span>
                 </Tooltip>
                 <span class={webSearchLinkDomain}>{extractDomain(link.url)}</span>

--- a/frontend/src/components/chat/toolTitleRenderers.tsx
+++ b/frontend/src/components/chat/toolTitleRenderers.tsx
@@ -4,6 +4,7 @@ import { Show } from 'solid-js'
 import { DiffStatsBadge } from '~/components/tree/gitStatusUtils'
 import { relativizePath } from '~/lib/paths'
 import { pluralize } from '~/lib/plural'
+import { UNTRUSTED_LINK_ATTRIBUTE } from '~/lib/untrustedLinkClicks'
 import {
   toolInputCode,
   toolInputPath,
@@ -111,7 +112,13 @@ export function renderUrlTitle(url?: string): JSX.Element | null {
   if (!url)
     return null
   return url.startsWith('https://')
-    ? <span class={toolInputText}><a href={url} target="_blank" rel="noopener noreferrer nofollow">{url}</a></span>
+    ? (
+        <span class={toolInputText}>
+          {/* Agent-authored, so the click takes the same prompt a terminal
+              hyperlink takes -- see `interceptUntrustedLinkClicks`. */}
+          <a href={url} target="_blank" rel="noopener noreferrer nofollow" {...{ [UNTRUSTED_LINK_ATTRIBUTE]: '' }}>{url}</a>
+        </span>
+      )
     : <span class={toolInputText}>{url}</span>
 }
 

--- a/frontend/src/components/common/UntrustedLinkDialog.css.ts
+++ b/frontend/src/components/common/UntrustedLinkDialog.css.ts
@@ -1,0 +1,22 @@
+import { style } from '@vanilla-extract/css'
+
+/**
+ * The address itself, and the text that the terminal shows for it.
+ *
+ * Monospace, because the whole point of the prompt is that the reader compares
+ * two strings character by character: a proportional font hides the difference
+ * between `rn` and `m`, and between `l` and `I`. `break-all` keeps a long
+ * address inside the dialog instead of widening it off the screen.
+ */
+export const linkValue = style({
+  fontFamily: 'var(--font-mono)',
+  fontSize: 'var(--text-8)',
+  wordBreak: 'break-all',
+  userSelect: 'text',
+})
+
+/** The second-order warning under the two addresses. */
+export const note = style({
+  color: 'var(--muted-foreground)',
+  fontSize: 'var(--text-8)',
+})

--- a/frontend/src/components/common/UntrustedLinkDialog.test.tsx
+++ b/frontend/src/components/common/UntrustedLinkDialog.test.tsx
@@ -1,0 +1,119 @@
+import type { UntrustedLinkConfirmRequest } from '~/lib/untrustedLinks'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UntrustedLinkDialog } from './UntrustedLinkDialog'
+
+// jsdom does not implement the native <dialog> API. Keep the `open` attribute
+// and the `close` event consistent, so Dialog's mount and cleanup behave as
+// they do in a browser.
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '')
+  })
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open')
+    this.dispatchEvent(new Event('close'))
+  })
+})
+
+function requestOf(overrides: Partial<UntrustedLinkConfirmRequest> = {}): UntrustedLinkConfirmRequest {
+  return {
+    uri: 'https://evil.example/steal',
+    label: 'Click here',
+    insecure: false,
+    labelMismatch: true,
+    misleadingLabel: null,
+    ...overrides,
+  }
+}
+
+describe('terminal link dialog', () => {
+  it('shows both the text and the address, so the reader can compare them', () => {
+    render(() => <UntrustedLinkDialog request={requestOf()} onResolve={() => {}} />)
+
+    expect(screen.getByTestId('untrusted-link-shown')).toHaveTextContent('Click here')
+    expect(screen.getByTestId('untrusted-link-target')).toHaveTextContent('https://evil.example/steal')
+  })
+
+  it('names the deception when the text is an address of its own', () => {
+    render(() => (
+      <UntrustedLinkDialog
+        request={requestOf({ label: 'https://good.example', misleadingLabel: 'https://good.example' })}
+        onResolve={() => {}}
+      />
+    ))
+
+    expect(screen.getByText('The link text looks like an address. It is not the address that this link opens.')).toBeInTheDocument()
+  })
+
+  it('states the plainer reason when the text is not an address', () => {
+    render(() => <UntrustedLinkDialog request={requestOf()} onResolve={() => {}} />)
+
+    expect(screen.getByText('The link text does not name the address that it opens.')).toBeInTheDocument()
+  })
+
+  it('warns about the missing encryption, and drops the text row when there is none', () => {
+    render(() => (
+      <UntrustedLinkDialog
+        request={requestOf({ uri: 'http://example.test/', label: '', labelMismatch: false, insecure: true })}
+        onResolve={() => {}}
+      />
+    ))
+
+    expect(screen.getByText('This address is not encrypted.')).toBeInTheDocument()
+    expect(screen.getByText(/travels unencrypted/)).toBeInTheDocument()
+    expect(screen.queryByTestId('untrusted-link-shown')).not.toBeInTheDocument()
+  })
+
+  it('resolves true on open and false on cancel', () => {
+    const onResolve = vi.fn()
+    render(() => <UntrustedLinkDialog request={requestOf()} onResolve={onResolve} />)
+
+    fireEvent.click(screen.getByTestId('untrusted-link-open'))
+    expect(onResolve).toHaveBeenCalledWith(true)
+
+    fireEvent.click(screen.getByTestId('untrusted-link-cancel'))
+    expect(onResolve).toHaveBeenLastCalledWith(false)
+  })
+
+  it('leaves a prose label unarmed: it states no destination to misstate', () => {
+    const onResolve = vi.fn()
+    render(() => <UntrustedLinkDialog request={requestOf()} onResolve={onResolve} />)
+
+    fireEvent.click(screen.getByTestId('untrusted-link-open'))
+    expect(onResolve).toHaveBeenCalledWith(true)
+  })
+
+  it('arms the open button for a plaintext address too', () => {
+    const onResolve = vi.fn()
+    render(() => (
+      <UntrustedLinkDialog
+        request={requestOf({ uri: 'http://foo.test/bar', label: 'foo.test/bar', labelMismatch: false, insecure: true })}
+        onResolve={onResolve}
+      />
+    ))
+
+    fireEvent.click(screen.getByTestId('untrusted-link-open'))
+    expect(onResolve).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByTestId('untrusted-link-open'))
+    expect(onResolve).toHaveBeenCalledWith(true)
+  })
+
+  it('arms the open button for the deceptive case', () => {
+    const onResolve = vi.fn()
+    render(() => (
+      <UntrustedLinkDialog
+        request={requestOf({ label: 'https://good.example', misleadingLabel: 'https://good.example' })}
+        onResolve={onResolve}
+      />
+    ))
+
+    // ConfirmButton takes two clicks: the first only arms it, so a reader who
+    // clicks through the prompt still stops once before a deceptive link opens.
+    fireEvent.click(screen.getByTestId('untrusted-link-open'))
+    expect(onResolve).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByTestId('untrusted-link-open'))
+    expect(onResolve).toHaveBeenCalledWith(true)
+  })
+})

--- a/frontend/src/components/common/UntrustedLinkDialog.tsx
+++ b/frontend/src/components/common/UntrustedLinkDialog.tsx
@@ -1,0 +1,77 @@
+import type { Component } from 'solid-js'
+import type { UntrustedLinkConfirmRequest } from '~/lib/untrustedLinks'
+import { Show } from 'solid-js'
+import { ConfirmDialog } from '~/components/common/ConfirmDialog'
+import { labelRow } from '~/components/common/Dialog.css'
+import * as styles from './UntrustedLinkDialog.css'
+
+interface UntrustedLinkDialogProps {
+  request: UntrustedLinkConfirmRequest
+  /** True opens the link, false drops it. Closes the dialog either way. */
+  onResolve: (approved: boolean) => void
+}
+
+/**
+ * The one sentence that states what is wrong, strongest case first.
+ *
+ * A terminal prints whatever a program tells it to, including an OSC 8
+ * hyperlink whose text names one site and whose address points at another. The
+ * user reads the text, so the text is what the sentence answers.
+ */
+function leadSentence(request: UntrustedLinkConfirmRequest): string {
+  // "looks like an address" rather than "is one": the same test accepts a
+  // filename, and this sentence has to stay true of `README.md`.
+  if (request.misleadingLabel)
+    return 'The link text looks like an address. It is not the address that this link opens.'
+  if (request.labelMismatch)
+    return 'The link text does not name the address that it opens.'
+  return 'This address is not encrypted.'
+}
+
+/**
+ * Asks the user before an untrusted link opens: a hyperlink a program printed
+ * into a terminal, or an anchor an agent wrote into markdown.
+ *
+ * ONE dialog for both, because both carry the same risk. It appears only for a
+ * link that gives a reason to ask: the shown text disagrees with the address,
+ * or the address is `http:` to a host that is not loopback. A link whose text
+ * spells its own `https:` address opens with no prompt, because a prompt on
+ * every link teaches the reader to confirm without reading.
+ */
+export const UntrustedLinkDialog: Component<UntrustedLinkDialogProps> = props => (
+  <ConfirmDialog
+    title="Open this link?"
+    confirmLabel="Open link"
+    // Two-click arming for the two reasons that carry real risk: a label that
+    // states an address it does not open, and an address that puts what the
+    // reader sends on a network in the clear. A prose label such as `Click
+    // here` states no destination to misstate, so it prompts without arming --
+    // it is also the most common shape a program prints, and arming it would
+    // only teach the reader to double-click.
+    danger={props.request.misleadingLabel !== null || props.request.insecure}
+    data-testid="untrusted-link-dialog"
+    confirmTestId="untrusted-link-open"
+    cancelTestId="untrusted-link-cancel"
+    onConfirm={() => props.onResolve(true)}
+    onCancel={() => props.onResolve(false)}
+  >
+    <div class="vstack gap-3">
+      <p>{leadSentence(props.request)}</p>
+      <Show when={props.request.label !== ''}>
+        <div>
+          <div class={labelRow}>Shown</div>
+          <div class={styles.linkValue} data-testid="untrusted-link-shown">{props.request.label}</div>
+        </div>
+      </Show>
+      <div>
+        <div class={labelRow}>Opens</div>
+        <div class={styles.linkValue} data-testid="untrusted-link-target">{props.request.uri}</div>
+      </div>
+      <Show when={props.request.insecure}>
+        <p class={styles.note}>
+          The address uses http, not https. Anything that you send to it travels unencrypted.
+        </p>
+      </Show>
+    </div>
+  </ConfirmDialog>
+)

--- a/frontend/src/components/shell/AppShell.tsx
+++ b/frontend/src/components/shell/AppShell.tsx
@@ -11,6 +11,7 @@ import type { WorkspaceStartActions, WorkspaceStartAt } from '~/components/works
 import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
 import type { BranchRef } from '~/components/workspace/workspaceTabTree.model'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
+import type { LinkConfirmState } from '~/hooks/createLinkConfirm'
 import type { ChangeBranchMode } from '~/hooks/useGitModeState'
 import type { GoalAction, GoalSurface } from '~/stores/chatGoal'
 import type { SavedViewportScroll } from '~/stores/chatTypes'
@@ -30,6 +31,7 @@ import { useWorkspace } from '~/context/WorkspaceContext'
 import { SectionType } from '~/generated/proto/leapmux/v1/section_pb'
 import { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
 import { createDialogState } from '~/hooks/createDialogState'
+import { createLinkConfirm } from '~/hooks/createLinkConfirm'
 import { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import { useChatAutoFocus } from '~/hooks/useChatAutoFocus'
 import { useIsMobileLayout } from '~/hooks/useIsMobileLayout'
@@ -51,6 +53,7 @@ import { createActiveClientStore } from '~/lib/presence/activeClient'
 import { mountPresenceHeartbeat } from '~/lib/presence/heartbeat'
 import { isMac } from '~/lib/shortcuts/platform'
 import { printConsoleBanner } from '~/lib/systemInfo'
+import { interceptUntrustedLinkClicks } from '~/lib/untrustedLinkClicks'
 import { isWorkerKnownOnline, onlineWorkerIdSet, workerOnlineState } from '~/lib/workerLiveness'
 import { createAgentActivityStore } from '~/stores/agentActivity.store'
 import { createAgentInputQueueStore } from '~/stores/agentInputQueue.store'
@@ -195,6 +198,12 @@ export const AppShell: Component = () => {
   const sectionNameDialog = createDialogState<SectionNamePayload>()
   const confirmDeleteSectionDialog = createDialogState<SectionConfirmPayload>()
   const keyPinConfirmDialog = createDialogState<KeyPinConfirmState>()
+  const confirmLinkDialog = createDialogState<LinkConfirmState>()
+  // ONE prompt for every untrusted link, whoever wrote it: an OSC 8 hyperlink
+  // a program printed into a terminal, and an anchor an agent wrote into
+  // markdown. Both carry the same risk -- text that states one address over a
+  // link that opens another -- so both must answer it the same way.
+  const confirmLink = createLinkConfirm(confirmLinkDialog)
   // The session-goal editor. Carries the agent it acts on and the objective to
   // start from, so REPLACE opens with the current text rather than an empty box.
   const setGoalDialog = createDialogState<SetGoalState>()
@@ -234,6 +243,14 @@ export const AppShell: Component = () => {
   // whoever was signed in when the shell mounted — which is the whole divergence
   // this catches.
   setExpectedUserId(() => auth.user()?.id)
+
+  // Every untrusted anchor the app renders, wherever it lands. `document.body`
+  // rather than a chat container, because a dialog and a tooltip portal out of
+  // the tree that rendered them, and an anchor that escaped this listener would
+  // open with no prompt at all. The listener runs in the CAPTURE phase and
+  // stops nothing that the policy would open anyway -- see
+  // `interceptUntrustedLinkClicks`.
+  onMount(() => onCleanup(interceptUntrustedLinkClicks(document.body, confirmLink)))
 
   // Publish `--vvh` / `--vv-shift` (the visible region's size and place) for
   // the mobile layout, and report whether the soft keyboard is up. No-op on a
@@ -833,6 +850,7 @@ export const AppShell: Component = () => {
     lastTabConfirm: tabOps.lastTabConfirmDialog,
     busyTabConfirm: tabOps.busyTabConfirmDialog,
     keyPinConfirm: keyPinConfirmDialog,
+    confirmLink: confirmLinkDialog,
     setGoal: setGoalDialog,
     changeBranch: changeBranchDialog,
     deleteBranch: deleteBranchDialog,
@@ -1321,6 +1339,7 @@ export const AppShell: Component = () => {
       repoGitStore,
     },
     taskScope,
+    confirmLink,
     ops: { agentOps, termOps },
     clientId: ownClientId,
     workspace: {

--- a/frontend/src/components/shell/AppShellDialogs.test.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.test.tsx
@@ -173,6 +173,7 @@ function makeDialogs(): AppShellDialogStates {
     confirmDeleteWs: createDialogState(),
     confirmArchiveWs: createDialogState(),
     confirmEmptyArchive: createDialogState(),
+    confirmLink: createDialogState(),
     sectionName: createDialogState(),
     confirmDeleteSection: createDialogState(),
     lastTabConfirm: createUpdatableDialogState(),

--- a/frontend/src/components/shell/AppShellDialogs.tsx
+++ b/frontend/src/components/shell/AppShellDialogs.tsx
@@ -10,6 +10,7 @@ import type { useTerminalOperations } from './useTerminalOperations'
 import type { WorkspaceStartPoint } from '~/components/workspace/workspaceStartPoint'
 import type { AgentInfo, AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { DialogState, UpdatableDialogState } from '~/hooks/createDialogState'
+import type { LinkConfirmState } from '~/hooks/createLinkConfirm'
 import type { ChangeBranchMode } from '~/hooks/useGitModeState'
 import type { KeyPinDecision } from '~/lib/keyPinStore'
 import type { createLayoutStore } from '~/stores/layout.store'
@@ -25,6 +26,7 @@ import { SetGoalDialog } from '~/components/backgroundtasks/SetGoalDialog'
 import { ConfirmDialog } from '~/components/common/ConfirmDialog'
 import { KeyPinMismatchDialog } from '~/components/common/KeyPinMismatchDialog'
 import { showWarnToast } from '~/components/common/Toast'
+import { UntrustedLinkDialog } from '~/components/common/UntrustedLinkDialog'
 import { ChangeBranchDialog } from '~/components/workspace/ChangeBranchDialog'
 import { DeleteBranchDialog } from '~/components/workspace/DeleteBranchDialog'
 import { NewWorkspaceDialog } from '~/components/workspace/NewWorkspaceDialog'
@@ -166,6 +168,7 @@ export interface AppShellDialogStates {
   lastTabConfirm: UpdatableDialogState<LastTabConfirmState>
   busyTabConfirm: DialogState<BusyTabConfirmState>
   keyPinConfirm: DialogState<KeyPinConfirmState>
+  confirmLink: DialogState<LinkConfirmState>
   setGoal: DialogState<SetGoalState>
   changeBranch: DialogState<ChangeBranchState>
   deleteBranch: DialogState<DeleteBranchState>
@@ -555,6 +558,18 @@ export const AppShellDialogs: Component<AppShellDialogsProps> = (props) => {
           <BusyTabCloseDialog
             state={state}
             onDismiss={() => props.dialogs.busyTabConfirm.close()}
+          />
+        )}
+      </Show>
+
+      <Show when={props.dialogs.confirmLink.value()} keyed>
+        {state => (
+          <UntrustedLinkDialog
+            request={state.request}
+            onResolve={(approved) => {
+              state.resolve(approved)
+              props.dialogs.confirmLink.close()
+            }}
           />
         )}
       </Show>

--- a/frontend/src/components/shell/TileRenderer.test.tsx
+++ b/frontend/src/components/shell/TileRenderer.test.tsx
@@ -134,6 +134,7 @@ function renderRenderer(s: RendererSetup, focusedTileId: string, options: Render
         tasksForRoot: () => [],
       }),
       clientId: () => 'test-client',
+      confirmLink: async () => false,
       ops: {
         agentOps: {
           availableProviders: () => [],

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -14,6 +14,7 @@ import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { DialogState } from '~/hooks/createDialogState'
 import type { createLoadingSignal } from '~/hooks/createLoadingSignal'
 import type { ImperativeRef } from '~/lib/imperativeRef'
+import type { UntrustedLinkConfirm } from '~/lib/untrustedLinks'
 import type { AgentActivityStore } from '~/stores/agentActivity.store'
 import type { createAgentInputQueueStore } from '~/stores/agentInputQueue.store'
 import type { createAgentSessionStore } from '~/stores/agentSession.store'
@@ -97,6 +98,12 @@ interface TileRendererOpts {
    * helper are two places a later change can update only one of.
    */
   taskScope: TabTaskScope
+  /**
+   * Asks the user before an untrusted link opens. The shell's own, shared with
+   * the markdown interceptor, so a terminal hyperlink and an agent-written
+   * anchor cannot answer the same risk differently.
+   */
+  confirmLink: UntrustedLinkConfirm
   /** Tab/agent/terminal lifecycle hooks. */
   ops: {
     agentOps: ReturnType<typeof useAgentOperations>
@@ -208,6 +215,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
     repoGitStore,
   } = opts.stores
   const { agentOps, termOps } = opts.ops
+  const confirmLink = opts.confirmLink
   const mruEditorDeps = opts.mruEditorDeps
 
   // A child (subagent) tab whose provider cannot steer a subagent conversation
@@ -733,6 +741,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
           onInput={termOps.handleTerminalInput}
           onResize={termOps.handleTerminalResize}
           onContentReady={id => metadata.patch(id, { contentReady: true })}
+          confirmLink={confirmLink}
           pageScrollRef={(fn) => {
             terminalPageScroll = fn
             syncTerminalHandler()

--- a/frontend/src/components/terminal/TerminalView.test.tsx
+++ b/frontend/src/components/terminal/TerminalView.test.tsx
@@ -13,6 +13,11 @@ import { webglPool } from '~/lib/webglTerminalPool'
 import { compositionPreview } from '~/test-support/compositionPreview'
 import { stubMatchMedia } from '~/test-support/matchMediaStub'
 
+// Every render below needs the prop, and none of these suites exercise the
+// link flow -- the prompt and the policy have their own tests. Refusing is
+// the fail-closed default the production fallback uses too.
+const stubConfirmLink = async () => false
+
 const mockCreateTerminalInstance = vi.fn()
 // Overridable only where a test needs to drive the disposal-capture guard; the
 // default delegates to the real implementation so every other suite is
@@ -118,6 +123,7 @@ function makeMockTerminalInstance(): TerminalInstance {
     webglAllowed: false,
     fontsReady: Promise.resolve(),
     webglAddon: undefined,
+    setConfirmLink: vi.fn(),
     dispose: vi.fn(),
   }
 }
@@ -142,6 +148,7 @@ describe('terminalView', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[
             { id: 'vis-A', ...baseTab },
             { id: 'hid-B', ...baseTab },
@@ -193,6 +200,7 @@ describe('terminalView', () => {
     const { container } = render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={terminals()}
           activeTerminalId="term-1"
           visible
@@ -218,6 +226,50 @@ describe('terminalView', () => {
     expect(mockCreateTerminalInstance.mock.calls.length, 'and no xterm was re-created').toBe(createCalls)
   })
 
+  it('hands the link prompt to a cached instance on every mount', async () => {
+    // The instance outlives the view, and the prompt it must reach belongs to
+    // the app shell -- which an error boundary can replace under it. A prompt
+    // installed at construction alone would then leave a click waiting on a
+    // dialog that nothing renders.
+    const instance = makeMockTerminalInstance()
+    const setConfirmLink = instance.setConfirmLink as ReturnType<typeof vi.fn>
+    mockCreateTerminalInstance.mockReturnValue(instance)
+    const tab = (): TerminalTab => ({
+      id: 'term-cached',
+      type: TabType.TERMINAL,
+      workspaceId: 'ws-1',
+      screen: new Uint8Array(),
+    } as TerminalTab)
+    const view = (confirmLink: () => Promise<boolean>) => (
+      <PreferencesProvider>
+        <TerminalView
+          confirmLink={confirmLink}
+          terminals={[tab()]}
+          activeTerminalId="term-cached"
+          visible
+          tileFocused={false}
+          onInput={vi.fn()}
+          onResize={vi.fn()}
+          onContentReady={vi.fn()}
+        />
+      </PreferencesProvider>
+    )
+
+    const first = render(() => view(stubConfirmLink))
+    await waitFor(() => expect(setConfirmLink).toHaveBeenCalled())
+    first.unmount()
+
+    const second = vi.fn(async () => true)
+    setConfirmLink.mockClear()
+    render(() => view(second))
+    await waitFor(() => expect(setConfirmLink).toHaveBeenCalled())
+
+    // The remount installed a prompt, and it routes to the CURRENT props.
+    const installed = setConfirmLink.mock.calls.at(-1)?.[0] as (r: unknown) => Promise<boolean>
+    await installed({})
+    expect(second).toHaveBeenCalled()
+  })
+
   // Bell during snapshot replay is owned by the worker-side test suite
   // (service/terminal_test.go); TerminalView no longer wires xterm onBell.
 
@@ -233,6 +285,7 @@ describe('terminalView', () => {
     const { findByTestId, findByText } = render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[{
             id: 'term-1',
             type: TabType.TERMINAL,
@@ -262,6 +315,7 @@ describe('terminalView', () => {
     const { findByTestId, findByText } = render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[{
             id: 'term-1',
             type: TabType.TERMINAL,
@@ -290,6 +344,7 @@ describe('terminalView', () => {
     const { queryByTestId, queryByText } = render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[{
             id: 'term-exited-empty',
             type: TabType.TERMINAL,
@@ -338,6 +393,7 @@ describe('terminalView', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={terminals()}
           activeTerminalId="dispose-test-A"
           visible
@@ -386,6 +442,7 @@ describe('terminalView', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[
             { id: 'switch-A', ...baseTab },
             { id: 'switch-B', ...baseTab },
@@ -440,6 +497,7 @@ describe('terminalView', () => {
       render(() => (
         <PreferencesProvider>
           <TerminalView
+            confirmLink={stubConfirmLink}
             terminals={[{ id: 'theme-A', ...baseTab }]}
             activeTerminalId="theme-A"
             visible
@@ -520,6 +578,7 @@ describe('terminalView', () => {
       render(() => (
         <PreferencesProvider>
           <TerminalView
+            confirmLink={stubConfirmLink}
             terminals={[{ id: 'themed-A', ...baseTab }]}
             activeTerminalId="themed-A"
             visible
@@ -529,6 +588,7 @@ describe('terminalView', () => {
             onContentReady={vi.fn()}
           />
           <TerminalView
+            confirmLink={stubConfirmLink}
             terminals={[{ id: 'themed-B', ...baseTab }]}
             activeTerminalId="themed-B"
             visible
@@ -582,6 +642,7 @@ describe('terminalView', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[{
             id: 'term-1',
             type: TabType.TERMINAL,
@@ -633,6 +694,7 @@ describe('terminalView', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={terminals}
           activeTerminalId="term-late-screen"
           visible
@@ -681,6 +743,7 @@ describe('terminalView', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={terminals}
           activeTerminalId="term-no-double-write"
           visible
@@ -742,6 +805,7 @@ describe('disposeTerminalInstance scrollback capture', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[{ id, type: TabType.TERMINAL, workspaceId: 'ws-1', screen: new Uint8Array() } as TerminalTab]}
           activeTerminalId={id}
           visible
@@ -838,6 +902,7 @@ describe('terminalView IME wiring', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[{ id, type: TabType.TERMINAL, workspaceId: 'ws-1', screen: new Uint8Array() } as TerminalTab]}
           activeTerminalId={id}
           visible
@@ -1022,6 +1087,7 @@ describe('terminalView focus while a tab is being renamed', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[{ id: 'focus-guard', ...baseTab }]}
           activeTerminalId="focus-guard"
           visible
@@ -1058,6 +1124,7 @@ describe('terminalView focus while a tab is being renamed', () => {
     render(() => (
       <PreferencesProvider>
         <TerminalView
+          confirmLink={stubConfirmLink}
           terminals={[{ id: 'no-tabbar', ...baseTab }]}
           activeTerminalId="no-tabbar"
           visible

--- a/frontend/src/components/terminal/TerminalView.tsx
+++ b/frontend/src/components/terminal/TerminalView.tsx
@@ -1,6 +1,7 @@
 import type { ITheme } from '@xterm/xterm'
 import type { Component } from 'solid-js'
 import type { TerminalInstance } from '~/lib/terminal'
+import type { UntrustedLinkConfirm } from '~/lib/untrustedLinks'
 import type { TerminalTab } from '~/stores/tab.types'
 import { createEffect, createMemo, For, Match, onCleanup, onMount, Show, Switch } from 'solid-js'
 import { StartupErrorBody, StartupSpinner } from '~/components/common/StartupPanel'
@@ -47,6 +48,14 @@ interface TerminalViewProps {
   onResize: (id: string, cols: number, rows: number) => void
   /** Called once the terminal has painted any non-whitespace content. */
   onContentReady: (id: string) => void
+  /**
+   * Asks the user before a hyperlink in the terminal opens.
+   *
+   * Threaded from the shell rather than built here, because the prompt it
+   * raises is an app-shell dialog. Each mount hands the current one to the
+   * xterm instance, which is cached and outlives this component.
+   */
+  confirmLink: UntrustedLinkConfirm
   pageScrollRef?: (fn: (direction: -1 | 1) => void) => void
   writeRef?: (fn: (data: string) => void) => void
 }
@@ -222,6 +231,38 @@ if (typeof window !== 'undefined') {
     instance.sendInput(utf8Encoder.encode(text))
     return true
   }
+  // E2E hook: where on screen a piece of the active terminal's text sits, as
+  // viewport coordinates a real mouse click can use.
+  //
+  // A spec that clicks an OSC 8 hyperlink has no other way to find it. The
+  // WebGL renderer paints to a canvas and leaves `.xterm-rows` empty, so there
+  // is no element to target, and the link layer draws no element of its own
+  // either. Returning the POINT keeps xterm's own hit testing in the test --
+  // the click still goes through the mouse.
+  ;(window as any).__activeTerminalPointAt = (text: string) => {
+    const instance = getActiveInstance()
+    const screen = instance?.terminal.element?.querySelector('.xterm-screen')
+    if (!instance || !screen)
+      return null
+    const terminal = instance.terminal
+    const buffer = terminal.buffer.active
+    for (let row = 0; row < terminal.rows; row++) {
+      const line = buffer.getLine(buffer.viewportY + row)
+      const column = line?.translateToString(true).indexOf(text) ?? -1
+      if (column < 0)
+        continue
+      const rect = screen.getBoundingClientRect()
+      const rowHeight = rect.height / terminal.rows
+      return {
+        x: rect.left + ((column + text.length / 2) * rect.width) / terminal.cols,
+        y: rect.top + (row + 0.5) * rowHeight,
+        // A cell on another row, for a caller that has to make xterm ask for
+        // the link again. See `clickTerminalText`.
+        awayY: rect.top + (row === 0 ? 1.5 : 0.5) * rowHeight,
+      }
+    }
+    return null
+  }
   // E2E hooks for the WebGL context pool: assert that the number of live
   // contexts stays bounded and that hidden tabs hold none.
   ;(window as any).__webglTerminalCount = () => webglPool.size()
@@ -264,6 +305,7 @@ const TerminalContainer: Component<{
   onInput: (id: string, data: Uint8Array) => void
   onResize: (id: string, cols: number, rows: number) => void
   onContentReady: (id: string) => void
+  confirmLink: UntrustedLinkConfirm
 }> = (props) => {
   let ref: HTMLDivElement | undefined
 
@@ -286,6 +328,12 @@ const TerminalContainer: Component<{
       instances.set(id, instance)
       notifyTerminalInstanceReady(id)
     }
+    // On every mount, and for a cached instance too: the prompt belongs to the
+    // app shell, and this component is the newest thing that can reach a live
+    // one. Tracked, so a shell that hands down a different prompt replaces the
+    // one the cached instance holds. See `TerminalInstance.setConfirmLink`.
+    const mounted = instance
+    createEffect(() => mounted.setConfirmLink(props.confirmLink))
 
     // xterm's `Terminal.open()` is idempotent in a way that breaks
     // re-mount: on the second call it sees `this.element` already set and
@@ -695,6 +743,7 @@ export const TerminalView: Component<TerminalViewProps> = (props) => {
                     onInput={props.onInput}
                     onResize={props.onResize}
                     onContentReady={props.onContentReady}
+                    confirmLink={props.confirmLink}
                   />
                 )}
               >

--- a/frontend/src/hooks/createLinkConfirm.test.ts
+++ b/frontend/src/hooks/createLinkConfirm.test.ts
@@ -1,0 +1,41 @@
+import type { LinkConfirmState } from './createLinkConfirm'
+import { describe, expect, it } from 'vitest'
+import { createDialogState } from './createDialogState'
+import { createLinkConfirm } from './createLinkConfirm'
+
+describe('createLinkConfirm', () => {
+  it('opens the prompt with the request, and resolves what the user chose', async () => {
+    const dialog = createDialogState<LinkConfirmState>()
+    const confirmLink = createLinkConfirm(dialog)
+    const request = {
+      uri: 'https://evil.example/',
+      label: 'https://good.example/',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: 'https://good.example/',
+    }
+
+    const answer = confirmLink(request)
+    expect(dialog.value()?.request).toEqual(request)
+
+    dialog.value()?.resolve(true)
+    await expect(answer).resolves.toBe(true)
+  })
+
+  it('refuses a still-open prompt before it asks the next one', async () => {
+    const dialog = createDialogState<LinkConfirmState>()
+    const confirmLink = createLinkConfirm(dialog)
+    const base = { insecure: false, labelMismatch: true, misleadingLabel: null }
+
+    // One slot holds one request, so the abandoned one must be ANSWERED. A
+    // dropped resolver would park the first click's promise forever.
+    const first = confirmLink({ uri: 'https://one.test/', label: 'one', ...base })
+    const second = confirmLink({ uri: 'https://two.test/', label: 'two', ...base })
+
+    await expect(first).resolves.toBe(false)
+    expect(dialog.value()?.request.uri).toBe('https://two.test/')
+
+    dialog.value()?.resolve(true)
+    await expect(second).resolves.toBe(true)
+  })
+})

--- a/frontend/src/hooks/createLinkConfirm.ts
+++ b/frontend/src/hooks/createLinkConfirm.ts
@@ -1,0 +1,29 @@
+import type { DialogState } from './createDialogState'
+import type { UntrustedLinkConfirm, UntrustedLinkConfirmRequest } from '~/lib/untrustedLinks'
+
+/** What the link prompt acts on while it is open. */
+export interface LinkConfirmState {
+  request: UntrustedLinkConfirmRequest
+  resolve: (approved: boolean) => void
+}
+
+/**
+ * Build the prompt that every untrusted link -- a terminal hyperlink, an
+ * anchor in agent-authored markdown -- must pass.
+ *
+ * ONE function for both surfaces, because they carry the same risk and must
+ * not answer it differently. It lives beside the dialog handle rather than in
+ * either surface's own module for the same reason.
+ *
+ * The dialog holds ONE request. A second click while the first prompt is up
+ * answers the first with `false` and takes its place, so the user's latest
+ * click is what the dialog asks about and no promise is left pending -- an
+ * abandoned resolver would park the earlier `activateUntrustedLink` call
+ * forever.
+ */
+export function createLinkConfirm(dialog: DialogState<LinkConfirmState>): UntrustedLinkConfirm {
+  return request => new Promise<boolean>((resolve) => {
+    dialog.value()?.resolve(false)
+    dialog.open({ request, resolve })
+  })
+}

--- a/frontend/src/lib/applyTerminalData.test.ts
+++ b/frontend/src/lib/applyTerminalData.test.ts
@@ -23,6 +23,7 @@ function makeStubInstance(): TerminalInstance & { _log: string[] } {
     webglAllowed: false,
     fontsReady: Promise.resolve(),
     webglAddon: undefined,
+    setConfirmLink: vi.fn(),
     dispose: vi.fn(),
     _log: log,
   }

--- a/frontend/src/lib/markdownProcessor.test.ts
+++ b/frontend/src/lib/markdownProcessor.test.ts
@@ -6,6 +6,7 @@ import { collectShikiStyles } from '~/lib/shikiStyleClass'
 import { syntaxThemePair } from '~/lib/shikiThemes'
 import { loadSyntaxTheme, syntaxPairFor } from '~/lib/syntaxThemes'
 import { DEFAULT_THEME_ID } from '~/styles/themes'
+import { UNTRUSTED_LINK_ATTRIBUTE } from './untrustedLinkClicks'
 
 type Processor = Parameters<typeof renderWithPlainFallback>[0]
 
@@ -368,6 +369,19 @@ describe('link hardening in both processors', () => {
       // rather than shipping a rel browsers parse as one unknown token.
       expect(html, name).toContain('rel="noopener noreferrer nofollow"')
       expect(html, name).not.toContain('noopener,')
+    }
+  })
+
+  it('marks every surviving link untrusted, so a click reaches the prompt', async () => {
+    for (const [name, render] of await processors()) {
+      // An agent wrote both halves, so the text may state one address over a
+      // link that opens another. The mark is what routes the click through
+      // `interceptUntrustedLinkClicks`. Pinned on the pass EVERY markdown path
+      // ends with, so a new render path cannot ship without it.
+      expect(render('[https://good.example](https://evil.example)'), name)
+        .toContain(`${UNTRUSTED_LINK_ATTRIBUTE}=""`)
+      // A non-http(s) link is unwrapped, so there is no anchor left to mark.
+      expect(render('[x](javascript:alert(1))'), name).not.toContain('<a ')
     }
   })
 

--- a/frontend/src/lib/markdownProcessor.ts
+++ b/frontend/src/lib/markdownProcessor.ts
@@ -11,6 +11,7 @@ import { createMarkdownParser } from './markdownParse'
 import { rehypeBlockRemoteImages } from './rehypeBlockRemoteImages'
 import { shikiStyleClassTransformer } from './shikiStyleClass'
 import { dualThemeTokenOptions } from './shikiThemes'
+import { UNTRUSTED_LINK_ATTRIBUTE } from './untrustedLinkClicks'
 
 /**
  * The remark+rehype+Shiki markdown pipeline configuration, shared by BOTH the
@@ -112,6 +113,12 @@ function rehypeExternalLinks() {
         // `rel` is a space-separated token list, which hast models as an array;
         // hast-util-to-html joins it back into `rel="noopener noreferrer nofollow"`.
         node.properties.rel = ['noopener', 'noreferrer', 'nofollow']
+        // An agent wrote both the text and the address, so the two may
+        // disagree on purpose. The mark is what routes the click through the
+        // same prompt a terminal hyperlink takes. Set HERE, on the one pass
+        // every markdown render path already ends with, so a future path
+        // cannot forget it -- the same argument `withHardeningTail` makes.
+        node.properties[UNTRUSTED_LINK_ATTRIBUTE] = ''
       }
       else if (parent && typeof index === 'number') {
         // Non-http(s) link — unwrap: replace <a> with its children

--- a/frontend/src/lib/terminal.test.ts
+++ b/frontend/src/lib/terminal.test.ts
@@ -1,7 +1,9 @@
 import type { Terminal } from '@xterm/xterm'
 import type { CopyTextOptions } from './clipboard'
+import type { UntrustedLinkConfirmRequest } from './untrustedLinks'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveVariant, themeById } from '~/styles/themes'
+import { flush } from '~/test-support/async'
 import { stubMatchMedia } from '~/test-support/matchMediaStub'
 import { KEY_BROWSER_PREFS, localStorageClearForTests, localStorageSet } from './browserStorage'
 import { applyTerminalData, attachWebgl, createTerminalInstance, detachWebgl, getTerminalRendererPreference, getTerminalThemePreference, loadTerminalFonts, refreshTerminalFont, resolveTerminalRendererPreference, resolveTerminalTheme, resolveTerminalThemeMode, serializeXtermBuffer, terminalThemeFor } from './terminal'
@@ -10,6 +12,15 @@ import { applyTerminalData, attachWebgl, createTerminalInstance, detachWebgl, ge
 // reaches it is copy-on-select, and its contract is the ARGUMENTS it passes.
 const copyTextToClipboard = vi.hoisted(() => vi.fn(async (_text: string, _options?: CopyTextOptions) => true))
 vi.mock('./clipboard', () => ({ copyTextToClipboard }))
+
+// The link handler ends at the platform gateway, and its contract is the URL
+// it hands over. Everything else in the bridge stays real, because
+// `createTerminalInstance` pulls in preferences and themes through it.
+const openExternalUrl = vi.hoisted(() => vi.fn(async (_url: string) => {}))
+vi.mock('~/api/platformBridge', async importOriginal => ({
+  ...await importOriginal<typeof import('~/api/platformBridge')>(),
+  openExternalUrl,
+}))
 
 // xterm.js requires a DOM element for open(), but we can still test
 // the suppressInput mechanism without rendering.
@@ -748,5 +759,87 @@ describe('terminal copy-on-select', () => {
     finally {
       dispose()
     }
+  })
+})
+
+describe('createTerminalInstance link handling', () => {
+  /** The range xterm reports for a link: 1-based, and `end.x` is inclusive. */
+  const linkRange = (startColumn: number, endColumn: number) => ({
+    start: { x: startColumn, y: 1 },
+    end: { x: endColumn, y: 1 },
+  })
+
+  /** An instance whose buffer already holds `text` on its first row. */
+  async function instanceShowing(text: string, confirmLink?: (request: UntrustedLinkConfirmRequest) => Promise<boolean>) {
+    const instance = createTerminalInstance()
+    if (confirmLink)
+      instance.setConfirmLink(confirmLink)
+    await new Promise<void>(resolve => instance.terminal.write(text, resolve))
+    return instance
+  }
+
+  beforeEach(() => {
+    openExternalUrl.mockClear()
+  })
+
+  it('installs a handler, so xterm never reaches its own confirm-and-open default', async () => {
+    const instance = await instanceShowing('')
+
+    expect(instance.terminal.options.linkHandler).toBeTruthy()
+    // Unset, so xterm's OscLinkProvider keeps refusing every scheme but
+    // http(s) before a link is ever registered.
+    expect(instance.terminal.options.linkHandler?.allowNonHttpProtocols).toBeFalsy()
+  })
+
+  it('opens a link whose text spells its own address, with no prompt', async () => {
+    const confirmLink = vi.fn(async () => true)
+    const instance = await instanceShowing('https://example.test/x', confirmLink)
+
+    instance.terminal.options.linkHandler?.activate(new MouseEvent('click'), 'https://example.test/x', linkRange(1, 22))
+    await flush()
+
+    expect(confirmLink).not.toHaveBeenCalled()
+    expect(openExternalUrl).toHaveBeenCalledWith('https://example.test/x')
+  })
+
+  it('asks first, and reports the text the terminal actually shows', async () => {
+    const confirmLink = vi.fn(async () => true)
+    const instance = await instanceShowing('Click here', confirmLink)
+
+    instance.terminal.options.linkHandler?.activate(new MouseEvent('click'), 'https://evil.example/', linkRange(1, 10))
+    await flush()
+
+    expect(confirmLink).toHaveBeenCalledWith({
+      uri: 'https://evil.example/',
+      label: 'Click here',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: null,
+    })
+    expect(openExternalUrl).toHaveBeenCalledWith('https://evil.example/')
+  })
+
+  it('sends a link to the prompt installed LAST, not the one it was built with', async () => {
+    // The instance is cached per terminal id and outlives the view that made
+    // it, so a stale prompt would belong to a shell that renders nothing.
+    const stale = vi.fn(async () => true)
+    const live = vi.fn(async () => true)
+    const instance = await instanceShowing('Click here', stale)
+    instance.setConfirmLink(live)
+
+    instance.terminal.options.linkHandler?.activate(new MouseEvent('click'), 'https://evil.example/', linkRange(1, 10))
+    await flush()
+
+    expect(stale).not.toHaveBeenCalled()
+    expect(live).toHaveBeenCalled()
+  })
+
+  it('refuses the link when no prompt is wired, rather than opening it unannounced', async () => {
+    const instance = await instanceShowing('Click here')
+
+    instance.terminal.options.linkHandler?.activate(new MouseEvent('click'), 'https://evil.example/', linkRange(1, 10))
+    await flush()
+
+    expect(openExternalUrl).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -1,6 +1,7 @@
 import type { ITheme } from '@xterm/xterm'
 import type { BrowserPreferences, TerminalRendererPreference } from './browserPreferences'
 import type { TerminalImeHandle } from './terminalIme'
+import type { UntrustedLinkConfirm } from './untrustedLinks'
 import type {
   ResolvedThemeMode,
   TerminalThemeMode,
@@ -18,7 +19,9 @@ import { copyTextToClipboard } from './clipboard'
 import { DEFAULT_MONO_FONT_FAMILY } from './fontStack'
 import { createLogger } from './logger'
 import { sleep } from './sleep'
+import { readTerminalLinkLabel } from './terminalLinkLabel'
 import { DEFAULT_TERMINAL_THEME_VALUE, DEFAULT_THEME_VALUE, parseTerminalThemeValue, parseThemeValue } from './themeStore'
+import { activateUntrustedLink } from './untrustedLinks'
 
 const log = createLogger('terminal')
 // TextEncoder construction is not free, so one stateless instance serves
@@ -86,6 +89,16 @@ export interface TerminalInstance {
    * driven by the WebGL terminal pool.
    */
   webglAddon?: WebglAddon
+  /**
+   * Install the prompt that a hyperlink in this terminal must pass.
+   *
+   * Called by the view on EVERY mount, not once at construction: the instance
+   * is cached per terminal id and survives a remount of the view, while the
+   * prompt belongs to the app shell around it. A shell that an error boundary
+   * replaced leaves the old prompt unable to render anything, so the newest
+   * mount is the only one that can supply a live one.
+   */
+  setConfirmLink: (confirm: UntrustedLinkConfirm) => void
   /** Send raw input data to the PTY backing this terminal. */
   sendInput?: (data: Uint8Array) => void
   /**
@@ -348,6 +361,18 @@ export function bufferHasVisibleContent(terminal: Terminal): boolean {
   return false
 }
 
+/**
+ * Ask nobody and open nothing.
+ *
+ * What a terminal starts with, until a mounted view installs the shell's real
+ * prompt. It fails CLOSED, because a link whose risk the app cannot disclose
+ * must not open on its own.
+ */
+const refuseLinkWithoutPrompt: UntrustedLinkConfirm = async () => {
+  log.warn('refused a terminal link: no confirm prompt is wired to this terminal')
+  return false
+}
+
 export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: ITheme }): TerminalInstance {
   const prefs = loadBrowserPrefs()
   const theme = opts?.theme ?? resolveTerminalTheme(
@@ -360,6 +385,7 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
   const fontFamily = opts?.fontFamily || DEFAULT_MONO_FONT_FAMILY
   const fontSize = opts?.fontSize || DEFAULT_FONT_SIZE
 
+  let confirmLink = refuseLinkWithoutPrompt
   const terminal = new Terminal({
     cursorBlink: true,
     fontSize,
@@ -367,6 +393,29 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
     theme,
     ...(opts?.cols ? { cols: opts.cols } : {}),
     ...(opts?.rows ? { rows: opts.rows } : {}),
+    // Supplying this is what keeps xterm's own `defaultActivate` unreachable,
+    // and that handler is broken under the desktop shell in two ways at once.
+    // It calls `window.confirm`, which Tauri replaces with an ASYNCHRONOUS
+    // shim: the shim returns a promise, every promise is truthy, so the answer
+    // is read as yes before the user sees the question -- and the promise then
+    // rejects, because the shell grants no `dialog:allow-confirm` permission.
+    // It then calls `window.open`, which returns null in a webview that has no
+    // new-window handler, so the link never opened even when the user said yes.
+    //
+    // `allowNonHttpProtocols` stays UNSET on purpose. It leaves xterm's own
+    // scheme allowlist in force, so a `file:` or `javascript:` URI never
+    // becomes a clickable link at all. `classifyUntrustedLink` refuses the same
+    // set a second time, for a link that reaches here from anywhere else.
+    linkHandler: {
+      // Reads `confirmLink` at CLICK time, never at construction. The
+      // instance outlives the view that mounted it -- `TerminalView` caches
+      // one per terminal id across remounts -- so a prompt captured here once
+      // would still point at the shell that has since been torn down and
+      // replaced, and the click would then wait on a dialog nobody renders.
+      activate: (_event, uri, range) => {
+        void activateUntrustedLink(uri, readTerminalLinkLabel(terminal, range), confirmLink)
+      },
+    },
   })
 
   const fitAddon = new FitAddon()
@@ -423,6 +472,9 @@ export function createTerminalInstance(opts?: TerminalFontOptions & { theme?: IT
     webglAllowed,
     fontsReady,
     webglAddon: undefined,
+    setConfirmLink(confirm) {
+      confirmLink = confirm
+    },
     dispose() {
       terminal.dispose()
     },

--- a/frontend/src/lib/terminalLinkLabel.test.ts
+++ b/frontend/src/lib/terminalLinkLabel.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { linkRange, terminalWith } from '~/test-support/xtermBuffer'
+import { readTerminalLinkLabel } from './terminalLinkLabel'
+
+describe('readTerminalLinkLabel', () => {
+  it('reads the cells the range covers, and where they sit in the row', async () => {
+    const terminal = await terminalWith('go to example now')
+
+    const placement = readTerminalLinkLabel(terminal, linkRange(1, 7, 13))
+
+    expect(placement?.label).toBe('example')
+    expect(placement?.labelStart).toBe(6)
+    expect(placement?.labelEnd).toBe(13)
+    expect(placement?.rowStart).toBe(0)
+    // The row is joined untrimmed, so a column keeps its offset.
+    expect(placement?.rowEnd).toBe(40)
+  })
+
+  it('joins every row of a wrapped line, so a fragment can be placed in it', async () => {
+    // 20 columns, so the address below occupies the first row and part of the
+    // second — which is what makes xterm report two ranges for one link.
+    const terminal = await terminalWith('https://example.test/abcdefgh', 20)
+
+    const secondRow = readTerminalLinkLabel(terminal, linkRange(2, 1, 9))
+
+    expect(secondRow?.label).toBe('/abcdefgh')
+    expect(secondRow?.logicalLine.startsWith('https://example.test/abcdefgh')).toBe(true)
+    expect(secondRow?.rowStart).toBe(20)
+    expect(secondRow?.labelStart).toBe(20)
+  })
+
+  it('measures a label in CHARACTERS, past text that is two columns wide', async () => {
+    // A wide (CJK) cell fills two columns and yields one character, so column
+    // arithmetic and string offsets diverge the moment such text precedes a
+    // link. Getting this wrong slices the label and prompts over an address
+    // that matches -- the loudest possible false alarm.
+    const terminal = await terminalWith('\u65E5\u672C\u8A9E https://example.test/x')
+
+    // Columns 8..29 hold the address: three wide cells and a space take 7.
+    const placement = readTerminalLinkLabel(terminal, linkRange(1, 8, 29))
+
+    expect(placement?.label).toBe('https://example.test/x')
+    // Four characters precede it, not seven columns.
+    expect(placement?.labelStart).toBe(4)
+  })
+
+  it('returns null when the clicked row already left the buffer', async () => {
+    const terminal = await terminalWith('one line')
+
+    expect(readTerminalLinkLabel(terminal, linkRange(999, 1, 3))).toBeNull()
+  })
+})

--- a/frontend/src/lib/terminalLinkLabel.ts
+++ b/frontend/src/lib/terminalLinkLabel.ts
@@ -1,0 +1,54 @@
+import type { IBufferRange, Terminal } from '@xterm/xterm'
+import type { UntrustedLinkLabel } from './untrustedLinks'
+
+/**
+ * Read the text a link shows, and where that text sits in its logical line.
+ *
+ * Returns null when the row is gone -- scrollback drops the oldest rows, so a
+ * busy terminal can retire the clicked line between the click and this read.
+ */
+export function readTerminalLinkLabel(terminal: Terminal, range: IBufferRange): UntrustedLinkLabel | null {
+  const buffer = terminal.buffer.active
+  // `IBufferRange` positions are 1-based, and their `y` counts whole buffer
+  // rows (scrollback included), which is the index `getLine` takes once it is
+  // made 0-based. See xterm's `Linkifier._positionFromMouseEvent`, which adds
+  // `buffer.ydisp` to the viewport row before it builds the range.
+  const clickedRow = range.start.y - 1
+  const clicked = buffer.getLine(clickedRow)
+  if (!clicked)
+    return null
+
+  // A wrapped line is ONE logical line spread over several buffer rows, and
+  // xterm reports one link range per row -- so the clicked range holds only a
+  // fragment of the label whenever the link crosses a row edge. Walk to both
+  // ends of the wrap group, so the comparison below can see the whole label.
+  let firstRow = clickedRow
+  while (firstRow > 0 && buffer.getLine(firstRow)?.isWrapped)
+    firstRow--
+  let lastRow = clickedRow
+  while (lastRow + 1 < buffer.length && buffer.getLine(lastRow + 1)?.isWrapped)
+    lastRow++
+
+  let logicalLine = ''
+  let rowStart = 0
+  let rowEnd = 0
+  for (let row = firstRow; row <= lastRow; row++) {
+    const line = buffer.getLine(row)
+    if (!line)
+      continue
+    if (row === clickedRow)
+      rowStart = logicalLine.length
+    // Untrimmed, so a column keeps its offset: trimming a row would shorten
+    // the prefix that every later row's offset is measured from. A wide (CJK)
+    // cell still yields one character for two columns, which is why the
+    // offsets below come from `translateToString` too and never from column
+    // arithmetic.
+    logicalLine += line.translateToString(false)
+    if (row === clickedRow)
+      rowEnd = logicalLine.length
+  }
+
+  const label = clicked.translateToString(false, range.start.x - 1, range.end.x)
+  const labelStart = rowStart + clicked.translateToString(false, 0, range.start.x - 1).length
+  return { label, logicalLine, labelStart, labelEnd: labelStart + label.length, rowStart, rowEnd }
+}

--- a/frontend/src/lib/untrustedLinkClicks.test.ts
+++ b/frontend/src/lib/untrustedLinkClicks.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { interceptUntrustedLinkClicks, UNTRUSTED_LINK_ATTRIBUTE } from './untrustedLinkClicks'
+
+const openExternalUrl = vi.hoisted(() => vi.fn(async (_url: string) => {}))
+vi.mock('~/api/platformBridge', () => ({ openExternalUrl }))
+
+describe('interceptUntrustedLinkClicks', () => {
+  let root: HTMLElement
+  let detach: () => void
+  const confirm = vi.fn(async () => true)
+
+  /** An anchor under the listener, marked untrusted unless told otherwise. */
+  function anchor(text: string, href: string, untrusted = true): HTMLAnchorElement {
+    const el = document.createElement('a')
+    el.href = href
+    el.target = '_blank'
+    el.textContent = text
+    if (untrusted)
+      el.setAttribute(UNTRUSTED_LINK_ATTRIBUTE, '')
+    root.appendChild(el)
+    return el
+  }
+
+  /** Click `el` and report whether the default action survived. */
+  function click(el: HTMLElement, init: MouseEventInit = {}): boolean {
+    return el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, ...init }))
+  }
+
+  beforeEach(() => {
+    openExternalUrl.mockClear()
+    confirm.mockClear()
+    confirm.mockResolvedValue(true)
+    root = document.createElement('div')
+    document.body.appendChild(root)
+    detach = interceptUntrustedLinkClicks(root, confirm)
+  })
+
+  afterEach(() => {
+    detach()
+    root.remove()
+  })
+
+  it('leaves an honest link to the route that already opens it', async () => {
+    // No preventDefault and no open of our own: under the desktop shell the
+    // opener plugin's own listener takes it from here, and in a browser the
+    // anchor does. Taking it over would only cost the click its user
+    // activation, which is what a popup blocker looks for.
+    const notCancelled = click(anchor('https://example.test/x', 'https://example.test/x'))
+
+    expect(notCancelled).toBe(true)
+    expect(confirm).not.toHaveBeenCalled()
+    expect(openExternalUrl).not.toHaveBeenCalled()
+  })
+
+  it('asks first when the text names a different address, then opens it', async () => {
+    const notCancelled = click(anchor('https://good.example', 'https://evil.example/steal'))
+    await vi.waitFor(() => expect(openExternalUrl).toHaveBeenCalled())
+
+    // Cancelled, which is also what disengages the opener plugin's listener:
+    // it returns immediately on `event.defaultPrevented`.
+    expect(notCancelled).toBe(false)
+    expect(confirm).toHaveBeenCalledWith(expect.objectContaining({
+      uri: 'https://evil.example/steal',
+      label: 'https://good.example',
+      misleadingLabel: 'https://good.example',
+    }))
+    expect(openExternalUrl).toHaveBeenCalledWith('https://evil.example/steal')
+  })
+
+  it('opens nothing when the user refuses', async () => {
+    confirm.mockResolvedValue(false)
+
+    click(anchor('Click here', 'https://evil.example/'))
+    await vi.waitFor(() => expect(confirm).toHaveBeenCalled())
+
+    expect(openExternalUrl).not.toHaveBeenCalled()
+  })
+
+  it('takes the same route for a modified click and a middle click', async () => {
+    // Each one is another way to open the link, so each one is another way
+    // around the prompt. A browser reports the middle button as `auxclick`.
+    const el = anchor('https://good.example', 'https://evil.example/')
+
+    expect(click(el, { metaKey: true })).toBe(false)
+    expect(click(el, { ctrlKey: true })).toBe(false)
+    expect(el.dispatchEvent(new MouseEvent('auxclick', { bubbles: true, cancelable: true, button: 1 }))).toBe(false)
+    await vi.waitFor(() => expect(confirm).toHaveBeenCalledTimes(3))
+  })
+
+  it('blocks a scheme no click may open, and opens nothing', async () => {
+    const notCancelled = click(anchor('passwords', 'file:///etc/passwd'))
+
+    expect(notCancelled).toBe(false)
+    expect(confirm).not.toHaveBeenCalled()
+    expect(openExternalUrl).not.toHaveBeenCalled()
+  })
+
+  it('ignores an anchor the app itself wrote', async () => {
+    // `AboutDialog`'s licence link reads as prose over a leapmux.dev address --
+    // an honest label and a mismatch at once. First-party copy is not a
+    // deception risk, so the mark is opt-IN.
+    const notCancelled = click(anchor('Functional Source License', 'https://leapmux.dev/legal/', false))
+
+    expect(notCancelled).toBe(true)
+    expect(confirm).not.toHaveBeenCalled()
+  })
+
+  it('leaves a click that something else already claimed', async () => {
+    // `defaultPrevented` means another handler owns this click. Taking it over
+    // anyway would open a link the app had already decided not to follow.
+    const claimed = document.createElement('div')
+    document.body.appendChild(claimed)
+    claimed.addEventListener('click', event => event.preventDefault(), { capture: true })
+    const stop = interceptUntrustedLinkClicks(claimed, confirm)
+    const el = document.createElement('a')
+    el.href = 'https://evil.example/'
+    el.textContent = 'https://good.example'
+    el.setAttribute(UNTRUSTED_LINK_ATTRIBUTE, '')
+    claimed.appendChild(el)
+
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(openExternalUrl).not.toHaveBeenCalled()
+    stop()
+    claimed.remove()
+  })
+
+  it('resolves a relative address the way the click would', async () => {
+    // `href` is read as the resolved property, never as the raw attribute, so
+    // the policy judges the address the browser would actually open.
+    const el = anchor('docs', '/NOTICE.html')
+
+    expect(click(el)).toBe(false)
+    await vi.waitFor(() => expect(confirm).toHaveBeenCalled())
+    expect(confirm).toHaveBeenCalledWith(expect.objectContaining({
+      uri: `${window.location.origin}/NOTICE.html`,
+    }))
+  })
+
+  it('stops listening once detached', async () => {
+    const el = anchor('https://good.example', 'https://evil.example/')
+    detach()
+
+    expect(click(el)).toBe(true)
+    expect(confirm).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/untrustedLinkClicks.ts
+++ b/frontend/src/lib/untrustedLinkClicks.ts
@@ -1,0 +1,69 @@
+import type { UntrustedLinkConfirm } from './untrustedLinks'
+import { activateUntrustedLink, classifyUntrustedLink, linkLabelFromText } from './untrustedLinks'
+
+/**
+ * The attribute that marks an anchor as untrusted: an agent wrote its text and
+ * its address, so the two may disagree on purpose.
+ *
+ * `rehypeExternalLinks` puts it on every anchor that survives the markdown
+ * hardening pass, which is why no render path has to remember it. The few
+ * agent-authored anchors that markdown does not build -- a web-search result,
+ * a tool title, an image link -- set it themselves.
+ *
+ * An anchor WITHOUT it is first-party, and the app's own copy is not a
+ * deception risk. `AboutDialog` is the reason the default runs this way round:
+ * its licence link reads "Functional Source License, Version 1.1" over a
+ * leapmux.dev address, which is an honest label and a mismatch at once.
+ */
+export const UNTRUSTED_LINK_ATTRIBUTE = 'data-untrusted-link'
+
+/**
+ * Route every click on an untrusted anchor under `root` through the same
+ * policy a terminal hyperlink takes.
+ *
+ * Returns the function that removes the listeners.
+ *
+ * It intercepts NOTHING that the policy would open anyway. That is deliberate
+ * on two counts: the existing route stays in charge of the ordinary link (the
+ * opener plugin's own listener under the desktop shell, the browser otherwise),
+ * and `window.open` keeps the user activation that a popup blocker looks for.
+ * Only a link that needs a prompt, or that must not open at all, is taken over
+ * -- and `preventDefault` is what takes it over, because the opener plugin's
+ * injected listener begins by returning on `event.defaultPrevented`.
+ *
+ * A modified click (a new tab, a background tab) and a middle click are held
+ * to the same rule. Each one is a way to open the link, so each one is a way
+ * around the prompt, and `auxclick` is where a browser reports the middle
+ * button.
+ */
+export function interceptUntrustedLinkClicks(
+  root: HTMLElement,
+  confirm: UntrustedLinkConfirm,
+): () => void {
+  const onClick = (event: MouseEvent) => {
+    if (event.defaultPrevented)
+      return
+    const anchor = event.composedPath().find(
+      (node): node is HTMLAnchorElement => node instanceof HTMLAnchorElement,
+    )
+    if (!anchor?.hasAttribute(UNTRUSTED_LINK_ATTRIBUTE))
+      return
+    // `href` over `getAttribute('href')`: the property is already resolved
+    // against the document, so a relative address arrives here as the absolute
+    // one the click would actually open.
+    const uri = anchor.href
+    const label = linkLabelFromText(anchor.textContent ?? '')
+    if (classifyUntrustedLink(uri, label).kind === 'open')
+      return
+
+    event.preventDefault()
+    void activateUntrustedLink(uri, label, confirm)
+  }
+
+  root.addEventListener('click', onClick, { capture: true })
+  root.addEventListener('auxclick', onClick, { capture: true })
+  return () => {
+    root.removeEventListener('click', onClick, { capture: true })
+    root.removeEventListener('auxclick', onClick, { capture: true })
+  }
+}

--- a/frontend/src/lib/untrustedLinks.test.ts
+++ b/frontend/src/lib/untrustedLinks.test.ts
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { linkRange, terminalWith } from '~/test-support/xtermBuffer'
+import { readTerminalLinkLabel } from './terminalLinkLabel'
+import { activateUntrustedLink, classifyUntrustedLink, linkLabelFromText } from './untrustedLinks'
+
+const openExternalUrl = vi.hoisted(() => vi.fn(async (_url: string) => {}))
+vi.mock('~/api/platformBridge', () => ({ openExternalUrl }))
+
+/**
+ * The placement of a link whose visible text is exactly `label`, on a row of
+ * its own. The shortest way to state "the label reads like this" for the
+ * classifier tests, which do not care where the cells are.
+ */
+function placementOf(label: string, logicalLine = label) {
+  const labelStart = logicalLine.indexOf(label)
+  return {
+    label,
+    logicalLine,
+    labelStart,
+    labelEnd: labelStart + label.length,
+    rowStart: 0,
+    rowEnd: logicalLine.length,
+  }
+}
+
+describe('classifyUntrustedLink', () => {
+  it.each([
+    ['file:///etc/passwd'],
+    ['javascript:alert(1)'],
+    ['vscode://file/etc/passwd'],
+    ['mailto:someone@example.test'],
+    ['tel:+15550100'],
+    ['C:\\Windows\\system32'],
+    [''],
+  ])('blocks %s, which no click may open', (uri) => {
+    expect(classifyUntrustedLink(uri, placementOf(uri))).toEqual({ kind: 'block' })
+  })
+
+  it('opens an https link whose text spells its own address', () => {
+    const uri = 'https://example.test/path'
+
+    expect(classifyUntrustedLink(uri, placementOf(uri))).toEqual({ kind: 'open' })
+  })
+
+  it.each([
+    ['example.test/path', 'https://example.test/path'],
+    ['https://example.test', 'https://example.test/'],
+    ['example.test', 'https://example.test/'],
+    ['www.google.com', 'https://www.google.com'],
+    ['www.google.com', 'https://www.google.com/'],
+    ['foo.com/bar', 'https://foo.com/bar'],
+  ])('opens on %s, the ordinary shorthand for %s', (label, uri) => {
+    expect(classifyUntrustedLink(uri, placementOf(label))).toEqual({ kind: 'open' })
+  })
+
+  it('still confirms the same shorthand over plaintext http', () => {
+    // The shorthand hides the scheme, so the missing encryption is exactly
+    // what the reader cannot see. It prompts on `insecure` alone.
+    expect(classifyUntrustedLink('http://foo.com/bar', placementOf('foo.com/bar'))).toEqual({
+      kind: 'confirm',
+      insecure: true,
+      labelMismatch: false,
+      misleadingLabel: null,
+    })
+  })
+
+  it('confirms an http link even when its text matches', () => {
+    const uri = 'http://example.test/path'
+
+    expect(classifyUntrustedLink(uri, placementOf(uri))).toEqual({
+      kind: 'confirm',
+      insecure: true,
+      labelMismatch: false,
+      misleadingLabel: null,
+    })
+  })
+
+  it('confirms when the text names something other than the address', () => {
+    expect(classifyUntrustedLink('https://example.test/path', placementOf('Click here'))).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: null,
+    })
+  })
+
+  it.each([
+    ['https://good.example/login'],
+    ['www.good.example'],
+    ['HTTPS://Good.Example'],
+  ])('reports %s as an impersonated address', (label) => {
+    expect(classifyUntrustedLink('https://evil.example/steal', placementOf(label))).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: label,
+    })
+  })
+
+  it('reports both reasons at once', () => {
+    const action = classifyUntrustedLink('http://evil.example', placementOf('https://good.example'))
+
+    expect(action).toEqual({
+      kind: 'confirm',
+      insecure: true,
+      labelMismatch: true,
+      misleadingLabel: 'https://good.example',
+    })
+  })
+
+  it.each([
+    ['www.google.com', 'https://google.com'],
+    ['https://www.google.com', 'https://google.com/'],
+    ['www.paypal.com', 'https://paypal.com.evil.test/'],
+  ])('warns on %s, which is not the DNS name that %s opens', (label, uri) => {
+    // A `www.` that the address does not carry (or drops) is a different host,
+    // and nothing makes the two resolve to the same server. The label is
+    // URL-shaped, so this lands in the loudest category on purpose.
+    expect(classifyUntrustedLink(uri, placementOf(label))).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: label,
+    })
+  })
+
+  it('warns the SAME way in both www directions', () => {
+    // The mirror of the case above, and it must not be quieter: `google.com`
+    // over `https://www.google.com` is the identical deception reversed.
+    expect(classifyUntrustedLink('https://www.google.com', placementOf('google.com'))).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: 'google.com',
+    })
+  })
+
+  it.each([
+    ['Click here'],
+    ['PR #472'],
+    ['docs'],
+  ])('leaves %s unarmed, because it states no destination to misstate', (label) => {
+    expect(classifyUntrustedLink('https://example.test/x', placementOf(label))).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: null,
+    })
+  })
+
+  it.each([
+    ['http://localhost:3000/'],
+    ['http://127.0.0.1:8080/x'],
+    ['http://app.localhost/'],
+    ['http://[::1]:9000/'],
+  ])('opens %s with no prompt: loopback puts nothing on a network', (uri) => {
+    expect(classifyUntrustedLink(uri, placementOf(uri))).toEqual({ kind: 'open' })
+  })
+
+  it('still confirms plaintext http to a host that is not loopback', () => {
+    expect(classifyUntrustedLink('http://127.example.test/', placementOf('http://127.example.test/'))).toMatchObject({
+      kind: 'confirm',
+      insecure: true,
+    })
+  })
+
+  it.each([
+    ['..'],
+    ['./x'],
+    ['../up'],
+    ['foo.'],
+    ['.foo'],
+    ['plainword'],
+  ])('does not read %s as an address, so it prompts without arming', (label) => {
+    // A dot alone is not a host. Each of these still MISMATCHES and still
+    // prompts -- it just makes no claim about a destination, so the button
+    // stays unarmed.
+    expect(classifyUntrustedLink('https://example.test/x', placementOf(label))).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: null,
+    })
+  })
+
+  it('accepts a filename as address-shaped, the cost of having no TLD test', () => {
+    // `md` is a real country code, so no list of top-level domains separates
+    // `README.md` from `google.com`. It arms, and the prompt only claims the
+    // text LOOKS LIKE an address -- which stays true here.
+    const action = classifyUntrustedLink('https://example.test/readme', placementOf('README.md'))
+
+    expect(action).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: 'README.md',
+    })
+  })
+
+  it('confirms when the row is gone and the text cannot be checked', () => {
+    expect(classifyUntrustedLink('https://example.test/', null)).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: null,
+    })
+  })
+
+  it('opens a fragment of an address the terminal wrapped', async () => {
+    const uri = 'https://example.test/abcdefgh'
+    const terminal = await terminalWith(uri, 20)
+
+    // Both rows carry a fragment of one honest label. Neither equals the
+    // address, and neither may raise a prompt.
+    expect(classifyUntrustedLink(uri, readTerminalLinkLabel(terminal, linkRange(1, 1, 20)))).toEqual({ kind: 'open' })
+    expect(classifyUntrustedLink(uri, readTerminalLinkLabel(terminal, linkRange(2, 1, 9)))).toEqual({ kind: 'open' })
+  })
+
+  it('confirms a fragment that the address merely contains somewhere else', async () => {
+    // The hostile shape the wrap carve-out has to survive: the address quotes
+    // a harmless site, and the label puts that quote alone on the second row.
+    // The clicked fragment IS part of the address as a string, and it must
+    // still prompt, because the whole label is nowhere in that address.
+    const uri = 'https://evil.example/?next=https://good.example'
+    const terminal = await terminalWith('SEE BELOW FOR THE https://good.example', 20)
+
+    const action = classifyUntrustedLink(uri, readTerminalLinkLabel(terminal, linkRange(2, 1, 18)))
+
+    // And the wrapped fragment is still named as an impersonation: it is read
+    // back out of the joined line, where the scheme it lost survives.
+    expect(action).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: 'https://good.example',
+    })
+  })
+
+  it('ignores an address elsewhere on the line that the link does not cover', async () => {
+    // `docs` is the link; the printed address beside it belongs to nobody.
+    const terminal = await terminalWith('https://other.test/x see docs', 40)
+
+    const action = classifyUntrustedLink('https://example.test/d', readTerminalLinkLabel(terminal, linkRange(1, 26, 29)))
+
+    expect(action).toEqual({
+      kind: 'confirm',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: null,
+    })
+  })
+})
+
+describe('linkLabelFromText', () => {
+  it('collapses the whitespace HTML indentation adds', () => {
+    // `textContent` carries the source formatting of the markup around it, and
+    // none of that is what the reader sees.
+    expect(linkLabelFromText('\n      https://good.example\n    ').label).toBe('https://good.example')
+    expect(linkLabelFromText('the\n  docs').label).toBe('the docs')
+  })
+
+  it('places the whole label, so a single-line label needs no wrap arithmetic', () => {
+    expect(linkLabelFromText('docs')).toEqual({
+      label: 'docs',
+      logicalLine: 'docs',
+      labelStart: 0,
+      labelEnd: 4,
+      rowStart: 0,
+      rowEnd: 4,
+    })
+  })
+
+  it('survives an anchor with no text at all', () => {
+    // An image-only anchor. Empty cannot spell any address, so it prompts.
+    expect(classifyUntrustedLink('https://example.test/', linkLabelFromText(''))).toMatchObject({
+      kind: 'confirm',
+      labelMismatch: true,
+      misleadingLabel: null,
+    })
+  })
+})
+
+describe('activateUntrustedLink', () => {
+  const confirm = vi.fn(async () => true)
+
+  beforeEach(() => {
+    openExternalUrl.mockClear()
+    confirm.mockClear()
+    confirm.mockResolvedValue(true)
+  })
+
+  it('opens a matching https link with no prompt', async () => {
+    const uri = 'https://example.test/path'
+
+    await activateUntrustedLink(uri, placementOf(uri), confirm)
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(openExternalUrl).toHaveBeenCalledWith(uri)
+  })
+
+  it('opens nothing and asks nothing for a blocked scheme', async () => {
+    await activateUntrustedLink('file:///etc/passwd', placementOf('passwords'), confirm)
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(openExternalUrl).not.toHaveBeenCalled()
+  })
+
+  it('opens after the user approves, and states both the text and the address', async () => {
+    await activateUntrustedLink('https://evil.example', placementOf('https://good.example'), confirm)
+
+    expect(confirm).toHaveBeenCalledWith({
+      uri: 'https://evil.example',
+      label: 'https://good.example',
+      insecure: false,
+      labelMismatch: true,
+      misleadingLabel: 'https://good.example',
+    })
+    expect(openExternalUrl).toHaveBeenCalledWith('https://evil.example')
+  })
+
+  it('opens nothing when the user refuses', async () => {
+    confirm.mockResolvedValue(false)
+
+    await activateUntrustedLink('http://example.test/', placementOf('http://example.test/'), confirm)
+
+    expect(confirm).toHaveBeenCalled()
+    expect(openExternalUrl).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/untrustedLinks.ts
+++ b/frontend/src/lib/untrustedLinks.ts
@@ -1,0 +1,269 @@
+import { openExternalUrl } from '~/api/platformBridge'
+import { createLogger } from './logger'
+
+const log = createLogger('untrustedLinks')
+
+/**
+ * The schemes an untrusted link may point at. A click on anything else does
+ * nothing at all.
+ *
+ * Neither surface's text is the app's own. An OSC 8 hyperlink carries whatever
+ * URI a program printed into a terminal, and a markdown anchor carries
+ * whatever an agent wrote, so `file:`, `javascript:` and every custom
+ * application scheme are refused rather than handed to the operating system.
+ *
+ * Each surface also refuses them upstream, and this is the gate that holds
+ * when one of those stops: xterm drops a non-http(s) URI in `OscLinkProvider`,
+ * but only while `ILinkHandler.allowNonHttpProtocols` stays unset, and
+ * `rehypeExternalLinks` unwraps the anchor entirely, but only for what runs
+ * through the markdown pipeline.
+ */
+const ALLOWED_LINK_PROTOCOLS: readonly string[] = ['http:', 'https:']
+
+/**
+ * A label that reads as an address of its own, rather than as prose: it holds
+ * no whitespace, and it either opens with a scheme or carries a dot inside its
+ * first segment. That is what the confirm prompt exists to expose -- a link
+ * that shows `google.com` and opens `https://www.google.com`.
+ *
+ * The dot test accepts `README.md` too, and that is the deliberate trade. The
+ * alternative is a list of top-level domains, which cannot separate the two:
+ * `md`, `io`, `sh`, `rs` and `py` are all real country codes AND all common
+ * file extensions. So the wider test wins, at the cost of one extra click on a
+ * filename -- and the prompt says the text LOOKS LIKE an address, which stays
+ * true of a filename.
+ *
+ * A label that holds whitespace (`Click here`, `PR #472`) states no
+ * destination at all, so it cannot misstate one. It still prompts, without the
+ * arming.
+ */
+const ADDRESS_SCHEME = /^[a-z][a-z0-9+.-]*:\/\/./i
+
+function looksLikeAddress(label: string): boolean {
+  if (label.length === 0 || /\s/.test(label))
+    return false
+  if (ADDRESS_SCHEME.test(label))
+    return true
+  // The host part, up to the first path separator. Written as a split rather
+  // than as one regex because the regex form needs two open-ended quantifiers
+  // that can trade characters, and a hostile label would then cost polynomial
+  // time to reject.
+  const host = label.split('/', 1)[0]
+  return host.includes('.') && !host.startsWith('.') && !host.endsWith('.')
+}
+
+/**
+ * Hosts that `http:` reaches without putting anything on a network.
+ *
+ * Loopback traffic never leaves the machine, so the prompt's own sentence --
+ * that what you send travels unencrypted -- is false for it. A development
+ * terminal prints `http://localhost:3000` on almost every run, and a prompt
+ * that fires there teaches the reader to click through the ones that matter.
+ * RFC 6761 reserves the whole `.localhost` name, and `127.0.0.0/8` is loopback
+ * in its entirety.
+ */
+function isLoopbackHost(url: URL): boolean {
+  const host = url.hostname.toLowerCase()
+  return host === 'localhost'
+    || host.endsWith('.localhost')
+    || host === '[::1]'
+    || /^127\.\d+\.\d+\.\d+$/.test(host)
+}
+
+/** Where a link's visible text sits inside the logical line that holds it. */
+export interface UntrustedLinkLabel {
+  /** The text of the cells the clicked link range covers. */
+  label: string
+  /** Every row of the wrapped-line group, joined untrimmed. */
+  logicalLine: string
+  /** Offset of `label` in `logicalLine`. */
+  labelStart: number
+  /** End offset of `label` in `logicalLine`, exclusive. */
+  labelEnd: number
+  /** Offset in `logicalLine` where the clicked row starts. */
+  rowStart: number
+  /** Offset in `logicalLine` where the clicked row ends, exclusive. */
+  rowEnd: number
+}
+
+/** What the app must do with a link the user clicked. */
+export type UntrustedLinkAction
+  = | { kind: 'block' }
+    | { kind: 'open' }
+    | ({ kind: 'confirm' } & UntrustedLinkRisk)
+
+/** Why a link needs the user to confirm before it opens. */
+export interface UntrustedLinkRisk {
+  /** The address is `http:`, so nothing it carries is encrypted. */
+  insecure: boolean
+  /** The shown text does not spell the address behind it. */
+  labelMismatch: boolean
+  /**
+   * The shown text, when it reads as an address of its own and disagrees with
+   * the one behind it. Null in every other case. This is the deceptive one,
+   * and the only one that arms the prompt's button.
+   */
+  misleadingLabel: string | null
+}
+
+/** What the confirm prompt shows the user. */
+export interface UntrustedLinkConfirmRequest extends UntrustedLinkRisk {
+  /** The address the link opens. */
+  uri: string
+  /** The text the terminal shows for it. Empty when the row is already gone. */
+  label: string
+}
+
+/** Asks the user whether to open a link. Resolves false to refuse it. */
+export type UntrustedLinkConfirm = (request: UntrustedLinkConfirmRequest) => Promise<boolean>
+
+/**
+ * The placement of a label that sits on one line and nothing else -- every
+ * label outside a terminal.
+ *
+ * Only a terminal wraps one logical line over several rows and reports a link
+ * once per row, so only a terminal needs the joined-line form that
+ * `UntrustedLinkLabel` carries. A rendered anchor holds its whole text, and
+ * the whitespace is collapsed because HTML indentation is not part of what the
+ * reader sees.
+ */
+export function linkLabelFromText(text: string): UntrustedLinkLabel {
+  const label = text.replace(/\s+/g, ' ').trim()
+  return { label, logicalLine: label, labelStart: 0, labelEnd: label.length, rowStart: 0, rowEnd: label.length }
+}
+
+/**
+ * Every spelling of `uri` that a label may honestly use.
+ *
+ * A terminal program routinely prints `example.com/x` for
+ * `https://example.com/x`, and dropping the trailing slash of a bare origin is
+ * just as common. Refusing those would put a prompt in front of the most
+ * ordinary link there is, and a prompt that fires on everything teaches the
+ * user to confirm without reading.
+ *
+ * Dropping the scheme cannot hide a downgrade, because `http:` raises
+ * `insecure` on its own and prompts whatever the label says.
+ *
+ * A leading `www.` is NOT one of these spellings, deliberately. `www.foo.test`
+ * and `foo.test` are two DNS names, and nothing makes them resolve to the same
+ * server, so a label that adds or drops the prefix states an address that the
+ * link does not open. That is the case the prompt exists for.
+ */
+function linkSpellings(uri: string): string[] {
+  const spellings = new Set([uri, uri.replace(/\/$/, '')])
+  for (const spelling of [...spellings]) {
+    const bare = spelling.replace(/^https?:\/\//, '')
+    if (bare)
+      spellings.add(bare)
+  }
+  return [...spellings]
+}
+
+/** Whether the visible label spells the address behind it. */
+function labelSpellsUri(placement: UntrustedLinkLabel, uri: string): boolean {
+  const { label, logicalLine, labelStart, labelEnd, rowStart, rowEnd } = placement
+  for (const spelling of linkSpellings(uri)) {
+    if (label === spelling)
+      return true
+    // The label may be one row's fragment of an address the terminal wrapped.
+    // Accept the fragment only where the WHOLE spelling is present and sits so
+    // that the fragment is the part of it that fell on this row: it must start
+    // where the spelling starts or at the row's left edge, and end where the
+    // spelling ends or at the row's right edge.
+    //
+    // A logical line that merely CONTAINS the fragment somewhere else fails,
+    // which is what stops a label from borrowing a harmless-looking substring
+    // out of a hostile address.
+    for (let at = logicalLine.indexOf(spelling); at !== -1; at = logicalLine.indexOf(spelling, at + 1)) {
+      const end = at + spelling.length
+      if (at > labelStart || end < labelEnd)
+        continue
+      if (at !== labelStart && labelStart !== rowStart)
+        continue
+      if (end !== labelEnd && labelEnd !== rowEnd)
+        continue
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * The URL-shaped word that the clicked label sits inside, when it disagrees
+ * with the address behind it.
+ *
+ * It reads the whole logical line rather than the clicked range alone, because
+ * a wrapped label reaches this function one row at a time: the deceptive
+ * `https://good.example` arrives as the fragment `tps://good.example`, which
+ * starts with no scheme and would read as an ordinary mismatch. A word that
+ * does NOT overlap the clicked cells is somebody else's text on the same line,
+ * so the overlap test is what keeps an unrelated address off this prompt.
+ */
+function misleadingLabelAt(placement: UntrustedLinkLabel, uri: string): string | null {
+  const spellings = new Set(linkSpellings(uri))
+  const words = /\S+/g
+  for (let word = words.exec(placement.logicalLine); word !== null; word = words.exec(placement.logicalLine)) {
+    const start = word.index
+    const end = start + word[0].length
+    if (end <= placement.labelStart || start >= placement.labelEnd)
+      continue
+    if (looksLikeAddress(word[0]) && !spellings.has(word[0]))
+      return word[0]
+  }
+  return null
+}
+
+/** Decide what a click on `uri` may do, given the text the terminal shows for it. */
+export function classifyUntrustedLink(uri: string, placement: UntrustedLinkLabel | null): UntrustedLinkAction {
+  let parsed: URL
+  try {
+    parsed = new URL(uri)
+  }
+  catch {
+    return { kind: 'block' }
+  }
+  if (!ALLOWED_LINK_PROTOCOLS.includes(parsed.protocol))
+    return { kind: 'block' }
+
+  const insecure = parsed.protocol === 'http:' && !isLoopbackHost(parsed)
+  // A missing placement means the row scrolled out of the buffer, so the label
+  // cannot be checked. An unchecked label is exactly what the prompt exists to
+  // disclose, so it counts as a mismatch rather than as a pass.
+  const labelMismatch = placement === null || !labelSpellsUri(placement, uri)
+  const misleadingLabel = labelMismatch && placement ? misleadingLabelAt(placement, uri) : null
+  if (!insecure && !labelMismatch)
+    return { kind: 'open' }
+  return { kind: 'confirm', insecure, labelMismatch, misleadingLabel }
+}
+
+/**
+ * Open an untrusted link the user clicked -- a terminal hyperlink, an anchor
+ * an agent wrote: refuse it, confirm it, or hand it to the browser.
+ *
+ * `confirm` asks the user. A caller with no prompt to show passes one that
+ * resolves false, which fails CLOSED -- a link whose risk nobody can disclose
+ * must not open by itself.
+ */
+export async function activateUntrustedLink(
+  uri: string,
+  placement: UntrustedLinkLabel | null,
+  confirm: UntrustedLinkConfirm,
+): Promise<void> {
+  const action = classifyUntrustedLink(uri, placement)
+  if (action.kind === 'block') {
+    log.debug('refused a terminal link outside the allowed schemes', { uri })
+    return
+  }
+  if (action.kind === 'confirm') {
+    const approved = await confirm({
+      uri,
+      label: placement?.label ?? '',
+      insecure: action.insecure,
+      labelMismatch: action.labelMismatch,
+      misleadingLabel: action.misleadingLabel,
+    })
+    if (!approved)
+      return
+  }
+  await openExternalUrl(uri)
+}

--- a/frontend/src/test-support/untrustedAnchorsAreMarked.test.ts
+++ b/frontend/src/test-support/untrustedAnchorsAreMarked.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { UNTRUSTED_LINK_ATTRIBUTE } from '~/lib/untrustedLinkClicks'
+import { collectFiles, frontendRoot, posixRelative } from '~/test-support/sourceTree'
+
+/*
+ * Guard: an anchor that opens a new tab must say whose words it carries.
+ *
+ * `interceptUntrustedLinkClicks` acts on `data-untrusted-link` and on nothing
+ * else, so a surface that renders agent-authored text into an anchor and omits
+ * the mark opens with no prompt at all -- silently, and only for that surface.
+ * That is the one exposure the opt-in default buys, and this is what keeps it
+ * from growing.
+ *
+ * The mark is opt-IN rather than opt-out because first-party copy is not a
+ * deception risk, and `AboutDialog` proves the point: its licence link reads
+ * "Functional Source License, Version 1.1, ALv2 Future License" over a
+ * leapmux.dev address, which is honest text and a label/address mismatch at
+ * once. Under an opt-out default the app would prompt over its own copy.
+ *
+ * So each `target="_blank"` anchor lands in one of two sets, and a new one
+ * fails here until somebody decides which.
+ */
+
+/** Surfaces whose anchor text the APP writes. No prompt belongs on these. */
+const FIRST_PARTY: ReadonlySet<string> = new Set([
+  'src/components/shell/AboutDialog.tsx',
+])
+
+/** `target="_blank"` in either quote style, which is what opens a new tab. */
+const OPENS_NEW_TAB = /target=(["'])_blank\1/
+
+const srcRoot = join(frontendRoot, 'src')
+
+describe('untrusted anchors', () => {
+  it('marks every agent-authored anchor, or names it first-party', () => {
+    const unmarked: string[] = []
+    const files = collectFiles(srcRoot, { matches: name => name.endsWith('.tsx') && !name.includes('.test.') })
+    for (const file of files) {
+      const source = readFileSync(file, 'utf-8')
+      if (!OPENS_NEW_TAB.test(source))
+        continue
+      const relative = posixRelative(frontendRoot, file)
+      if (FIRST_PARTY.has(relative) || source.includes('UNTRUSTED_LINK_ATTRIBUTE'))
+        continue
+      unmarked.push(relative)
+    }
+    expect(
+      unmarked,
+      'each of these renders a target="_blank" anchor. Add UNTRUSTED_LINK_ATTRIBUTE '
+      + 'if an agent wrote its text, or add it to FIRST_PARTY if the app did.',
+    ).toEqual([])
+  })
+
+  // The walk passes vacuously the day `src/` moves, so pin that it found the
+  // surfaces this guard exists for.
+  it('sees both sets, so the walk is not empty', () => {
+    const files = collectFiles(srcRoot, { matches: name => name.endsWith('.tsx') && !name.includes('.test.') })
+    const withAnchors = files
+      .filter(file => OPENS_NEW_TAB.test(readFileSync(file, 'utf-8')))
+      .map(file => posixRelative(frontendRoot, file))
+
+    expect(withAnchors).toContain('src/components/shell/AboutDialog.tsx')
+    expect(withAnchors).toContain('src/components/chat/results/webSearchResults.tsx')
+  })
+
+  // Markdown is the bulk of it, and it sets the mark in the hardening pass
+  // rather than at any render site -- so no render path can forget it.
+  it('is spelled the same way the markdown pipeline writes it', () => {
+    const processor = readFileSync(join(srcRoot, 'lib', 'markdownProcessor.ts'), 'utf-8')
+    expect(processor).toContain('UNTRUSTED_LINK_ATTRIBUTE')
+    expect(UNTRUSTED_LINK_ATTRIBUTE).toBe('data-untrusted-link')
+  })
+})

--- a/frontend/src/test-support/xtermBuffer.ts
+++ b/frontend/src/test-support/xtermBuffer.ts
@@ -1,0 +1,21 @@
+import type { IBufferRange } from '@xterm/xterm'
+import { Terminal } from '@xterm/xterm'
+
+/**
+ * A headless terminal holding `text`, with every write already applied to the
+ * buffer.
+ *
+ * `Terminal.write` is asynchronous even without `open()`, so a test that reads
+ * the buffer straight after it sees the previous state. The callback is the
+ * only signal that the parser drained.
+ */
+export async function terminalWith(text: string, cols = 40): Promise<Terminal> {
+  const terminal = new Terminal({ cols, rows: 8 })
+  await new Promise<void>(resolve => terminal.write(text, resolve))
+  return terminal
+}
+
+/** The range xterm reports for a link: 1-based, and `end.x` is inclusive. */
+export function linkRange(row: number, startColumn: number, endColumn: number): IBufferRange {
+  return { start: { x: startColumn, y: row }, end: { x: endColumn, y: row } }
+}

--- a/frontend/tests/e2e/075-untrusted-links.spec.ts
+++ b/frontend/tests/e2e/075-untrusted-links.spec.ts
@@ -1,0 +1,175 @@
+import type { Page } from '@playwright/test'
+import { expect, test } from './fixtures'
+import { clickTerminalText, printTerminalHyperlink, waitForTerminalReady, waitForTerminalText } from './helpers/terminal'
+import { openAboutDialog, openTerminalViaUI, sendMessage, userBubbles } from './helpers/ui'
+
+/**
+ * Record what the app tries to open instead of opening it.
+ *
+ * `openExternalUrl` takes the browser branch here -- there is no desktop shell
+ * behind a Playwright page -- and a real `window.open` would put a request on
+ * the network for an address that does not exist. Patched live rather than
+ * through `addInitScript`, because the workspace fixture has already navigated
+ * and the app reads `window.open` at call time.
+ */
+async function recordOpenedUrls(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const opened: string[] = [];
+    (window as any).__openedUrls = opened
+    window.open = ((url?: string | URL) => {
+      opened.push(String(url))
+      return null
+    }) as typeof window.open
+  })
+}
+
+/**
+ * Record every anchor click, and whether the app took it over.
+ *
+ * Registered on `window` in the BUBBLE phase, so the app's own capture-phase
+ * listener has already decided by the time this runs: `defaultPrevented` is
+ * exactly the answer to "did the prompt claim this link". It then stops the
+ * navigation itself, because these addresses are outside the test.
+ */
+async function recordAnchorClicks(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const clicks: { href: string, defaultPrevented: boolean }[] = [];
+    (window as any).__anchorClicks = clicks
+    window.addEventListener('click', (event) => {
+      const anchor = event.composedPath().find(node => node instanceof HTMLAnchorElement)
+      if (!anchor)
+        return
+      clicks.push({ href: (anchor as HTMLAnchorElement).href, defaultPrevented: event.defaultPrevented })
+      event.preventDefault()
+    })
+  })
+}
+
+function anchorClicks(page: Page): Promise<{ href: string, defaultPrevented: boolean }[]> {
+  return page.evaluate(() => ((window as any).__anchorClicks ?? []) as { href: string, defaultPrevented: boolean }[])
+}
+
+function openedUrls(page: Page): Promise<string[]> {
+  return page.evaluate(() => ((window as any).__openedUrls ?? []) as string[])
+}
+
+const dialog = (page: Page) => page.locator('dialog[data-testid="untrusted-link-dialog"]')
+
+/**
+ * A terminal hyperlink and an agent-written markdown link carry the same risk:
+ * the text states one address and the link opens another. Both reach the same
+ * prompt, and these are the only tests that prove the whole path -- a real
+ * OSC 8 sequence from a real shell, xterm's own hit testing, the app's policy,
+ * and the dialog.
+ *
+ * The unit suites own the policy itself (`src/lib/untrustedLinks.test.ts`, 40+
+ * cases over schemes, wrapped labels and loopback). What only a browser can
+ * show is that the link is clickable at all.
+ */
+test.describe('Untrusted link prompt', () => {
+  test('warns before opening a terminal hyperlink whose text names a different address', async ({ page, authenticatedWorkspace }) => {
+    await openTerminalViaUI(page)
+    await expect(page.locator('.xterm')).toBeVisible()
+    await waitForTerminalReady(page)
+    await recordOpenedUrls(page)
+
+    await printTerminalHyperlink(page, 'https://evil.example/steal', 'https://good.example')
+    await waitForTerminalText(page, 'https://good.example')
+    await clickTerminalText(page, 'https://good.example')
+
+    // Both strings, side by side: comparing them is the whole point.
+    await expect(dialog(page)).toBeVisible()
+    await expect(dialog(page).getByTestId('untrusted-link-shown')).toHaveText('https://good.example')
+    await expect(dialog(page).getByTestId('untrusted-link-target')).toHaveText('https://evil.example/steal')
+
+    // Cancel opens nothing. A prompt that navigated anyway would be worse than
+    // no prompt, because the reader would believe they had refused.
+    await dialog(page).getByTestId('untrusted-link-cancel').click()
+    await expect(dialog(page)).toBeHidden()
+    expect(await openedUrls(page)).toEqual([])
+
+    // Then the override. The text reads as an address of its own, so the
+    // primary is a two-click ConfirmButton.
+    await clickTerminalText(page, 'https://good.example')
+    await expect(dialog(page)).toBeVisible()
+    await dialog(page).getByTestId('untrusted-link-open').click()
+    await page.getByRole('button', { name: 'Confirm?' }).click()
+
+    await expect(dialog(page)).toBeHidden()
+    await expect.poll(() => openedUrls(page)).toEqual(['https://evil.example/steal'])
+  })
+
+  // The mirror. A prompt on every link would pass the test above and teach the
+  // reader to confirm without reading.
+  test('opens a terminal hyperlink that spells its own address, with no prompt', async ({ page, authenticatedWorkspace }) => {
+    await openTerminalViaUI(page)
+    await expect(page.locator('.xterm')).toBeVisible()
+    await waitForTerminalReady(page)
+    await recordOpenedUrls(page)
+
+    await printTerminalHyperlink(page, 'https://example.test/docs', 'https://example.test/docs')
+    await waitForTerminalText(page, 'https://example.test/docs')
+    await clickTerminalText(page, 'https://example.test/docs')
+
+    await expect.poll(() => openedUrls(page)).toEqual(['https://example.test/docs'])
+    await expect(dialog(page)).toBeHidden()
+  })
+
+  test('warns before opening a markdown link whose text names a different address', async ({ page, authenticatedWorkspace }) => {
+    await recordOpenedUrls(page)
+    // Rendered through the same pipeline an agent's reply takes, so the anchor
+    // carries the mark `rehypeExternalLinks` puts on every link it hardens.
+    await sendMessage(page, '[https://good.example](https://evil.example/steal)')
+
+    const link = userBubbles(page).first().getByRole('link', { name: 'https://good.example' })
+    await expect(link).toBeVisible()
+    await link.click()
+
+    await expect(dialog(page)).toBeVisible()
+    await expect(dialog(page).getByTestId('untrusted-link-target')).toHaveText('https://evil.example/steal')
+    expect(await openedUrls(page)).toEqual([])
+
+    await dialog(page).getByTestId('untrusted-link-open').click()
+    await page.getByRole('button', { name: 'Confirm?' }).click()
+    await expect.poll(() => openedUrls(page)).toEqual(['https://evil.example/steal'])
+  })
+
+  /**
+   * The app's OWN links must not prompt.
+   *
+   * The mark that routes a link to the prompt is opt-IN, and this dialog is
+   * why. Its licence link reads "Functional Source License, Version 1.1, ALv2
+   * Future License" over a leapmux.dev address -- honest copy the app wrote,
+   * and a text/address mismatch at the same time. Under an opt-OUT default it
+   * would raise the prompt every time, over first-party text that carries no
+   * deception risk at all.
+   */
+  test('opens the About dialog links with no prompt, first-party text included', async ({ page, authenticatedWorkspace }) => {
+    await recordOpenedUrls(page)
+    await recordAnchorClicks(page)
+    const about = await openAboutDialog(page)
+
+    // The licence link first: prose label, mismatched address, and the whole
+    // reason the default runs this way round.
+    await about.getByRole('link', { name: /Functional Source License/ }).click()
+    await expect(dialog(page)).toBeHidden()
+
+    // Then the plain ones, and NOTICE.html, which is same-origin and relative.
+    await about.getByRole('link', { name: 'leapmux.dev' }).click()
+    await about.getByRole('link', { name: 'github.com/leapmux/leapmux' }).click()
+    await about.getByRole('link', { name: 'NOTICE.html' }).click()
+
+    await expect(dialog(page)).toBeHidden()
+    // Untouched by the app: every one reached the browser's own handling, and
+    // nothing was routed through `openExternalUrl`.
+    const clicks = await anchorClicks(page)
+    expect(clicks.map(c => c.defaultPrevented)).toEqual([false, false, false, false])
+    expect(clicks.map(c => c.href)).toEqual([
+      'https://leapmux.dev/docs/reference/legal/',
+      'https://leapmux.dev/',
+      'https://github.com/leapmux/leapmux',
+      `${new URL(page.url()).origin}/NOTICE.html`,
+    ])
+    expect(await openedUrls(page)).toEqual([])
+  })
+})

--- a/frontend/tests/e2e/helpers/terminal.ts
+++ b/frontend/tests/e2e/helpers/terminal.ts
@@ -91,3 +91,58 @@ export async function sendActiveTerminalInput(page: Page, text: string): Promise
     return typeof fn === 'function' ? fn(s) === true : false
   }, text)
 }
+
+/**
+ * Click a piece of the active terminal's text with a real mouse.
+ *
+ * The coordinates come from the app's own buffer-to-screen hook, because the
+ * WebGL renderer paints to a canvas: there is no element for a Playwright
+ * locator to find, and an OSC 8 hyperlink adds none of its own. Retried,
+ * because the shell's output reaches the buffer after the command returns.
+ */
+export async function clickTerminalText(page: Page, text: string): Promise<void> {
+  interface Point { x: number, y: number, awayY: number }
+  let point: Point | null = null
+  await expect(async () => {
+    point = await page.evaluate(
+      t => ((window as any).__activeTerminalPointAt?.(t) ?? null) as Point | null,
+      text,
+    )
+    expect(point, `no terminal cell shows ${text}`).not.toBeNull()
+  }).toPass()
+
+  // Hover ANOTHER cell first. xterm activates a link on mouseup, and only for
+  // the link its last hover resolved -- so a modal that opened over the
+  // terminal, and took a `mouseleave` with it, leaves that link cleared. A
+  // second click at the same coordinates then re-asks for nothing, because
+  // xterm skips the lookup while the buffer cell under the mouse is unchanged.
+  await page.mouse.move(point!.x, point!.awayY)
+  await page.mouse.click(point!.x, point!.y)
+}
+
+/**
+ * Split a string by an empty quote pair, so the SHELL reassembles it.
+ *
+ * The typed command line is echoed into the same buffer the assertions read,
+ * so a caller that searched for the whole string would find the echo first --
+ * on a row that holds no link and that a click therefore does nothing to.
+ * Split, the command line never contains the string and only the output does.
+ * `'a''b'` is one word to every POSIX shell, and `printf` receives `ab`.
+ */
+function reassembledByShell(text: string): string {
+  const half = Math.ceil(text.length / 2)
+  return `${text.slice(0, half)}''${text.slice(half)}`
+}
+
+/**
+ * Print an OSC 8 hyperlink into the active terminal: `label` over `uri`.
+ *
+ * Written with `printf` and octal escapes so the sequence survives the shell
+ * unchanged -- `echo -e` is not portable across the shells a worker may run,
+ * and `\\e` is not portable inside `printf` either.
+ */
+export async function printTerminalHyperlink(page: Page, uri: string, label: string): Promise<void> {
+  const target = reassembledByShell(uri)
+  const shown = reassembledByShell(label)
+  await typeInTerminal(page, `printf '\\033]8;;${target}\\033\\\\${shown}\\033]8;;\\033\\\\\\n'`)
+}

--- a/frontend/tests/e2e/helpers/ui.ts
+++ b/frontend/tests/e2e/helpers/ui.ts
@@ -571,6 +571,20 @@ async function openAppMenu(page: Page) {
 }
 
 /**
+ * Open the About dialog from the app menu.
+ *
+ * The item's label differs between the desktop shell and the browser ("About
+ * LeapMux Desktop..." against "About..."), so it is matched by prefix.
+ */
+export async function openAboutDialog(page: Page): Promise<Locator> {
+  await openAppMenu(page)
+  await page.getByRole('menuitem', { name: /^About/ }).click()
+  const dialog = page.getByRole('dialog', { name: 'About' })
+  await expect(dialog).toBeVisible()
+  return dialog
+}
+
+/**
  * Open the Preferences dialog from the app menu and land on a category.
  *
  * The dialog's navigation is a category list (sidebar tabs on desktop, an


### PR DESCRIPTION
## Motivation

- A hyperlink in a terminal did nothing under the desktop shell, and it
  printed two errors on the way. xterm had no `linkHandler`, so activation
  fell to its built-in one.
- That built-in handler calls `window.confirm`. Tauri replaces
  `window.confirm` with an asynchronous shim. The shim returns a Promise,
  and every Promise is truthy, so the code reads the answer as yes before
  the user sees the question. The Promise then rejects, because the shell
  grants no `dialog:allow-confirm` permission.
- The handler then calls `window.open`, which returns null in a webview
  that has no new-window handler. The link never opened, even on yes.
- Terminal output and agent-authored markdown carry the same risk. Each one
  can show one address over a link that opens a different one. Neither
  surface asked the user anything.

## Modifications

### One policy, one prompt

- Add `classifyUntrustedLink` in `lib/untrustedLinks.ts`. It returns
  `block`, `open`, or `confirm` for any link that an agent authored. The
  terminal path and the markdown path both call it, so the two surfaces
  cannot drift apart.
- Refuse every scheme but `http:` and `https:`. Such a URI never becomes a
  clickable link in a terminal, and the classifier refuses it a second time.
- Ask before a link opens when the shown text does not spell the address,
  or when the address is `http:` to a host that is not loopback.
- Accept the ordinary shorthands — a dropped scheme, a bare host, and one
  trailing slash — so the prompt stays rare. A `www.` prefix that only one
  side carries is a different DNS name, and it still warns.
- `UntrustedLinkDialog` shows the label and the address. It picks its lead
  sentence by severity: a misleading label, then a plain mismatch, then the
  insecure scheme. It arms the confirm button for a misleading label and for
  an insecure address. Prose such as `Click here` states no destination, so
  it stays at one click.

### The terminal

- Supply `createTerminalInstance` with its own `linkHandler.activate`, so
  xterm never reaches its built-in one. Until the shell installs a prompt,
  the handler refuses the link and logs a warning.
- `TerminalContainer` calls `setConfirmLink` in an effect on every mount. A
  cached instance outlives the view that built it, so a prompt captured once
  at construction can point at a shell that is gone.
- Add `readTerminalLinkLabel`. xterm reports one link range for each buffer
  row, so a wrapped address arrives in pieces. The helper walks the
  `isWrapped` rows and rebuilds the label with `translateToString`, because
  a wide character fills two columns and column arithmetic misplaces the
  text.

### Markdown and the hand-written anchors

- Mark each agent-authored anchor with `data-untrusted-link` in
  `rehypeExternalLinks`, the one pass that every markdown path already ends
  with.
- Mark the three hand-written anchors that show text from an agent or a
  remote party: the web-search result, the "open" link on a skipped image,
  and the tool-title URL.
- `interceptUntrustedLinkClicks` listens on `document.body` in the capture
  phase, so a link inside a portaled dialog or tooltip is also covered. It
  handles `auxclick` too, which covers a middle click and a ctrl-click. It
  leaves an `open` verdict alone, so the browser keeps the user activation
  that a popup blocker looks for.
- `createLinkConfirm` holds one dialog slot. A second link that arrives
  while the prompt is open resolves the first one as refused, rather than
  leaving that promise pending.

### Opening the link

- Add `openExternalUrl` to `platformBridge`. Under the desktop shell it
  invokes `plugin:opener|open_url` directly, because the opener plugin's
  injected click listener needs an anchor in the composed path and the xterm
  link layer has none. `opener:default` already permits the command, so the
  capabilities do not change.
- The browser build calls `window.open` with `noopener,noreferrer`.
- `openExternalUrl` reports a failure through a warning toast instead of
  rejecting. Its callers are event handlers with no error sink.

### Tests

- Unit tests cover the classifier, the click interceptor, the confirm hook,
  the dialog, the terminal handler, and the label rebuild.
- `untrustedAnchorsAreMarked.test.ts` reads every `.tsx` file under `src/`.
  An anchor with `target="_blank"` must carry the attribute or sit in the
  first-party list, and the test fails the suite with the file names when
  one does neither. A second assertion stops the guard from passing on an
  empty walk, and a third pins the attribute name that
  `markdownProcessor.ts` writes.
- `075-untrusted-links.spec.ts` covers four end-to-end (E2E) paths: a
  terminal hyperlink with a mismatched label, a terminal hyperlink that
  spells its own address, a markdown link with a mismatched label, and the
  four first-party links in the About dialog.
- New E2E helpers click terminal text through a real mouse and print an
  OSC 8 hyperlink, because the WebGL renderer paints to a canvas and leaves
  no DOM element for a glyph.

## Result

- A hyperlink in a terminal opens again under the desktop shell, and it
  prints no error.
- A link whose text does not spell its address, or whose address is plain
  `http:`, now asks first and shows both the label and the destination. A
  link that spells its own `https:` address opens at one click, as before.
- A link with a scheme other than `http:` or `https:` never opens from agent
  output.
- First-party copy, such as the About dialog, opens untouched. A new
  `target="_blank"` anchor that picks neither side fails the test suite.
