### PR TITLE
fix(chat): Preserve permission choices and align control pills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ test-results/
 frontend/test-results/
 frontend/playwright-report/
 coverage/
+
+# Local scratch files
+/.tmp/

--- a/backend/internal/worker/agent/manager_goal_test.go
+++ b/backend/internal/worker/agent/manager_goal_test.go
@@ -5,11 +5,29 @@
 package agent
 
 import (
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newClaudeGoalAgent gives a Claude agent whose stdin is a real pipe. The read
+// end drains so a long command cannot fill the pipe buffer.
+func newClaudeGoalAgent(t *testing.T, sink OutputSink) *ClaudeCodeAgent {
+	t.Helper()
+	readPipe, writePipe, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = writePipe.Close()
+		_ = readPipe.Close()
+	})
+	go func() { _, _ = io.Copy(io.Discard, readPipe) }()
+	agent := newTestAgent(sink)
+	agent.stdin = writePipe
+	return agent
+}
 
 // goalStub implements the Agent provider surface (via stubProvider) plus
 // GoalWriter, so Manager.UpdateGoal can reach it.

--- a/backend/internal/worker/agent/provider_goal_test.go
+++ b/backend/internal/worker/agent/provider_goal_test.go
@@ -2,8 +2,6 @@ package agent
 
 import (
 	"encoding/json"
-	"io"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -757,22 +755,6 @@ func TestZCodeGoal_IgnoresAPatchForAReplacedSession(t *testing.T) {
 		`{"scope":"session","sessionId":"sess-old","patch":{"goal":{"objective":"stale goal","status":"active"}}}`))
 
 	assert.Empty(t, sink.Goals(), "a patch for the replaced session is not this session's goal")
-}
-
-// newClaudeGoalAgent gives a Claude agent whose stdin is a real pipe. The read
-// end drains so a long command cannot fill the pipe buffer.
-func newClaudeGoalAgent(t *testing.T, sink OutputSink) *ClaudeCodeAgent {
-	t.Helper()
-	readPipe, writePipe, err := os.Pipe()
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = writePipe.Close()
-		_ = readPipe.Close()
-	})
-	go func() { _, _ = io.Copy(io.Discard, readPipe) }()
-	agent := newTestAgent(sink)
-	agent.stdin = writePipe
-	return agent
 }
 
 // Claude Code does not report a command-driven goal change. The observer writes

--- a/frontend/src/components/chat/AgentEditorPanel.test.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.test.tsx
@@ -5,6 +5,7 @@ import { create } from '@bufbuild/protobuf'
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { compactControl } from '~/components/common/CompactControl.css'
 import { PreferencesProvider } from '~/context/PreferencesContext'
 import { CLAUDE_MODE } from '~/generated/contracts/claude-protocol'
 import { AgentInputKind, AgentInputQueuePauseReason, AgentInputQueueSnapshotSchema, AgentInputState, AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
@@ -139,11 +140,29 @@ function questionRequestPayload(): Record<string, unknown> {
   }
 }
 
+/** The mutable permission-mode catalog that Claude reports. */
+function claudePermissionModeGroup(currentValue: string = CLAUDE_MODE.Default): AgentInfo['optionGroups'][number] {
+  return {
+    id: 'permissionMode',
+    label: 'Approval',
+    order: 30,
+    mutable: true,
+    defaultValue: CLAUDE_MODE.Default,
+    currentValue,
+    options: Object.values(CLAUDE_MODE).map(mode => ({ id: mode, name: mode })),
+  } as unknown as AgentInfo['optionGroups'][number]
+}
+
 function addControlRequest(
   controlStore: ReturnType<typeof createControlStore>,
   request: Omit<ControlRequest, 'agentId'>,
 ) {
   controlStore.addRequest('a1', { agentId: 'a1', ...request })
+}
+
+/** Waits until the saved answer for the active request is ready. */
+async function waitForControlActionsReady() {
+  await waitFor(() => expect(screen.getByTestId('control-actions')).not.toBeDisabled())
 }
 
 // The crash this suite's sibling reproduces (`ControlRequestBanner.test.tsx`)
@@ -202,6 +221,7 @@ describe('agentEditorPanel control request lifecycle', () => {
     renderPanel({ controlStore })
 
     const clearContext = () => screen.getByTestId('plan-clear-context-checkbox').querySelector('input[type="checkbox"]')!
+    await waitForControlActionsReady()
     fireEvent.click(clearContext())
     expect(clearContext()).toBeChecked()
 
@@ -230,6 +250,7 @@ describe('agentEditorPanel control request lifecycle', () => {
     renderPanel({ controlStore, onControlResponse })
 
     const clearContext = () => screen.getByTestId('plan-clear-context-checkbox').querySelector('input[type="checkbox"]')!
+    await waitForControlActionsReady()
     fireEvent.click(clearContext())
     expect(clearContext()).toBeChecked()
 
@@ -238,6 +259,7 @@ describe('agentEditorPanel control request lifecycle', () => {
 
     expect(clearContext()).not.toBeChecked()
 
+    await waitForControlActionsReady()
     fireEvent.click(screen.getByTestId('plan-approve-btn'))
 
     const [request, content] = onControlResponse.mock.calls[0]
@@ -261,6 +283,7 @@ describe('agentEditorPanel control request lifecycle', () => {
     })
     renderPanel({ controlStore, onControlResponse })
 
+    await waitForControlActionsReady()
     fireEvent.click(screen.getByTestId('plan-approve-btn'))
 
     expect(onControlResponse).toHaveBeenCalledOnce()
@@ -282,6 +305,7 @@ describe('agentEditorPanel control request lifecycle', () => {
     addControlRequest(controlStore, { requestId: 'plan-1', payload: toolRequestPayload('ExitPlanMode') })
     renderPanel({ controlStore, onControlResponse })
 
+    await waitForControlActionsReady()
     fireEvent.click(screen.getByTestId('plan-approve-btn'))
 
     expect(onControlResponse).toHaveBeenCalledOnce()
@@ -298,7 +322,13 @@ describe('agentEditorPanel control request lifecycle', () => {
     saveDraft('a1-ctrl-plan-1', 'no handler', 0)
     renderPanel({ controlStore })
 
-    expect(() => fireEvent.click(screen.getByTestId('plan-approve-btn'))).not.toThrow()
+    await waitForControlActionsReady()
+    const feedback = await waitFor(() => {
+      const button = screen.getByTestId('plan-reject-btn')
+      expect(button).toHaveTextContent('Send feedback')
+      return button
+    })
+    expect(() => fireEvent.click(feedback)).not.toThrow()
 
     expect((await loadDraft('a1-ctrl-plan-1')).content).toBe('')
   })
@@ -322,6 +352,7 @@ describe('agentEditorPanel control request lifecycle', () => {
     localStorageStore(`${PREFIX_CONTROL_STATE}a1:bash-1`, { selections: { 0: ['MySQL'] } })
     renderPanel({ controlStore, onControlResponse })
 
+    await waitForControlActionsReady()
     fireEvent.click(screen.getByTestId('plan-approve-btn'))
 
     expect((await loadDraft('a1-ctrl-plan-1')).content).toBe('')
@@ -343,11 +374,13 @@ describe('agentEditorPanel control request lifecycle', () => {
     saveDraft('a1-ctrl-ask-1-q-0', 'note for the first question', 0)
     saveDraft('a1-ctrl-ask-1-q-1', 'note for the second question', 0)
     saveDraft('a1-ctrl-bash-1', 'queued sibling reason', 0)
+    expect(await localStorageStore(`${PREFIX_CONTROL_STATE}a1:ask-1`, {
+      selections: { 0: ['Postgres'], 1: ['Bun'] },
+      currentPage: 1,
+    }).durable).toBe(true)
     renderPanel({ controlStore, onControlResponse })
 
-    // One click per question: a single-select answer advances the page itself.
-    fireEvent.click(screen.getByTestId('question-option-Postgres'))
-    fireEvent.click(screen.getByTestId('question-option-Bun'))
+    await waitForControlActionsReady()
     fireEvent.click(screen.getByTestId('control-submit-btn'))
 
     expect(onControlResponse).toHaveBeenCalledOnce()
@@ -368,16 +401,7 @@ describe('agentEditorPanel control request lifecycle', () => {
   it('draws the permission pills only while the catalog carries the preset axes', async () => {
     const controlStore = createControlStore()
     addControlRequest(controlStore, { requestId: 'plan-1', payload: toolRequestPayload('ExitPlanMode'), claimToken: 'claim-1' })
-    const modeGroup = {
-      id: 'permissionMode',
-      label: 'Approval',
-      order: 30,
-      mutable: true,
-      defaultValue: CLAUDE_MODE.Default,
-      currentValue: CLAUDE_MODE.Default,
-      options: Object.values(CLAUDE_MODE).map(mode => ({ id: mode, name: mode })),
-    } as unknown as AgentInfo['optionGroups'][number]
-    renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [modeGroup] })
+    renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [claudePermissionModeGroup()] })
     await waitFor(() => expect(screen.getByRole('radiogroup', { name: 'Permissions' })).toBeInTheDocument())
 
     // The catalog drops the permissionMode group: no preset the banner could
@@ -388,21 +412,22 @@ describe('agentEditorPanel control request lifecycle', () => {
     await waitFor(() => expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument())
   })
 
+  it('draws plan permission choices without a settings change handler', async () => {
+    const controlStore = createControlStore()
+    addControlRequest(controlStore, { requestId: 'plan-1', payload: toolRequestPayload('ExitPlanMode'), claimToken: 'claim-1' })
+
+    renderPanel({ controlStore, optionGroups: [claudePermissionModeGroup()] })
+
+    await waitFor(() => expect(screen.getByRole('radiogroup', { name: 'Permissions' })).toBeInTheDocument())
+    expect(within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Smart' })).toBeChecked()
+  })
+
   // The panel is the only scope that holds BOTH halves the opening choice needs
   // -- the live catalog and the confirmed values -- so it is the only place the
   // wiring from `activePermissionPreset` to the drawn pill can be checked.
   it('opens an ordinary request on the preset the session already has on', async () => {
     const controlStore = createControlStore()
     addControlRequest(controlStore, { requestId: 'bash-1', payload: toolRequestPayload('Bash'), claimToken: 'claim-1' })
-    const modeGroup = (currentValue: string) => ({
-      id: 'permissionMode',
-      label: 'Approval',
-      order: 30,
-      mutable: true,
-      defaultValue: CLAUDE_MODE.Default,
-      currentValue,
-      options: Object.values(CLAUDE_MODE).map(mode => ({ id: mode, name: mode })),
-    } as unknown as AgentInfo['optionGroups'][number])
     const pill = () => within(screen.getByRole('radiogroup', { name: 'Permissions' }))
 
     // The session runs on Claude's bypass mode, so the group opens there and an
@@ -410,7 +435,7 @@ describe('agentEditorPanel control request lifecycle', () => {
     const running = renderPanel({
       controlStore,
       onSettingChange: vi.fn(),
-      optionGroups: [modeGroup(CLAUDE_MODE.BypassPermissions)],
+      optionGroups: [claudePermissionModeGroup(CLAUDE_MODE.BypassPermissions)],
     })
     await waitFor(() => expect(pill().getByRole('radio', { name: 'Bypass' })).toBeChecked())
 
@@ -421,37 +446,62 @@ describe('agentEditorPanel control request lifecycle', () => {
     renderPanel({
       controlStore,
       onSettingChange: vi.fn(),
-      optionGroups: [modeGroup(CLAUDE_MODE.Default)],
+      optionGroups: [claudePermissionModeGroup()],
     })
     await waitFor(() => expect(pill().getByRole('radio', { name: 'Unchanged' })).toBeChecked())
     expect(pill().getByRole('radio', { name: 'Bypass' })).not.toBeChecked()
   })
 
   // The pill choice belongs to the request INSTANCE like a switch: a rebuild of
-  // the control component must not reset it to Default.
+  // the control component must not reset it to Unchanged.
   it('restores the permission pill choice of the rendered request instance after a remount', async () => {
     const controlStore = createControlStore()
     addControlRequest(controlStore, { requestId: 'plan-1', payload: toolRequestPayload('ExitPlanMode'), claimToken: 'claim-1' })
-    const modeGroup = {
-      id: 'permissionMode',
-      label: 'Approval',
-      order: 30,
-      mutable: true,
-      defaultValue: CLAUDE_MODE.Default,
-      currentValue: CLAUDE_MODE.Default,
-      options: Object.values(CLAUDE_MODE).map(mode => ({ id: mode, name: mode })),
-    } as unknown as AgentInfo['optionGroups'][number]
     const bypassRadio = () => within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass' })
-    const first = renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [modeGroup] })
+    const first = renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [claudePermissionModeGroup()] })
 
+    await waitForControlActionsReady()
     fireEvent.click(bypassRadio())
     expect(bypassRadio()).toBeChecked()
 
     first.unmount()
-    renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [modeGroup] })
+    renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [claudePermissionModeGroup()] })
 
     // Polled: the saved record is read after the remount, not during it.
     await waitFor(() => expect(bypassRadio()).toBeChecked())
+  })
+
+  it('blocks plan approval until the saved permission choice restores', async () => {
+    const controlStore = createControlStore()
+    const onControlResponse = vi.fn().mockResolvedValue(undefined)
+    addControlRequest(controlStore, { requestId: 'plan-1', payload: toolRequestPayload('ExitPlanMode'), claimToken: 'claim-1' })
+    const key = `${PREFIX_CONTROL_STATE}a1:plan-1:claim-1`
+    expect(await localStorageStore(key, {
+      choices: { 'control-permissions-pill': 'bypass' },
+    }).durable).toBe(true)
+
+    renderPanel({
+      controlStore,
+      onControlResponse,
+      onSettingChange: vi.fn(),
+      optionGroups: [claudePermissionModeGroup()],
+    })
+
+    const approve = screen.getByTestId('plan-approve-btn')
+    expect(approve).toBeDisabled()
+    fireEvent.click(approve)
+    expect(onControlResponse).not.toHaveBeenCalled()
+
+    await waitFor(() => expect(within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass' })).toBeChecked())
+    expect(approve).not.toBeDisabled()
+    fireEvent.click(approve)
+
+    await waitFor(() => expect(onControlResponse).toHaveBeenCalledOnce())
+    const [, content] = onControlResponse.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(content as Uint8Array))).toHaveProperty(
+      'permissionMode',
+      CLAUDE_MODE.BypassPermissions,
+    )
   })
 
   it('restores the plan switches of the rendered request instance after a remount', async () => {
@@ -460,6 +510,7 @@ describe('agentEditorPanel control request lifecycle', () => {
     const clearContext = () => screen.getByTestId('plan-clear-context-checkbox').querySelector('input[type="checkbox"]')!
     const first = renderPanel({ controlStore })
 
+    await waitForControlActionsReady()
     fireEvent.click(clearContext())
     expect(clearContext()).toBeChecked()
 
@@ -483,6 +534,7 @@ describe('agentEditorPanel control request lifecycle', () => {
     const remember = () => screen.getByTestId('control-remember-checkbox').querySelector('input[type="checkbox"]')!
     const first = renderPanel({ controlStore, agentProvider: AgentProvider.CODEX })
 
+    await waitForControlActionsReady()
     fireEvent.click(remember())
     expect(remember()).toBeChecked()
 
@@ -504,6 +556,7 @@ describe('agentEditorPanel control request lifecycle', () => {
     renderPanel({ controlStore, onControlResponse })
     const key = `${PREFIX_CONTROL_STATE}a1:plan-1:claim-1`
 
+    await waitForControlActionsReady()
     fireEvent.click(screen.getByTestId('plan-clear-context-checkbox').querySelector('input[type="checkbox"]')!)
     await waitFor(async () => {
       expect((await localStorageLoad<{ switches?: Record<string, boolean> }>(key))?.switches)
@@ -647,14 +700,14 @@ describe('agent editor panel', () => {
     expect(screen.getByTestId('queue-pause-button').querySelector('svg')).not.toBeNull()
   })
 
-  it('sizes every composer action with the shared small class', () => {
+  it('sizes every composer action with the shared compact style', () => {
     // The footer slot's own rule states no size, so a button that omits this
-    // class falls back to Oat's full-size metrics and breaks the row it shares
-    // with the `[+]` button, whose height is derived from `.small`.
+    // style falls back to the full-size metrics and breaks the row it shares
+    // with the `[+]` button, whose height uses the same compact metrics.
     renderPanel()
 
-    expect(screen.getByTestId('queue-pause-button')).toHaveClass('outline', 'small')
-    expect(screen.getByTestId('send-button')).toHaveClass('small')
+    expect(screen.getByTestId('queue-pause-button')).toHaveClass('outline', compactControl)
+    expect(screen.getByTestId('send-button')).toHaveClass(compactControl)
     expect(screen.getByTestId('send-button')).not.toHaveClass('outline')
   })
 

--- a/frontend/src/components/chat/AgentEditorPanel.test.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.test.tsx
@@ -388,6 +388,45 @@ describe('agentEditorPanel control request lifecycle', () => {
     await waitFor(() => expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument())
   })
 
+  // The panel is the only scope that holds BOTH halves the opening choice needs
+  // -- the live catalog and the confirmed values -- so it is the only place the
+  // wiring from `activePermissionPreset` to the drawn pill can be checked.
+  it('opens an ordinary request on the preset the session already has on', async () => {
+    const controlStore = createControlStore()
+    addControlRequest(controlStore, { requestId: 'bash-1', payload: toolRequestPayload('Bash'), claimToken: 'claim-1' })
+    const modeGroup = (currentValue: string) => ({
+      id: 'permissionMode',
+      label: 'Approval',
+      order: 30,
+      mutable: true,
+      defaultValue: CLAUDE_MODE.Default,
+      currentValue,
+      options: Object.values(CLAUDE_MODE).map(mode => ({ id: mode, name: mode })),
+    } as unknown as AgentInfo['optionGroups'][number])
+    const pill = () => within(screen.getByRole('radiogroup', { name: 'Permissions' }))
+
+    // The session runs on Claude's bypass mode, so the group opens there and an
+    // Allow keeps it there instead of dropping the session back to asking.
+    const running = renderPanel({
+      controlStore,
+      onSettingChange: vi.fn(),
+      optionGroups: [modeGroup(CLAUDE_MODE.BypassPermissions)],
+    })
+    await waitFor(() => expect(pill().getByRole('radio', { name: 'Bypass' })).toBeChecked())
+
+    // Nothing on: the group opens on the option that changes nothing. Bypass
+    // must never arrive without the user choosing it.
+    running.unmount()
+    cleanup()
+    renderPanel({
+      controlStore,
+      onSettingChange: vi.fn(),
+      optionGroups: [modeGroup(CLAUDE_MODE.Default)],
+    })
+    await waitFor(() => expect(pill().getByRole('radio', { name: 'Unchanged' })).toBeChecked())
+    expect(pill().getByRole('radio', { name: 'Bypass' })).not.toBeChecked()
+  })
+
   // The pill choice belongs to the request INSTANCE like a switch: a rebuild of
   // the control component must not reset it to Default.
   it('restores the permission pill choice of the rendered request instance after a remount', async () => {
@@ -402,7 +441,7 @@ describe('agentEditorPanel control request lifecycle', () => {
       currentValue: CLAUDE_MODE.Default,
       options: Object.values(CLAUDE_MODE).map(mode => ({ id: mode, name: mode })),
     } as unknown as AgentInfo['optionGroups'][number]
-    const bypassRadio = () => within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass permissions' })
+    const bypassRadio = () => within(screen.getByRole('radiogroup', { name: 'Permissions' })).getByRole('radio', { name: 'Bypass' })
     const first = renderPanel({ controlStore, onSettingChange: vi.fn(), optionGroups: [modeGroup] })
 
     fireEvent.click(bypassRadio())
@@ -606,6 +645,17 @@ describe('agent editor panel', () => {
   it('shows an icon beside the queue pause label', () => {
     renderPanel()
     expect(screen.getByTestId('queue-pause-button').querySelector('svg')).not.toBeNull()
+  })
+
+  it('sizes every composer action with the shared small class', () => {
+    // The footer slot's own rule states no size, so a button that omits this
+    // class falls back to Oat's full-size metrics and breaks the row it shares
+    // with the `[+]` button, whose height is derived from `.small`.
+    renderPanel()
+
+    expect(screen.getByTestId('queue-pause-button')).toHaveClass('outline', 'small')
+    expect(screen.getByTestId('send-button')).toHaveClass('small')
+    expect(screen.getByTestId('send-button')).not.toHaveClass('outline')
   })
 
   it('shows no pause banner while the queue runs', () => {

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -368,7 +368,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
     // opens on it, and only this scope holds both halves it needs -- the live
     // catalog and the confirmed values.
     const active = activePermissionPreset(usable, props.agent?.optionGroups, currentOptionValues())
-    return (usable.smart || usable.bypass) && props.onSettingChange
+    return Object.keys(usable).length > 0
       ? { ...usable, apply: props.onSettingChange, active }
       : undefined
   })

--- a/frontend/src/components/chat/AgentEditorPanel.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.tsx
@@ -47,10 +47,11 @@ import { ComposerPlusMenu } from './composer/ComposerPlusMenu'
 import { ComposerStatusBar } from './composer/ComposerStatusBar'
 import { ControlRequestActions, ControlRequestContent } from './ControlRequestBanner'
 import { useControlResponseHandling } from './controlResponseHandling'
+import { actionButtonClass } from './controls/ControlActionRow'
 import { createControlAnswerState } from './controls/types'
 import { MarkdownEditor } from './markdownEditor/MarkdownEditor'
 import { providerFor } from './providers/registry'
-import { usablePresets } from './providerSettings'
+import { activePermissionPreset, usablePresets } from './providerSettings'
 import { createQueueEditSession } from './queueEditSession'
 import {
   OPTION_ID_MODEL,
@@ -169,7 +170,7 @@ const AgentInputQueuePauseButton: Component<{
     <Tooltip text={label()} ariaLabel>
       <button
         type="button"
-        class="outline"
+        class={actionButtonClass(true)}
         disabled={props.busy}
         onMouseDown={keepFocusOnPress}
         onClick={() => props.onToggle()}
@@ -363,8 +364,12 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
       ? providerFor(props.agent.agentProvider)?.permissionPresets
       : undefined
     const usable = usablePresets(presets, props.agent?.optionGroups)
+    // The preset the session already has on. A control request's pill group
+    // opens on it, and only this scope holds both halves it needs -- the live
+    // catalog and the confirmed values.
+    const active = activePermissionPreset(usable, props.agent?.optionGroups, currentOptionValues())
     return (usable.smart || usable.bypass) && props.onSettingChange
-      ? { ...usable, apply: props.onSettingChange }
+      ? { ...usable, apply: props.onSettingChange, active }
       : undefined
   })
 
@@ -810,7 +815,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                         */}
                         <Tooltip text={interruptLoading.loading() ? 'Interrupting...' : 'Interrupt'} ariaLabel>
                           <button
-                            class="outline"
+                            class={actionButtonClass(true)}
                             onMouseDown={keepFocusOnPress}
                             onClick={() => {
                               interruptLoading.start()
@@ -848,6 +853,7 @@ export const AgentEditorPanel: Component<AgentEditorPanelProps> = (props) => {
                       <Tooltip text={queuePaused() ? 'Add to queue' : 'Send'} ariaLabel>
                         <button
                           type="button"
+                          class={actionButtonClass()}
                           disabled={(!hasContent() && attachments().length === 0) || disabled() || sending()}
                           onMouseDown={keepFocusOnPress}
                           onClick={() => { void triggerSend?.() }}

--- a/frontend/src/components/chat/ControlRequestBanner.tsx
+++ b/frontend/src/components/chat/ControlRequestBanner.tsx
@@ -2,7 +2,7 @@ import type { Component } from 'solid-js'
 import type { BannerActionsProps, BannerContentProps } from './controls/types'
 import Braces from 'lucide-solid/icons/braces'
 import Check from 'lucide-solid/icons/check'
-import { createMemo, Show } from 'solid-js'
+import { createMemo, onCleanup, Show } from 'solid-js'
 import { Dynamic } from 'solid-js/web'
 import { IconButton } from '~/components/common/IconButton'
 import { useCopyButton } from '~/hooks/useCopyButton'
@@ -64,22 +64,39 @@ export const ControlRequestActions: Component<BannerActionsProps> = (props) => {
   return (
     <Show when={props.request}>
       {request => (
-        <Show when={question()} fallback={<Dynamic component={pluginActions()} {...props} request={request()} />}>
-          {question => (
-            <AskUserQuestionActions
-              {...props}
-              request={request()}
-              questions={question().questions}
-              onSubmitAnswers={() => question().capability.sendAnswer(
-                request(),
-                props.onRespond,
-                question().questions,
-                props.answerState,
-              )}
-              onReject={message => question().capability.sendReject(request(), props.onRespond, message)}
-            />
-          )}
-        </Show>
+        <fieldset
+          data-testid="control-actions"
+          disabled={!props.answerState.ready()}
+          aria-busy={!props.answerState.ready() ? 'true' : undefined}
+          style={{ display: 'contents' }}
+          ref={(element) => {
+            const blockUntilReady = (event: MouseEvent) => {
+              if (props.answerState.ready())
+                return
+              event.preventDefault()
+              event.stopPropagation()
+            }
+            element.addEventListener('click', blockUntilReady, true)
+            onCleanup(() => element.removeEventListener('click', blockUntilReady, true))
+          }}
+        >
+          <Show when={question()} fallback={<Dynamic component={pluginActions()} {...props} request={request()} />}>
+            {question => (
+              <AskUserQuestionActions
+                {...props}
+                request={request()}
+                questions={question().questions}
+                onSubmitAnswers={() => question().capability.sendAnswer(
+                  request(),
+                  props.onRespond,
+                  question().questions,
+                  props.answerState,
+                )}
+                onReject={message => question().capability.sendReject(request(), props.onRespond, message)}
+              />
+            )}
+          </Show>
+        </fieldset>
       )}
     </Show>
   )

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'solid-js'
-import type { ProviderPermissionPreset, ProviderSettingChangeHandler } from '~/components/chat/providerSettings'
+import type { PermissionPresetKind, ProviderPermissionPreset, ProviderSettingChangeHandler } from '~/components/chat/providerSettings'
 import type { WorkingTreeInfo } from '~/components/common/WorkingTree'
 import type { BranchMenuActions } from '~/components/workspace/branchActions'
 import type { AgentProvider, AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
@@ -9,7 +9,7 @@ import Paperclip from 'lucide-solid/icons/paperclip'
 import Plus from 'lucide-solid/icons/plus'
 import { createMemo, createSignal, For, Show } from 'solid-js'
 import { pluginFor } from '~/components/chat/providers/registry'
-import { PERMISSION_PRESET_LABELS, permissionPresetActive, permissionPresetAvailable, usablePresets } from '~/components/chat/providerSettings'
+import { PERMISSION_PRESET_SPECS, permissionPresetActive, permissionPresetAvailable, usablePresets } from '~/components/chat/providerSettings'
 import { hasOptions } from '~/components/chat/settingsGroups'
 import { DisabledReasonMenuItem } from '~/components/common/DisabledReasonMenuItem'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
@@ -153,19 +153,12 @@ function hasMenuRows(s: MenuStructure): boolean {
   return s.groupIds.length > 0 || !!s.branchName || !!s.agentInfo || s.permissionActions.length > 0
 }
 
-type PermissionActionKind = 'smart' | 'bypass'
-
 interface PermissionAction {
-  kind: PermissionActionKind
+  kind: PermissionPresetKind
   label: string
   testId: string
   preset: ProviderPermissionPreset
 }
-
-const PERMISSION_ACTIONS: ReadonlyArray<Omit<PermissionAction, 'preset'>> = [
-  { kind: 'smart', label: PERMISSION_PRESET_LABELS.smart.full, testId: 'composer-smart-permissions' },
-  { kind: 'bypass', label: PERMISSION_PRESET_LABELS.bypass.full, testId: 'composer-bypass-permissions' },
-]
 
 function permissionActionsFor(
   provider: AgentProvider | undefined,
@@ -175,10 +168,10 @@ function permissionActionsFor(
   // menu and a banner's pills cannot offer different preset sets.
   const usable = usablePresets(pluginFor(provider)?.permissionPresets, groups)
   const actions: PermissionAction[] = []
-  for (const action of PERMISSION_ACTIONS) {
-    const preset = usable[action.kind]
+  for (const spec of PERMISSION_PRESET_SPECS) {
+    const preset = usable[spec.kind]
     if (preset)
-      actions.push({ ...action, preset })
+      actions.push({ kind: spec.kind, label: spec.fullLabel, testId: `composer-${spec.kind}-permissions`, preset })
   }
   return actions
 }

--- a/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
+++ b/frontend/src/components/chat/composer/ComposerPlusMenu.tsx
@@ -9,8 +9,8 @@ import Paperclip from 'lucide-solid/icons/paperclip'
 import Plus from 'lucide-solid/icons/plus'
 import { createMemo, createSignal, For, Show } from 'solid-js'
 import { pluginFor } from '~/components/chat/providers/registry'
-import { PERMISSION_PRESET_LABELS, permissionPresetAvailable, usablePresets } from '~/components/chat/providerSettings'
-import { hasOptions, resolvedCurrent } from '~/components/chat/settingsGroups'
+import { PERMISSION_PRESET_LABELS, permissionPresetActive, permissionPresetAvailable, usablePresets } from '~/components/chat/providerSettings'
+import { hasOptions } from '~/components/chat/settingsGroups'
 import { DisabledReasonMenuItem } from '~/components/common/DisabledReasonMenuItem'
 import { DropdownMenu, DropdownMenuCheckableItem } from '~/components/common/DropdownMenu'
 import { Icon } from '~/components/common/Icon'
@@ -163,8 +163,8 @@ interface PermissionAction {
 }
 
 const PERMISSION_ACTIONS: ReadonlyArray<Omit<PermissionAction, 'preset'>> = [
-  { kind: 'smart', label: PERMISSION_PRESET_LABELS.smart, testId: 'composer-smart-permissions' },
-  { kind: 'bypass', label: PERMISSION_PRESET_LABELS.bypass, testId: 'composer-bypass-permissions' },
+  { kind: 'smart', label: PERMISSION_PRESET_LABELS.smart.full, testId: 'composer-smart-permissions' },
+  { kind: 'bypass', label: PERMISSION_PRESET_LABELS.bypass.full, testId: 'composer-bypass-permissions' },
 ]
 
 function permissionActionsFor(
@@ -431,9 +431,8 @@ export function ComposerPlusMenu(props: ComposerPlusMenuProps): JSX.Element {
             <button
               role="menuitem"
               data-testid={action.testId}
-              disabled={!props.onSettingChange || !!props.disabledReason || !permissionActionAvailable(action) || Object.entries(action.preset.sets).every(
-                ([k, v]) => resolvedCurrent(props.optionGroups, props.optionValues, k) === v,
-              )}
+              disabled={!props.onSettingChange || !!props.disabledReason || !permissionActionAvailable(action)
+                || permissionPresetActive(action.preset, props.optionGroups, props.optionValues)}
               onClick={() => props.onSettingChange?.({ sets: { ...action.preset.sets } })}
             >
               {action.label}

--- a/frontend/src/components/chat/controlResponseHandling.test.ts
+++ b/frontend/src/components/chat/controlResponseHandling.test.ts
@@ -359,6 +359,7 @@ describe('handleControlSend', () => {
     // the owner of the answers -- which is the state a real session answers in.
     answerState.setSelections({ 0: ['Build'] })
     expect(await localStorageLoad(key)).toBeDefined()
+    await vi.waitFor(() => expect(answerState.ready()).toBe(true))
 
     batch(() => result.handleControlSend(''))
 
@@ -510,13 +511,15 @@ describe('handleControlSend', () => {
       onSendMessage,
     }
     const resetEditorHeight = vi.fn()
+    const answerState = createControlAnswerState()
     const result = useControlResponseHandling(
       props,
-      createControlAnswerState(),
+      answerState,
       () => undefined,
       resetEditorHeight,
       () => attachments,
     )
+    await vi.waitFor(() => expect(answerState.ready()).toBe(true))
     // handleControlSend builds a control response — it should NOT include attachments.
     result.handleControlSend('')
     // onSendMessage should NOT have been called (it's a control response, not a user message).
@@ -538,7 +541,9 @@ describe('handleControlSend', () => {
       onControlResponse,
       onSendMessage: vi.fn(),
     }
-    const result = useControlResponseHandling(props, createControlAnswerState(), () => undefined, vi.fn())
+    const answerState = createControlAnswerState()
+    const result = useControlResponseHandling(props, answerState, () => undefined, vi.fn())
+    await vi.waitFor(() => expect(answerState.ready()).toBe(true))
     expect(result.handleControlSend('')).toBe(false)
     expect(onControlResponse).not.toHaveBeenCalled()
     expect(showWarnToast).toHaveBeenCalledWith(expect.stringContaining('unsupported agent provider'))

--- a/frontend/src/components/chat/controlResponseHandling.ts
+++ b/frontend/src/components/chat/controlResponseHandling.ts
@@ -173,6 +173,7 @@ export function useControlResponseHandling(
     activeControlRequest,
     (request) => {
       answerOwner = request
+      answerState.setReady(!request || !props.agentId)
       // RESET FIRST, then fill in from storage if there is anything to fill in.
       // The read is asynchronous (saved answers are an unbounded family on the
       // unmirrored storage tier), and leaving the previous request's answers on
@@ -206,18 +207,22 @@ export function useControlResponseHandling(
         if (token !== restoreToken)
           return
         restoringFor = null
-        if (!saved)
+        // The user can answer while the read is in flight. Their in-memory
+        // value is newer, so the saved copy loses. Otherwise, install every
+        // saved field before the actions become available.
+        if (saved && isBlankAnswer(currentAnswer())) {
+          answerState.setSelections(saved.selections ?? {})
+          answerState.setCustomTexts(saved.customTexts ?? {})
+          answerState.setCurrentPage(saved.currentPage ?? 0)
+          answerState.setSwitches(saved.switches ?? {})
+          answerState.setChoices(saved.choices ?? {})
+        }
+        answerState.setReady(true)
+      }).catch(() => {
+        if (token !== restoreToken)
           return
-        // The user answered something while the read was in flight. What they
-        // just did is newer than what was on disk, so the saved copy loses --
-        // and the persist effect has already stored theirs.
-        if (!isBlankAnswer(currentAnswer()))
-          return
-        answerState.setSelections(saved.selections ?? {})
-        answerState.setCustomTexts(saved.customTexts ?? {})
-        answerState.setCurrentPage(saved.currentPage ?? 0)
-        answerState.setSwitches(saved.switches ?? {})
-        answerState.setChoices(saved.choices ?? {})
+        restoringFor = null
+        answerState.setReady(true)
       })
     },
   ))
@@ -309,6 +314,8 @@ export function useControlResponseHandling(
     const req = activeControlRequest()
     if (!req)
       return
+    if (!answerState.ready())
+      return false
     const respond = respondTo(req)
     // Resolve the agent's own provider plugin -- no Claude fallback. A live agent
     // always carries a real provider, so a missing plugin means an UNSPECIFIED or

--- a/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
+++ b/frontend/src/components/chat/controls/AskUserQuestionControl.tsx
@@ -13,7 +13,7 @@ import { buildAllowResponse, getToolInput } from '~/utils/controlResponse'
 import * as styles from '../ControlRequestBanner.css'
 import { pluginFor } from '../providers/registry'
 import { CollapsibleList } from './CollapsibleList'
-import { ControlActionRow } from './ControlActionRow'
+import { actionButtonClass, ControlActionRow } from './ControlActionRow'
 
 // ---------------------------------------------------------------------------
 // Selection helpers
@@ -392,7 +392,7 @@ export const AskUserQuestionActions: Component<ActionsProps & {
       secondary={(
         <>
           <button
-            class="outline"
+            class={actionButtonClass(true)}
             onClick={handleStop}
             disabled={stopping()}
             data-testid="control-stop-btn"
@@ -402,7 +402,7 @@ export const AskUserQuestionActions: Component<ActionsProps & {
           </button>
           <Tooltip text="Auto-fill unanswered questions and submit">
             <button
-              class="outline"
+              class={actionButtonClass(true)}
               onClick={handleYolo}
               disabled={!anyUnanswered()}
               data-testid="control-yolo-btn"
@@ -435,6 +435,7 @@ export const AskUserQuestionActions: Component<ActionsProps & {
       )}
       primary={(
         <button
+          class={actionButtonClass()}
           onClick={handleSubmit}
           disabled={!allAnswered() || submitting()}
           data-testid="control-submit-btn"

--- a/frontend/src/components/chat/controls/ControlActionRow.test.tsx
+++ b/frontend/src/components/chat/controls/ControlActionRow.test.tsx
@@ -1,6 +1,19 @@
 import { render, screen } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
-import { ControlActionRow } from './ControlActionRow'
+import { actionButtonClass, ControlActionRow } from './ControlActionRow'
+
+describe('actionButtonClass', () => {
+  it('sizes a filled action', () => {
+    expect(actionButtonClass()).toBe('small')
+    expect(actionButtonClass(false)).toBe('small')
+  })
+
+  it('keeps the outline variant beside the size', () => {
+    // Oat reads the two as independent classes, so an outline action must
+    // carry both. Dropping either one restores the full-size metrics.
+    expect(actionButtonClass(true)).toBe('outline small')
+  })
+})
 
 describe('controlActionRow', () => {
   it('puts the primary actions in the right-hand zone', () => {

--- a/frontend/src/components/chat/controls/ControlActionRow.test.tsx
+++ b/frontend/src/components/chat/controls/ControlActionRow.test.tsx
@@ -1,17 +1,16 @@
 import { render, screen } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
+import { compactControl } from '~/components/common/CompactControl.css'
 import { actionButtonClass, ControlActionRow } from './ControlActionRow'
 
 describe('actionButtonClass', () => {
   it('sizes a filled action', () => {
-    expect(actionButtonClass()).toBe('small')
-    expect(actionButtonClass(false)).toBe('small')
+    expect(actionButtonClass()).toBe(compactControl)
+    expect(actionButtonClass(false)).toBe(compactControl)
   })
 
   it('keeps the outline variant beside the size', () => {
-    // Oat reads the two as independent classes, so an outline action must
-    // carry both. Dropping either one restores the full-size metrics.
-    expect(actionButtonClass(true)).toBe('outline small')
+    expect(actionButtonClass(true)).toBe(`${compactControl} outline`)
   })
 })
 
@@ -46,6 +45,20 @@ describe('controlActionRow', () => {
     const text = screen.getByTestId('control-footer').textContent ?? ''
     expect(text.indexOf('Reject')).toBeLessThan(text.indexOf('1 2 3'))
     expect(text.indexOf('1 2 3')).toBeLessThan(text.indexOf('Submit'))
+  })
+
+  it('puts leading controls before decisions in the right-hand zone', () => {
+    render(() => (
+      <ControlActionRow
+        leading={<span data-testid="choice">Choice</span>}
+        primary={<button data-testid="allow">Allow</button>}
+      />
+    ))
+
+    const choice = screen.getByTestId('choice')
+    const allow = screen.getByTestId('allow')
+    expect(choice.parentElement).toBe(allow.parentElement)
+    expect(choice.compareDocumentPosition(allow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
   it('marks every row with one test id, whatever zones it fills', () => {

--- a/frontend/src/components/chat/controls/ControlActionRow.tsx
+++ b/frontend/src/components/chat/controls/ControlActionRow.tsx
@@ -1,5 +1,6 @@
 import type { Component, JSX } from 'solid-js'
 import { Show } from 'solid-js'
+import { compactControl } from '~/components/common/CompactControl.css'
 import * as styles from '../ControlRequestBanner.css'
 
 /**
@@ -33,7 +34,9 @@ export interface ControlActionRowProps {
    * action. Today only the multi-question pagination uses it.
    */
   centre?: JSX.Element
-  /** The right-end actions: the decision on the request. */
+  /** Controls that qualify the decision, before the decision buttons. */
+  leading?: JSX.Element
+  /** The right-end decision buttons. */
   primary: JSX.Element
 }
 
@@ -42,19 +45,13 @@ export interface ControlActionRowProps {
  * control-request decisions here, and the composer's own Pause, Interrupt and
  * Send.
  *
- * Oat's `.small` supplies the metrics (`--text-8`, and
- * `var(--space-1) var(--space-3)` of padding), which the `CompactSwitch` beside
- * them and the `PillGroup` `small` variant match. It is the ONE source for that
- * size: `--editor-btn-h` is derived from it so the `[+]` button matches, and the
- * slot's own rule in `~/components/chat/markdownEditor/MarkdownEditor.css.ts`
- * deliberately states no size, because an unlayered rule there would outrank
- * this class and could never lose to it.
+ * The shared compact-control style supplies the metrics. `CompactSwitch`, the
+ * `PillGroup` small variant, and the editor height use the same source.
  *
- * One function rather than a literal at each button, so a button added to the
- * slot later cannot fall back to Oat's full-size metrics by omission.
+ * One function keeps the current call sites on the same class string.
  */
 export function actionButtonClass(outline?: boolean): string {
-  return outline === true ? 'outline small' : 'small'
+  return outline === true ? `${compactControl} outline` : compactControl
 }
 
 export const ControlActionRow: Component<ControlActionRowProps> = props => (
@@ -65,6 +62,9 @@ export const ControlActionRow: Component<ControlActionRowProps> = props => (
     <Show when={props.centre}>
       <div class={styles.controlFooterCentre}>{props.centre}</div>
     </Show>
-    <div class={styles.controlFooterRight}>{props.primary}</div>
+    <div class={styles.controlFooterRight}>
+      <Show when={props.leading}>{props.leading}</Show>
+      {props.primary}
+    </div>
   </div>
 )

--- a/frontend/src/components/chat/controls/ControlActionRow.tsx
+++ b/frontend/src/components/chat/controls/ControlActionRow.tsx
@@ -37,6 +37,26 @@ export interface ControlActionRowProps {
   primary: JSX.Element
 }
 
+/**
+ * The class every action button in the composer's footer slot carries — the
+ * control-request decisions here, and the composer's own Pause, Interrupt and
+ * Send.
+ *
+ * Oat's `.small` supplies the metrics (`--text-8`, and
+ * `var(--space-1) var(--space-3)` of padding), which the `CompactSwitch` beside
+ * them and the `PillGroup` `small` variant match. It is the ONE source for that
+ * size: `--editor-btn-h` is derived from it so the `[+]` button matches, and the
+ * slot's own rule in `~/components/chat/markdownEditor/MarkdownEditor.css.ts`
+ * deliberately states no size, because an unlayered rule there would outrank
+ * this class and could never lose to it.
+ *
+ * One function rather than a literal at each button, so a button added to the
+ * slot later cannot fall back to Oat's full-size metrics by omission.
+ */
+export function actionButtonClass(outline?: boolean): string {
+  return outline === true ? 'outline small' : 'small'
+}
+
 export const ControlActionRow: Component<ControlActionRowProps> = props => (
   <div class={styles.controlFooter} data-testid="control-footer">
     <Show when={props.secondary}>

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.test.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { Minus } from 'lucide-solid'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
+import { compactControl } from '~/components/common/CompactControl.css'
+import { SHOW_DELAY_MS } from '~/components/common/Tooltip'
 import { ControlDecisionFooter } from './ControlDecisionFooter'
 
 describe('controlDecisionFooter', () => {
@@ -32,8 +35,7 @@ describe('controlDecisionFooter', () => {
 
   it('draws every decision at the small row metrics', () => {
     // The row mixes a switch, a pill group and these buttons. One size for all
-    // three is the reason the buttons carry Oat's `.small` rather than its
-    // default metrics.
+    // three is the reason the buttons carry the shared compact style.
     render(() => (
       <ControlDecisionFooter
         hasEditorContent={false}
@@ -45,10 +47,10 @@ describe('controlDecisionFooter', () => {
     ))
 
     // The negative action is always an outline; the positive one is filled.
-    expect(screen.getByTestId('deny')).toHaveClass('outline', 'small')
-    expect(screen.getByTestId('allow')).toHaveClass('small')
+    expect(screen.getByTestId('deny')).toHaveClass('outline', compactControl)
+    expect(screen.getByTestId('allow')).toHaveClass(compactControl)
     expect(screen.getByTestId('allow')).not.toHaveClass('outline')
-    expect(screen.getByTestId('allow-all')).toHaveClass('outline', 'small')
+    expect(screen.getByTestId('allow-all')).toHaveClass('outline', compactControl)
   })
 
   it('keeps the feedback action at the same metrics', () => {
@@ -61,6 +63,38 @@ describe('controlDecisionFooter', () => {
       />
     ))
 
-    expect(screen.getByTestId('deny')).toHaveClass('outline', 'small')
+    expect(screen.getByTestId('deny')).toHaveClass('outline', compactControl)
+  })
+
+  it('describes the permission group and gives its icon the specific tooltip', () => {
+    vi.useFakeTimers()
+    try {
+      render(() => (
+        <ControlDecisionFooter
+          hasEditorContent={false}
+          onSendFeedback={vi.fn()}
+          negativeAction={{ label: 'Deny', testId: 'deny', onSelect: vi.fn() }}
+          positiveAction={{ label: 'Allow', testId: 'allow', onSelect: vi.fn() }}
+          permissionPill={() => ({
+            options: [
+              { key: 'unspecified', label: 'Unchanged', icon: Minus },
+              { key: 'smart', label: 'Smart' },
+            ],
+            selected: 'unspecified',
+            onSelect: vi.fn(),
+          })}
+        />
+      ))
+
+      const group = screen.getByRole('radiogroup', { name: 'Permissions' })
+      expect(group).toHaveAccessibleDescription('The selected preset applies when you allow or approve this request')
+
+      screen.getByRole('radio', { name: 'Unchanged' }).focus()
+      vi.advanceTimersByTime(SHOW_DELAY_MS)
+      expect(screen.getByRole('tooltip', { hidden: true })).toHaveTextContent('Unchanged')
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.test.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.test.tsx
@@ -29,4 +29,38 @@ describe('controlDecisionFooter', () => {
     expect(screen.getByTestId('remember').querySelector('input')).toBe(input)
     expect(document.activeElement).toBe(input)
   })
+
+  it('draws every decision at the small row metrics', () => {
+    // The row mixes a switch, a pill group and these buttons. One size for all
+    // three is the reason the buttons carry Oat's `.small` rather than its
+    // default metrics.
+    render(() => (
+      <ControlDecisionFooter
+        hasEditorContent={false}
+        onSendFeedback={vi.fn()}
+        negativeAction={{ label: 'Deny', testId: 'deny', onSelect: vi.fn() }}
+        positiveAction={{ label: 'Allow', testId: 'allow', onSelect: vi.fn() }}
+        additionalActions={() => [{ label: 'Allow all', testId: 'allow-all', onSelect: vi.fn(), outline: true }]}
+      />
+    ))
+
+    // The negative action is always an outline; the positive one is filled.
+    expect(screen.getByTestId('deny')).toHaveClass('outline', 'small')
+    expect(screen.getByTestId('allow')).toHaveClass('small')
+    expect(screen.getByTestId('allow')).not.toHaveClass('outline')
+    expect(screen.getByTestId('allow-all')).toHaveClass('outline', 'small')
+  })
+
+  it('keeps the feedback action at the same metrics', () => {
+    render(() => (
+      <ControlDecisionFooter
+        hasEditorContent
+        onSendFeedback={vi.fn()}
+        negativeAction={{ label: 'Deny', testId: 'deny', onSelect: vi.fn() }}
+        positiveAction={{ label: 'Allow', testId: 'allow', onSelect: vi.fn() }}
+      />
+    ))
+
+    expect(screen.getByTestId('deny')).toHaveClass('outline', 'small')
+  })
 })

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
@@ -43,28 +43,30 @@ export const ControlDecisionFooter: Component<{
 
   return (
     <ControlActionRow
+      leading={(
+        <Show when={!props.hasEditorContent && leadingOptions()}>
+          <div class={styles.controlRequestSwitches}>
+            <Index each={switches()}>
+              {item => (
+                <CompactSwitch
+                  checked={item().checked}
+                  onChange={item().onChange}
+                  data-testid={item().id}
+                  fontSize="var(--text-8)"
+                >
+                  {item().label}
+                  {item().suffix}
+                </CompactSwitch>
+              )}
+            </Index>
+            <Show when={props.permissionPill?.()}>
+              {pill => <ControlPermissionPillGroup pill={pill()} />}
+            </Show>
+          </div>
+        </Show>
+      )}
       primary={(
         <>
-          <Show when={!props.hasEditorContent && leadingOptions()}>
-            <div class={styles.controlRequestSwitches}>
-              <Index each={switches()}>
-                {item => (
-                  <CompactSwitch
-                    checked={item().checked}
-                    onChange={item().onChange}
-                    data-testid={item().id}
-                    fontSize="var(--text-8)"
-                  >
-                    {item().label}
-                    {item().suffix}
-                  </CompactSwitch>
-                )}
-              </Index>
-              <Show when={props.permissionPill?.()}>
-                {pill => <ControlPermissionPillGroup pill={pill()} />}
-              </Show>
-            </div>
-          </Show>
           <button
             class={actionButtonClass(true)}
             onMouseDown={keepFocusOnPress}

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
@@ -5,7 +5,7 @@ import { For, Index, Show } from 'solid-js'
 import { CompactSwitch } from '~/components/common/CompactSwitch'
 import { keepFocusOnPress } from '~/lib/focusRetention'
 import * as styles from '../ControlRequestBanner.css'
-import { ControlActionRow } from './ControlActionRow'
+import { actionButtonClass, ControlActionRow } from './ControlActionRow'
 import { ControlPermissionPillGroup } from './ControlPillGroups'
 
 export interface ControlRequestSwitch {
@@ -66,7 +66,7 @@ export const ControlDecisionFooter: Component<{
             </div>
           </Show>
           <button
-            class="outline"
+            class={actionButtonClass(true)}
             onMouseDown={keepFocusOnPress}
             onClick={() => props.hasEditorContent ? props.onSendFeedback() : props.negativeAction.onSelect()}
             data-testid={props.negativeAction.testId}
@@ -75,7 +75,7 @@ export const ControlDecisionFooter: Component<{
           </button>
           <Show when={!props.hasEditorContent}>
             <button
-              class={props.positiveAction.outline ? 'outline' : undefined}
+              class={actionButtonClass(props.positiveAction.outline)}
               onClick={props.positiveAction.onSelect}
               data-testid={props.positiveAction.testId}
             >
@@ -84,7 +84,7 @@ export const ControlDecisionFooter: Component<{
             <For each={additionalActions()}>
               {decision => (
                 <button
-                  class={decision.outline ? 'outline' : undefined}
+                  class={actionButtonClass(decision.outline)}
                   onClick={decision.onSelect}
                   data-testid={decision.testId}
                 >

--- a/frontend/src/components/chat/controls/ControlPillGroups.tsx
+++ b/frontend/src/components/chat/controls/ControlPillGroups.tsx
@@ -8,8 +8,9 @@ import * as styles from '../ControlRequestBanner.css'
 
 /**
  * The permission pill group a control request's decision row offers: Default /
- * Smart permissions / Bypass permissions, one row segment shared by the decision
- * footer and the providers that lay out their own action row (ACP, OpenCode).
+ * Smart / Bypass, one row segment shared by the decision footer and the
+ * providers that lay out their own action row (ACP, OpenCode). The group's own
+ * name supplies the noun each option drops.
  */
 export const ControlPermissionPillGroup: Component<{ pill: ControlPermissionPill }> = props => (
   <Tooltip text="The selected preset applies when you allow or approve this request">
@@ -19,6 +20,7 @@ export const ControlPermissionPillGroup: Component<{ pill: ControlPermissionPill
         options={props.pill.options}
         selectedKey={props.pill.selected}
         onSelect={props.pill.onSelect}
+        small
       />
     </div>
   </Tooltip>
@@ -41,6 +43,7 @@ export const ControlAllowScopePillGroup: Component<{
       options={props.options}
       selectedKey={props.selected}
       onSelect={props.onSelect}
+      small
     />
   </div>
 )

--- a/frontend/src/components/chat/controls/ControlPillGroups.tsx
+++ b/frontend/src/components/chat/controls/ControlPillGroups.tsx
@@ -3,27 +3,25 @@ import type { ControlPermissionPill } from './permissionPresets'
 
 import type { PillOptions } from '~/components/common/PillGroup'
 import { PillGroup } from '~/components/common/PillGroup'
-import { Tooltip } from '~/components/common/Tooltip'
 import * as styles from '../ControlRequestBanner.css'
 
 /**
- * The permission pill group a control request's decision row offers: Default /
+ * The permission pill group a control request's decision row offers: Unchanged /
  * Smart / Bypass, one row segment shared by the decision footer and the
  * providers that lay out their own action row (ACP, OpenCode). The group's own
  * name supplies the noun each option drops.
  */
 export const ControlPermissionPillGroup: Component<{ pill: ControlPermissionPill }> = props => (
-  <Tooltip text="The selected preset applies when you allow or approve this request">
-    <div class={styles.controlRequestPill} data-testid="control-permissions-pill-group">
-      <PillGroup
-        label="Permissions"
-        options={props.pill.options}
-        selectedKey={props.pill.selected}
-        onSelect={props.pill.onSelect}
-        small
-      />
-    </div>
-  </Tooltip>
+  <div class={styles.controlRequestPill} data-testid="control-permissions-pill-group">
+    <PillGroup
+      label="Permissions"
+      description="The selected preset applies when you allow or approve this request"
+      options={props.pill.options}
+      selectedKey={props.pill.selected}
+      onSelect={props.pill.onSelect}
+      small
+    />
+  </div>
 )
 
 /**

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
@@ -170,7 +170,7 @@ describe('exitPlanModeActions', () => {
   })
 
   it('carries no mode when the catalog offers no smart preset', () => {
-    // The opening choice clamps to Default, so an untouched group leaves the
+    // The opening choice clamps to Unchanged, so an untouched group leaves the
     // agent's permission mode where it is.
     const onRespond = vi.fn().mockResolvedValue(undefined)
 

--- a/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
+++ b/frontend/src/components/chat/controls/ExitPlanModeControl.test.tsx
@@ -37,9 +37,10 @@ describe('exitPlanModeActions', () => {
     expect(screen.getByTestId('plan-reject-btn')).toBeInTheDocument()
     expect(screen.getByTestId('plan-approve-btn')).toBeInTheDocument()
     expect(screen.getByTestId('plan-clear-context-checkbox')).toHaveTextContent('Clear Context (30%)')
-    expect(permissionPillGroup().getByRole('radio', { name: 'Default' })).toBeChecked()
-    expect(permissionPillGroup().getByRole('radio', { name: 'Smart permissions' })).toBeInTheDocument()
-    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' })).toBeInTheDocument()
+    // A plan approval opens on Smart, whatever the session runs on.
+    expect(permissionPillGroup().getByRole('radio', { name: 'Smart' })).toBeChecked()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Unchanged' })).not.toBeChecked()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass' })).not.toBeChecked()
   })
 
   it('shows only Send feedback when editor has content', () => {
@@ -84,7 +85,7 @@ describe('exitPlanModeActions', () => {
     expect(decoded.response.response.behavior).toBe('allow')
   })
 
-  it('sends allow response with the bypass mode when Bypass permissions is selected', () => {
+  it('sends allow response with the bypass mode when Bypass is selected', () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     const apply = vi.fn()
     const request = makeRequest('req-99', 'agent-3')
@@ -101,7 +102,7 @@ describe('exitPlanModeActions', () => {
     ))
 
     // Select bypass permissions, then approve.
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
     fireEvent.click(screen.getByTestId('plan-approve-btn'))
 
     expect(onRespond).toHaveBeenCalledOnce()
@@ -115,7 +116,7 @@ describe('exitPlanModeActions', () => {
     expect(apply).not.toHaveBeenCalled()
   })
 
-  it('sends allow response with the smart mode when Smart permissions is selected', () => {
+  it('sends allow response with the smart mode when Smart is selected', () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     const apply = vi.fn()
 
@@ -134,12 +135,60 @@ describe('exitPlanModeActions', () => {
       />
     ))
 
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Smart permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Smart' }))
     fireEvent.click(screen.getByTestId('plan-approve-btn'))
 
     const [bytes] = onRespond.mock.calls[0]
     expect(JSON.parse(new TextDecoder().decode(bytes)).permissionMode).toBe('auto')
     expect(apply).not.toHaveBeenCalled()
+  })
+
+  it('carries the smart mode when the user touches no pill', () => {
+    // Smart is the opening choice, so an approval attaches its mode with no
+    // click on the group.
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+
+    render(() => (
+      <ExitPlanModeActions
+        request={makeRequest()}
+        answerState={createControlAnswerState()}
+        onRespond={onRespond}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        presets={{
+          smart: { sets: { permissionMode: 'auto' } },
+          bypass: { sets: { permissionMode: 'bypassPermissions' } },
+          apply: vi.fn(),
+        }}
+      />
+    ))
+
+    fireEvent.click(screen.getByTestId('plan-approve-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).permissionMode).toBe('auto')
+  })
+
+  it('carries no mode when the catalog offers no smart preset', () => {
+    // The opening choice clamps to Default, so an untouched group leaves the
+    // agent's permission mode where it is.
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+
+    render(() => (
+      <ExitPlanModeActions
+        request={makeRequest()}
+        answerState={createControlAnswerState()}
+        onRespond={onRespond}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        presets={{ bypass: { sets: { permissionMode: 'bypassPermissions' } }, apply: vi.fn() }}
+      />
+    ))
+
+    fireEvent.click(screen.getByTestId('plan-approve-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).permissionMode).toBeUndefined()
   })
 
   // A preset that switches some axis OTHER than the permission mode cannot act

--- a/frontend/src/components/chat/controls/GenericToolControl.test.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.test.tsx
@@ -43,8 +43,9 @@ describe('genericToolActions', () => {
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Deny')
     expect(screen.getByTestId('control-allow-btn')).toBeInTheDocument()
     expect(screen.getByTestId('control-permissions-pill-group')).toBeInTheDocument()
-    expect(permissionPillGroup().getByRole('radio', { name: 'Default' })).toBeChecked()
-    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' })).not.toBeChecked()
+    // No preset is on, so the group opens on the pill that changes nothing.
+    expect(permissionPillGroup().getByRole('radio', { name: 'Unchanged' })).toBeChecked()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass' })).not.toBeChecked()
   })
 
   it('shows only Send feedback when editor has content', () => {
@@ -114,7 +115,7 @@ describe('genericToolActions', () => {
     })
   })
 
-  it('sends allow response and applies the bypass preset when Bypass permissions is selected', async () => {
+  it('sends allow response and applies the bypass preset when Bypass is selected', async () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     const apply = vi.fn()
     const request = makeRequest('req-42', 'agent-7')
@@ -134,7 +135,7 @@ describe('genericToolActions', () => {
       />
     ))
 
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
     // The handler AWAITS the allow before applying the preset, so the assertion
     // waits for that microtask -- ordering is the point of the fix.
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
@@ -151,7 +152,7 @@ describe('genericToolActions', () => {
     expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'bypassPermissions' } })
   })
 
-  it('applies the smart preset when Smart permissions is selected', async () => {
+  it('applies the smart preset when Smart is selected', async () => {
     const onRespond = vi.fn().mockResolvedValue(undefined)
     const apply = vi.fn()
 
@@ -170,10 +171,65 @@ describe('genericToolActions', () => {
       />
     ))
 
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Smart permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Smart' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'auto' } })
+  })
+
+  it('opens on the preset the session has on', async () => {
+    // The session runs on bypass, so the group opens there and an Allow keeps
+    // it there rather than dropping the session back to asking.
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const apply = vi.fn()
+
+    render(() => (
+      <GenericToolActions
+        request={makeRequest()}
+        answerState={createControlAnswerState()}
+        onRespond={onRespond}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        presets={{
+          smart: { sets: { permissionMode: 'auto' } },
+          bypass: { sets: { permissionMode: 'bypassPermissions' } },
+          apply,
+          active: 'bypass',
+        }}
+      />
+    ))
+
+    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass' })).toBeChecked()
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'bypassPermissions' } })
+  })
+
+  it('applies nothing when no preset is on', async () => {
+    // An ordinary request must never turn a preset ON by itself, so an
+    // untouched group leaves the agent's permission mode alone.
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const apply = vi.fn()
+
+    render(() => (
+      <GenericToolActions
+        request={makeRequest()}
+        answerState={createControlAnswerState()}
+        onRespond={onRespond}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+        presets={{
+          smart: { sets: { permissionMode: 'auto' } },
+          bypass: { sets: { permissionMode: 'bypassPermissions' } },
+          apply,
+        }}
+      />
+    ))
+
+    expect(permissionPillGroup().getByRole('radio', { name: 'Unchanged' })).toBeChecked()
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    expect(apply).not.toHaveBeenCalled()
   })
 
   it('does not apply a preset when deny is clicked with one selected', async () => {
@@ -191,7 +247,7 @@ describe('genericToolActions', () => {
       />
     ))
 
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
     await fireEvent.click(screen.getByTestId('control-deny-btn'))
 
     expect(apply).not.toHaveBeenCalled()

--- a/frontend/src/components/chat/controls/GenericToolControl.test.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.test.tsx
@@ -2,7 +2,6 @@ import type { ControlRequest } from '~/stores/control.store'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { GenericToolActions } from '~/components/chat/controls/GenericToolControl'
-import { hoverForTooltip } from '~/test-support/clipStub'
 import { permissionPillGroup } from '~/test-support/controlRequests'
 import { createControlAnswerState } from './types'
 
@@ -90,7 +89,7 @@ describe('genericToolActions', () => {
     expect(decoded.response.request_id).toBe('req-10')
     expect(decoded.response.response.behavior).toBe('allow')
     expect(decoded.response.response.updatedInput).toEqual({ command: 'ls' })
-    // Default applies nothing -- the answer is the whole decision.
+    // Unchanged applies nothing -- the answer is the whole decision.
     expect(apply).not.toHaveBeenCalled()
   })
 
@@ -268,9 +267,7 @@ describe('genericToolActions', () => {
     expect(screen.queryByRole('radiogroup', { name: 'Permissions' })).not.toBeInTheDocument()
   })
 
-  // The group carries the one explanation of its consequence: a selected preset
-  // applies when the request is allowed, so the hover text must stay attached.
-  it('explains through a tooltip that the selected preset applies on allow', () => {
+  it('describes that the selected preset applies on allow', () => {
     render(() => (
       <GenericToolActions
         request={makeRequest()}
@@ -282,7 +279,7 @@ describe('genericToolActions', () => {
       />
     ))
 
-    const tooltip = hoverForTooltip(screen.getByTestId('control-permissions-pill-group'))
-    expect(tooltip?.textContent).toContain('selected preset applies')
+    expect(screen.getByRole('radiogroup', { name: 'Permissions' }))
+      .toHaveAccessibleDescription('The selected preset applies when you allow or approve this request')
   })
 })

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -6,7 +6,7 @@ import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from
 import * as styles from '../ControlRequestBanner.css'
 import { CollapsibleText } from './CollapsibleText'
 import { ControlDecisionFooter } from './ControlDecisionFooter'
-import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from './permissionPresets'
+import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice, sessionPermissionChoice } from './permissionPresets'
 import { sendResponse } from './types'
 
 export const GenericToolContent: Component<{ request: ControlRequest }> = (props) => {
@@ -33,7 +33,7 @@ export const GenericToolContent: Component<{ request: ControlRequest }> = (props
 }
 
 export const GenericToolActions: Component<ActionsProps> = (props) => {
-  const permissionChoice = createPermissionPresetChoice(props)
+  const permissionChoice = createPermissionPresetChoice(props, () => sessionPermissionChoice(props.presets))
 
   const handleDeny = () => {
     return sendResponse(props.onRespond, buildDenyResponse(props.request.requestId))

--- a/frontend/src/components/chat/controls/GenericToolControl.tsx
+++ b/frontend/src/components/chat/controls/GenericToolControl.tsx
@@ -6,7 +6,7 @@ import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from
 import * as styles from '../ControlRequestBanner.css'
 import { CollapsibleText } from './CollapsibleText'
 import { ControlDecisionFooter } from './ControlDecisionFooter'
-import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice, sessionPermissionChoice } from './permissionPresets'
+import { buildSessionPermissionPill, createSessionPermissionPresetChoice, respondThenApplyPermissionPreset } from './permissionPresets'
 import { sendResponse } from './types'
 
 export const GenericToolContent: Component<{ request: ControlRequest }> = (props) => {
@@ -33,7 +33,7 @@ export const GenericToolContent: Component<{ request: ControlRequest }> = (props
 }
 
 export const GenericToolActions: Component<ActionsProps> = (props) => {
-  const permissionChoice = createPermissionPresetChoice(props, () => sessionPermissionChoice(props.presets))
+  const permissionChoice = createSessionPermissionPresetChoice(props)
 
   const handleDeny = () => {
     return sendResponse(props.onRespond, buildDenyResponse(props.request.requestId))
@@ -43,10 +43,11 @@ export const GenericToolActions: Component<ActionsProps> = (props) => {
   // concurrently, and applying a permission mode the provider cannot take live
   // relaunches the agent -- a relaunch that won the race killed the session
   // before the allow reached it, so the tool call was never answered.
-  const handleAllow = async () => {
-    await sendResponse(props.onRespond, buildAllowResponse(props.request.requestId, getToolInput(props.request.payload)))
-    await applyPermissionPreset(props.presets, permissionChoice.choice())
-  }
+  const handleAllow = () => respondThenApplyPermissionPreset(
+    sendResponse(props.onRespond, buildAllowResponse(props.request.requestId, getToolInput(props.request.payload))),
+    props.presets,
+    permissionChoice.choice(),
+  )
 
   return (
     <ControlDecisionFooter
@@ -54,7 +55,7 @@ export const GenericToolActions: Component<ActionsProps> = (props) => {
       onSendFeedback={props.onTriggerSend}
       negativeAction={{ label: 'Deny', testId: 'control-deny-btn', onSelect: handleDeny }}
       positiveAction={{ label: 'Allow', testId: 'control-allow-btn', onSelect: handleAllow }}
-      permissionPill={() => buildPermissionPill(props.presets, permissionChoice)}
+      permissionPill={() => buildSessionPermissionPill(props.presets, permissionChoice)}
     />
   )
 }

--- a/frontend/src/components/chat/controls/PermissionDecisionActions.tsx
+++ b/frontend/src/components/chat/controls/PermissionDecisionActions.tsx
@@ -17,7 +17,7 @@ import {
   permissionOptionLabel,
   resolvePermissionOption,
 } from './permissionOptions'
-import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice, sessionPermissionChoice } from './permissionPresets'
+import { buildSessionPermissionPill, createSessionPermissionPresetChoice, respondThenApplyPermissionPreset } from './permissionPresets'
 import { createControlChoice } from './types'
 
 /** Sends one selected option as the provider's permission reply (ACP- and OpenCode-family envelopes are the same). */
@@ -32,7 +32,7 @@ export type PermissionOptionsGetter = (payload: Record<string, unknown>) => Wire
 
 /**
  * The shared decision row for a wire-options permission request: scope pills
- * (Once / Always / Session / Project), the permission pill group (Default /
+ * (Once / Always / Session / Project), the permission pill group (Unchanged /
  * Smart / Bypass), Deny / Allow, and one extra button per option no slot or
  * group consumed. The ACP and OpenCode families differ only in their payload
  * extraction and sender, so each provider passes its `options` getter and `send`
@@ -43,7 +43,7 @@ export const PermissionDecisionActions: Component<ActionsProps & {
   send: SendPermissionOption
 }> = (props) => {
   const layout = createMemo(() => layoutPermissionOptions(props.options(props.request.payload)))
-  const permissionChoice = createPermissionPresetChoice(props, () => sessionPermissionChoice(props.presets))
+  const permissionChoice = createSessionPermissionPresetChoice(props)
   const scopeChoice = createControlChoice(() => props.answerState, ALLOW_SCOPE_CHOICE_ID)
 
   // The scope pills a payload with always options draws (Once / Always, or
@@ -62,7 +62,7 @@ export const PermissionDecisionActions: Component<ActionsProps & {
       ? scopeChoice.choice()
       : scope[0].optionId
   }
-  const permissionPill = createMemo(() => buildPermissionPill(props.presets, permissionChoice))
+  const permissionPill = createMemo(() => buildSessionPermissionPill(props.presets, permissionChoice))
 
   // The option's response is AWAITED before a permission preset is applied: the
   // worker dispatches the two concurrently, and a mode change the provider cannot
@@ -73,9 +73,15 @@ export const PermissionDecisionActions: Component<ActionsProps & {
   const handleOption = async (option: WirePermissionOption | undefined) => {
     if (!option)
       return
+    if (isAllowPermissionKind(option.kind)) {
+      await respondThenApplyPermissionPreset(
+        props.send(props.onRespond, props.request.requestId, option.optionId),
+        props.presets,
+        permissionChoice.choice(),
+      )
+      return
+    }
     await props.send(props.onRespond, props.request.requestId, option.optionId)
-    if (isAllowPermissionKind(option.kind))
-      await applyPermissionPreset(props.presets, permissionChoice.choice())
   }
 
   const handleDecision = (polarity: 'allow' | 'reject') =>
@@ -88,24 +94,26 @@ export const PermissionDecisionActions: Component<ActionsProps & {
 
   return (
     <ControlActionRow
+      leading={(
+        <Show when={pillCluster()}>
+          <div class={styles.controlRequestSwitches}>
+            <Show when={scopeOptions()}>
+              {options => (
+                <ControlAllowScopePillGroup
+                  options={options()}
+                  selected={selectedScope() ?? options()[0].key}
+                  onSelect={scopeChoice.setChoice}
+                />
+              )}
+            </Show>
+            <Show when={permissionPill()}>
+              {pill => <ControlPermissionPillGroup pill={pill()} />}
+            </Show>
+          </div>
+        </Show>
+      )}
       primary={(
         <>
-          <Show when={pillCluster()}>
-            <div class={styles.controlRequestSwitches}>
-              <Show when={scopeOptions()}>
-                {options => (
-                  <ControlAllowScopePillGroup
-                    options={options()}
-                    selected={selectedScope() ?? options()[0].key}
-                    onSelect={scopeChoice.setChoice}
-                  />
-                )}
-              </Show>
-              <Show when={permissionPill()}>
-                {pill => <ControlPermissionPillGroup pill={pill()} />}
-              </Show>
-            </div>
-          </Show>
           <ButtonGroup>
             <Show when={layout().negative}>
               <button

--- a/frontend/src/components/chat/controls/PermissionDecisionActions.tsx
+++ b/frontend/src/components/chat/controls/PermissionDecisionActions.tsx
@@ -5,7 +5,7 @@ import type { ActionsProps } from './types'
 import { createMemo, For, Show } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
 import * as styles from '../ControlRequestBanner.css'
-import { ControlActionRow } from './ControlActionRow'
+import { actionButtonClass, ControlActionRow } from './ControlActionRow'
 import { ControlAllowScopePillGroup, ControlPermissionPillGroup } from './ControlPillGroups'
 import {
   ALLOW_SCOPE_CHOICE_ID,
@@ -17,7 +17,7 @@ import {
   permissionOptionLabel,
   resolvePermissionOption,
 } from './permissionOptions'
-import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from './permissionPresets'
+import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice, sessionPermissionChoice } from './permissionPresets'
 import { createControlChoice } from './types'
 
 /** Sends one selected option as the provider's permission reply (ACP- and OpenCode-family envelopes are the same). */
@@ -43,7 +43,7 @@ export const PermissionDecisionActions: Component<ActionsProps & {
   send: SendPermissionOption
 }> = (props) => {
   const layout = createMemo(() => layoutPermissionOptions(props.options(props.request.payload)))
-  const permissionChoice = createPermissionPresetChoice(props)
+  const permissionChoice = createPermissionPresetChoice(props, () => sessionPermissionChoice(props.presets))
   const scopeChoice = createControlChoice(() => props.answerState, ALLOW_SCOPE_CHOICE_ID)
 
   // The scope pills a payload with always options draws (Once / Always, or
@@ -109,7 +109,7 @@ export const PermissionDecisionActions: Component<ActionsProps & {
           <ButtonGroup>
             <Show when={layout().negative}>
               <button
-                class="outline"
+                class={actionButtonClass(true)}
                 onClick={() => handleDecision('reject')}
                 data-testid="control-deny-btn"
               >
@@ -118,6 +118,7 @@ export const PermissionDecisionActions: Component<ActionsProps & {
             </Show>
             <Show when={layout().positive}>
               <button
+                class={actionButtonClass()}
                 onClick={() => handleDecision('allow')}
                 data-testid="control-allow-btn"
               >
@@ -127,7 +128,7 @@ export const PermissionDecisionActions: Component<ActionsProps & {
             <For each={layout().additional}>
               {option => (
                 <button
-                  class={isRejectPermissionKind(option.kind) ? 'outline' : undefined}
+                  class={actionButtonClass(isRejectPermissionKind(option.kind))}
                   onClick={() => handleOption(option)}
                   data-testid={`control-decision-${option.optionId}`}
                 >

--- a/frontend/src/components/chat/controls/permissionPresets.test.ts
+++ b/frontend/src/components/chat/controls/permissionPresets.test.ts
@@ -7,18 +7,16 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   applyPermissionPreset,
   buildPermissionPill,
+  buildSessionPermissionPill,
   createPermissionPresetChoice,
   permissionPillOptions,
-  planApprovalPresets,
-  presetPermissionMode,
+  respondThenApplyPermissionPreset,
   sessionPermissionChoice,
 } from './permissionPresets'
 import { createControlAnswerState } from './types'
 
 const SMART = { sets: { permissionMode: 'auto' } }
 const BYPASS = { sets: { permissionMode: 'bypassPermissions' } }
-const COPILOT_SMART = { sets: { copilot_assisted_approval: 'on' } }
-const COPILOT_BYPASS = { sets: { allow_all: 'on' } }
 
 function controller(partial: Partial<PermissionPresetController> = {}): PermissionPresetController {
   return { smart: SMART, bypass: BYPASS, apply: vi.fn(), ...partial }
@@ -41,7 +39,7 @@ describe('permissionPillOptions', () => {
   })
 
   it('omits a preset the controller does not carry', () => {
-    // ZCode and Codex ship no smart preset; their group is Default + Bypass.
+    // ZCode and Codex ship no smart preset; their group is Unchanged + Bypass.
     expect(permissionPillOptions(controller({ smart: undefined }))).toEqual([
       { key: 'unspecified', label: 'Unchanged', icon: Minus },
       { key: 'bypass', label: 'Bypass' },
@@ -51,6 +49,13 @@ describe('permissionPillOptions', () => {
   it('offers no group without presets', () => {
     expect(permissionPillOptions(undefined)).toBeUndefined()
     expect(permissionPillOptions(controller({ smart: undefined, bypass: undefined }))).toBeUndefined()
+  })
+})
+
+describe('buildSessionPermissionPill', () => {
+  it('requires a handler that can apply the selected preset', () => {
+    expect(buildSessionPermissionPill(controller(), openingChoice('smart'))).toBeDefined()
+    expect(buildSessionPermissionPill(controller({ apply: undefined }), openingChoice('smart'))).toBeUndefined()
   })
 })
 
@@ -118,9 +123,10 @@ describe('applyPermissionPreset', () => {
     expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'auto' } })
   })
 
-  it('applies nothing for Unchanged, a missing controller, or a withdrawn preset', async () => {
+  it('applies nothing for Unchanged, a missing handler, a missing controller, or a withdrawn preset', async () => {
     const apply = vi.fn()
     await applyPermissionPreset(controller({ apply }), 'unspecified')
+    await applyPermissionPreset(controller({ apply: undefined }), 'bypass')
     await applyPermissionPreset(undefined, 'bypass')
     // The catalog stopped offering smart while the stored choice still says it.
     await applyPermissionPreset(controller({ apply, smart: undefined }), 'smart')
@@ -128,38 +134,33 @@ describe('applyPermissionPreset', () => {
   })
 })
 
-describe('presetPermissionMode', () => {
-  it('reads the mode off the chosen preset and nothing off Unchanged', () => {
-    expect(presetPermissionMode(controller(), 'bypass')).toBe('bypassPermissions')
-    expect(presetPermissionMode(controller(), 'smart')).toBe('auto')
-    expect(presetPermissionMode(controller(), 'unspecified')).toBeUndefined()
+describe('respondThenApplyPermissionPreset', () => {
+  it('waits for the response before it applies the preset', async () => {
+    let finishResponse: () => void = () => {}
+    const respond = vi.fn(() => new Promise<void>((resolve) => {
+      finishResponse = resolve
+    }))
+    const apply = vi.fn()
+
+    const result = respondThenApplyPermissionPreset(respond(), controller({ apply }), 'bypass')
+    expect(respond).toHaveBeenCalledOnce()
+    expect(apply).not.toHaveBeenCalled()
+
+    finishResponse()
+    await result
+    expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'bypassPermissions' } })
   })
 
-  it('attaches nothing for a preset that switches some other axis', () => {
-    // Copilot's presets are not permission modes at all.
-    expect(presetPermissionMode(controller({ smart: COPILOT_SMART, bypass: COPILOT_BYPASS }), 'bypass')).toBeUndefined()
-  })
-})
+  it('does not apply the preset when the response fails', async () => {
+    const responseError = new Error('response failed')
+    const apply = vi.fn()
 
-describe('planApprovalPresets', () => {
-  it('keeps only the presets a plan approval response can act on', () => {
-    const filtered = planApprovalPresets(controller())!
-    expect(filtered.smart).toBe(SMART)
-    expect(filtered.bypass).toBe(BYPASS)
-    // No `apply` travels with the plan view: the mode rides inside the
-    // response, and the narrower type keeps a settings change out of it.
-    expect('apply' in filtered).toBe(false)
-  })
-
-  it('drops a preset with no permission mode, keeping the other', () => {
-    const filtered = planApprovalPresets(controller({ smart: COPILOT_SMART }))!
-    expect(filtered.smart).toBeUndefined()
-    expect(filtered.bypass).toBe(BYPASS)
-  })
-
-  it('offers nothing when no preset carries a mode', () => {
-    expect(planApprovalPresets(controller({ smart: COPILOT_SMART, bypass: COPILOT_BYPASS }))).toBeUndefined()
-    expect(planApprovalPresets(undefined)).toBeUndefined()
+    await expect(respondThenApplyPermissionPreset(
+      Promise.reject(responseError),
+      controller({ apply }),
+      'bypass',
+    )).rejects.toBe(responseError)
+    expect(apply).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/src/components/chat/controls/permissionPresets.test.ts
+++ b/frontend/src/components/chat/controls/permissionPresets.test.ts
@@ -1,5 +1,8 @@
 import type { PermissionPresetController } from '../providerSettings'
+import type { PermissionPresetChoice } from './permissionPresets'
 import type { ActionsProps } from './types'
+import { Minus } from 'lucide-solid'
+import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
 import {
   applyPermissionPreset,
@@ -8,6 +11,7 @@ import {
   permissionPillOptions,
   planApprovalPresets,
   presetPermissionMode,
+  sessionPermissionChoice,
 } from './permissionPresets'
 import { createControlAnswerState } from './types'
 
@@ -20,20 +24,27 @@ function controller(partial: Partial<PermissionPresetController> = {}): Permissi
   return { smart: SMART, bypass: BYPASS, apply: vi.fn(), ...partial }
 }
 
+/** A choice state with nothing stored, so it reports the opening choice alone. */
+function openingChoice(opening: PermissionPresetChoice) {
+  return createPermissionPresetChoice({ answerState: createControlAnswerState() }, () => opening)
+}
+
 describe('permissionPillOptions', () => {
-  it('offers Default first, then each preset the controller carries', () => {
+  it('offers Unchanged first, then each preset the controller carries', () => {
+    // `unspecified` applies no permission change at all, which is what the
+    // label says. It is not a "default mode" the agent switches to.
     expect(permissionPillOptions(controller())).toEqual([
-      { key: 'default', label: 'Default' },
-      { key: 'smart', label: 'Smart permissions' },
-      { key: 'bypass', label: 'Bypass permissions' },
+      { key: 'unspecified', label: 'Unchanged', icon: Minus },
+      { key: 'smart', label: 'Smart' },
+      { key: 'bypass', label: 'Bypass' },
     ])
   })
 
   it('omits a preset the controller does not carry', () => {
     // ZCode and Codex ship no smart preset; their group is Default + Bypass.
     expect(permissionPillOptions(controller({ smart: undefined }))).toEqual([
-      { key: 'default', label: 'Default' },
-      { key: 'bypass', label: 'Bypass permissions' },
+      { key: 'unspecified', label: 'Unchanged', icon: Minus },
+      { key: 'bypass', label: 'Bypass' },
     ])
   })
 
@@ -44,34 +55,56 @@ describe('permissionPillOptions', () => {
 })
 
 describe('buildPermissionPill', () => {
-  it('renders the stored choice and writes selections back', () => {
+  it('opens on the choice its surface supplies', () => {
+    expect(buildPermissionPill(controller(), openingChoice('smart'))!.selected).toBe('smart')
+    expect(buildPermissionPill(controller(), openingChoice('bypass'))!.selected).toBe('bypass')
+    expect(buildPermissionPill(controller(), openingChoice('unspecified'))!.selected).toBe('unspecified')
+  })
+
+  it('clamps an opening choice the group draws no pill for', () => {
+    // A plan approval opens on smart whether or not the provider ships one.
+    // Codex and ZCode draw Unchanged + Bypass, and Bypass must never arrive as
+    // an opening choice, so the group falls back to the pill that applies
+    // nothing.
+    const pill = buildPermissionPill(controller({ smart: undefined }), openingChoice('smart'))!
+
+    expect(pill.options.map(o => o.key)).toEqual(['unspecified', 'bypass'])
+    expect(pill.selected).toBe('unspecified')
+  })
+
+  it('follows a moving opening choice until the user picks a pill', () => {
+    // The session can switch mode under an open banner, and an untouched group
+    // must move with it. The first click pins the choice.
     const props: Pick<ActionsProps, 'answerState'> = { answerState: createControlAnswerState() }
-    const choice = createPermissionPresetChoice(props)
+    const [opening, setOpening] = createSignal<PermissionPresetChoice>('unspecified')
+    const choice = createPermissionPresetChoice(props, opening)
 
-    const pill = buildPermissionPill(controller(), choice)!
-    expect(pill.selected).toBe('default')
-
-    pill.onSelect('bypass')
+    expect(buildPermissionPill(controller(), choice)!.selected).toBe('unspecified')
+    setOpening('bypass')
     expect(buildPermissionPill(controller(), choice)!.selected).toBe('bypass')
-    expect(props.answerState.choices()).toEqual({ 'control-permissions-pill': 'bypass' })
+
+    buildPermissionPill(controller(), choice)!.onSelect('smart')
+    setOpening('unspecified')
+    expect(buildPermissionPill(controller(), choice)!.selected).toBe('smart')
+    expect(props.answerState.choices()).toEqual({ 'control-permissions-pill': 'smart' })
   })
 
   it('builds nothing without presets', () => {
-    const choice = createPermissionPresetChoice({ answerState: createControlAnswerState() })
-    expect(buildPermissionPill(undefined, choice)).toBeUndefined()
+    expect(buildPermissionPill(undefined, openingChoice('smart'))).toBeUndefined()
   })
 
-  it('clamps a stored choice the catalog no longer offers back to Default', () => {
+  it('clamps a stored choice the catalog no longer offers back to Unchanged', () => {
     // The catalog withdrew smart while the stored choice still says it: the
-    // group must report Default, not a selection with no radio to check it.
-    const choice = createPermissionPresetChoice({
-      answerState: createControlAnswerState({ choices: { 'control-permissions-pill': 'smart' } }),
-    })
+    // group must report Unchanged, not a selection with no radio to check it.
+    const choice = createPermissionPresetChoice(
+      { answerState: createControlAnswerState({ choices: { 'control-permissions-pill': 'smart' } }) },
+      () => 'unspecified',
+    )
 
     const pill = buildPermissionPill(controller({ smart: undefined }), choice)!
 
-    expect(pill.options.map(o => o.key)).toEqual(['default', 'bypass'])
-    expect(pill.selected).toBe('default')
+    expect(pill.options.map(o => o.key)).toEqual(['unspecified', 'bypass'])
+    expect(pill.selected).toBe('unspecified')
   })
 })
 
@@ -85,9 +118,9 @@ describe('applyPermissionPreset', () => {
     expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'auto' } })
   })
 
-  it('applies nothing for Default, a missing controller, or a withdrawn preset', async () => {
+  it('applies nothing for Unchanged, a missing controller, or a withdrawn preset', async () => {
     const apply = vi.fn()
-    await applyPermissionPreset(controller({ apply }), 'default')
+    await applyPermissionPreset(controller({ apply }), 'unspecified')
     await applyPermissionPreset(undefined, 'bypass')
     // The catalog stopped offering smart while the stored choice still says it.
     await applyPermissionPreset(controller({ apply, smart: undefined }), 'smart')
@@ -96,10 +129,10 @@ describe('applyPermissionPreset', () => {
 })
 
 describe('presetPermissionMode', () => {
-  it('reads the mode off the chosen preset and nothing off Default', () => {
+  it('reads the mode off the chosen preset and nothing off Unchanged', () => {
     expect(presetPermissionMode(controller(), 'bypass')).toBe('bypassPermissions')
     expect(presetPermissionMode(controller(), 'smart')).toBe('auto')
-    expect(presetPermissionMode(controller(), 'default')).toBeUndefined()
+    expect(presetPermissionMode(controller(), 'unspecified')).toBeUndefined()
   })
 
   it('attaches nothing for a preset that switches some other axis', () => {
@@ -127,5 +160,19 @@ describe('planApprovalPresets', () => {
   it('offers nothing when no preset carries a mode', () => {
     expect(planApprovalPresets(controller({ smart: COPILOT_SMART, bypass: COPILOT_BYPASS }))).toBeUndefined()
     expect(planApprovalPresets(undefined)).toBeUndefined()
+  })
+})
+
+describe('sessionPermissionChoice', () => {
+  it('reports the preset the session already has on', () => {
+    expect(sessionPermissionChoice(controller({ active: 'smart' }))).toBe('smart')
+    expect(sessionPermissionChoice(controller({ active: 'bypass' }))).toBe('bypass')
+  })
+
+  it('changes nothing when neither preset is on', () => {
+    // An ordinary request must never turn a preset ON by itself. It opens on
+    // the running one, or on the pill that applies nothing.
+    expect(sessionPermissionChoice(controller())).toBe('unspecified')
+    expect(sessionPermissionChoice(undefined)).toBe('unspecified')
   })
 })

--- a/frontend/src/components/chat/controls/permissionPresets.ts
+++ b/frontend/src/components/chat/controls/permissionPresets.ts
@@ -4,19 +4,48 @@ import type { ActionsProps } from './types'
 import type { PillOptions, PillOptionSpec } from '~/components/common/PillGroup'
 import type { PermissionMode } from '~/utils/controlResponse'
 
+import { Minus } from 'lucide-solid'
 import { OPTION_ID_PERMISSION_MODE } from '~/components/chat/settingsGroups'
 import { isPillOptions } from '~/components/common/PillGroup'
 import { PERMISSION_PRESET_LABELS } from '../providerSettings'
 import { createControlChoice } from './types'
 
-/** What the permission pill group does when the request's positive action is taken. */
+/**
+ * What the permission pill group does when the request's positive action is taken.
+ *
+ * `unspecified` applies NO permission change. It is not a "default mode" the
+ * agent switches to -- it leaves every axis where the session already has it.
+ */
 export type PermissionPresetChoice
-  = | 'default'
+  = | 'unspecified'
     | 'smart'
     | 'bypass'
 
 /** The answer-state key the permission pill group's choice is stored under. */
 const CONTROL_PERMISSION_CHOICE_ID = 'control-permissions-pill'
+
+/**
+ * The choice a PLAN APPROVAL opens on.
+ *
+ * Approving a plan is the moment the user hands the agent the work, so the
+ * banner offers Smart rather than asking for it again on the first tool call.
+ * A provider whose catalog offers no smart preset draws no smart pill, and
+ * `buildPermissionPill` clamps this to `unspecified` there.
+ */
+export const PLAN_APPROVAL_PERMISSION_CHOICE: PermissionPresetChoice = 'smart'
+
+/**
+ * The choice an ORDINARY permission request opens on: whichever preset the
+ * session already has on.
+ *
+ * A request that arrives while the session runs on bypass opens on Bypass, so
+ * an Allow keeps the session where the user put it. Neither preset on means
+ * `unspecified`, which changes nothing. This never TURNS ON a preset the user
+ * did not choose -- it reports the one already running.
+ */
+export function sessionPermissionChoice(presets: PermissionPresetController | undefined): PermissionPresetChoice {
+  return presets?.active ?? 'unspecified'
+}
 
 export interface PermissionPresetChoiceState {
   choice: Accessor<PermissionPresetChoice>
@@ -27,21 +56,29 @@ export interface PermissionPresetChoiceState {
  * Binds the permission pill group's selection to the composer's shared answer
  * record, so a rebuild of the control component cannot discard it.
  *
+ * `opening` supplies the choice for as long as the user picks no pill, and it is
+ * an ACCESSOR because the session can move under an open banner -- a mode switch
+ * from the composer must move the untouched group with it. A stored choice wins
+ * over it from the first click onward.
+ *
  * `createControlChoice` stores strings; every value this group writes is a
  * `PermissionPresetChoice` key (its pills carry no other keys), so the read-back
  * cast cannot surface a foreign string.
  */
-export function createPermissionPresetChoice(props: Pick<ActionsProps, 'answerState'>): PermissionPresetChoiceState {
-  const { choice, setChoice } = createControlChoice(() => props.answerState, CONTROL_PERMISSION_CHOICE_ID, 'default')
+export function createPermissionPresetChoice(
+  props: Pick<ActionsProps, 'answerState'>,
+  opening: () => PermissionPresetChoice,
+): PermissionPresetChoiceState {
+  const { choice, setChoice } = createControlChoice(() => props.answerState, CONTROL_PERMISSION_CHOICE_ID)
   return {
-    choice: () => choice() as PermissionPresetChoice,
+    choice: () => (choice() as PermissionPresetChoice | undefined) ?? opening(),
     setChoice,
   }
 }
 
 /**
- * The pill group's options: `Default` first (the do-nothing state the group opens
- * on), then each preset the live catalog offers. A preset the catalog does not
+ * The pill group's options: `Unchanged` first (the do-nothing state), then each
+ * preset the live catalog offers. A preset the catalog does not
  * offer has no pill, mirroring the composer menu's hide-when-unavailable rule; when
  * NEITHER is offered there is no group at all, so a provider without presets (Pi,
  * OpenCode, Cursor, ...) draws the row it drew before the group existed.
@@ -49,12 +86,16 @@ export function createPermissionPresetChoice(props: Pick<ActionsProps, 'answerSt
 export function permissionPillOptions(presets: ProviderPermissionPresets | undefined): PillOptions<PermissionPresetChoice> | undefined {
   if (!presets)
     return undefined
-  const options: PillOptionSpec<PermissionPresetChoice>[] = [{ key: 'default', label: 'Default' }]
+  // An icon, not the word. This group shares one composer footer row with the
+  // decision buttons, and the do-nothing option is the one that can give up its
+  // text: the other two name a preset the user is choosing. `Minus` reads as
+  // "no change"; the label stays as the accessible name and the tooltip.
+  const options: PillOptionSpec<PermissionPresetChoice>[] = [{ key: 'unspecified', label: 'Unchanged', icon: Minus }]
   for (const kind of ['smart', 'bypass'] as const) {
     if (presets[kind])
-      options.push({ key: kind, label: PERMISSION_PRESET_LABELS[kind] })
+      options.push({ key: kind, label: PERMISSION_PRESET_LABELS[kind].short })
   }
-  // A lone Default pill is no choice at all: presets the catalog stopped
+  // A lone Unchanged pill is no choice at all: presets the catalog stopped
   // offering draw no group, same as no presets at all.
   return options.length > 1 && isPillOptions(options) ? options : undefined
 }
@@ -73,11 +114,14 @@ export function buildPermissionPill(
   const options = permissionPillOptions(presets)
   if (!options)
     return undefined
-  // The stored choice is clamped to the offered pills: a preset the catalog
-  // stopped offering while its choice was stored must not leave a group with no
-  // radio checked and an Allow that silently applies nothing.
+  // The choice is clamped to the offered pills: a preset the catalog stopped
+  // offering while its choice was stored must not leave a group with no radio
+  // checked and an Allow that silently applies nothing. This also catches an
+  // OPENING choice the group draws no pill for -- a plan approval opens on
+  // `smart` whether or not the provider ships one. `unspecified` is the clamp
+  // target because it is the one pill every group draws, and it applies nothing.
   const stored = choiceState.choice()
-  const selected = options.some(option => option.key === stored) ? stored : 'default'
+  const selected = options.some(option => option.key === stored) ? stored : 'unspecified'
   return { options, selected, onSelect: choiceState.setChoice }
 }
 
@@ -89,14 +133,14 @@ export function buildPermissionPill(
  * The CALLER must await the answer before calling this. The worker dispatches the
  * response and the settings change concurrently, and applying a permission mode the
  * provider cannot take live relaunches the agent -- a relaunch that won the race
- * killed the session before the answer reached it. `Default`, a missing controller
+ * killed the session before the answer reached it. `Unchanged`, a missing controller
  * or a preset the catalog stopped offering applies nothing.
  */
 export function applyPermissionPreset(
   presets: PermissionPresetController | undefined,
   choice: PermissionPresetChoice,
 ): Promise<void> {
-  const preset = choice === 'default' ? undefined : presets?.[choice]
+  const preset = choice === 'unspecified' ? undefined : presets?.[choice]
   if (!presets || !preset)
     return Promise.resolve()
   return Promise.resolve(presets.apply({ sets: { ...preset.sets } }))
@@ -104,7 +148,7 @@ export function applyPermissionPreset(
 
 /**
  * The permission mode a PLAN APPROVAL attaches to its allow envelope: the chosen
- * preset's own mode axis, or nothing for `Default`.
+ * preset's own mode axis, or nothing for `Unchanged`.
  *
  * Plan approvals switch the mode INSIDE the control response rather than through a
  * separate settings change: the worker applies it atomically with the approval, and
@@ -117,7 +161,7 @@ export function presetPermissionMode(
   presets: ProviderPermissionPresets | undefined,
   choice: PermissionPresetChoice,
 ): PermissionMode | undefined {
-  return choice === 'default' ? undefined : presets?.[choice]?.sets[OPTION_ID_PERMISSION_MODE]
+  return choice === 'unspecified' ? undefined : presets?.[choice]?.sets[OPTION_ID_PERMISSION_MODE]
 }
 
 /**

--- a/frontend/src/components/chat/controls/permissionPresets.ts
+++ b/frontend/src/components/chat/controls/permissionPresets.ts
@@ -1,13 +1,11 @@
 import type { Accessor } from 'solid-js'
-import type { PermissionPresetController, ProviderPermissionPresets } from '../providerSettings'
+import type { PermissionPresetController, PermissionPresetKind, ProviderPermissionPresets } from '../providerSettings'
 import type { ActionsProps } from './types'
 import type { PillOptions, PillOptionSpec } from '~/components/common/PillGroup'
-import type { PermissionMode } from '~/utils/controlResponse'
 
 import { Minus } from 'lucide-solid'
-import { OPTION_ID_PERMISSION_MODE } from '~/components/chat/settingsGroups'
 import { isPillOptions } from '~/components/common/PillGroup'
-import { PERMISSION_PRESET_LABELS } from '../providerSettings'
+import { PERMISSION_PRESET_SPECS } from '../providerSettings'
 import { createControlChoice } from './types'
 
 /**
@@ -18,21 +16,10 @@ import { createControlChoice } from './types'
  */
 export type PermissionPresetChoice
   = | 'unspecified'
-    | 'smart'
-    | 'bypass'
+    | PermissionPresetKind
 
 /** The answer-state key the permission pill group's choice is stored under. */
 const CONTROL_PERMISSION_CHOICE_ID = 'control-permissions-pill'
-
-/**
- * The choice a PLAN APPROVAL opens on.
- *
- * Approving a plan is the moment the user hands the agent the work, so the
- * banner offers Smart rather than asking for it again on the first tool call.
- * A provider whose catalog offers no smart preset draws no smart pill, and
- * `buildPermissionPill` clamps this to `unspecified` there.
- */
-export const PLAN_APPROVAL_PERMISSION_CHOICE: PermissionPresetChoice = 'smart'
 
 /**
  * The choice an ORDINARY permission request opens on: whichever preset the
@@ -76,6 +63,13 @@ export function createPermissionPresetChoice(
   }
 }
 
+/** Creates the permission choice for an ordinary request. */
+export function createSessionPermissionPresetChoice(
+  props: Pick<ActionsProps, 'answerState' | 'presets'>,
+): PermissionPresetChoiceState {
+  return createPermissionPresetChoice(props, () => sessionPermissionChoice(props.presets))
+}
+
 /**
  * The pill group's options: `Unchanged` first (the do-nothing state), then each
  * preset the live catalog offers. A preset the catalog does not
@@ -88,12 +82,12 @@ export function permissionPillOptions(presets: ProviderPermissionPresets | undef
     return undefined
   // An icon, not the word. This group shares one composer footer row with the
   // decision buttons, and the do-nothing option is the one that can give up its
-  // text: the other two name a preset the user is choosing. `Minus` reads as
+  // text: the other options identify a preset. `Minus` reads as
   // "no change"; the label stays as the accessible name and the tooltip.
   const options: PillOptionSpec<PermissionPresetChoice>[] = [{ key: 'unspecified', label: 'Unchanged', icon: Minus }]
-  for (const kind of ['smart', 'bypass'] as const) {
-    if (presets[kind])
-      options.push({ key: kind, label: PERMISSION_PRESET_LABELS[kind].short })
+  for (const spec of PERMISSION_PRESET_SPECS) {
+    if (presets[spec.kind])
+      options.push({ key: spec.kind, label: spec.shortLabel })
   }
   // A lone Unchanged pill is no choice at all: presets the catalog stopped
   // offering draw no group, same as no presets at all.
@@ -125,6 +119,14 @@ export function buildPermissionPill(
   return { options, selected, onSelect: choiceState.setChoice }
 }
 
+/** Builds the pill for an ordinary request that can apply a settings change. */
+export function buildSessionPermissionPill(
+  presets: PermissionPresetController | undefined,
+  choiceState: PermissionPresetChoiceState,
+): ControlPermissionPill | undefined {
+  return presets?.apply ? buildPermissionPill(presets, choiceState) : undefined
+}
+
 /**
  * Applies the chosen preset after a control request's positive answer — the same
  * `onSettingChange({ sets })` call the composer `[+]` menu's permission items make,
@@ -133,52 +135,30 @@ export function buildPermissionPill(
  * The CALLER must await the answer before calling this. The worker dispatches the
  * response and the settings change concurrently, and applying a permission mode the
  * provider cannot take live relaunches the agent -- a relaunch that won the race
- * killed the session before the answer reached it. `Unchanged`, a missing controller
- * or a preset the catalog stopped offering applies nothing.
+ * killed the session before the answer reached it. `Unchanged`, a missing
+ * apply handler, or a preset the catalog stopped offering applies nothing.
  */
 export function applyPermissionPreset(
   presets: PermissionPresetController | undefined,
   choice: PermissionPresetChoice,
 ): Promise<void> {
   const preset = choice === 'unspecified' ? undefined : presets?.[choice]
-  if (!presets || !preset)
+  if (!presets?.apply || !preset)
     return Promise.resolve()
   return Promise.resolve(presets.apply({ sets: { ...preset.sets } }))
 }
 
 /**
- * The permission mode a PLAN APPROVAL attaches to its allow envelope: the chosen
- * preset's own mode axis, or nothing for `Unchanged`.
+ * Sends the permission response before it applies the chosen preset.
  *
- * Plan approvals switch the mode INSIDE the control response rather than through a
- * separate settings change: the worker applies it atomically with the approval, and
- * a context-clearing approval restarts the agent targeted at exactly this mode -- a
- * follow-up settings RPC would race that restart. A preset that switches no
- * permission mode (Copilot's approval axes) attaches nothing here, and no provider
- * that offers a plan-approval banner has such a preset today.
+ * Some providers relaunch for a permission change. The response must reach the
+ * old session before that relaunch starts.
  */
-export function presetPermissionMode(
-  presets: ProviderPermissionPresets | undefined,
+export async function respondThenApplyPermissionPreset(
+  response: Promise<void>,
+  presets: PermissionPresetController | undefined,
   choice: PermissionPresetChoice,
-): PermissionMode | undefined {
-  return choice === 'unspecified' ? undefined : presets?.[choice]?.sets[OPTION_ID_PERMISSION_MODE]
-}
-
-/**
- * The presets a PLAN APPROVAL banner may offer: only those that switch the
- * permission mode, the one axis its single response can carry. The result carries
- * no `apply` handler — a plan approval switches the mode inside its response and
- * never fires a settings change, and the narrower type keeps that true at compile
- * time. A preset that switches some other axis (Copilot's `allow_all`) cannot act
- * there at all, so its pill is not drawn -- drawn and silently doing nothing is the
- * trap the plan banner's old bypass switch was narrowed to avoid. No provider with
- * a plan-approval banner ships such a preset today; this keeps the rule true if one
- * ever does.
- */
-export function planApprovalPresets(presets: PermissionPresetController | undefined): ProviderPermissionPresets | undefined {
-  if (!presets)
-    return undefined
-  const smart = presets.smart?.sets[OPTION_ID_PERMISSION_MODE] !== undefined ? presets.smart : undefined
-  const bypass = presets.bypass?.sets[OPTION_ID_PERMISSION_MODE] !== undefined ? presets.bypass : undefined
-  return smart || bypass ? { smart, bypass } : undefined
+): Promise<void> {
+  await response
+  await applyPermissionPreset(presets, choice)
 }

--- a/frontend/src/components/chat/controls/planApproval.test.ts
+++ b/frontend/src/components/chat/controls/planApproval.test.ts
@@ -1,0 +1,50 @@
+import type { PermissionPresetController } from '../providerSettings'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  PLAN_APPROVAL_PERMISSION_CHOICE,
+  planApprovalPresets,
+  presetPermissionMode,
+} from './planApproval'
+
+const SMART = { sets: { permissionMode: 'auto' } }
+const BYPASS = { sets: { permissionMode: 'bypassPermissions' } }
+const COPILOT_SMART = { sets: { copilot_assisted_approval: 'on' } }
+const COPILOT_BYPASS = { sets: { allow_all: 'on' } }
+
+function controller(partial: Partial<PermissionPresetController> = {}): PermissionPresetController {
+  return { smart: SMART, bypass: BYPASS, apply: vi.fn(), ...partial }
+}
+
+describe('plan approval permission presets', () => {
+  it('opens on Smart', () => {
+    expect(PLAN_APPROVAL_PERMISSION_CHOICE).toBe('smart')
+  })
+
+  it('reads the mode from the chosen preset and nothing from Unchanged', () => {
+    expect(presetPermissionMode(controller(), 'bypass')).toBe('bypassPermissions')
+    expect(presetPermissionMode(controller(), 'smart')).toBe('auto')
+    expect(presetPermissionMode(controller(), 'unspecified')).toBeUndefined()
+  })
+
+  it('attaches nothing for a preset that switches another axis', () => {
+    expect(presetPermissionMode(controller({ smart: COPILOT_SMART, bypass: COPILOT_BYPASS }), 'bypass')).toBeUndefined()
+  })
+
+  it('keeps only the presets that carry a permission mode', () => {
+    const filtered = planApprovalPresets(controller())!
+    expect(filtered.smart).toBe(SMART)
+    expect(filtered.bypass).toBe(BYPASS)
+    expect('apply' in filtered).toBe(false)
+  })
+
+  it('drops a preset with no permission mode and keeps the other', () => {
+    const filtered = planApprovalPresets(controller({ smart: COPILOT_SMART }))!
+    expect(filtered.smart).toBeUndefined()
+    expect(filtered.bypass).toBe(BYPASS)
+  })
+
+  it('offers nothing when no preset carries a permission mode', () => {
+    expect(planApprovalPresets(controller({ smart: COPILOT_SMART, bypass: COPILOT_BYPASS }))).toBeUndefined()
+    expect(planApprovalPresets(undefined)).toBeUndefined()
+  })
+})

--- a/frontend/src/components/chat/controls/planApproval.ts
+++ b/frontend/src/components/chat/controls/planApproval.ts
@@ -6,7 +6,7 @@ import type { PermissionMode } from '~/utils/controlResponse'
 
 import { createMemo } from 'solid-js'
 import { computePercentage } from '~/components/chat/widgets/ContextUsageGrid'
-import { buildPermissionPill, createPermissionPresetChoice, planApprovalPresets, presetPermissionMode } from './permissionPresets'
+import { buildPermissionPill, createPermissionPresetChoice, PLAN_APPROVAL_PERMISSION_CHOICE, planApprovalPresets, presetPermissionMode } from './permissionPresets'
 import { createControlSwitch } from './types'
 
 export interface PlanApprovalState {
@@ -25,7 +25,7 @@ export function createPlanApprovalState(props: Pick<ActionsProps, 'contextUsage'
   // choice is stored the same way under its own group id. See
   // `createControlSwitch` / `createPermissionPresetChoice`.
   const clear = createControlSwitch(() => props.answerState, 'plan-clear-context-checkbox')
-  const permissionChoice = createPermissionPresetChoice(props)
+  const permissionChoice = createPermissionPresetChoice(props, () => PLAN_APPROVAL_PERMISSION_CHOICE)
   const { checked: clearContext, set: setClearContext } = clear
   const contextPct = createMemo(() => {
     const pct = computePercentage(props.contextUsage, props.modelContextWindow, props.agentProvider)

--- a/frontend/src/components/chat/controls/planApproval.ts
+++ b/frontend/src/components/chat/controls/planApproval.ts
@@ -1,13 +1,47 @@
 import type { Accessor } from 'solid-js'
+import type { PermissionPresetController, ProviderPermissionPresets } from '../providerSettings'
 import type { ControlRequestSwitch } from './ControlDecisionFooter'
-import type { ControlPermissionPill } from './permissionPresets'
+import type { ControlPermissionPill, PermissionPresetChoice } from './permissionPresets'
 import type { ActionsProps } from './types'
 import type { PermissionMode } from '~/utils/controlResponse'
 
 import { createMemo } from 'solid-js'
+import { OPTION_ID_PERMISSION_MODE } from '~/components/chat/settingsGroups'
 import { computePercentage } from '~/components/chat/widgets/ContextUsageGrid'
-import { buildPermissionPill, createPermissionPresetChoice, PLAN_APPROVAL_PERMISSION_CHOICE, planApprovalPresets, presetPermissionMode } from './permissionPresets'
+import { PERMISSION_PRESET_SPECS } from '../providerSettings'
+import { buildPermissionPill, createPermissionPresetChoice } from './permissionPresets'
 import { createControlSwitch } from './types'
+
+/** The permission choice a plan approval opens on. */
+export const PLAN_APPROVAL_PERMISSION_CHOICE: PermissionPresetChoice = 'smart'
+
+/** Returns the mode that the selected plan preset carries. */
+export function presetPermissionMode(
+  presets: ProviderPermissionPresets | undefined,
+  choice: PermissionPresetChoice,
+): PermissionMode | undefined {
+  return choice === 'unspecified' ? undefined : presets?.[choice]?.sets[OPTION_ID_PERMISSION_MODE]
+}
+
+/**
+ * Returns the presets that a plan-approval response can apply.
+ *
+ * A plan approval carries the permission mode in its response. The worker then
+ * expands a provider mode, such as Codex Bypass, into its complete settings.
+ */
+export function planApprovalPresets(
+  presets: PermissionPresetController | undefined,
+): ProviderPermissionPresets | undefined {
+  if (!presets)
+    return undefined
+  const available: ProviderPermissionPresets = {}
+  for (const { kind } of PERMISSION_PRESET_SPECS) {
+    const preset = presets[kind]
+    if (preset?.sets[OPTION_ID_PERMISSION_MODE] !== undefined)
+      available[kind] = preset
+  }
+  return Object.keys(available).length > 0 ? available : undefined
+}
 
 export interface PlanApprovalState {
   clearContext: Accessor<boolean>

--- a/frontend/src/components/chat/controls/types.test.ts
+++ b/frontend/src/components/chat/controls/types.test.ts
@@ -24,13 +24,14 @@ describe('toRpcId', () => {
 })
 
 describe('createControlAnswerState', () => {
-  it('starts every field empty with no seed', () => {
+  it('starts each saved field empty and marks the state ready', () => {
     const state = createControlAnswerState()
     expect(state.selections()).toEqual({})
     expect(state.customTexts()).toEqual({})
     expect(state.currentPage()).toBe(0)
     expect(state.switches()).toEqual({})
     expect(state.choices()).toEqual({})
+    expect(state.ready()).toBe(true)
   })
 
   // A partial seed is the shape that comes back from storage: an older record

--- a/frontend/src/components/chat/controls/types.ts
+++ b/frontend/src/components/chat/controls/types.ts
@@ -46,6 +46,9 @@ export interface ControlAnswerState {
   setSwitches: Setter<Record<string, boolean>>
   choices: Accessor<Record<string, string>>
   setChoices: Setter<Record<string, string>>
+  /** Whether the active request's persisted answer is ready to use. */
+  ready: Accessor<boolean>
+  setReady: Setter<boolean>
 }
 
 /** The saved shape of a {@link ControlAnswerState}, as it is stored and restored. */
@@ -69,6 +72,7 @@ export function createControlAnswerState(seed: ControlAnswerSeed = {}): ControlA
   const [currentPage, setCurrentPage] = createSignal(seed.currentPage ?? 0)
   const [switches, setSwitches] = createSignal(seed.switches ?? {})
   const [choices, setChoices] = createSignal(seed.choices ?? {})
+  const [ready, setReady] = createSignal(true)
   return {
     selections,
     setSelections,
@@ -80,6 +84,8 @@ export function createControlAnswerState(seed: ControlAnswerSeed = {}): ControlA
     setSwitches,
     choices,
     setChoices,
+    ready,
+    setReady,
   }
 }
 
@@ -110,11 +116,9 @@ export function createControlSwitch(state: () => ControlAnswerState, id: string)
 
 /**
  * The one-of-N sibling of {@link createControlSwitch}: binds ONE pill group of a
- * control to the shared answer record, by the group's own id. The optional
- * fallback is the caller's to pass, and only for a group whose "no choice" state
- * is a meaningful key (the permission pill's `'default'`): a group with no
- * meaningful unset key (the allow-scope pill) reads `undefined` until a
- * selection lands, instead of a sentinel string every reader must know about.
+ * control to the shared answer record, by the group's own id. A caller can
+ * supply a fallback when its domain has a meaningful unset key. Without one,
+ * the choice stays `undefined` until a selection lands.
  */
 export function createControlChoice(state: () => ControlAnswerState, id: string, fallback?: string) {
   const answer = state()

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle, style } from '@vanilla-extract/css'
+import { compactControlHeight } from '~/components/common/CompactControl.css'
 import { codeBlockCode, codeBlockPre } from '~/styles/codeBlock'
 import { popoverBase } from '~/styles/popover.css'
 import { paginationContainer } from '../ControlRequestBanner.css'
@@ -13,19 +14,11 @@ export const container = style({
   borderRadius: 'var(--radius-medium)',
   backgroundColor: 'var(--background)',
   overflow: 'hidden',
-  // The composer button height: the natural height of an Oat `.small` button,
-  // which is what every action button in the footer slot is. One line of text
-  // (font-size × line-height), its top/bottom padding (space-1 × 2), and its
-  // top/bottom border (1px × 2, which Oat gives every button and which the
-  // `[+]` button below has no equivalent of -- it is sized to this value
-  // instead). Referenced by the `[+]` button, the editor wrapper min-height,
-  // the separator position, and the ProseMirror paddings.
-  //
-  // The action buttons do NOT read it. They reach this height by carrying
-  // `.small`, so the class is the one source for how they are sized and this
-  // value follows it. Change `.small` and this calc together.
+  // The composer button height comes from the same compact-control source as
+  // each action button and small pill. The `[+]` button, the editor wrapper,
+  // the separator, and the ProseMirror padding use this value.
   vars: {
-    '--editor-btn-h': 'calc(var(--text-8) * var(--leading-normal) + var(--space-1) * 2 + 2px)',
+    '--editor-btn-h': compactControlHeight,
     // Collapsed-mode left padding of the text area: the `[+]` button's left
     // offset + its width + a gap. Declared here so the stylesheet below and
     // the expand/collapse measurement in MarkdownEditor.tsx read one value
@@ -69,8 +62,7 @@ export const editorRow = style({
   'flex': 1,
   // Center the editor wrapper vertically so the text/placeholder sits between
   // the top edge and the bottom-anchored buttons, with equal gaps above and below.
-  // Min-height fits the button height (text-7 * leading-normal + space-1 * 2)
-  // plus a space-1 gap above and below.
+  // Min-height fits the compact button height plus a space-1 gap above and below.
   'alignItems': 'center',
   'minHeight': 'calc(var(--editor-btn-h) + var(--space-1) * 2)',
   // The expanded state reserves the button row here (see below). Animating it
@@ -150,13 +142,9 @@ globalStyle(`${footerSlot} > *`, {
 // The chrome the footer slot's ACTION buttons share (Pause, Interrupt, Send and
 // the control-request actions).
 //
-// SIZE is not here. Each of those buttons carries Oat's `.small` class, which
-// states its padding and font size, and `--editor-btn-h` above is derived from
-// that class so the `[+]` button matches. A size stated here would win over the
-// class and could never lose: this rule is unlayered while Oat's `.small` sits
-// in `@layer base`, so no specificity the class could reach would beat it. That
-// is what made the class inert, and what made the pill radios below disagree
-// with their own overlay.
+// SIZE is not here. Each action reads the shared compact-control style, and
+// `--editor-btn-h` comes from the same source. A size here would reach the real
+// pill radios but not their overlay copies, which would split their geometry.
 //
 // Two things in the slot are NOT action buttons, and each is excluded.
 //
@@ -254,7 +242,7 @@ export const linkPopoverInput = style({
   'color': 'var(--foreground)',
   // The field absorbs the row's slack and yields first when the box is narrow,
   // so the two buttons stay reachable at any width. `all: unset` resets
-  // `min-width` to `auto`, which would otherwise floor an input at its default
+  // `min-width` to `auto`, which would otherwise give an input its default
   // size and reintroduce the overflow.
   'flex': '1 1 14rem',
   'minWidth': 0,
@@ -269,7 +257,7 @@ export const linkPopoverInput = style({
 export const codeLangPopoverContent = style([popoverBase, {
   // popoverBase supplies the UA-reset (position:fixed; margin:0 -- so calcPopoverPosition's
   // top/left place the popover at the trigger instead of margin:auto re-centering it) and
-  // the `:popover-open`-gated `display: flex`. This adds the picker's own box.
+  // the `display: flex` that `:popover-open` controls. This adds the picker's box.
   flexDirection: 'column',
   backgroundColor: 'var(--background)',
   border: '1px solid var(--border)',

--- a/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
+++ b/frontend/src/components/chat/markdownEditor/MarkdownEditor.css.ts
@@ -13,12 +13,19 @@ export const container = style({
   borderRadius: 'var(--radius-medium)',
   backgroundColor: 'var(--background)',
   overflow: 'hidden',
-  // The composer button height: one line of text (font-size × line-height)
-  // plus its top/bottom padding (space-1 × 2). Referenced by the `[+]` button,
-  // the action buttons, the editor wrapper min-height, the separator position,
-  // and the ProseMirror paddings — all derived from this single value.
+  // The composer button height: the natural height of an Oat `.small` button,
+  // which is what every action button in the footer slot is. One line of text
+  // (font-size × line-height), its top/bottom padding (space-1 × 2), and its
+  // top/bottom border (1px × 2, which Oat gives every button and which the
+  // `[+]` button below has no equivalent of -- it is sized to this value
+  // instead). Referenced by the `[+]` button, the editor wrapper min-height,
+  // the separator position, and the ProseMirror paddings.
+  //
+  // The action buttons do NOT read it. They reach this height by carrying
+  // `.small`, so the class is the one source for how they are sized and this
+  // value follows it. Change `.small` and this calc together.
   vars: {
-    '--editor-btn-h': 'calc(var(--text-7) * var(--leading-normal) + var(--space-1) * 2)',
+    '--editor-btn-h': 'calc(var(--text-8) * var(--leading-normal) + var(--space-1) * 2 + 2px)',
     // Collapsed-mode left padding of the text area: the `[+]` button's left
     // offset + its width + a gap. Declared here so the stylesheet below and
     // the expand/collapse measurement in MarkdownEditor.tsx read one value
@@ -140,22 +147,38 @@ globalStyle(`${footerSlot} > *`, {
   pointerEvents: 'auto',
 })
 
-// Constrain the ACTION buttons in the footer slot (Interrupt/Send and the
-// control-request actions) to the single-line text area height so they match
-// the `[+]` button.
+// The chrome the footer slot's ACTION buttons share (Pause, Interrupt, Send and
+// the control-request actions).
 //
-// The pagination zone is excluded. Its items are square 22px page numbers, not
-// action buttons, and this rule outranks them: `.footerSlot button` is (0,1,1)
-// against `paginationItem`'s (0,1,0), so it would stretch each square to the
-// button height and give it 16px of horizontal padding inside a 22px box,
-// leaving no room for the digit. The exclusion specifies the CENTER zone rather
-// than the item, so a future non-action control placed there keeps its own
-// size too.
-globalStyle(`${footerSlot} button:not(.${paginationContainer} button)`, {
-  height: 'var(--editor-btn-h)',
-  padding: '0 var(--space-2)',
-  fontSize: 'var(--text-8)',
-  lineHeight: 1,
+// SIZE is not here. Each of those buttons carries Oat's `.small` class, which
+// states its padding and font size, and `--editor-btn-h` above is derived from
+// that class so the `[+]` button matches. A size stated here would win over the
+// class and could never lose: this rule is unlayered while Oat's `.small` sits
+// in `@layer base`, so no specificity the class could reach would beat it. That
+// is what made the class inert, and what made the pill radios below disagree
+// with their own overlay.
+//
+// Two things in the slot are NOT action buttons, and each is excluded.
+//
+// The pagination zone. Its items are square 22px page numbers that state their
+// own chrome, and this rule outranks them: `.footerSlot button` is (0,1,1)
+// against `paginationItem`'s (0,1,0). The exclusion specifies the CENTER zone
+// rather than the item, so a future non-action control placed there keeps its
+// own chrome too.
+//
+// A RADIO. It is one segment of a composite control -- `PillGroup`, which the
+// permission and allow-scope groups draw -- and that control owns its own
+// metrics. The exclusion is by role rather than by zone because a pill group
+// sits in the same zone as the actions it qualifies, so no zone separates them.
+//
+// A pill group is also the case where overriding a segment does more than
+// resize it. `PillGroup` paints the selected label TWICE: the real radio, and a
+// `<span>` copy in the sliding overlay that must cover that radio exactly. This
+// rule reaches the radios and not the copies, so the padding and font size it
+// forced laid the two rows out to different widths -- the copies' dividers fell
+// off the option boundaries, and the moving fill appeared to spill into the
+// next option.
+globalStyle(`${footerSlot} button:not(.${paginationContainer} button):not([role="radio"])`, {
   gap: 'var(--space-1)',
   borderRadius: 'var(--radius-small)',
 })

--- a/frontend/src/components/chat/providerSettings.test.ts
+++ b/frontend/src/components/chat/providerSettings.test.ts
@@ -3,9 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { activePermissionPreset, permissionPresetActive } from './providerSettings'
 
 /**
- * A mutable option group fixture. `permissionPresetActive` compares against
- * `resolvedCurrent`, which reads the optimistic value first and the catalog's
- * `currentValue` second.
+ * A mutable option group fixture. `permissionPresetActive` reads the optimistic
+ * value first and the catalog's confirmed `currentValue` second.
  */
 function group(id: string, optionIds: string[], currentValue: string): AvailableOptionGroup {
   return {
@@ -61,6 +60,15 @@ describe('permissionPresetActive', () => {
     expect(permissionPresetActive(undefined, groups, {})).toBe(false)
     expect(permissionPresetActive({ sets: {} }, groups, {})).toBe(false)
   })
+
+  it.each([
+    ['missing', ''],
+    ['off-list', 'unknown'],
+  ])('does not treat a %s current value as the default preset', (_, currentValue) => {
+    const unresolvedCurrent = [group('permissionMode', ['smart', 'bypass'], currentValue)]
+
+    expect(permissionPresetActive({ sets: { permissionMode: 'smart' } }, unresolvedCurrent, {})).toBe(false)
+  })
 })
 
 describe('activePermissionPreset', () => {
@@ -69,18 +77,20 @@ describe('activePermissionPreset', () => {
     bypass: { sets: { permissionMode: 'bypassPermissions' } },
   }
 
-  it('names the preset the session has on', () => {
+  it('reports the preset the session has on', () => {
     expect(activePermissionPreset(presets, [group('permissionMode', MODES, 'auto')], {})).toBe('smart')
     expect(activePermissionPreset(presets, [group('permissionMode', MODES, 'bypassPermissions')], {})).toBe('bypass')
   })
 
-  it('names nothing when neither preset is on', () => {
+  it('reports nothing when neither preset is on', () => {
     expect(activePermissionPreset(presets, [group('permissionMode', MODES, 'default')], {})).toBeUndefined()
     expect(activePermissionPreset({}, [group('permissionMode', MODES, 'auto')], {})).toBeUndefined()
   })
 
-  it('prefers smart when both report active', () => {
-    // Copilot's two presets switch DIFFERENT axes, so both can be on at once.
+  it('prefers bypass when both presets report active', () => {
+    // Copilot can keep both axes on, but Allow All supplies the effective
+    // permission behavior. An untouched request must preserve that stronger
+    // state rather than reapply Assisted Approval and clear Allow All.
     const copilot = {
       smart: { sets: { copilot_assisted_approval: 'on' } },
       bypass: { sets: { allow_all: 'on' } },
@@ -90,10 +100,10 @@ describe('activePermissionPreset', () => {
       group('allow_all', ['off', 'on'], 'on'),
     ]
 
-    expect(activePermissionPreset(copilot, groups, {})).toBe('smart')
+    expect(activePermissionPreset(copilot, groups, {})).toBe('bypass')
   })
 
-  it('names nothing without a catalog', () => {
+  it('reports nothing without a catalog', () => {
     expect(activePermissionPreset(presets, undefined, undefined)).toBeUndefined()
   })
 })

--- a/frontend/src/components/chat/providerSettings.test.ts
+++ b/frontend/src/components/chat/providerSettings.test.ts
@@ -1,0 +1,99 @@
+import type { AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
+import { describe, expect, it } from 'vitest'
+import { activePermissionPreset, permissionPresetActive } from './providerSettings'
+
+/**
+ * A mutable option group fixture. `permissionPresetActive` compares against
+ * `resolvedCurrent`, which reads the optimistic value first and the catalog's
+ * `currentValue` second.
+ */
+function group(id: string, optionIds: string[], currentValue: string): AvailableOptionGroup {
+  return {
+    id,
+    label: id,
+    options: optionIds.map(optionId => ({ id: optionId })),
+    defaultValue: optionIds[0],
+    currentValue,
+    mutable: true,
+  } as unknown as AvailableOptionGroup
+}
+
+const MODES = ['default', 'auto', 'bypassPermissions']
+
+describe('permissionPresetActive', () => {
+  const groups = [group('permissionMode', MODES, 'auto')]
+
+  it('reports a preset whose every axis already holds its value', () => {
+    expect(permissionPresetActive({ sets: { permissionMode: 'auto' } }, groups, {})).toBe(true)
+  })
+
+  it('reports nothing for a preset that would change an axis', () => {
+    expect(permissionPresetActive({ sets: { permissionMode: 'bypassPermissions' } }, groups, {})).toBe(false)
+  })
+
+  it('prefers the optimistic value over the catalog value', () => {
+    // A switch the user just made, before the agent confirms it. The pill must
+    // open on where the session is going, not where it was.
+    const values = { permissionMode: 'bypassPermissions' }
+    expect(permissionPresetActive({ sets: { permissionMode: 'bypassPermissions' } }, groups, values)).toBe(true)
+    expect(permissionPresetActive({ sets: { permissionMode: 'auto' } }, groups, values)).toBe(false)
+  })
+
+  it('requires EVERY axis of a multi-axis preset', () => {
+    // Codex switches approval, network and sandbox together. Two of three
+    // matching is not the preset.
+    const codex = [
+      group('permissionMode', ['on-request', 'never'], 'never'),
+      group('network_access', ['disabled', 'enabled'], 'enabled'),
+      group('sandbox_policy', ['read-only', 'danger-full-access'], 'read-only'),
+    ]
+    const preset = {
+      sets: { permissionMode: 'never', network_access: 'enabled', sandbox_policy: 'danger-full-access' },
+    }
+
+    expect(permissionPresetActive(preset, codex, {})).toBe(false)
+    expect(permissionPresetActive(preset, codex, { sandbox_policy: 'danger-full-access' })).toBe(true)
+  })
+
+  it('reports nothing for an absent preset or one that sets nothing', () => {
+    // An empty change writes no axis, so "already applied" would be vacuously
+    // true and would open the group on a preset that does nothing.
+    expect(permissionPresetActive(undefined, groups, {})).toBe(false)
+    expect(permissionPresetActive({ sets: {} }, groups, {})).toBe(false)
+  })
+})
+
+describe('activePermissionPreset', () => {
+  const presets = {
+    smart: { sets: { permissionMode: 'auto' } },
+    bypass: { sets: { permissionMode: 'bypassPermissions' } },
+  }
+
+  it('names the preset the session has on', () => {
+    expect(activePermissionPreset(presets, [group('permissionMode', MODES, 'auto')], {})).toBe('smart')
+    expect(activePermissionPreset(presets, [group('permissionMode', MODES, 'bypassPermissions')], {})).toBe('bypass')
+  })
+
+  it('names nothing when neither preset is on', () => {
+    expect(activePermissionPreset(presets, [group('permissionMode', MODES, 'default')], {})).toBeUndefined()
+    expect(activePermissionPreset({}, [group('permissionMode', MODES, 'auto')], {})).toBeUndefined()
+  })
+
+  it('prefers smart when both report active', () => {
+    // Copilot's two presets switch DIFFERENT axes, so both can be on at once.
+    const copilot = {
+      smart: { sets: { copilot_assisted_approval: 'on' } },
+      bypass: { sets: { allow_all: 'on' } },
+    }
+    const groups = [
+      group('copilot_assisted_approval', ['off', 'on'], 'on'),
+      group('allow_all', ['off', 'on'], 'on'),
+    ]
+
+    expect(activePermissionPreset(copilot, groups, {})).toBe('smart')
+  })
+
+  it('names nothing without a catalog', () => {
+    expect(activePermissionPreset(presets, undefined, undefined)).toBeUndefined()
+  })
+})

--- a/frontend/src/components/chat/providerSettings.ts
+++ b/frontend/src/components/chat/providerSettings.ts
@@ -1,5 +1,5 @@
 import type { AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
-import { optionGroup, resolvedCurrent, valueValidForGroup } from './settingsGroups'
+import { effectiveCurrent, optionGroup, valueValidForGroup } from './settingsGroups'
 
 /** One atomic change to one or more provider settings. */
 export interface ProviderSettingChange {
@@ -20,48 +20,36 @@ export type ProviderSettingChangeHandler = (change: ProviderSettingChange) => vo
  */
 export type ProviderPermissionPreset = ProviderSettingChange
 
+/**
+ * The standard permission presets, from narrower to broader access.
+ *
+ * The order controls presentation and active-state precedence. A provider can
+ * keep two preset axes on together. The broader preset then represents the
+ * effective behavior and must win the single selected state.
+ *
+ * Each label has two forms. A control group already states `Permissions`, so
+ * its short label omits that noun. The composer menu states no subject, so its
+ * full label includes it.
+ */
+export const PERMISSION_PRESET_SPECS = [
+  { kind: 'smart', shortLabel: 'Smart', fullLabel: 'Smart permissions' },
+  { kind: 'bypass', shortLabel: 'Bypass', fullLabel: 'Bypass permissions' },
+] as const
+
+export type PermissionPresetKind = typeof PERMISSION_PRESET_SPECS[number]['kind']
+
 /** The standard permission presets that a provider can offer. */
-export interface ProviderPermissionPresets {
-  smart?: ProviderPermissionPreset
-  bypass?: ProviderPermissionPreset
-}
-
-/** What one standard preset is called, in each of the two contexts that offer it. */
-export interface PermissionPresetLabel {
-  /**
-   * The name for a surface that already states the subject. The control
-   * request's pill group is titled `Permissions`, so an option that repeated
-   * the word said it twice and pushed the row to wrap mid-word.
-   */
-  short: string
-  /**
-   * The name for a surface that states no subject of its own. The composer
-   * `[+]` menu draws its permission items as bare rows under a rule, so each
-   * one must say what it acts on.
-   */
-  full: string
-}
+export type ProviderPermissionPresets = Partial<Record<PermissionPresetKind, ProviderPermissionPreset>>
 
 /**
- * The names each standard preset shows, wherever a preset is offered: the composer
- * `[+]` menu's permission items and a control request's permission pill group read
- * this one table, so the two surfaces cannot drift apart on a rename.
+ * The usable permission presets for one control request.
+ *
+ * `apply` is present when an ordinary request can change settings. A plan
+ * approval carries its mode in the response and needs only the preset data.
  */
-export const PERMISSION_PRESET_LABELS: Record<keyof ProviderPermissionPresets, PermissionPresetLabel> = {
-  smart: { short: 'Smart', full: 'Smart permissions' },
-  bypass: { short: 'Bypass', full: 'Bypass permissions' },
-}
-
-/**
- * The usable permission presets a control request can apply: every preset the live
- * catalog offers, plus the ONE handler that applies a settings change — the composer's
- * `onSettingChange`, the same call the `[+]` menu's permission items make. A preset
- * the catalog does not currently offer is `undefined`, so the pill for it is not drawn.
- */
-export interface PermissionPresetController {
-  smart?: ProviderPermissionPreset
-  bypass?: ProviderPermissionPreset
-  apply: ProviderSettingChangeHandler
+export type PermissionPresetController = ProviderPermissionPresets & {
+  /** Applies a preset outside a plan-approval response. */
+  apply?: ProviderSettingChangeHandler
   /**
    * The preset the session already has on, or `undefined` when neither is on.
    *
@@ -70,7 +58,15 @@ export interface PermissionPresetController {
    * because it needs the live catalog AND the confirmed values, and a control
    * request's props carry neither.
    */
-  active?: keyof ProviderPermissionPresets
+  active?: PermissionPresetKind
+}
+
+/** Returns the non-empty settings entries of a preset. */
+function nonEmptyPresetEntries(preset: ProviderPermissionPreset | undefined): [string, string][] | undefined {
+  if (!preset)
+    return undefined
+  const entries = Object.entries(preset.sets)
+  return entries.length > 0 ? entries : undefined
 }
 
 /**
@@ -87,28 +83,26 @@ export function permissionPresetActive(
   groups: AvailableOptionGroup[] | undefined,
   values: Record<string, string> | undefined,
 ): boolean {
-  if (!preset)
+  const entries = nonEmptyPresetEntries(preset)
+  if (!entries)
     return false
-  const entries = Object.entries(preset.sets)
-  // An empty change sets nothing, so "already applied" would be vacuously true.
-  if (entries.length === 0)
-    return false
-  return entries.every(([groupId, value]) => resolvedCurrent(groups, values, groupId) === value)
+  return entries.every(([groupId, value]) => effectiveCurrent(values, optionGroup(groups, groupId)) === value)
 }
 
 /**
- * Which standard preset the session has on, smart before bypass.
+ * Which standard preset represents the session's effective permission behavior.
  *
- * The order settles the one case where both can report active: Copilot's two
- * presets switch DIFFERENT axes, so both can be on at once. Claude's, Codex's
- * and Goose's switch the same permission mode and exclude each other.
+ * The last matching spec wins because the specs run from narrower to broader
+ * access. Copilot can keep Assisted Approval and Allow All on together. Allow
+ * All supplies the effective behavior, so Bypass wins in that state.
  */
 export function activePermissionPreset(
   presets: ProviderPermissionPresets,
   groups: AvailableOptionGroup[] | undefined,
   values: Record<string, string> | undefined,
-): keyof ProviderPermissionPresets | undefined {
-  for (const kind of ['smart', 'bypass'] as const) {
+): PermissionPresetKind | undefined {
+  for (let index = PERMISSION_PRESET_SPECS.length - 1; index >= 0; index--) {
+    const { kind } = PERMISSION_PRESET_SPECS[index]!
     if (permissionPresetActive(presets[kind], groups, values))
       return kind
   }
@@ -120,10 +114,8 @@ export function permissionPresetAvailable(
   preset: ProviderPermissionPreset | undefined,
   groups: AvailableOptionGroup[] | undefined,
 ): preset is ProviderPermissionPreset {
-  if (!preset)
-    return false
-  const entries = Object.entries(preset.sets)
-  if (entries.length === 0)
+  const entries = nonEmptyPresetEntries(preset)
+  if (!entries)
     return false
   return entries.every(([groupId, value]) =>
     !!optionGroup(groups, groupId)?.mutable && valueValidForGroup(groups, groupId, value),
@@ -140,8 +132,11 @@ export function usablePresets(
   presets: ProviderPermissionPresets | undefined,
   groups: AvailableOptionGroup[] | undefined,
 ): ProviderPermissionPresets {
-  return {
-    smart: permissionPresetAvailable(presets?.smart, groups) ? presets?.smart : undefined,
-    bypass: permissionPresetAvailable(presets?.bypass, groups) ? presets?.bypass : undefined,
+  const usable: ProviderPermissionPresets = {}
+  for (const { kind } of PERMISSION_PRESET_SPECS) {
+    const preset = presets?.[kind]
+    if (permissionPresetAvailable(preset, groups))
+      usable[kind] = preset
   }
+  return usable
 }

--- a/frontend/src/components/chat/providerSettings.ts
+++ b/frontend/src/components/chat/providerSettings.ts
@@ -1,5 +1,5 @@
 import type { AvailableOptionGroup } from '~/generated/proto/leapmux/v1/agent_pb'
-import { optionGroup, valueValidForGroup } from './settingsGroups'
+import { optionGroup, resolvedCurrent, valueValidForGroup } from './settingsGroups'
 
 /** One atomic change to one or more provider settings. */
 export interface ProviderSettingChange {
@@ -26,14 +26,30 @@ export interface ProviderPermissionPresets {
   bypass?: ProviderPermissionPreset
 }
 
+/** What one standard preset is called, in each of the two contexts that offer it. */
+export interface PermissionPresetLabel {
+  /**
+   * The name for a surface that already states the subject. The control
+   * request's pill group is titled `Permissions`, so an option that repeated
+   * the word said it twice and pushed the row to wrap mid-word.
+   */
+  short: string
+  /**
+   * The name for a surface that states no subject of its own. The composer
+   * `[+]` menu draws its permission items as bare rows under a rule, so each
+   * one must say what it acts on.
+   */
+  full: string
+}
+
 /**
- * The label each standard preset shows, wherever a preset is offered: the composer
+ * The names each standard preset shows, wherever a preset is offered: the composer
  * `[+]` menu's permission items and a control request's permission pill group read
  * this one table, so the two surfaces cannot drift apart on a rename.
  */
-export const PERMISSION_PRESET_LABELS: Record<keyof ProviderPermissionPresets, string> = {
-  smart: 'Smart permissions',
-  bypass: 'Bypass permissions',
+export const PERMISSION_PRESET_LABELS: Record<keyof ProviderPermissionPresets, PermissionPresetLabel> = {
+  smart: { short: 'Smart', full: 'Smart permissions' },
+  bypass: { short: 'Bypass', full: 'Bypass permissions' },
 }
 
 /**
@@ -46,6 +62,57 @@ export interface PermissionPresetController {
   smart?: ProviderPermissionPreset
   bypass?: ProviderPermissionPreset
   apply: ProviderSettingChangeHandler
+  /**
+   * The preset the session already has on, or `undefined` when neither is on.
+   *
+   * A control request's pill group opens on this, so an Allow keeps the session
+   * where the user put it instead of changing it. Only the composer knows it,
+   * because it needs the live catalog AND the confirmed values, and a control
+   * request's props carry neither.
+   */
+  active?: keyof ProviderPermissionPresets
+}
+
+/**
+ * Reports whether the session already has `preset` on: every axis it would set
+ * already holds the value it would write.
+ *
+ * The one implementation of the rule. The composer `[+]` menu disables an item
+ * that would change nothing, and a control request's pill group opens on the
+ * preset this reports, so a drift between the two would show a menu item as
+ * available while the pill says it is already on.
+ */
+export function permissionPresetActive(
+  preset: ProviderPermissionPreset | undefined,
+  groups: AvailableOptionGroup[] | undefined,
+  values: Record<string, string> | undefined,
+): boolean {
+  if (!preset)
+    return false
+  const entries = Object.entries(preset.sets)
+  // An empty change sets nothing, so "already applied" would be vacuously true.
+  if (entries.length === 0)
+    return false
+  return entries.every(([groupId, value]) => resolvedCurrent(groups, values, groupId) === value)
+}
+
+/**
+ * Which standard preset the session has on, smart before bypass.
+ *
+ * The order settles the one case where both can report active: Copilot's two
+ * presets switch DIFFERENT axes, so both can be on at once. Claude's, Codex's
+ * and Goose's switch the same permission mode and exclude each other.
+ */
+export function activePermissionPreset(
+  presets: ProviderPermissionPresets,
+  groups: AvailableOptionGroup[] | undefined,
+  values: Record<string, string> | undefined,
+): keyof ProviderPermissionPresets | undefined {
+  for (const kind of ['smart', 'bypass'] as const) {
+    if (permissionPresetActive(presets[kind], groups, values))
+      return kind
+  }
+  return undefined
 }
 
 /** Reports whether the catalog offers every group and value in a preset. */

--- a/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
@@ -121,10 +121,25 @@ describe('acpControlActions', () => {
     expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
     expect(scope.getByRole('radio', { name: 'Always' })).not.toBeChecked()
     const pill = permissionPillGroup()
-    expect(pill.getByRole('radio', { name: 'Default' })).toBeChecked()
+    // An ordinary request opens on the preset the session has on. This one
+    // reports none, so the group opens on the pill that changes nothing.
+    expect(pill.getByRole('radio', { name: 'Unchanged' })).toBeChecked()
+    expect(pill.getByRole('radio', { name: 'Smart' })).not.toBeChecked()
     // The always options live in the scope group, not as their own buttons.
     expect(screen.queryByTestId('control-decision-allow_always')).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-reject_always')).not.toBeInTheDocument()
+  })
+
+  it('sizes the decisions with the shared small class', () => {
+    // This row builds its own decisions rather than going through
+    // `ControlDecisionFooter`, so it carries the class on its own. The footer
+    // slot states no size, and a button that omits it falls back to Oat's
+    // full-size metrics.
+    renderGooseActions()
+
+    expect(screen.getByTestId('control-deny-btn')).toHaveClass('outline', 'small')
+    expect(screen.getByTestId('control-allow-btn')).toHaveClass('small')
+    expect(screen.getByTestId('control-allow-btn')).not.toHaveClass('outline')
   })
 
   it('sends the once options while Once is selected', async () => {
@@ -198,7 +213,7 @@ describe('acpControlActions', () => {
   it('applies the chosen permission preset after an allow and never after a reject', async () => {
     const { onRespond, apply } = renderGooseActions()
 
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
     expect(onRespond).toHaveBeenCalledTimes(1)
     expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'auto' } })
@@ -235,7 +250,7 @@ describe('acpControlActions', () => {
       presets: { bypass: { sets: { permissionMode: 'yolo' } }, apply },
     }))
 
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
     await fireEvent.click(screen.getByTestId('control-decision-ask'))
 
     expect(onRespond).toHaveBeenCalledOnce()

--- a/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
@@ -1,6 +1,7 @@
 import type { PermissionPresetController } from '../../providerSettings'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
+import { compactControl } from '~/components/common/CompactControl.css'
 import { allowScopePillGroup, permissionPillGroup } from '~/test-support/controlRequests'
 import { createControlAnswerState } from '../../controls/types'
 import { ACPControlActions, sendACPPermissionResponse } from './ACPControlRequest'
@@ -130,15 +131,14 @@ describe('acpControlActions', () => {
     expect(screen.queryByTestId('control-decision-reject_always')).not.toBeInTheDocument()
   })
 
-  it('sizes the decisions with the shared small class', () => {
+  it('sizes the decisions with the shared compact style', () => {
     // This row builds its own decisions rather than going through
     // `ControlDecisionFooter`, so it carries the class on its own. The footer
-    // slot states no size, and a button that omits it falls back to Oat's
-    // full-size metrics.
+    // slot states no size, so each action uses the shared compact style.
     renderGooseActions()
 
-    expect(screen.getByTestId('control-deny-btn')).toHaveClass('outline', 'small')
-    expect(screen.getByTestId('control-allow-btn')).toHaveClass('small')
+    expect(screen.getByTestId('control-deny-btn')).toHaveClass('outline', compactControl)
+    expect(screen.getByTestId('control-allow-btn')).toHaveClass(compactControl)
     expect(screen.getByTestId('control-allow-btn')).not.toHaveClass('outline')
   })
 

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
@@ -45,8 +45,9 @@ describe('codex control request actions', () => {
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Reject')
     expect(screen.getByTestId('control-allow-btn')).toHaveTextContent('Allow')
     expect(screen.getByTestId('control-remember-checkbox')).toHaveTextContent('Remember')
-    expect(permissionPillGroup().getByRole('radio', { name: 'Default' })).toBeChecked()
-    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' })).toBeInTheDocument()
+    // No preset is on, so the group opens on the pill that changes nothing.
+    expect(permissionPillGroup().getByRole('radio', { name: 'Unchanged' })).toBeChecked()
+    expect(permissionPillGroup().getByRole('radio', { name: 'Bypass' })).not.toBeChecked()
   })
 
   it('uses the remembered Codex decision only when Remember is checked', async () => {
@@ -162,7 +163,7 @@ describe('codex control request actions', () => {
       finishResponse = resolve
     }))
 
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
     fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     expect(onRespond).toHaveBeenCalledOnce()
@@ -200,10 +201,10 @@ describe('codex control request actions', () => {
     })
   })
 
-  it('embeds the bypass mode in a plan approval when Bypass permissions is selected', async () => {
+  it('embeds the bypass mode in a plan approval when Bypass is selected', async () => {
     const { onRespond, onSettingChange } = renderActions(makePlanRequest())
 
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     const [bytes] = onRespond.mock.calls[0]

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
@@ -8,7 +8,7 @@ import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from
 import * as styles from '../../ControlRequestBanner.css'
 import { CollapsibleText } from '../../controls/CollapsibleText'
 import { ControlDecisionFooter } from '../../controls/ControlDecisionFooter'
-import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice, sessionPermissionChoice } from '../../controls/permissionPresets'
+import { buildSessionPermissionPill, createSessionPermissionPresetChoice, respondThenApplyPermissionPreset } from '../../controls/permissionPresets'
 import { createPlanApprovalState, planApprovalSwitches } from '../../controls/planApproval'
 import { createControlSwitch, sendJsonRpcResult, sendResponse } from '../../controls/types'
 import { codexDecisionKey, codexDecisionLabel, parseCodexDecision } from './controlResponse'
@@ -205,16 +205,17 @@ export const CodexControlContent: Component<ContentProps> = (props) => {
 
 const CodexPermissionsActions: Component<ActionsProps> = (props) => {
   const rememberSwitch = createControlSwitch(() => props.answerState, 'control-remember-checkbox')
-  const permissionChoice = createPermissionPresetChoice(props, () => sessionPermissionChoice(props.presets))
-  const handleAllow = async () => {
-    await sendCodexPermissionsResponse(
+  const permissionChoice = createSessionPermissionPresetChoice(props)
+  const handleAllow = () => respondThenApplyPermissionPreset(
+    sendCodexPermissionsResponse(
       props.onRespond,
       props.request.requestId,
       codexRequestedPermissions(props.request.payload),
       rememberSwitch.checked() ? 'session' : 'turn',
-    )
-    await applyPermissionPreset(props.presets, permissionChoice.choice())
-  }
+    ),
+    props.presets,
+    permissionChoice.choice(),
+  )
   return (
     <ControlDecisionFooter
       hasEditorContent={props.hasEditorContent}
@@ -228,7 +229,7 @@ const CodexPermissionsActions: Component<ActionsProps> = (props) => {
       switches={() => [
         { id: 'control-remember-checkbox', label: 'Remember', checked: rememberSwitch.checked(), onChange: rememberSwitch.set },
       ]}
-      permissionPill={() => buildPermissionPill(props.presets, permissionChoice)}
+      permissionPill={() => buildSessionPermissionPill(props.presets, permissionChoice)}
     />
   )
 }
@@ -268,7 +269,7 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
   const params = () => getCodexParams(props.request.payload)
   const decisions = createMemo(() => resolveCodexDecisions(params()?.availableDecisions))
   const rememberSwitch = createControlSwitch(() => props.answerState, 'control-remember-checkbox')
-  const permissionChoice = createPermissionPresetChoice(props, () => sessionPermissionChoice(props.presets))
+  const permissionChoice = createSessionPermissionPresetChoice(props)
 
   const handleDecision = (decision: CodexDecision) => sendCodexDecision(
     props.onRespond,
@@ -276,10 +277,11 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
     decision,
   )
 
-  const handleAllow = async () => {
-    await handleDecision(rememberSwitch.checked() ? (decisions().remembered ?? decisions().positive) : decisions().positive)
-    await applyPermissionPreset(props.presets, permissionChoice.choice())
-  }
+  const handleAllow = () => respondThenApplyPermissionPreset(
+    handleDecision(rememberSwitch.checked() ? (decisions().remembered ?? decisions().positive) : decisions().positive),
+    props.presets,
+    permissionChoice.choice(),
+  )
 
   return (
     <Switch
@@ -299,7 +301,7 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
                 }]
               : []),
           ]}
-          permissionPill={() => buildPermissionPill(props.presets, permissionChoice)}
+          permissionPill={() => buildSessionPermissionPill(props.presets, permissionChoice)}
           additionalActions={() => decisions().additional.map(decision => ({
             label: codexDecisionLabel(decision),
             testId: `control-decision-${codexDecisionKey(decision)}`,

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
@@ -8,7 +8,7 @@ import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from
 import * as styles from '../../ControlRequestBanner.css'
 import { CollapsibleText } from '../../controls/CollapsibleText'
 import { ControlDecisionFooter } from '../../controls/ControlDecisionFooter'
-import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice } from '../../controls/permissionPresets'
+import { applyPermissionPreset, buildPermissionPill, createPermissionPresetChoice, sessionPermissionChoice } from '../../controls/permissionPresets'
 import { createPlanApprovalState, planApprovalSwitches } from '../../controls/planApproval'
 import { createControlSwitch, sendJsonRpcResult, sendResponse } from '../../controls/types'
 import { codexDecisionKey, codexDecisionLabel, parseCodexDecision } from './controlResponse'
@@ -205,7 +205,7 @@ export const CodexControlContent: Component<ContentProps> = (props) => {
 
 const CodexPermissionsActions: Component<ActionsProps> = (props) => {
   const rememberSwitch = createControlSwitch(() => props.answerState, 'control-remember-checkbox')
-  const permissionChoice = createPermissionPresetChoice(props)
+  const permissionChoice = createPermissionPresetChoice(props, () => sessionPermissionChoice(props.presets))
   const handleAllow = async () => {
     await sendCodexPermissionsResponse(
       props.onRespond,
@@ -268,7 +268,7 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
   const params = () => getCodexParams(props.request.payload)
   const decisions = createMemo(() => resolveCodexDecisions(params()?.availableDecisions))
   const rememberSwitch = createControlSwitch(() => props.answerState, 'control-remember-checkbox')
-  const permissionChoice = createPermissionPresetChoice(props)
+  const permissionChoice = createPermissionPresetChoice(props, () => sessionPermissionChoice(props.presets))
 
   const handleDecision = (decision: CodexDecision) => sendCodexDecision(
     props.onRespond,

--- a/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
@@ -59,7 +59,7 @@ describe('openCodeControlActions', () => {
     expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('once')
     expect(apply).not.toHaveBeenCalled()
 
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
 
     fireEvent.click(allowScopePillGroup().getByRole('radio', { name: 'Always' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))

--- a/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
@@ -54,7 +54,7 @@ describe('openCodeControlActions', () => {
   it('sends once while Once is selected and always beyond it, applying the preset after each allow', async () => {
     const { onRespond, apply } = renderOptionsActions()
 
-    // A preset applies only when the pill selects one; Default applies nothing.
+    // A preset applies only when the pill selects one; Unchanged applies nothing.
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
     expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('once')
     expect(apply).not.toHaveBeenCalled()

--- a/frontend/src/components/chat/providers/pi/controls.tsx
+++ b/frontend/src/components/chat/providers/pi/controls.tsx
@@ -92,7 +92,7 @@ export const PiControlActions: Component<ActionsProps> = (props) => {
   // The dialog method drives both the deny/primary button labels and the
   // primary handler. Computing the four pieces as one memo keeps a single
   // ButtonGroup at the bottom of the footer and avoids three near-identical
-  // `<ButtonGroup>` blocks across the per-method Match arms.
+  // `<ButtonGroup>` blocks across the per-method Match branches.
   const buttons = createMemo<PiButtonShape>(() => {
     switch (method()) {
       case PI_DIALOG_METHOD.Confirm:
@@ -122,40 +122,40 @@ export const PiControlActions: Component<ActionsProps> = (props) => {
 
   return (
     <ControlActionRow
+      leading={(
+        <Switch>
+          <Match when={method() === PI_DIALOG_METHOD.Input}>
+            <input
+              type="text"
+              placeholder={placeholder()}
+              value={localText()}
+              onInput={e => setLocalText((e.currentTarget as HTMLInputElement).value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  sendValue(localText())
+                }
+              }}
+              data-testid="pi-input"
+              style={{ 'flex': '1 1 auto', 'min-width': '200px' }}
+            />
+          </Match>
+          <Match when={method() === PI_DIALOG_METHOD.Editor}>
+            <textarea
+              value={localText()}
+              onInput={e => setLocalText((e.currentTarget as HTMLTextAreaElement).value)}
+              data-testid="pi-editor"
+              rows={4}
+              style={{ 'flex': '1 1 auto', 'min-width': '300px', 'resize': 'vertical' }}
+            />
+          </Match>
+        </Switch>
+      )}
       primary={(
-        <>
-          <Switch>
-            <Match when={method() === PI_DIALOG_METHOD.Input}>
-              <input
-                type="text"
-                placeholder={placeholder()}
-                value={localText()}
-                onInput={e => setLocalText((e.currentTarget as HTMLInputElement).value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault()
-                    sendValue(localText())
-                  }
-                }}
-                data-testid="pi-input"
-                style={{ 'flex': '1 1 auto', 'min-width': '200px' }}
-              />
-            </Match>
-            <Match when={method() === PI_DIALOG_METHOD.Editor}>
-              <textarea
-                value={localText()}
-                onInput={e => setLocalText((e.currentTarget as HTMLTextAreaElement).value)}
-                data-testid="pi-editor"
-                rows={4}
-                style={{ 'flex': '1 1 auto', 'min-width': '300px', 'resize': 'vertical' }}
-              />
-            </Match>
-          </Switch>
-          <ButtonGroup>
-            <button class={actionButtonClass(true)} onClick={buttons().denyClick} data-testid="control-deny-btn">{buttons().denyLabel}</button>
-            <button class={actionButtonClass()} onClick={buttons().primaryClick} data-testid="control-allow-btn">{buttons().primaryLabel}</button>
-          </ButtonGroup>
-        </>
+        <ButtonGroup>
+          <button class={actionButtonClass(true)} onClick={buttons().denyClick} data-testid="control-deny-btn">{buttons().denyLabel}</button>
+          <button class={actionButtonClass()} onClick={buttons().primaryClick} data-testid="control-allow-btn">{buttons().primaryLabel}</button>
+        </ButtonGroup>
       )}
     />
   )

--- a/frontend/src/components/chat/providers/pi/controls.tsx
+++ b/frontend/src/components/chat/providers/pi/controls.tsx
@@ -5,7 +5,7 @@ import { ButtonGroup } from '~/components/common/ButtonGroup'
 import { PI_DIALOG_METHOD } from '~/generated/contracts/pi-protocol'
 import { pickNumber, pickString } from '~/lib/jsonPick'
 import * as styles from '../../ControlRequestBanner.css'
-import { ControlActionRow } from '../../controls/ControlActionRow'
+import { actionButtonClass, ControlActionRow } from '../../controls/ControlActionRow'
 import {
   piCancelResponse,
   piConfirmResponse,
@@ -152,8 +152,8 @@ export const PiControlActions: Component<ActionsProps> = (props) => {
             </Match>
           </Switch>
           <ButtonGroup>
-            <button class="outline" onClick={buttons().denyClick} data-testid="control-deny-btn">{buttons().denyLabel}</button>
-            <button onClick={buttons().primaryClick} data-testid="control-allow-btn">{buttons().primaryLabel}</button>
+            <button class={actionButtonClass(true)} onClick={buttons().denyClick} data-testid="control-deny-btn">{buttons().denyLabel}</button>
+            <button class={actionButtonClass()} onClick={buttons().primaryClick} data-testid="control-allow-btn">{buttons().primaryLabel}</button>
           </ButtonGroup>
         </>
       )}

--- a/frontend/src/components/chat/providers/stubs/CursorControlRequest.tsx
+++ b/frontend/src/components/chat/providers/stubs/CursorControlRequest.tsx
@@ -5,7 +5,7 @@ import { Match, Show, Switch } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
 import { buildAllowResponse, buildDenyResponse } from '~/utils/controlResponse'
 import * as styles from '../../ControlRequestBanner.css'
-import { ControlActionRow } from '../../controls/ControlActionRow'
+import { actionButtonClass, ControlActionRow } from '../../controls/ControlActionRow'
 import { sendResponse, toRpcId } from '../../controls/types'
 
 function getCursorParams(payload: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -119,8 +119,8 @@ export const CursorControlActions: Component<ActionsProps> = (props) => {
     <ControlActionRow
       primary={(
         <ButtonGroup>
-          <button class="outline" onClick={createPlanReject} data-testid="control-deny-btn">Reject</button>
-          <button onClick={createPlanAllow} data-testid="control-allow-btn">Allow</button>
+          <button class={actionButtonClass(true)} onClick={createPlanReject} data-testid="control-deny-btn">Reject</button>
+          <button class={actionButtonClass()} onClick={createPlanAllow} data-testid="control-allow-btn">Allow</button>
         </ButtonGroup>
       )}
     />

--- a/frontend/src/components/chat/providers/zcode/controls.test.tsx
+++ b/frontend/src/components/chat/providers/zcode/controls.test.tsx
@@ -229,7 +229,7 @@ describe('zcode permission control', () => {
         }}
       />
     ))
-    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass permissions' }))
+    fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
     fireEvent.click(getByTestId('control-allow-btn'))
     await vi.waitFor(() => expect(order).toEqual(['allow', `mode:${ZCODE_MODE.Yolo}`]))
   })

--- a/frontend/src/components/common/CompactControl.css.ts
+++ b/frontend/src/components/common/CompactControl.css.ts
@@ -1,0 +1,18 @@
+import { style } from '@vanilla-extract/css'
+
+const COMPACT_FONT_SIZE = 'var(--text-8)'
+const COMPACT_PADDING_BLOCK = 'var(--space-1)'
+const COMPACT_PADDING_INLINE = 'var(--space-3)'
+const CONTROL_BORDER_HEIGHT = '2px'
+
+/** The natural height of a compact button with one line of text. */
+export const compactControlHeight = `calc(${COMPACT_FONT_SIZE} * var(--leading-normal) + ${COMPACT_PADDING_BLOCK} * 2 + ${CONTROL_BORDER_HEIGHT})`
+
+/** Shared typography and padding rules for compact controls. */
+export const compactControlProperties = {
+  padding: `${COMPACT_PADDING_BLOCK} ${COMPACT_PADDING_INLINE}`,
+  fontSize: COMPACT_FONT_SIZE,
+} as const
+
+/** Shared typography and padding for compact buttons. */
+export const compactControl = style(compactControlProperties)

--- a/frontend/src/components/common/PillGroup.css.ts
+++ b/frontend/src/components/common/PillGroup.css.ts
@@ -32,8 +32,28 @@ const pillOptionLayout = style({
   fontSize: 'var(--text-7)',
   lineHeight: 'var(--leading-normal)',
   fontWeight: 'var(--font-normal)',
+  // A `<button>` carries its own font-family from the UA stylesheet, so it does
+  // NOT inherit one. Oat sets `--font-sans` on `body` and on the other form
+  // controls, never on `button`, so without this the real radios render in the
+  // UA control font while their `<span>` copies render in the user's UI font.
+  // The two rows then lay out to different widths, and the moving fill lands
+  // off the option boundary it is clipped to.
+  fontFamily: 'inherit',
   whiteSpace: 'normal',
   overflowWrap: 'anywhere',
+})
+
+/**
+ * Oat's `.small` button metrics, so a group reads as one control with the small
+ * action buttons beside it. An option keeps `border: 0` while the group keeps
+ * its own 1px border, so the group stays exactly as tall as such a button.
+ *
+ * Both the real radios and their copies take this class. A size on one row
+ * alone desyncs the copies from the buttons they cover.
+ */
+export const pillOptionSmall = style({
+  padding: 'var(--space-1) var(--space-3)',
+  fontSize: 'var(--text-8)',
 })
 
 /** Shape and behavior for each real radio. */
@@ -164,15 +184,18 @@ export const selectionLabels = style([selectionWindow, {
   },
 }])
 
-/** One label copy. It has the exact metrics of its real radio. */
+/**
+ * One label copy. It has the exact metrics of its real radio, and renders the
+ * same content -- the label text, or the icon an icon-only option draws.
+ *
+ * The content is real children rather than a `content: attr(data-label)`
+ * pseudo-element. `attr()` can only reproduce a STRING, so an icon option had
+ * no copy at all, and the copy is what paints the label once the fill slides
+ * under it.
+ */
 export const selectionLabel = style([pillOptionLayout, {
   backgroundColor: 'transparent',
   color: 'inherit',
-  selectors: {
-    '&::before': {
-      content: 'attr(data-label)',
-    },
-  },
 }])
 
 /** Slide both clipped layers after the first valid measurement. */

--- a/frontend/src/components/common/PillGroup.css.ts
+++ b/frontend/src/components/common/PillGroup.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css'
+import { compactControlProperties } from './CompactControl.css'
 
 /** One content-sized control with one outer border. */
 export const pillGroup = style({
@@ -43,18 +44,8 @@ const pillOptionLayout = style({
   overflowWrap: 'anywhere',
 })
 
-/**
- * Oat's `.small` button metrics, so a group reads as one control with the small
- * action buttons beside it. An option keeps `border: 0` while the group keeps
- * its own 1px border, so the group stays exactly as tall as such a button.
- *
- * Both the real radios and their copies take this class. A size on one row
- * alone desyncs the copies from the buttons they cover.
- */
-export const pillOptionSmall = style({
-  padding: 'var(--space-1) var(--space-3)',
-  fontSize: 'var(--text-8)',
-})
+/** Compact metrics for both the real radios and their visual copies. */
+export const pillOptionSmall = style(compactControlProperties)
 
 /** Shape and behavior for each real radio. */
 export const pillOption = style([pillOptionLayout, {

--- a/frontend/src/components/common/PillGroup.test.tsx
+++ b/frontend/src/components/common/PillGroup.test.tsx
@@ -1,5 +1,6 @@
 import type { PillOptions } from './PillGroup'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
+import { Minus } from 'lucide-solid'
 import { createSignal } from 'solid-js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { installControllableResizeObserver, triggerResizeObserversSync } from '~/test-support/resizeObserverStub'
@@ -570,5 +571,102 @@ describe('pill group sliding selection', () => {
     expect([...labels!.querySelectorAll('[data-label]')].map(label => label.getAttribute('data-label')))
       .toEqual(['First', 'A wider second option'])
     expect(secondRadio).toHaveClass(styles.pillOptionSelectedTarget)
+  })
+})
+
+describe('pill group small variant', () => {
+  const first = { key: 'first', label: 'First' }
+  const second = { key: 'second', label: 'Second' }
+
+  beforeEach(() => installControllableResizeObserver())
+
+  function renderSized(small: boolean | undefined) {
+    render(() => (
+      <PillGroup
+        label="Sized options"
+        options={[first, second]}
+        selectedKey="first"
+        onSelect={vi.fn()}
+        small={small}
+      />
+    ))
+    const group = screen.getByRole('radiogroup', { name: 'Sized options' })
+    const radios = [
+      screen.getByRole('radio', { name: first.label }),
+      screen.getByRole('radio', { name: second.label }),
+    ]
+    stubSelectionGeometry(group, radios[0], { groupWidth: 220, left: 0, width: 70 })
+    stubSelectionGeometry(group, radios[1], { groupWidth: 220, left: 70, width: 150 })
+    triggerResizeObserversSync()
+    return { copies: [...group.querySelectorAll('[data-label]')], radios }
+  }
+
+  it('keeps the full metrics when no size is asked for', () => {
+    const { copies, radios } = renderSized(undefined)
+
+    for (const element of [...radios, ...copies])
+      expect(element).not.toHaveClass(styles.pillOptionSmall)
+  })
+
+  it('sizes the radios and their label copies together', () => {
+    // Each copy covers one real radio exactly, and the moving fill is clipped
+    // to the radio underneath. A size that reached one of the two rows alone
+    // would move every copy off the radio it covers.
+    const { copies, radios } = renderSized(true)
+
+    expect(copies).toHaveLength(2)
+    for (const element of [...radios, ...copies])
+      expect(element).toHaveClass(styles.pillOptionSmall)
+  })
+})
+
+describe('pill group icon option', () => {
+  const icon = { key: 'icon', label: 'Unchanged', icon: Minus }
+  const text = { key: 'text', label: 'Smart' }
+
+  beforeEach(() => installControllableResizeObserver())
+
+  function renderIconGroup() {
+    render(() => (
+      <PillGroup
+        label="Named options"
+        options={[icon, text]}
+        selectedKey="icon"
+        onSelect={vi.fn()}
+      />
+    ))
+    const group = screen.getByRole('radiogroup', { name: 'Named options' })
+    const radios = [
+      screen.getByRole('radio', { name: icon.label }),
+      screen.getByRole('radio', { name: text.label }),
+    ]
+    stubSelectionGeometry(group, radios[0], { groupWidth: 220, left: 0, width: 70 })
+    stubSelectionGeometry(group, radios[1], { groupWidth: 220, left: 70, width: 150 })
+    triggerResizeObserversSync()
+    return { copies: [...group.querySelectorAll('[data-label]')], group, radios }
+  }
+
+  it('keeps the name of an option that spells out no text', () => {
+    // The label is the accessible name and the tooltip. Without it the option
+    // reaches neither a screen reader nor a by-name lookup.
+    const { radios } = renderIconGroup()
+
+    expect(radios[0]).toHaveAttribute('aria-label', 'Unchanged')
+    expect(radios[0]!.querySelector('svg')).not.toBeNull()
+    expect(radios[0]).not.toHaveTextContent('Unchanged')
+    expect(radios[1]).toHaveTextContent('Smart')
+    expect(radios[1]!.querySelector('svg')).toBeNull()
+  })
+
+  it('copies an icon into the sliding overlay', () => {
+    // The copy is what paints the option once the fill slides under it. A copy
+    // that reproduced the label STRING would leave an icon option blank there.
+    const { copies } = renderIconGroup()
+
+    expect(copies).toHaveLength(2)
+    expect(copies[0]!.querySelector('svg')).not.toBeNull()
+    expect(copies[0]).not.toHaveTextContent('Unchanged')
+    expect(copies[1]!.querySelector('svg')).toBeNull()
+    expect(copies[1]).toHaveTextContent('Smart')
   })
 })

--- a/frontend/src/components/common/PillGroup.tsx
+++ b/frontend/src/components/common/PillGroup.tsx
@@ -1,9 +1,11 @@
 import type { LucideIcon } from 'lucide-solid'
-import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from 'solid-js'
+import type { Component } from 'solid-js'
+import { createEffect, createMemo, createSignal, createUniqueId, For, onCleanup, onMount, Show } from 'solid-js'
 import { createKeyedElementRefs } from '~/lib/keyedElementRefs'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
 import { nextRovingValue } from '~/lib/rovingFocus'
 import { sameValueZero, shallowEqualMapKeyArrays } from '~/lib/shallowEqual'
+import { srOnly } from '~/styles/shared.css'
 import { Icon } from './Icon'
 import * as styles from './PillGroup.css'
 import { Tooltip } from './Tooltip'
@@ -57,6 +59,13 @@ interface SelectionMetrics {
   left: number
   right: number
 }
+
+/** The content shared by a radio and its selection-overlay copy. */
+const PillOptionContent: Component<Pick<PillOptionSpec<unknown>, 'label' | 'icon'>> = props => (
+  <Show when={props.icon} fallback={props.label}>
+    {icon => <Icon icon={icon()} size={OPTION_ICON_SIZE} />}
+  </Show>
+)
 
 /** One radio in the group. */
 function PillOption(props: {
@@ -115,9 +124,7 @@ function PillOption(props: {
       onClick={props.onClick}
       onFocus={props.onFocus}
     >
-      <Show when={props.icon} fallback={props.label}>
-        {icon => <Icon icon={icon()} size={OPTION_ICON_SIZE} />}
-      </Show>
+      <PillOptionContent label={props.label} icon={props.icon} />
     </button>
   )
 
@@ -150,9 +157,12 @@ export function PillGroup<K>(props: {
   onSelect: (key: K) => void
   /** Show the current selection and refuse all changes. */
   disabled?: boolean
-  /** Draw the group at Oat's `.small` button metrics. */
+  /** Draw the group at the shared compact-control metrics. */
   small?: boolean
+  /** Explanation that assistive technology associates with the radio group. */
+  description?: string
 }) {
+  const descriptionId = createUniqueId()
   const optionsByKey = createMemo(() => optionMap(props.label, props.options))
   const optionKeys = createMemo(
     () => [...optionsByKey().keys()],
@@ -374,6 +384,7 @@ export function PillGroup<K>(props: {
       classList={{ [styles.pillGroupDisabled]: props.disabled === true }}
       role="radiogroup"
       aria-label={props.label}
+      aria-describedby={props.description ? descriptionId : undefined}
       onKeyDown={onKeyDown}
       onFocusOut={onFocusOut}
     >
@@ -413,9 +424,7 @@ export function PillGroup<K>(props: {
                         }}
                         data-label={option().label}
                       >
-                        <Show when={option().icon} fallback={option().label}>
-                          {icon => <Icon icon={icon()} size={OPTION_ICON_SIZE} />}
-                        </Show>
+                        <PillOptionContent label={option().label} icon={option().icon} />
                       </span>
                     )}
                   </Show>
@@ -452,6 +461,9 @@ export function PillGroup<K>(props: {
           </Show>
         )}
       </For>
+      <Show when={props.description}>
+        {description => <span id={descriptionId} class={srOnly}>{description()}</span>}
+      </Show>
     </div>
   )
 }

--- a/frontend/src/components/common/PillGroup.tsx
+++ b/frontend/src/components/common/PillGroup.tsx
@@ -1,8 +1,10 @@
+import type { LucideIcon } from 'lucide-solid'
 import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show } from 'solid-js'
 import { createKeyedElementRefs } from '~/lib/keyedElementRefs'
 import { createRafResizeObserver } from '~/lib/resizeObserver'
 import { nextRovingValue } from '~/lib/rovingFocus'
 import { sameValueZero, shallowEqualMapKeyArrays } from '~/lib/shallowEqual'
+import { Icon } from './Icon'
 import * as styles from './PillGroup.css'
 import { Tooltip } from './Tooltip'
 
@@ -11,9 +13,18 @@ export interface PillOptionSpec<K> {
   /** The unique selection key. */
   key: K
   label: string
+  /**
+   * Draw this in place of the label text, for an option too narrow to spell
+   * out. `label` stays the accessible name and becomes the tooltip, so the
+   * option keeps a name for a screen reader and for a by-name lookup.
+   */
+  icon?: LucideIcon
   /** A non-empty reason that makes this option unavailable. */
   disabledReason?: string
 }
+
+/** The icon size an option draws at. One line of `--text-8` is 18px tall. */
+const OPTION_ICON_SIZE = 'xs'
 
 /** One through four fixed choices. Use a menu for any other list. */
 export type PillOptions<K>
@@ -55,13 +66,32 @@ function PillOption(props: {
   tabStop: boolean
   state: PillOptionState
   separated: boolean
+  small: boolean
+  label: string
+  icon?: LucideIcon
   onClick: () => void
   onFocus: () => void
   ref: (element: HTMLButtonElement) => void
-  children: string
 }) {
   const optionRefused = () => props.state.kind === 'option-refused'
   const groupRefused = () => props.state.kind === 'group-refused'
+  /**
+   * What the tooltip says: the reason this option refuses selection, or the
+   * name an icon-only option does not spell out. A named option with no reason
+   * needs no tooltip, because its own text already says what it is.
+   */
+  const tooltipText = () => {
+    if (props.state.kind === 'option-refused')
+      return props.state.reason
+    return props.icon === undefined ? undefined : props.label
+  }
+  /**
+   * The name an icon-only option carries. Passed as a STRING rather than
+   * `true`, so it stays the name even when the tooltip states a refusal reason
+   * instead; `Tooltip` then publishes the reason as a description, because the
+   * two strings differ.
+   */
+  const tooltipName = () => (props.icon === undefined ? undefined : props.label)
   const pill = () => (
     <button
       type="button"
@@ -73,6 +103,7 @@ function PillOption(props: {
           && props.selectionSettled,
         [styles.pillOptionDimmed]: optionRefused() && !props.selected,
         [styles.pillOptionSeparated]: props.separated,
+        [styles.pillOptionSmall]: props.small,
         [styles.pillOptionUnavailable]: optionRefused(),
       }}
       role="radio"
@@ -84,16 +115,15 @@ function PillOption(props: {
       onClick={props.onClick}
       onFocus={props.onFocus}
     >
-      {props.children}
+      <Show when={props.icon} fallback={props.label}>
+        {icon => <Icon icon={icon()} size={OPTION_ICON_SIZE} />}
+      </Show>
     </button>
   )
 
   return (
-    <Show
-      when={props.state.kind === 'option-refused' ? props.state.reason : undefined}
-      fallback={pill()}
-    >
-      {reason => <Tooltip text={reason()}>{pill()}</Tooltip>}
+    <Show when={tooltipText()} fallback={pill()}>
+      {text => <Tooltip text={text()} ariaLabel={tooltipName()}>{pill()}</Tooltip>}
     </Show>
   )
 }
@@ -120,6 +150,8 @@ export function PillGroup<K>(props: {
   onSelect: (key: K) => void
   /** Show the current selection and refuse all changes. */
   disabled?: boolean
+  /** Draw the group at Oat's `.small` button metrics. */
+  small?: boolean
 }) {
   const optionsByKey = createMemo(() => optionMap(props.label, props.options))
   const optionKeys = createMemo(
@@ -375,9 +407,16 @@ export function PillGroup<K>(props: {
                     {option => (
                       <span
                         class={styles.selectionLabel}
-                        classList={{ [styles.pillOptionSeparated]: index() > 0 }}
+                        classList={{
+                          [styles.pillOptionSeparated]: index() > 0,
+                          [styles.pillOptionSmall]: props.small === true,
+                        }}
                         data-label={option().label}
-                      />
+                      >
+                        <Show when={option().icon} fallback={option().label}>
+                          {icon => <Icon icon={icon()} size={OPTION_ICON_SIZE} />}
+                        </Show>
+                      </span>
                     )}
                   </Show>
                 )}
@@ -397,6 +436,9 @@ export function PillGroup<K>(props: {
                 tabStop={ownsTabStop(key)}
                 state={stateFor(option())}
                 separated={index() > 0}
+                small={props.small === true}
+                label={option().label}
+                icon={option().icon}
                 onClick={() => select(key)}
                 onFocus={() => setFocusedKey({ value: key })}
                 ref={(element) => {
@@ -405,9 +447,7 @@ export function PillGroup<K>(props: {
                   onCleanup(() => resizeObserver?.unobserve(element))
                   restoreFocusAfterRemoval(element)
                 }}
-              >
-                {option().label}
-              </PillOption>
+              />
             )}
           </Show>
         )}

--- a/frontend/src/components/shell/QuakeTerminalPanel.test.tsx
+++ b/frontend/src/components/shell/QuakeTerminalPanel.test.tsx
@@ -50,7 +50,7 @@ function mount(over: { entry?: QuakeEntry, detached?: DetachedTerminal[] } = {})
       metadata={metadata as never}
       activeAgentId={() => entry?.ownerId ?? null}
       onClose={onClose}
-      confirmLink={async () => false}
+      confirmLink={() => Promise.resolve(false)}
       onInput={vi.fn()}
       onResize={vi.fn()}
       onContentReady={vi.fn()}
@@ -155,7 +155,7 @@ describe('quakeTerminalPanel', () => {
         metadata={{ get: () => undefined } as never}
         activeAgentId={() => 'a1'}
         onClose={vi.fn()}
-        confirmLink={async () => false}
+        confirmLink={() => Promise.resolve(false)}
         onInput={vi.fn()}
         onResize={vi.fn()}
         onContentReady={vi.fn()}

--- a/frontend/src/components/tree/DirectoryTree.tsx
+++ b/frontend/src/components/tree/DirectoryTree.tsx
@@ -902,14 +902,14 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
   const visibleRows = createMemo<VisibleRow[]>(() => {
     const rp = rootPath()
     const rows: VisibleRow[] = [{ path: rp, isDir: true, parent: undefined }]
-    const hidden = showHidden()
-    const visible = props.isVisible
-    const compare = comparator()
     const walk = (parent: string) => {
       const all = getChildren(parent)
       if (!all)
         return
-      for (const child of visibleSortedChildren(all, hidden, visible, compare)) {
+      // Read here rather than once above `walk`. This memo calls `walk` and
+      // nothing else does, so each read tracks exactly as a hoisted one did,
+      // and no inner function holds a value that a later run leaves stale.
+      for (const child of visibleSortedChildren(all, showHidden(), props.isVisible, comparator())) {
         rows.push({ path: child.path, isDir: child.isDir, parent })
         if (child.isDir && isNodeExpanded(child.path))
           walk(child.path)
@@ -931,8 +931,7 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
 
   const [focusedPath, setFocusedPath] = createSignal('')
   const tabStopPath = createMemo(() => {
-    const rows = visibleRows()
-    const onScreen = (path: string) => !!path && rows.some(r => r.path === path)
+    const onScreen = (path: string) => !!path && visibleRows().some(r => r.path === path)
     if (onScreen(focusedPath()))
       return focusedPath()
     if (onScreen(props.selectedPath))
@@ -1019,13 +1018,17 @@ export const DirectoryTree: Component<DirectoryTreeProps> = (props) => {
 
   // The root row's element, registered under the CURRENT root. `rootPath` can
   // change under a mounted tree, and a ref callback fires once per element.
+  // The `static` prefix marks the snapshot as deliberate, for the lint rule and
+  // for the reader: the cleanup must unregister the root this run REGISTERED,
+  // not whichever root is current when it fires. Reading `rootPath()` in the
+  // cleanup would delete the new root's entry and leave the old one behind.
   createEffect(() => {
     const el = rootNodeEl()
-    const rp = rootPath()
+    const staticRoot = rootPath()
     if (!el)
       return
-    registerRow(rp, el)
-    onCleanup(() => registerRow(rp, undefined))
+    registerRow(staticRoot, el)
+    onCleanup(() => registerRow(staticRoot, undefined))
   })
 
   /**

--- a/frontend/src/test-support/controlRequests.ts
+++ b/frontend/src/test-support/controlRequests.ts
@@ -10,7 +10,7 @@ import { screen, within } from '@solidjs/testing-library'
  * rename cannot be applied to some suites and missed in others.
  */
 
-/** The permission preset group (Default / Smart permissions / Bypass permissions). */
+/** The permission preset group (Default / Smart / Bypass). */
 export function permissionPillGroup() {
   return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
 }

--- a/frontend/src/test-support/controlRequests.ts
+++ b/frontend/src/test-support/controlRequests.ts
@@ -10,7 +10,7 @@ import { screen, within } from '@solidjs/testing-library'
  * rename cannot be applied to some suites and missed in others.
  */
 
-/** The permission preset group (Default / Smart / Bypass). */
+/** The permission preset group (Unchanged / Smart / Bypass). */
 export function permissionPillGroup() {
   return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
 }

--- a/frontend/tests/e2e/051-plan-mode-bypass.spec.ts
+++ b/frontend/tests/e2e/051-plan-mode-bypass.spec.ts
@@ -26,9 +26,11 @@ test.describe('Plan Mode - Bypass Permissions', () => {
     await expect(clearContextSwitch).not.toBeChecked()
 
     const permissionPill = page.getByRole('radiogroup', { name: 'Permissions' })
-    const bypassRadio = permissionPill.getByRole('radio', { name: 'Bypass permissions' })
-    await expect(permissionPill.getByRole('radio', { name: 'Default' })).toBeVisible()
-    await expect(permissionPill.getByRole('radio', { name: 'Default' })).toBeChecked()
+    const bypassRadio = permissionPill.getByRole('radio', { name: 'Bypass' })
+    await expect(permissionPill.getByRole('radio', { name: 'Unchanged' })).toBeVisible()
+    // A plan approval opens on Smart, which Claude offers.
+    await expect(permissionPill.getByRole('radio', { name: 'Smart' })).toBeChecked()
+    await expect(permissionPill.getByRole('radio', { name: 'Unchanged' })).not.toBeChecked()
     await expect(bypassRadio).toBeVisible()
     await expect(bypassRadio).not.toBeChecked()
 
@@ -77,5 +79,63 @@ test.describe('Plan Mode - Bypass Permissions', () => {
     // Reject and Approve visible again
     await expect(page.locator('[data-testid="plan-reject-btn"]')).toBeVisible()
     await expect(page.locator('[data-testid="plan-approve-btn"]')).toBeVisible()
+  })
+
+  test('lays the pill radios and their moving copies out identically', async ({ page, authenticatedWorkspace }) => {
+    const banner = await enterAndExitPlanMode(page)
+    await expect(banner.getByText('Plan Ready for Review')).toBeVisible()
+
+    const group = page.getByRole('radiogroup', { name: 'Permissions' })
+    await expect(group).toBeVisible()
+
+    // A serif face, far from the UA control font. A `<button>` takes its family
+    // from the UA stylesheet unless the rule states `inherit`, and on some
+    // platforms that family and `system-ui` resolve to the SAME face -- which
+    // would let a font divergence pass unseen here. The write goes through the
+    // CSSOM, which the page's content security policy does not restrict.
+    await page.evaluate(() => {
+      document.documentElement.style.setProperty('--font-sans', '"Times New Roman", serif')
+    })
+    await expect.poll(async () => group.evaluate(el =>
+      getComputedStyle(el.querySelector('[role="radio"]')!).fontFamily)).toContain('Times New Roman')
+
+    const measured = await group.evaluate((element) => {
+      const metrics = (el: Element | null | undefined) => {
+        if (!el)
+          return undefined
+        const rect = el.getBoundingClientRect()
+        const style = getComputedStyle(el)
+        return {
+          x: rect.x,
+          width: rect.width,
+          font: style.fontFamily,
+          fontSize: style.fontSize,
+          padding: style.padding,
+        }
+      }
+      const radios = [...element.querySelectorAll('[role="radio"]')]
+      const copies = [...element.querySelectorAll('[data-pill-selection-labels] [data-label]')]
+      return radios.map((radio, index) => ({
+        label: radio.textContent ?? '',
+        radio: metrics(radio),
+        copy: metrics(copies[index]),
+      }))
+    })
+
+    // The group paints each label twice: the real radio carries the text, and
+    // the sliding overlay repeats it as a copy that must cover that radio
+    // exactly. The fill is clipped to the RADIO, so a copy that lays out to a
+    // different width drags its 1px divider off the boundary and the primary
+    // window appears to spill into the next option. Every metric that decides
+    // the width is compared, so a rule that reaches one row and not the other
+    // fails here whatever property it sets.
+    expect(measured.length).toBeGreaterThan(1)
+    for (const option of measured) {
+      expect(option.copy?.font).toBe(option.radio?.font)
+      expect(option.copy?.fontSize).toBe(option.radio?.fontSize)
+      expect(option.copy?.padding).toBe(option.radio?.padding)
+      expect(Math.abs((option.copy?.x ?? 0) - (option.radio?.x ?? 0))).toBeLessThanOrEqual(0.5)
+      expect(Math.abs((option.copy?.width ?? 0) - (option.radio?.width ?? 0))).toBeLessThanOrEqual(0.5)
+    }
   })
 })

--- a/frontend/tests/e2e/051-plan-mode-bypass.spec.ts
+++ b/frontend/tests/e2e/051-plan-mode-bypass.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from './fixtures'
 import { ENTER_PLAN_PROMPT, enterAndExitPlanMode, EXIT_PLAN_PROMPT } from './helpers/plan-mode'
 import { expectSettingsChip, sendMessage, settingsBar, waitForAgentIdle, waitForControlBanner, waitForSettingsIdle } from './helpers/ui'
 
-test.describe('Plan Mode - Bypass Permissions', () => {
+test.describe('plan mode - bypass permissions', () => {
   test('bypass permissions from ExitPlanMode banner', async ({ page, authenticatedWorkspace }) => {
     const trigger = settingsBar(page)
     await expect(trigger).toBeVisible()
@@ -20,7 +20,7 @@ test.describe('Plan Mode - Bypass Permissions', () => {
     const banner = await waitForControlBanner(page)
     await expect(banner.getByText('Plan Ready for Review')).toBeVisible()
 
-    // Verify the switch and the permission pills are visible, Default selected.
+    // Verify the switch and the permission pills are visible, with Smart selected.
     const clearContextSwitch = page.locator('[data-testid="plan-clear-context-checkbox"] input[type="checkbox"]')
     await expect(clearContextSwitch).toBeVisible()
     await expect(clearContextSwitch).not.toBeChecked()

--- a/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
+++ b/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
@@ -62,8 +62,8 @@ zcodeTest.describe('ZCode Permission Prompt', () => {
     const banner = await waitForControlBanner(page)
     await expect(banner).toContainText('Bash')
     const pills = page.getByRole('radiogroup', { name: 'Permissions' })
-    await expect(pills.getByRole('radio', { name: 'Default' })).toBeChecked()
-    const bypass = pills.getByRole('radio', { name: 'Bypass permissions' })
+    await expect(pills.getByRole('radio', { name: 'Unchanged' })).toBeChecked()
+    const bypass = pills.getByRole('radio', { name: 'Bypass' })
     await bypass.click()
     await expect(bypass).toBeChecked()
 

--- a/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
+++ b/frontend/tests/e2e/190-zcode-basic-chat.spec.ts
@@ -3,7 +3,7 @@ import { expect, ZCODE_E2E_SKIP_REASON, zcodeTest } from './zcode-fixtures'
 
 zcodeTest.skip(!!ZCODE_E2E_SKIP_REASON, ZCODE_E2E_SKIP_REASON || '')
 
-zcodeTest.describe('ZCode Basic Chat', () => {
+zcodeTest.describe('uses ZCode for basic chat', () => {
   zcodeTest('opens, sends a prompt, and receives a response', async ({ authenticatedZCodeWorkspace, page }) => {
     void authenticatedZCodeWorkspace
     await sendMessage(page, ARITHMETIC_PROMPT)
@@ -24,7 +24,7 @@ zcodeTest.describe('ZCode Basic Chat', () => {
   })
 })
 
-zcodeTest.describe('ZCode Tool Execution', () => {
+zcodeTest.describe('uses ZCode for tool execution', () => {
   zcodeTest('a bash command renders as a tool card with its output', async ({ authenticatedZCodeWorkspace, page }) => {
     void authenticatedZCodeWorkspace
     await sendMessage(page, 'Run the bash command: echo "zcode-test-output" and show me the output.')
@@ -35,7 +35,7 @@ zcodeTest.describe('ZCode Tool Execution', () => {
   })
 })
 
-zcodeTest.describe('ZCode Permission Prompt', () => {
+zcodeTest.describe('handles ZCode permission prompts', () => {
   // Build is the default and asks before a risky action. A destructive command
   // is the shape that produces a permission banner rather than running silently.
   zcodeTest('a risky command produces a permission banner that can be denied', async ({ authenticatedZCodeWorkspace, page }) => {
@@ -74,7 +74,7 @@ zcodeTest.describe('ZCode Permission Prompt', () => {
   })
 })
 
-zcodeTest.describe('ZCode Mode Switch', () => {
+zcodeTest.describe('changes ZCode modes', () => {
   zcodeTest('offers only the bypass permission shortcut', async ({ authenticatedZCodeWorkspace, page }) => {
     void authenticatedZCodeWorkspace
     await waitForSettingsHydrated(page)


### PR DESCRIPTION
## Motivation

- Permission pill overlays used different font and sizing rules from their radios. The selected fill could cross an option boundary.
- Control actions could run before saved answer state loaded. An approval could ignore a saved permission choice.
- Copilot can keep Smart and Bypass axes active together. The prior priority could remove Bypass after an unchanged Allow.

## Modifications

- Share compact control metrics across composer actions, permission pills, and editor geometry.
- Add icon options and accessible descriptions to `PillGroup`. Render the same content in each radio and overlay copy.
- Centralize permission preset metadata, active-state priority, validation, session defaults, and response sequencing.
- Disable control actions until persisted answers finish loading. Keep plan choices independent from the optional settings handler.
- Separate leading controls from decision buttons in the shared footer row.
- Add unit and end-to-end coverage for restoration, preset overlap, missing values, accessibility, and pill geometry.

## Result

- Permission banners preserve saved choices and the session's effective permission preset.
- Applying a preset no longer races the response that approved the current request.
- Selected pill fills, labels, icons, and dividers stay aligned across fonts and compact layouts.
