### PR TITLE
feat(frontend): Refine agent controls and test settings

### DIFF
--- a/frontend/src/components/chat/AgentEditorPanel.test.tsx
+++ b/frontend/src/components/chat/AgentEditorPanel.test.tsx
@@ -81,6 +81,8 @@ interface RenderPanelOptions {
   controlStore?: ReturnType<typeof createControlStore>
   onControlResponse?: AgentEditorPanelProps['onControlResponse']
   onSettingChange?: AgentEditorPanelProps['onSettingChange']
+  onInterrupt?: AgentEditorPanelProps['onInterrupt']
+  agentWorking?: boolean
   optionGroups?: AgentInfo['optionGroups']
 }
 
@@ -109,6 +111,8 @@ function renderPanel(options: RenderPanelOptions = {}) {
         controlRequests={options.controlStore?.getRequests('a1')}
         onControlResponse={options.onControlResponse}
         onSettingChange={options.onSettingChange}
+        onInterrupt={options.onInterrupt}
+        agentWorking={options.agentWorking}
         branchActions={stubBranchMenuActions()}
         branchWorkerId={workerId}
       />
@@ -521,32 +525,31 @@ describe('agentEditorPanel control request lifecycle', () => {
     await waitFor(() => expect(clearContext()).toBeChecked())
   })
 
-  // The same record covers every control's switches, not the plan pair alone.
-  // A Codex permission prompt draws Remember from it, so one mechanism serves
-  // both and a new switch needs no further work.
-  it('restores a Codex permission prompt switch after a remount', async () => {
+  // The same record covers the pill groups that a control request draws.
+  // A Codex permission prompt stores its Allow-as selection in that record.
+  it('restores a Codex permission prompt allow choice after a remount', async () => {
     const controlStore = createControlStore()
     addControlRequest(controlStore, {
       requestId: 'perm-1',
       claimToken: 'claim-1',
       payload: { method: 'item/permissions/requestApproval', params: { permissions: { read: ['/repo'] } } },
     })
-    const remember = () => screen.getByTestId('control-remember-checkbox').querySelector('input[type="checkbox"]')!
     const first = renderPanel({ controlStore, agentProvider: AgentProvider.CODEX })
 
     await waitForControlActionsReady()
-    fireEvent.click(remember())
-    expect(remember()).toBeChecked()
+    const sessionChoice = screen.getByRole('radio', { name: 'Session' })
+    fireEvent.click(sessionChoice)
+    expect(sessionChoice).toBeChecked()
 
     first.unmount()
     renderPanel({ controlStore, agentProvider: AgentProvider.CODEX })
 
     // Polled: the saved record is read after the remount, not during it.
-    await waitFor(() => expect(remember()).toBeChecked())
+    await waitFor(() => expect(screen.getByRole('radio', { name: 'Session' })).toBeChecked())
   })
 
   // The record is written for EVERY control request now, not only a question,
-  // because a permission prompt and a plan approval carry switches. Answering
+  // because permission prompts and plan approvals carry saved choices. Answering
   // must therefore discard it: a record that outlived its request would be
   // storage that nothing can ever read again.
   it('discards the persisted switches of the answered request', async () => {
@@ -704,9 +707,10 @@ describe('agent editor panel', () => {
     // The footer slot's own rule states no size, so a button that omits this
     // style falls back to the full-size metrics and breaks the row it shares
     // with the `[+]` button, whose height uses the same compact metrics.
-    renderPanel()
+    renderPanel({ agentWorking: true, onInterrupt: vi.fn() })
 
     expect(screen.getByTestId('queue-pause-button')).toHaveClass('outline', compactControl)
+    expect(screen.getByTestId('interrupt-button')).toHaveClass('outline', compactControl)
     expect(screen.getByTestId('send-button')).toHaveClass(compactControl)
     expect(screen.getByTestId('send-button')).not.toHaveClass('outline')
   })

--- a/frontend/src/components/chat/AgentInputQueue.css.ts
+++ b/frontend/src/components/chat/AgentInputQueue.css.ts
@@ -6,6 +6,11 @@ export const root = style({
   flexDirection: 'column',
   gap: 'var(--space-1)',
   maxHeight: 'min(40vh, 20rem)',
+  // A vertical `auto` value changes the initial horizontal `visible` value to
+  // `auto`. A dragged row then extends the scrollable area with its transform
+  // and makes a horizontal scrollbar appear. Keep vertical scrolling, but
+  // hide that temporary horizontal overflow.
+  overflowX: 'hidden',
   overflowY: 'auto',
   overscrollBehavior: 'contain',
   // `inputArea` owns the gap to the neighbours. See the `inputArea` comment in

--- a/frontend/src/components/chat/AgentInputQueue.css.ts
+++ b/frontend/src/components/chat/AgentInputQueue.css.ts
@@ -6,11 +6,6 @@ export const root = style({
   flexDirection: 'column',
   gap: 'var(--space-1)',
   maxHeight: 'min(40vh, 20rem)',
-  // A vertical `auto` value changes the initial horizontal `visible` value to
-  // `auto`. A dragged row then extends the scrollable area with its transform
-  // and makes a horizontal scrollbar appear. Keep vertical scrolling, but
-  // hide that temporary horizontal overflow.
-  overflowX: 'hidden',
   overflowY: 'auto',
   overscrollBehavior: 'contain',
   // `inputArea` owns the gap to the neighbours. See the `inputArea` comment in

--- a/frontend/src/components/chat/AgentInputQueue.test.tsx
+++ b/frontend/src/components/chat/AgentInputQueue.test.tsx
@@ -124,6 +124,31 @@ describe('agentInputQueue', () => {
     expect(screen.getByTestId('queued-input-one').className).not.toContain('itemDragging')
   })
 
+  it('removes all drag wiring when the queue shrinks to one input', async () => {
+    const handlers = renderQueue({ items: [item('one'), item('two')] })
+    await flush()
+    const row = screen.getByTestId('queued-input-one')
+    const grip = screen.getByTestId('queue-drag-handle-one')
+
+    expect(row.className).toContain('itemDraggable')
+    expect(grip.className).not.toContain('dragHandleInert')
+
+    handlers.push([item('one')])
+    await flush()
+
+    expect(row.className).not.toContain('itemDraggable')
+    expect(grip.className).toContain('dragHandleInert')
+
+    grip.dispatchEvent(pointerEvent('pointerdown', { x: 10, y: 10, pointerType: 'touch' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 10, y: 90, pointerType: 'touch' }))
+    await flush()
+    const dragStarted = row.className.includes('itemDragging')
+    document.dispatchEvent(pointerEvent('pointerup', { x: 10, y: 90, pointerType: 'touch' }))
+
+    expect(dragStarted).toBe(false)
+    expect(handlers.onMove).not.toHaveBeenCalled()
+  })
+
   it('turns a drop into onMove, which is the wiring the arithmetic tests cannot reach', async () => {
     const handlers = renderQueue({ items: [item('one'), item('two')] })
     await flush()

--- a/frontend/src/components/chat/AgentInputQueue.test.tsx
+++ b/frontend/src/components/chat/AgentInputQueue.test.tsx
@@ -98,8 +98,11 @@ describe('agentInputQueue', () => {
     expect(handlers.onMove).toHaveBeenCalledWith(expect.objectContaining({ id: 'two' }), '')
   })
 
+  // THREE rows, so two remain movable once the head dispatches. A two-row queue
+  // whose head dispatches leaves the other row no destination at all, which the
+  // case below covers.
   it('gives a dispatching row an inert grip, so it offers no drag it cannot do', () => {
-    renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two')] })
+    renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two'), item('three')] })
     const dispatching = screen.getByTestId('queue-drag-handle-one')
     const movable = screen.getByTestId('queue-drag-handle-two')
     // Hidden rather than REMOVED, so the grip keeps its flex slot and the row's
@@ -112,7 +115,7 @@ describe('agentInputQueue', () => {
   })
 
   it('withholds the drag activators from a dispatching row grip', async () => {
-    const handlers = renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two')] })
+    const handlers = renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two'), item('three')] })
     await flush()
     // An affordance that cannot drag must not behave like one. Hiding the grip
     // is only half of it: without withholding the activators, a press that
@@ -122,6 +125,43 @@ describe('agentInputQueue', () => {
     document.dispatchEvent(pointerEvent('pointerup', { x: 10, y: 90, pointerType: 'touch' }))
     expect(handlers.onMove).not.toHaveBeenCalled()
     expect(screen.getByTestId('queued-input-one').className).not.toContain('itemDragging')
+  })
+
+  // The queue has two ROWS and one movable row, so no legal destination exists:
+  // `resolveQueueMove` refuses a DISPATCHING row at either end and refuses a
+  // move onto the row itself. A row count cannot see this, which is why the
+  // affordance follows the count of MOVABLE rows.
+  it('offers no drag when the only other row is dispatching', async () => {
+    const handlers = renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two')] })
+    await flush()
+    const row = screen.getByTestId('queued-input-two')
+    const grip = screen.getByTestId('queue-drag-handle-two')
+
+    expect(row.className).not.toContain('itemDraggable')
+    expect(grip.className).toContain('dragHandleInert')
+
+    grip.dispatchEvent(pointerEvent('pointerdown', { x: 10, y: 10, pointerType: 'touch' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 10, y: 90, pointerType: 'touch' }))
+    await flush()
+    const dragStarted = row.className.includes('itemDragging')
+    document.dispatchEvent(pointerEvent('pointerup', { x: 10, y: 90, pointerType: 'touch' }))
+
+    expect(dragStarted).toBe(false)
+    expect(handlers.onMove).not.toHaveBeenCalled()
+  })
+
+  // The head finishes dispatching, so a second movable row appears and the drag
+  // affordance must come back on its own.
+  it('restores the drag affordance once a dispatching head becomes queued', async () => {
+    const handlers = renderQueue({ items: [item('one', { state: AgentInputState.DISPATCHING }), item('two')] })
+    await flush()
+    expect(screen.getByTestId('queued-input-two').className).not.toContain('itemDraggable')
+
+    handlers.push([item('one'), item('two')])
+    await flush()
+
+    expect(screen.getByTestId('queued-input-two').className).toContain('itemDraggable')
+    expect(screen.getByTestId('queue-drag-handle-two').className).not.toContain('dragHandleInert')
   })
 
   it('removes all drag wiring when the queue shrinks to one input', async () => {

--- a/frontend/src/components/chat/AgentInputQueue.tsx
+++ b/frontend/src/components/chat/AgentInputQueue.tsx
@@ -184,14 +184,20 @@ export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
   }
 
   /**
-   * Whether this key's row can be dragged, resolved through the LIVE lookup.
+   * Whether this key's row can be dragged, resolved through the LIVE queue.
    *
    * Read through `byKey()` and never from an item the row captured at mount.
    * The row keeps its identity now, so a captured item would freeze this at the
    * state the row started with, and a row that becomes DISPATCHING would keep a
    * live grip and live drag activators.
+   *
+   * A queue with one input has no legal destination. Withholding the same
+   * activators also removes the cursor and the visible touch grip, so the row
+   * does not offer an operation that cannot change its position.
    */
   const canDragKey = (key: string) => {
+    if (items().length < 2)
+      return false
     const item = byKey().get(key)
     return !!item && item.state !== AgentInputState.DISPATCHING
   }

--- a/frontend/src/components/chat/AgentInputQueue.tsx
+++ b/frontend/src/components/chat/AgentInputQueue.tsx
@@ -183,6 +183,13 @@ export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
       props.onMove(resolved.moved, resolved.beforeInputId)
   }
 
+  // ONE scan for the whole list, for the same reason as `anyItemIsEdited`: every
+  // row asks the same question, so a per-row scan costs the square of the queue
+  // length on every snapshot.
+  const movableCount = createMemo(
+    () => items().filter(candidate => candidate.state !== AgentInputState.DISPATCHING).length,
+  )
+
   /**
    * Whether this key's row can be dragged, resolved through the LIVE queue.
    *
@@ -191,15 +198,21 @@ export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
    * state the row started with, and a row that becomes DISPATCHING would keep a
    * live grip and live drag activators.
    *
-   * A queue with one input has no legal destination. Withholding the same
-   * activators also removes the cursor and the visible touch grip, so the row
-   * does not offer an operation that cannot change its position.
+   * The question is whether this row has a legal DESTINATION, which is what
+   * `resolveQueueMove` answers for the two arrow buttons. That function refuses
+   * a move onto the row itself and refuses a DISPATCHING row at either end, so a
+   * destination exists exactly when a second row that is not DISPATCHING does. A
+   * count of the whole queue is not the same test: a queue of one DISPATCHING
+   * row and one queued row has two rows and no legal move, and the queued row
+   * would lift and snap back with nothing saying why.
+   *
+   * Withholding the activators also removes the cursor and the visible touch
+   * grip, so the row does not offer an operation that cannot change its
+   * position.
    */
   const canDragKey = (key: string) => {
-    if (items().length < 2)
-      return false
     const item = byKey().get(key)
-    return !!item && item.state !== AgentInputState.DISPATCHING
+    return !!item && item.state !== AgentInputState.DISPATCHING && movableCount() >= 2
   }
 
   /**
@@ -211,7 +224,8 @@ export const AgentInputQueue: Component<AgentInputQueueProps> = (props) => {
    * at creation.
    */
   const setupRowDnd = (key: string) => {
-    const dragRow = createGuardedSortableRow(key)
+    // A vertical list: the row must not travel sideways past the queue.
+    const dragRow = createGuardedSortableRow(key, undefined, 'y')
     const [rowEl, setRowEl] = createSignal<HTMLElement>()
     // Fine-pointer presses on the row body drag it; touch presses do not, so a
     // swipe still scrolls the queue. The grip carries the raw activators, which

--- a/frontend/src/components/chat/ControlRequestBanner.css.ts
+++ b/frontend/src/components/chat/ControlRequestBanner.css.ts
@@ -192,10 +192,11 @@ export const controlFooterRight = style({
 })
 
 // The leading options cluster of a decision row: the request's switches, then
-// the permission pill group, on ONE line ahead of the decision buttons. The pill
-// group is button-high, so nothing here needs the second line the switch COLUMN
-// used to occupy; the cluster keeps `minWidth: 0` so a narrow composer can
-// compress the pills (they clip inside their own box) before the buttons move.
+// the allow-choice pill group, then the permission pill group, on ONE line ahead
+// of the decision buttons. A pill group is button-high, so nothing here needs
+// the second line the switch COLUMN used to occupy; the cluster keeps
+// `minWidth: 0` so a narrow composer can compress the pills (they clip inside
+// their own box) before the buttons move.
 export const controlRequestSwitches = style({
   display: 'flex',
   flexDirection: 'row',

--- a/frontend/src/components/chat/ControlRequestBanner.css.ts
+++ b/frontend/src/components/chat/ControlRequestBanner.css.ts
@@ -151,16 +151,46 @@ export const controlBannerTitle = style({
 // Interrupt/Send cluster included. A border here as well painted a SECOND line
 // a couple of pixels from the first, because a control request forces the
 // expanded layout and therefore always renders both.
+/**
+ * The action row of a control request.
+ *
+ * NO vertical padding. The row is the only child of the composer's footer slot
+ * that sets its own height, and the slot centres what it holds -- so padding
+ * here made the slot taller than the Pause button inside it, and that button
+ * then sat 4px above the `[+]` anchored to the same bottom line. The slot's own
+ * `bottom` offset is what separates the row from the box edge.
+ *
+ * It SHRINKS. `flex-shrink: 0` pinned the row at its max-content width, so a
+ * row wider than the composer overflowed to the LEFT -- `justify-content:
+ * flex-end` pushes the overflow that way -- and the editor's `overflow: hidden`
+ * clipped it. On a phone the whole allow-choice group sat off the left edge,
+ * invisible and impossible to tap. `min-width: 0` alone could not help, because
+ * a shrink factor of zero refuses to shrink at all.
+ *
+ * The tracks are `auto auto 1fr`, so a zone the caller omits reserves nothing.
+ * `1fr auto 1fr` gave the empty left zone an equal share of the row, which left
+ * a decision row half the width it had.
+ */
 export const controlFooter = style({
   display: 'grid',
-  gridTemplateColumns: '1fr auto 1fr',
+  gridTemplateColumns: 'auto auto 1fr',
   alignItems: 'center',
   gap: 'var(--space-1)',
-  padding: 'var(--space-1) var(--space-2)',
+  padding: '0 var(--space-2)',
   backgroundColor: 'var(--background)',
-  flexShrink: 0,
   flexGrow: 1,
   minWidth: 0,
+})
+
+/**
+ * The track shape that CENTRES the middle zone, for a row that fills it.
+ *
+ * Equal outer tracks are what put the centre in the middle, and they are also
+ * what wastes a row that has no middle -- so the base rule above omits them and
+ * this restores them exactly where the centring is the point.
+ */
+export const controlFooterCentred = style({
+  gridTemplateColumns: '1fr auto 1fr',
 })
 
 // All three zones pin their own column. Auto-placement would put a zone's column
@@ -183,20 +213,35 @@ export const controlFooterCentre = style({
   gridColumn: 2,
 })
 
+// `minWidth: 0`, so the `1fr` track can actually constrain this zone. A grid
+// item's automatic minimum size is its min-content width, and the decision
+// buttons never wrap, so without this the track grew to fit them and the row
+// overflowed the composer instead of compressing.
 export const controlFooterRight = style({
   display: 'flex',
   alignItems: 'center',
   gap: 'var(--space-1)',
   justifyContent: 'flex-end',
   gridColumn: 3,
+  minWidth: 0,
 })
 
-// The leading options cluster of a decision row: the request's switches, then
-// the allow-choice pill group, then the permission pill group, on ONE line ahead
-// of the decision buttons. A pill group is button-high, so nothing here needs
-// the second line the switch COLUMN used to occupy; the cluster keeps
-// `minWidth: 0` so a narrow composer can compress the pills (they clip inside
-// their own box) before the buttons move.
+/**
+ * The leading options cluster of a decision row: the request's switches, then
+ * the allow-choice pill group, then the permission pill group, on ONE line ahead
+ * of the decision buttons. A pill group is button-high, so nothing here needs
+ * the second line the switch COLUMN used to occupy.
+ *
+ * It SCROLLS sideways, and it is the only part of the row that gives way. The
+ * decision buttons keep their size, because Allow and Reject must stay readable
+ * and reachable at every width; this cluster takes what is left and the user
+ * swipes it. The alternative -- letting the pills compress -- squeezed a group
+ * to two pixels on a phone, which states nothing and answers nothing.
+ *
+ * The scrollbar is HIDDEN, as the tab strip hides its own (`tabList` in
+ * `~/components/shell/TabBar.css.ts`). A scrollbar inside a 28px row would eat
+ * most of it, and this is a swipe surface rather than a scroll region.
+ */
 export const controlRequestSwitches = style({
   display: 'flex',
   flexDirection: 'row',
@@ -204,15 +249,23 @@ export const controlRequestSwitches = style({
   gap: 'var(--space-1)',
   marginRight: 'var(--space-1)',
   minWidth: 0,
+  flex: '1 1 auto',
+  overflowX: 'auto',
+  scrollbarWidth: 'none',
+  WebkitOverflowScrolling: 'touch',
+  touchAction: 'pan-x',
 })
 
-// The pill group yields width before the decision buttons do: `flexShrink` lets
-// the row compress it, and PillGroup's own `max-width: 100%` + `overflow: hidden`
-// decide what a compressed group shows.
+globalStyle(`${controlRequestSwitches}::-webkit-scrollbar`, {
+  display: 'none',
+})
+
+// A pill group keeps its natural width and the cluster around it scrolls, so
+// `flexShrink: 0`. It used to shrink, and the group's own `max-width: 100%` then
+// resolved against a box the row had already squeezed to nothing.
 export const controlRequestPill = style({
   display: 'flex',
-  minWidth: 0,
-  flexShrink: 1,
+  flexShrink: 0,
 })
 
 export const bannerReason = style({

--- a/frontend/src/components/chat/ControlRequestBanner.test.tsx
+++ b/frontend/src/components/chat/ControlRequestBanner.test.tsx
@@ -2,6 +2,7 @@ import type { ControlRequest } from '~/stores/control.store'
 import { render, screen } from '@solidjs/testing-library'
 import { createSignal } from 'solid-js'
 import { describe, expect, it, vi } from 'vitest'
+import { compactControl } from '~/components/common/CompactControl.css'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { ControlRequestActions, ControlRequestContent } from './ControlRequestBanner'
 import { createControlAnswerState } from './controls/types'
@@ -130,6 +131,9 @@ describe('controlRequestBanner reactive request removal', () => {
     }).not.toThrow()
 
     expect(screen.queryByTestId('plan-approve-btn')).not.toBeInTheDocument()
-    expect(screen.getByTestId('control-submit-btn')).toBeInTheDocument()
+    expect(screen.getByTestId('control-stop-btn')).toHaveClass('outline', compactControl)
+    expect(screen.getByTestId('control-yolo-btn')).toHaveClass('outline', compactControl)
+    expect(screen.getByTestId('control-submit-btn')).toHaveClass(compactControl)
+    expect(screen.getByTestId('control-submit-btn')).not.toHaveClass('outline')
   })
 })

--- a/frontend/src/components/chat/ControlRequestBanner.test.tsx
+++ b/frontend/src/components/chat/ControlRequestBanner.test.tsx
@@ -131,6 +131,24 @@ describe('controlRequestBanner reactive request removal', () => {
     }).not.toThrow()
 
     expect(screen.queryByTestId('plan-approve-btn')).not.toBeInTheDocument()
+    expect(screen.getByTestId('control-submit-btn')).toBeInTheDocument()
+  })
+
+  // Its own case, so a metrics regression names the metrics. Folded into the
+  // removal test above, it failed under a name that sent the reader to the
+  // request lifecycle instead.
+  it('uses Oat small metrics for question actions', () => {
+    render(() => (
+      <ControlRequestActions
+        request={questionRequest()}
+        answerState={createControlAnswerState()}
+        agentProvider={AgentProvider.CLAUDE_CODE}
+        onRespond={vi.fn().mockResolvedValue(undefined)}
+        hasEditorContent={false}
+        onTriggerSend={() => {}}
+      />
+    ))
+
     expect(screen.getByTestId('control-stop-btn')).toHaveClass('outline', compactControl)
     expect(screen.getByTestId('control-yolo-btn')).toHaveClass('outline', compactControl)
     expect(screen.getByTestId('control-submit-btn')).toHaveClass(compactControl)

--- a/frontend/src/components/chat/controls/ControlActionRow.tsx
+++ b/frontend/src/components/chat/controls/ControlActionRow.tsx
@@ -55,7 +55,10 @@ export function actionButtonClass(outline?: boolean): string {
 }
 
 export const ControlActionRow: Component<ControlActionRowProps> = props => (
-  <div class={styles.controlFooter} data-testid="control-footer">
+  <div
+    class={props.centre ? `${styles.controlFooter} ${styles.controlFooterCentred}` : styles.controlFooter}
+    data-testid="control-footer"
+  >
     <Show when={props.secondary}>
       <div class={styles.controlFooterLeft}>{props.secondary}</div>
     </Show>

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.test.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.test.tsx
@@ -121,4 +121,36 @@ describe('controlDecisionFooter', () => {
     fireEvent.click(screen.getByRole('radio', { name: 'Session' }))
     expect(onSelect).toHaveBeenCalledWith('session')
   })
+
+  // The order runs from what this request grants to what the session keeps. It
+  // lives in the JSX alone, so without this a reorder changes the reading order
+  // of every Codex and ACP approval row and nothing fails.
+  it('renders the leading cluster in one order', () => {
+    render(() => (
+      <ControlDecisionFooter
+        hasEditorContent={false}
+        onSendFeedback={vi.fn()}
+        negativeAction={{ label: 'Deny', testId: 'deny', onSelect: vi.fn() }}
+        positiveAction={{ label: 'Allow', testId: 'allow', onSelect: vi.fn() }}
+        switches={() => [{ id: 'clear-context', label: 'Clear Context', checked: false, onChange: vi.fn() }]}
+        allowChoicePill={() => ({
+          label: 'Allow as',
+          options: [{ key: 'once', label: 'Once' }, { key: 'session', label: 'Session' }],
+          selected: 'once',
+          onSelect: vi.fn(),
+        })}
+        permissionPill={() => ({
+          options: [{ key: 'unspecified', label: 'Unchanged' }, { key: 'bypass', label: 'Bypass' }],
+          selected: 'unspecified',
+          onSelect: vi.fn(),
+        })}
+      />
+    ))
+
+    const switchEl = screen.getByTestId('clear-context')
+    const allowGroup = screen.getByTestId('control-allow-choice-pill-group')
+    const permissionGroup = screen.getByTestId('control-permissions-pill-group')
+    expect(switchEl.compareDocumentPosition(allowGroup) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(allowGroup.compareDocumentPosition(permissionGroup) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
 })

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.test.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.test.tsx
@@ -16,20 +16,20 @@ describe('controlDecisionFooter', () => {
         negativeAction={{ label: 'Deny', testId: 'deny', onSelect: vi.fn() }}
         positiveAction={{ label: 'Allow', testId: 'allow', onSelect: vi.fn() }}
         switches={() => [{
-          id: 'remember',
-          label: 'Remember',
+          id: 'clear-context',
+          label: 'Clear Context',
           checked: checked(),
           onChange: setChecked,
         }]}
       />
     ))
 
-    const input = screen.getByTestId('remember').querySelector('input')!
+    const input = screen.getByTestId('clear-context').querySelector('input')!
     input.focus()
     fireEvent.click(input)
 
     expect(input.checked).toBe(true)
-    expect(screen.getByTestId('remember').querySelector('input')).toBe(input)
+    expect(screen.getByTestId('clear-context').querySelector('input')).toBe(input)
     expect(document.activeElement).toBe(input)
   })
 
@@ -96,5 +96,29 @@ describe('controlDecisionFooter', () => {
     finally {
       vi.useRealTimers()
     }
+  })
+
+  it('renders provider allow choices in the leading controls', () => {
+    const onSelect = vi.fn()
+    render(() => (
+      <ControlDecisionFooter
+        hasEditorContent={false}
+        onSendFeedback={vi.fn()}
+        negativeAction={{ label: 'Deny', testId: 'deny', onSelect: vi.fn() }}
+        positiveAction={{ label: 'Allow', testId: 'allow', onSelect: vi.fn() }}
+        allowChoicePill={() => ({
+          label: 'Allow as',
+          options: [
+            { key: 'once', label: 'Once' },
+            { key: 'session', label: 'Session' },
+          ],
+          selected: 'once',
+          onSelect,
+        })}
+      />
+    ))
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Session' }))
+    expect(onSelect).toHaveBeenCalledWith('session')
   })
 })

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
@@ -28,8 +28,15 @@ export interface ControlDecisionAction {
 export const ControlDecisionFooter: Component<{
   hasEditorContent: boolean
   onSendFeedback: () => void
-  negativeAction: ControlDecisionAction
-  positiveAction: ControlDecisionAction
+  /**
+   * The refusal. OMIT it only when the provider offered no way to refuse: the
+   * slot then draws nothing, rather than a button that sends a decision the
+   * request never carried. `hasEditorContent` still turns the slot into Send
+   * feedback, which needs no decision of its own.
+   */
+  negativeAction?: ControlDecisionAction
+  /** The approval. Omit it when the provider offered no way to approve. */
+  positiveAction?: ControlDecisionAction
   switches?: Accessor<ControlRequestSwitch[]>
   /** The provider-derived choices for how the positive action grants access. */
   allowChoicePill?: Accessor<ControlAllowChoicePill | undefined>
@@ -39,8 +46,11 @@ export const ControlDecisionFooter: Component<{
 }> = (props) => {
   const switches = () => props.switches?.() ?? []
   const additionalActions = () => props.additionalActions?.() ?? []
-  // One leading cluster keeps the options before the decisions. Each pill is
-  // button-high, so the pills share the row with the switches.
+  // One leading cluster -- [switches][allow-choice pill][permission pill] -- so
+  // the row reads as options followed by decisions. Each pill is button-high, so
+  // the pills share the row with the switches instead of stacking above them.
+  // The order runs from what this request grants to what the session keeps, and
+  // `controlDecisionFooter renders the leading cluster in one order` pins it.
   const leadingOptions = () => switches().length > 0 || !!props.allowChoicePill?.() || !!props.permissionPill?.()
 
   return (
@@ -72,22 +82,28 @@ export const ControlDecisionFooter: Component<{
       )}
       primary={(
         <>
-          <button
-            class={actionButtonClass(true)}
-            onMouseDown={keepFocusOnPress}
-            onClick={() => props.hasEditorContent ? props.onSendFeedback() : props.negativeAction.onSelect()}
-            data-testid={props.negativeAction.testId}
-          >
-            {props.hasEditorContent ? 'Send feedback' : props.negativeAction.label}
-          </button>
-          <Show when={!props.hasEditorContent}>
+          <Show when={props.hasEditorContent || props.negativeAction}>
             <button
-              class={actionButtonClass(props.positiveAction.outline)}
-              onClick={props.positiveAction.onSelect}
-              data-testid={props.positiveAction.testId}
+              class={actionButtonClass(true)}
+              onMouseDown={keepFocusOnPress}
+              onClick={() => props.hasEditorContent ? props.onSendFeedback() : props.negativeAction?.onSelect()}
+              data-testid={props.negativeAction?.testId ?? 'control-deny-btn'}
             >
-              {props.positiveAction.label}
+              {props.hasEditorContent ? 'Send feedback' : props.negativeAction?.label}
             </button>
+          </Show>
+          <Show when={!props.hasEditorContent}>
+            <Show when={props.positiveAction}>
+              {action => (
+                <button
+                  class={actionButtonClass(action().outline)}
+                  onClick={action().onSelect}
+                  data-testid={action().testId}
+                >
+                  {action().label}
+                </button>
+              )}
+            </Show>
             <For each={additionalActions()}>
               {decision => (
                 <button

--- a/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
+++ b/frontend/src/components/chat/controls/ControlDecisionFooter.tsx
@@ -1,4 +1,5 @@
 import type { Accessor, Component } from 'solid-js'
+import type { ControlAllowChoicePill } from './ControlPillGroups'
 import type { ControlPermissionPill } from './permissionPresets'
 
 import { For, Index, Show } from 'solid-js'
@@ -6,7 +7,7 @@ import { CompactSwitch } from '~/components/common/CompactSwitch'
 import { keepFocusOnPress } from '~/lib/focusRetention'
 import * as styles from '../ControlRequestBanner.css'
 import { actionButtonClass, ControlActionRow } from './ControlActionRow'
-import { ControlPermissionPillGroup } from './ControlPillGroups'
+import { ControlAllowChoicePillGroup, ControlPermissionPillGroup } from './ControlPillGroups'
 
 export interface ControlRequestSwitch {
   id: string
@@ -30,16 +31,17 @@ export const ControlDecisionFooter: Component<{
   negativeAction: ControlDecisionAction
   positiveAction: ControlDecisionAction
   switches?: Accessor<ControlRequestSwitch[]>
+  /** The provider-derived choices for how the positive action grants access. */
+  allowChoicePill?: Accessor<ControlAllowChoicePill | undefined>
   /** The permission pill group, or omit it when no preset is available. */
   permissionPill?: Accessor<ControlPermissionPill | undefined>
   additionalActions?: Accessor<ControlDecisionAction[]>
 }> = (props) => {
   const switches = () => props.switches?.() ?? []
   const additionalActions = () => props.additionalActions?.() ?? []
-  // One leading cluster -- [switches][permission pill] -- so the row reads as
-  // options followed by decisions: a pill is button-high, so it shares the row
-  // with the switches instead of stacking above them.
-  const leadingOptions = () => switches().length > 0 || !!props.permissionPill?.()
+  // One leading cluster keeps the options before the decisions. Each pill is
+  // button-high, so the pills share the row with the switches.
+  const leadingOptions = () => switches().length > 0 || !!props.allowChoicePill?.() || !!props.permissionPill?.()
 
   return (
     <ControlActionRow
@@ -59,6 +61,9 @@ export const ControlDecisionFooter: Component<{
                 </CompactSwitch>
               )}
             </Index>
+            <Show when={props.allowChoicePill?.()}>
+              {pill => <ControlAllowChoicePillGroup pill={pill()} />}
+            </Show>
             <Show when={props.permissionPill?.()}>
               {pill => <ControlPermissionPillGroup pill={pill()} />}
             </Show>

--- a/frontend/src/components/chat/controls/ControlPillGroups.tsx
+++ b/frontend/src/components/chat/controls/ControlPillGroups.tsx
@@ -24,23 +24,27 @@ export const ControlPermissionPillGroup: Component<{ pill: ControlPermissionPill
   </div>
 )
 
-/**
- * The allow-scope pill group a permission request offers when one allow-once
- * faces one or more allow-always scopes (Once / Always, or Once / Session /
- * Project): the scope control for HOW LONG an allow lasts, keys being optionIds
- * so a selection maps straight onto the wire reply.
- */
-export const ControlAllowScopePillGroup: Component<{
+/** One provider-derived choice for how the positive action grants access. */
+export interface ControlAllowChoicePill {
+  label: string
+  description?: string
   options: PillOptions<string>
   selected: string
-  onSelect: (optionId: string) => void
-}> = props => (
-  <div class={styles.controlRequestPill} data-testid="control-allow-scope-pill-group">
+  onSelect: (key: string) => void
+}
+
+/**
+ * The allow-choice pill group for a control request. ACP supplies duration
+ * scopes. Codex supplies its native turn, session, and policy choices.
+ */
+export const ControlAllowChoicePillGroup: Component<{ pill: ControlAllowChoicePill }> = props => (
+  <div class={styles.controlRequestPill} data-testid="control-allow-choice-pill-group">
     <PillGroup
-      label="Allow scope"
-      options={props.options}
-      selectedKey={props.selected}
-      onSelect={props.onSelect}
+      label={props.pill.label}
+      description={props.pill.description}
+      options={props.pill.options}
+      selectedKey={props.pill.selected}
+      onSelect={props.pill.onSelect}
       small
     />
   </div>

--- a/frontend/src/components/chat/controls/ControlPillGroups.tsx
+++ b/frontend/src/components/chat/controls/ControlPillGroups.tsx
@@ -24,10 +24,21 @@ export const ControlPermissionPillGroup: Component<{ pill: ControlPermissionPill
   </div>
 )
 
-/** One provider-derived choice for how the positive action grants access. */
+/**
+ * One provider-derived choice for how the positive action grants access.
+ *
+ * A `key` is OPAQUE to this group. The group reports the selected key back, and
+ * the caller maps it to its own reply. Each caller picks a different vocabulary:
+ * ACP and OpenCode use the wire `optionId`, so a key IS the reply; Codex's
+ * decision pills use a synthetic `codex-allow-<n>` that must never reach the
+ * wire; Codex's permission pills use `turn` and `session`, which are the reply's
+ * `scope`. So never send a key onward without the caller's own lookup.
+ *
+ * The `label` is also the accessible name the tests and the E2E specs look the
+ * group up by (`~/test-support/controlRequests`), and each caller owns it.
+ */
 export interface ControlAllowChoicePill {
   label: string
-  description?: string
   options: PillOptions<string>
   selected: string
   onSelect: (key: string) => void
@@ -35,13 +46,12 @@ export interface ControlAllowChoicePill {
 
 /**
  * The allow-choice pill group for a control request. ACP supplies duration
- * scopes. Codex supplies its native turn, session, and policy choices.
+ * scopes. Codex supplies its own turn, session, and policy decisions.
  */
 export const ControlAllowChoicePillGroup: Component<{ pill: ControlAllowChoicePill }> = props => (
   <div class={styles.controlRequestPill} data-testid="control-allow-choice-pill-group">
     <PillGroup
       label={props.pill.label}
-      description={props.pill.description}
       options={props.pill.options}
       selectedKey={props.pill.selected}
       onSelect={props.pill.onSelect}

--- a/frontend/src/components/chat/controls/PermissionDecisionActions.tsx
+++ b/frontend/src/components/chat/controls/PermissionDecisionActions.tsx
@@ -6,9 +6,8 @@ import { createMemo, For, Show } from 'solid-js'
 import { ButtonGroup } from '~/components/common/ButtonGroup'
 import * as styles from '../ControlRequestBanner.css'
 import { actionButtonClass, ControlActionRow } from './ControlActionRow'
-import { ControlAllowScopePillGroup, ControlPermissionPillGroup } from './ControlPillGroups'
+import { ControlAllowChoicePillGroup, ControlPermissionPillGroup } from './ControlPillGroups'
 import {
-  ALLOW_SCOPE_CHOICE_ID,
   allowScopePillOptions,
   decisionLabel,
   isAllowPermissionKind,
@@ -18,7 +17,7 @@ import {
   resolvePermissionOption,
 } from './permissionOptions'
 import { buildSessionPermissionPill, createSessionPermissionPresetChoice, respondThenApplyPermissionPreset } from './permissionPresets'
-import { createControlChoice } from './types'
+import { CONTROL_ALLOW_CHOICE_ID, createControlChoice } from './types'
 
 /** Sends one selected option as the provider's permission reply (ACP- and OpenCode-family envelopes are the same). */
 export type SendPermissionOption = (
@@ -44,7 +43,7 @@ export const PermissionDecisionActions: Component<ActionsProps & {
 }> = (props) => {
   const layout = createMemo(() => layoutPermissionOptions(props.options(props.request.payload)))
   const permissionChoice = createSessionPermissionPresetChoice(props)
-  const scopeChoice = createControlChoice(() => props.answerState, ALLOW_SCOPE_CHOICE_ID)
+  const scopeChoice = createControlChoice(() => props.answerState, CONTROL_ALLOW_CHOICE_ID)
 
   // The scope pills a payload with always options draws (Once / Always, or
   // Once / Session / Project). The stored selection is clamped to the offered
@@ -99,10 +98,13 @@ export const PermissionDecisionActions: Component<ActionsProps & {
           <div class={styles.controlRequestSwitches}>
             <Show when={scopeOptions()}>
               {options => (
-                <ControlAllowScopePillGroup
-                  options={options()}
-                  selected={selectedScope() ?? options()[0].key}
-                  onSelect={scopeChoice.setChoice}
+                <ControlAllowChoicePillGroup
+                  pill={{
+                    label: 'Allow scope',
+                    options: options(),
+                    selected: selectedScope() ?? options()[0].key,
+                    onSelect: scopeChoice.setChoice,
+                  }}
                 />
               )}
             </Show>

--- a/frontend/src/components/chat/controls/permissionOptions.ts
+++ b/frontend/src/components/chat/controls/permissionOptions.ts
@@ -15,9 +15,6 @@ const KIND_REJECT_ALWAYS = 'reject_always'
 
 const CANONICAL_KINDS = [KIND_ALLOW_ONCE, KIND_ALLOW_ALWAYS, KIND_REJECT_ONCE, KIND_REJECT_ALWAYS]
 
-/** The answer-state key the allow-scope pill group's selection is stored under. */
-export const ALLOW_SCOPE_CHOICE_ID = 'control-allow-scope-pill'
-
 export function isRejectPermissionKind(kind: string): boolean {
   return kind === KIND_REJECT_ONCE || kind === KIND_REJECT_ALWAYS
 }

--- a/frontend/src/components/chat/controls/permissionOptions.ts
+++ b/frontend/src/components/chat/controls/permissionOptions.ts
@@ -1,5 +1,5 @@
 import type { PillOptions } from '~/components/common/PillGroup'
-import { isPillOptions, PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
+import { disambiguateLabels, isPillOptions, PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
 
 export interface WirePermissionOption {
   optionId: string
@@ -226,13 +226,7 @@ export function allowScopeLabel(option: WirePermissionOption): string {
  * one group share a label the user cannot distinguish.
  */
 export function allowScopePillOptions(scope: readonly WirePermissionOption[]): PillOptions<string> | undefined {
-  const labels = scope.map(option => allowScopeLabel(option))
-  const counts = new Map<string, number>()
-  for (const label of labels)
-    counts.set(label, (counts.get(label) ?? 0) + 1)
-  const pills = scope.map((option, index) => ({
-    key: option.optionId,
-    label: (counts.get(labels[index]) ?? 0) > 1 ? permissionOptionLabel(option) : labels[index]!,
-  }))
+  const labels = disambiguateLabels(scope, allowScopeLabel, permissionOptionLabel)
+  const pills = scope.map((option, index) => ({ key: option.optionId, label: labels[index]! }))
   return isPillOptions(pills) ? pills : undefined
 }

--- a/frontend/src/components/chat/controls/types.test.ts
+++ b/frontend/src/components/chat/controls/types.test.ts
@@ -71,14 +71,14 @@ describe('createControlSwitch', () => {
   // apart. A write must leave its siblings alone rather than replace the map.
   it('keeps two switches of one record apart by id', () => {
     const state = createControlAnswerState()
-    const remember = createControlSwitch(() => state, 'control-remember-checkbox')
+    const preview = createControlSwitch(() => state, 'control-preview-checkbox')
     const clear = createControlSwitch(() => state, 'plan-clear-context-checkbox')
 
-    remember.set(true)
+    preview.set(true)
     clear.set(true)
-    remember.set(false)
+    preview.set(false)
 
-    expect(remember.checked()).toBe(false)
+    expect(preview.checked()).toBe(false)
     expect(clear.checked()).toBe(true)
   })
 
@@ -123,18 +123,18 @@ describe('createControlChoice', () => {
     expect(state.choices()).toEqual({ 'control-permissions-pill': 'bypass' })
   })
 
-  // The permission pill's choice and a switch share one RECORD but not one map,
+  // The permission pill's choice and a switch share one record but not one map,
   // so a choice write must leave the switches untouched and vice versa.
   it('keeps the choices map apart from the switches map', () => {
     const state = createControlAnswerState()
     const pill = createControlChoice(() => state, 'control-permissions-pill', 'default')
-    const remember = createControlSwitch(() => state, 'control-remember-checkbox')
+    const clear = createControlSwitch(() => state, 'plan-clear-context-checkbox')
 
     pill.setChoice('bypass')
-    remember.set(true)
+    clear.set(true)
 
     expect(state.choices()).toEqual({ 'control-permissions-pill': 'bypass' })
-    expect(state.switches()).toEqual({ 'control-remember-checkbox': true })
+    expect(state.switches()).toEqual({ 'plan-clear-context-checkbox': true })
   })
 
   // The record is captured ONCE, at creation, for the same reason as a switch:

--- a/frontend/src/components/chat/controls/types.test.ts
+++ b/frontend/src/components/chat/controls/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { createControlAnswerState, createControlChoice, createControlSwitch, toRpcId } from './types'
+import { CONTROL_ALLOW_CHOICE_ID, createControlAnswerState, createControlChoice, createControlSwitch, toRpcId } from './types'
 
 describe('toRpcId', () => {
   it('converts numeric string to number', () => {
@@ -106,7 +106,7 @@ describe('createControlChoice', () => {
 
   it('reads undefined before any selection when no fallback is passed', () => {
     const state = createControlAnswerState()
-    const scope = createControlChoice(() => state, 'control-allow-scope-pill')
+    const scope = createControlChoice(() => state, CONTROL_ALLOW_CHOICE_ID)
     expect(scope.choice()).toBeUndefined()
 
     scope.setChoice('always')

--- a/frontend/src/components/chat/controls/types.ts
+++ b/frontend/src/components/chat/controls/types.ts
@@ -28,11 +28,11 @@ export interface Question {
  * or a reload brings the answer back.
  *
  * `switches` holds every toggle a control offers, by the switch's own id
- * (`plan-clear-context-checkbox`, `control-remember-checkbox`). One map covers
- * every control rather than a field per switch, so a new switch needs no change
- * here and cannot be the one that a rebuild silently unchecks. `choices` is its
- * one-of-N sibling, holding a pill group's selection by the group's id
- * (`control-permissions-pill`) — a string, because a pill picks a key, not a
+ * (`plan-clear-context-checkbox`). One map covers every control rather than a
+ * field per switch, so a new switch needs no change here and cannot be the one
+ * that a rebuild silently unchecks. `choices` is its one-of-N sibling, holding
+ * a pill group's selection by the group's id (`control-permissions-pill`,
+ * `control-allow-scope-pill`) — a string, because a pill picks a key, not a
  * boolean.
  */
 export interface ControlAnswerState {
@@ -127,6 +127,12 @@ export function createControlChoice(state: () => ControlAnswerState, id: string,
     setChoice: (value: string) => answer.setChoices(prev => ({ ...prev, [id]: value })),
   }
 }
+
+/**
+ * The saved choice key for a control request's allow behavior. The string stays
+ * compatible with saved ACP request state from before Codex used the same pill.
+ */
+export const CONTROL_ALLOW_CHOICE_ID = 'control-allow-scope-pill'
 
 /** Ref object for getting/setting editor content programmatically. */
 export interface EditorContentRef {

--- a/frontend/src/components/chat/controls/types.ts
+++ b/frontend/src/components/chat/controls/types.ts
@@ -32,7 +32,7 @@ export interface Question {
  * field per switch, so a new switch needs no change here and cannot be the one
  * that a rebuild silently unchecks. `choices` is its one-of-N sibling, holding
  * a pill group's selection by the group's id (`control-permissions-pill`,
- * `control-allow-scope-pill`) — a string, because a pill picks a key, not a
+ * `control-allow-choice-pill`) — a string, because a pill picks a key, not a
  * boolean.
  */
 export interface ControlAnswerState {
@@ -128,11 +128,8 @@ export function createControlChoice(state: () => ControlAnswerState, id: string,
   }
 }
 
-/**
- * The saved choice key for a control request's allow behavior. The string stays
- * compatible with saved ACP request state from before Codex used the same pill.
- */
-export const CONTROL_ALLOW_CHOICE_ID = 'control-allow-scope-pill'
+/** The saved choice key for a control request's allow behavior. */
+export const CONTROL_ALLOW_CHOICE_ID = 'control-allow-choice-pill'
 
 /** Ref object for getting/setting editor content programmatically. */
 export interface EditorContentRef {

--- a/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/acp/ACPControlRequest.test.ts
@@ -2,7 +2,7 @@ import type { PermissionPresetController } from '../../providerSettings'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { compactControl } from '~/components/common/CompactControl.css'
-import { allowScopePillGroup, permissionPillGroup } from '~/test-support/controlRequests'
+import { allowChoicePillGroup, permissionPillGroup } from '~/test-support/controlRequests'
 import { createControlAnswerState } from '../../controls/types'
 import { ACPControlActions, sendACPPermissionResponse } from './ACPControlRequest'
 
@@ -118,7 +118,7 @@ describe('acpControlActions', () => {
     expect(allow.textContent).toBe('Allow')
     expect(deny.compareDocumentPosition(allow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
-    const scope = allowScopePillGroup()
+    const scope = allowChoicePillGroup()
     expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
     expect(scope.getByRole('radio', { name: 'Always' })).not.toBeChecked()
     const pill = permissionPillGroup()
@@ -155,7 +155,7 @@ describe('acpControlActions', () => {
   it('sends the always options once a scope beyond Once is selected', async () => {
     const { onRespond } = renderGooseActions()
 
-    fireEvent.click(allowScopePillGroup().getByRole('radio', { name: 'Always' }))
+    fireEvent.click(allowChoicePillGroup().getByRole('radio', { name: 'Always' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
     expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('allow_always')
 
@@ -167,7 +167,7 @@ describe('acpControlActions', () => {
   it('keeps the reject-once option under a remembering scope when the agent offers no reject_always', async () => {
     const { onRespond } = renderOpenCodeShapeActions()
 
-    fireEvent.click(allowScopePillGroup().getByRole('radio', { name: 'Always' }))
+    fireEvent.click(allowChoicePillGroup().getByRole('radio', { name: 'Always' }))
     await fireEvent.click(screen.getByTestId('control-deny-btn'))
     expect(decodeOptionId(onRespond.mock.calls[0][0])).toBe('reject')
 
@@ -282,7 +282,7 @@ describe('acpControlActions', () => {
     }))
 
     // The scope group replaces the extra button the project option used to be.
-    const scope = allowScopePillGroup()
+    const scope = allowChoicePillGroup()
     expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
     expect(scope.getByRole('radio', { name: 'Session' })).toBeInTheDocument()
     expect(scope.getByRole('radio', { name: 'Project' })).toBeInTheDocument()

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
@@ -2,8 +2,8 @@ import type { ControlRequest } from '~/stores/control.store'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import { CODEX_BYPASS_SETTINGS } from '~/generated/contracts/codex-bypass'
-import { permissionPillGroup } from '~/test-support/controlRequests'
-import { createControlAnswerState } from '../../controls/types'
+import { allowChoicePillGroup, permissionPillGroup } from '~/test-support/controlRequests'
+import { CONTROL_ALLOW_CHOICE_ID, createControlAnswerState } from '../../controls/types'
 import { CodexControlActions } from './CodexControlRequest'
 
 function makeRequest(params: Record<string, unknown> = {}): ControlRequest {
@@ -22,13 +22,17 @@ function makePlanRequest(): ControlRequest {
   }
 }
 
-function renderActions(request: ControlRequest, hasEditorContent = false) {
+function renderActions(
+  request: ControlRequest,
+  hasEditorContent = false,
+  answerState = createControlAnswerState(),
+) {
   const onRespond = vi.fn().mockResolvedValue(undefined)
   const onSettingChange = vi.fn()
   render(() => (
     <CodexControlActions
       request={request}
-      answerState={createControlAnswerState()}
+      answerState={answerState}
       onRespond={onRespond}
       hasEditorContent={hasEditorContent}
       onTriggerSend={vi.fn()}
@@ -39,41 +43,108 @@ function renderActions(request: ControlRequest, hasEditorContent = false) {
 }
 
 describe('codex control request actions', () => {
-  it('renders Deny and Allow with the Remember switch and the permission pills', () => {
+  it('renders Deny and Allow with allow-choice and permission pills', () => {
     renderActions(makeRequest({ availableDecisions: ['accept', 'decline', { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } }] }))
 
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Reject')
     expect(screen.getByTestId('control-allow-btn')).toHaveTextContent('Allow')
-    expect(screen.getByTestId('control-remember-checkbox')).toHaveTextContent('Remember')
+    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Once' })).toBeChecked()
+    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Command rule' })).not.toBeChecked()
     // No preset is on, so the group opens on the pill that changes nothing.
     expect(permissionPillGroup().getByRole('radio', { name: 'Unchanged' })).toBeChecked()
     expect(permissionPillGroup().getByRole('radio', { name: 'Bypass' })).not.toBeChecked()
   })
 
-  it('uses the remembered Codex decision only when Remember is checked', async () => {
+  it('uses the Codex decision that the allow-choice pills select', async () => {
     const { onRespond } = renderActions(makeRequest({ availableDecisions: ['accept', 'decline', { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } }] }))
 
-    fireEvent.click(screen.getByTestId('control-remember-checkbox').querySelector('input')!)
+    fireEvent.click(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Command rule' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     const [bytes] = onRespond.mock.calls[0]
     expect(JSON.parse(new TextDecoder().decode(bytes)).result.decision).toEqual({ acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } })
   })
 
-  it('appends decisions that the fixed controls do not cover', () => {
+  it('sends an allowed host-policy amendment from the Host rule pill', async () => {
+    const hostDecision = { applyNetworkPolicyAmendment: { network_policy_amendment: { host: 'example.com', action: 'allow' } } }
+    const { onRespond } = renderActions(makeRequest({ availableDecisions: ['accept', 'decline', hostDecision] }))
+
+    fireEvent.click(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Host rule' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).result.decision).toEqual(hostDecision)
+  })
+
+  it('restores the old Remember selection as its native Codex rule choice', async () => {
+    const commandRule = { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } }
+    const { onRespond } = renderActions(
+      makeRequest({ availableDecisions: ['accept', 'acceptForSession', commandRule, 'decline'] }),
+      false,
+      createControlAnswerState({ switches: { 'control-remember-checkbox': true } }),
+    )
+
+    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Command rule' })).toBeChecked()
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).result.decision).toEqual(commandRule)
+  })
+
+  it('groups each supported allow decision and appends other decisions', () => {
     renderActions(makeRequest({ availableDecisions: ['accept', 'decline', 'cancel', 'acceptForSession', { applyNetworkPolicyAmendment: { network_policy_amendment: { host: 'example.com', action: 'allow' } } }] }))
 
-    expect(screen.getByTestId('control-remember-checkbox')).toBeInTheDocument()
+    const allowChoices = allowChoicePillGroup('Allow as')
+    expect(allowChoices.getByRole('radio', { name: 'Once' })).toBeChecked()
+    expect(allowChoices.getByRole('radio', { name: 'Session' })).toBeInTheDocument()
+    expect(allowChoices.getByRole('radio', { name: 'Host rule' })).toBeInTheDocument()
     expect(screen.getByTestId('control-decision-cancel')).toHaveTextContent('Cancel')
-    expect(screen.getByTestId('control-decision-acceptForSession')).toHaveTextContent('Allow for Session')
+    expect(screen.queryByTestId('control-decision-acceptForSession')).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-accept')).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-decline')).not.toBeInTheDocument()
+  })
+
+  it('keeps allow decisions beyond the four-pill limit as buttons', async () => {
+    const overflowHostRule = { applyNetworkPolicyAmendment: { network_policy_amendment: { host: 'overflow.example.com', action: 'allow' } } }
+    const { onRespond } = renderActions(makeRequest({
+      availableDecisions: [
+        'accept',
+        'acceptForSession',
+        { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } },
+        { applyNetworkPolicyAmendment: { network_policy_amendment: { host: 'example.com', action: 'allow' } } },
+        overflowHostRule,
+        'decline',
+      ],
+    }))
+
+    expect(allowChoicePillGroup('Allow as').getAllByRole('radio')).toHaveLength(4)
+    const overflow = screen.getByTestId('control-decision-applyNetworkPolicyAmendment')
+    expect(overflow).toHaveTextContent('Allow Host & Remember')
+    await fireEvent.click(overflow)
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).result.decision).toEqual(overflowHostRule)
+  })
+
+  it('clamps an obsolete saved allow choice to Once', async () => {
+    const { onRespond } = renderActions(
+      makeRequest({ availableDecisions: ['accept', 'decline', { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } }] }),
+      false,
+      createControlAnswerState({ choices: { [CONTROL_ALLOW_CHOICE_ID]: 'gone' } }),
+    )
+
+    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Once' })).toBeChecked()
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).result.decision).toBe('accept')
   })
 
   it('uses only the negative decision that Codex offers', async () => {
     const { onRespond } = renderActions(makeRequest({ availableDecisions: ['accept', 'cancel'] }))
 
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Cancel')
+    expect(screen.queryByRole('radiogroup', { name: 'Allow as' })).not.toBeInTheDocument()
     await fireEvent.click(screen.getByTestId('control-deny-btn'))
 
     const [bytes] = onRespond.mock.calls[0]
@@ -93,6 +164,7 @@ describe('codex control request actions', () => {
     }
     const { onRespond } = renderActions(request)
 
+    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Once' })).toBeChecked()
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     const [bytes] = onRespond.mock.calls[0]
@@ -114,11 +186,44 @@ describe('codex control request actions', () => {
     }
     const { onRespond } = renderActions(request)
 
-    fireEvent.click(screen.getByTestId('control-remember-checkbox').querySelector('input')!)
+    fireEvent.click(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Session' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     const [bytes] = onRespond.mock.calls[0]
     expect(JSON.parse(new TextDecoder().decode(bytes)).result.scope).toBe('session')
+  })
+
+  it('restores the old Remember selection as Session for an in-flight permission request', () => {
+    const request = makeRequest()
+    request.payload = {
+      method: 'item/permissions/requestApproval',
+      params: { permissions: { network: { enabled: true } } },
+    }
+
+    renderActions(request, false, createControlAnswerState({
+      switches: { 'control-remember-checkbox': true },
+    }))
+
+    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Session' })).toBeChecked()
+  })
+
+  it('lets a new Once choice override a restored Remember selection', async () => {
+    const request = makeRequest()
+    request.payload = {
+      method: 'item/permissions/requestApproval',
+      params: { permissions: { network: { enabled: true } } },
+    }
+    const answerState = createControlAnswerState({
+      switches: { 'control-remember-checkbox': true },
+    })
+    const { onRespond } = renderActions(request, false, answerState)
+
+    fireEvent.click(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Once' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).result.scope).toBe('turn')
+    expect(answerState.choices()).toEqual({ [CONTROL_ALLOW_CHOICE_ID]: 'turn' })
   })
 
   it('denies a permission request with an empty grant', async () => {
@@ -135,7 +240,7 @@ describe('codex control request actions', () => {
     expect(JSON.parse(new TextDecoder().decode(bytes)).result).toEqual({ permissions: {}, scope: 'turn' })
   })
 
-  it('appends a second persistent allow decision that Remember does not select', () => {
+  it('groups session and command-rule decisions together', () => {
     renderActions(makeRequest({
       availableDecisions: [
         'accept',
@@ -145,8 +250,11 @@ describe('codex control request actions', () => {
       ],
     }))
 
-    expect(screen.getByTestId('control-remember-checkbox')).toBeInTheDocument()
-    expect(screen.getByTestId('control-decision-acceptForSession')).toHaveTextContent('Allow for Session')
+    const allowChoices = allowChoicePillGroup('Allow as')
+    expect(allowChoices.getByRole('radio', { name: 'Once' })).toBeChecked()
+    expect(allowChoices.getByRole('radio', { name: 'Session' })).toBeInTheDocument()
+    expect(allowChoices.getByRole('radio', { name: 'Command rule' })).toBeInTheDocument()
+    expect(screen.queryByTestId('control-decision-acceptForSession')).not.toBeInTheDocument()
   })
 
   it('ignores malformed available decisions', () => {
@@ -180,7 +288,7 @@ describe('codex control request actions', () => {
 
     expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Send feedback')
     expect(screen.queryByTestId('control-allow-btn')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('control-remember-checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByRole('radiogroup', { name: 'Allow as' })).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-permissions-pill-group')).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-cancel')).not.toBeInTheDocument()
   })

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.test.tsx
@@ -76,21 +76,6 @@ describe('codex control request actions', () => {
     expect(JSON.parse(new TextDecoder().decode(bytes)).result.decision).toEqual(hostDecision)
   })
 
-  it('restores the old Remember selection as its native Codex rule choice', async () => {
-    const commandRule = { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } }
-    const { onRespond } = renderActions(
-      makeRequest({ availableDecisions: ['accept', 'acceptForSession', commandRule, 'decline'] }),
-      false,
-      createControlAnswerState({ switches: { 'control-remember-checkbox': true } }),
-    )
-
-    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Command rule' })).toBeChecked()
-    await fireEvent.click(screen.getByTestId('control-allow-btn'))
-
-    const [bytes] = onRespond.mock.calls[0]
-    expect(JSON.parse(new TextDecoder().decode(bytes)).result.decision).toEqual(commandRule)
-  })
-
   it('groups each supported allow decision and appends other decisions', () => {
     renderActions(makeRequest({ availableDecisions: ['accept', 'decline', 'cancel', 'acceptForSession', { applyNetworkPolicyAmendment: { network_policy_amendment: { host: 'example.com', action: 'allow' } } }] }))
 
@@ -102,6 +87,80 @@ describe('codex control request actions', () => {
     expect(screen.queryByTestId('control-decision-acceptForSession')).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-accept')).not.toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-decline')).not.toBeInTheDocument()
+  })
+
+  // Two decisions of one family share a label, and a pill group refuses only
+  // duplicate KEYS. Two radios of one name let the user apply the wrong
+  // permanent rule and make a by-name lookup match both.
+  it('tells two host rules apart by their host', async () => {
+    const allowA = { applyNetworkPolicyAmendment: { network_policy_amendment: { host: 'a.example.com', action: 'allow' } } }
+    const allowB = { applyNetworkPolicyAmendment: { network_policy_amendment: { host: 'b.example.com', action: 'allow' } } }
+    const { onRespond } = renderActions(makeRequest({ availableDecisions: ['accept', allowA, allowB, 'decline'] }))
+
+    const allowChoices = allowChoicePillGroup('Allow as')
+    expect(allowChoices.queryByRole('radio', { name: 'Host rule' })).not.toBeInTheDocument()
+    expect(allowChoices.getByRole('radio', { name: 'Host: a.example.com' })).toBeInTheDocument()
+    await fireEvent.click(allowChoices.getByRole('radio', { name: 'Host: b.example.com' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).result.decision).toEqual(allowB)
+  })
+
+  it('tells two command rules apart by their command', () => {
+    const removeRule = { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } }
+    const moveRule = { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['mv', '-f'] } }
+    renderActions(makeRequest({ availableDecisions: ['accept', removeRule, moveRule, 'decline'] }))
+
+    const allowChoices = allowChoicePillGroup('Allow as')
+    expect(allowChoices.getByRole('radio', { name: 'Rule: rm' })).toBeInTheDocument()
+    expect(allowChoices.getByRole('radio', { name: 'Rule: mv -f' })).toBeInTheDocument()
+  })
+
+  // `detail` is a constant for the two string decisions, so nothing could tell
+  // a repeat apart. Both would answer identically, so one pill is the truth.
+  it('draws one pill for a repeated string decision', () => {
+    renderActions(makeRequest({ availableDecisions: ['accept', 'accept', 'acceptForSession', 'decline'] }))
+
+    const allowChoices = allowChoicePillGroup('Allow as')
+    expect(allowChoices.getAllByRole('radio')).toHaveLength(2)
+    expect(allowChoices.getByRole('radio', { name: 'Once' })).toBeChecked()
+    expect(allowChoices.getByRole('radio', { name: 'Session' })).toBeInTheDocument()
+  })
+
+  // One decision of a family keeps the plain label: the detail is what tells a
+  // COLLISION apart, and spelling it always would make every pill long.
+  it('keeps the plain label when a family has one decision', () => {
+    renderActions(makeRequest({
+      availableDecisions: [
+        'accept',
+        { acceptWithExecpolicyAmendment: { execpolicy_amendment: ['rm'] } },
+        { applyNetworkPolicyAmendment: { network_policy_amendment: { host: 'a.example.com', action: 'allow' } } },
+        'decline',
+      ],
+    }))
+
+    const allowChoices = allowChoicePillGroup('Allow as')
+    expect(allowChoices.getByRole('radio', { name: 'Command rule' })).toBeInTheDocument()
+    expect(allowChoices.getByRole('radio', { name: 'Host rule' })).toBeInTheDocument()
+  })
+
+  // The truncation and the disambiguation meet: the collision must be judged
+  // over the pills the group DRAWS, not over every candidate, or a detail
+  // appears for a name no visible pill repeats.
+  it('disambiguates a collision that survives the four-pill cut', () => {
+    const host = (name: string) => ({ applyNetworkPolicyAmendment: { network_policy_amendment: { host: name, action: 'allow' } } })
+    renderActions(makeRequest({
+      availableDecisions: ['accept', host('a.example.com'), host('b.example.com'), host('c.example.com'), host('d.example.com'), 'decline'],
+    }))
+
+    const allowChoices = allowChoicePillGroup('Allow as')
+    expect(allowChoices.getAllByRole('radio')).toHaveLength(4)
+    expect(allowChoices.getByRole('radio', { name: 'Once' })).toBeChecked()
+    for (const name of ['a', 'b', 'c'])
+      expect(allowChoices.getByRole('radio', { name: `Host: ${name}.example.com` })).toBeInTheDocument()
+    // The fourth host is past the cut, so it answers from its own button.
+    expect(screen.getByTestId('control-decision-applyNetworkPolicyAmendment')).toBeInTheDocument()
   })
 
   it('keeps allow decisions beyond the four-pill limit as buttons', async () => {
@@ -193,37 +252,38 @@ describe('codex control request actions', () => {
     expect(JSON.parse(new TextDecoder().decode(bytes)).result.scope).toBe('session')
   })
 
-  it('restores the old Remember selection as Session for an in-flight permission request', () => {
+  // A saved key the offered pair no longer holds clamps to the narrowest grant.
+  it('clamps an obsolete saved permission scope to Once', async () => {
     const request = makeRequest()
     request.payload = {
       method: 'item/permissions/requestApproval',
       params: { permissions: { network: { enabled: true } } },
     }
-
-    renderActions(request, false, createControlAnswerState({
-      switches: { 'control-remember-checkbox': true },
-    }))
-
-    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Session' })).toBeChecked()
-  })
-
-  it('lets a new Once choice override a restored Remember selection', async () => {
-    const request = makeRequest()
-    request.payload = {
-      method: 'item/permissions/requestApproval',
-      params: { permissions: { network: { enabled: true } } },
-    }
-    const answerState = createControlAnswerState({
-      switches: { 'control-remember-checkbox': true },
-    })
+    const answerState = createControlAnswerState({ choices: { [CONTROL_ALLOW_CHOICE_ID]: 'gone' } })
     const { onRespond } = renderActions(request, false, answerState)
 
-    fireEvent.click(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Once' }))
+    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Once' })).toBeChecked()
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
 
     const [bytes] = onRespond.mock.calls[0]
     expect(JSON.parse(new TextDecoder().decode(bytes)).result.scope).toBe('turn')
-    expect(answerState.choices()).toEqual({ [CONTROL_ALLOW_CHOICE_ID]: 'turn' })
+  })
+
+  it('writes the chosen permission scope into the shared answer record', async () => {
+    const request = makeRequest()
+    request.payload = {
+      method: 'item/permissions/requestApproval',
+      params: { permissions: { network: { enabled: true } } },
+    }
+    const answerState = createControlAnswerState()
+    const { onRespond } = renderActions(request, false, answerState)
+
+    fireEvent.click(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Session' }))
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).result.scope).toBe('session')
+    expect(answerState.choices()).toEqual({ [CONTROL_ALLOW_CHOICE_ID]: 'session' })
   })
 
   it('denies a permission request with an empty grant', async () => {
@@ -255,6 +315,44 @@ describe('codex control request actions', () => {
     expect(allowChoices.getByRole('radio', { name: 'Session' })).toBeInTheDocument()
     expect(allowChoices.getByRole('radio', { name: 'Command rule' })).toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-acceptForSession')).not.toBeInTheDocument()
+  })
+
+  // Codex offered no way to approve, so the banner offers none either. A
+  // fabricated `accept` would answer a request that never carried it.
+  it('draws no Allow when every offered decision refuses', () => {
+    renderActions(makeRequest({ availableDecisions: ['decline', 'cancel'] }))
+
+    expect(screen.queryByTestId('control-allow-btn')).not.toBeInTheDocument()
+    expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Reject')
+  })
+
+  it('draws no Deny when every offered decision approves', () => {
+    renderActions(makeRequest({ availableDecisions: ['accept', 'acceptForSession'] }))
+
+    expect(screen.queryByTestId('control-deny-btn')).not.toBeInTheDocument()
+    expect(screen.getByTestId('control-allow-btn')).toHaveTextContent('Allow')
+    expect(allowChoicePillGroup('Allow as').getByRole('radio', { name: 'Once' })).toBeChecked()
+  })
+
+  // The opposite case: OUR parser dropped the allow decision, so the request did
+  // offer one. Removing Allow would leave the user unable to approve at all.
+  it('keeps Allow when the parser dropped an unknown allow decision', async () => {
+    const { onRespond } = renderActions(makeRequest({
+      availableDecisions: [{ acceptWithSandboxAmendment: { sandbox_amendment: ['/tmp'] } }, 'decline'],
+    }))
+
+    await fireEvent.click(screen.getByTestId('control-allow-btn'))
+
+    const [bytes] = onRespond.mock.calls[0]
+    expect(JSON.parse(new TextDecoder().decode(bytes)).result.decision).toBe('accept')
+  })
+
+  // Send feedback replaces the refusal, so the slot draws even where the request
+  // carried no negative decision.
+  it('still offers Send feedback when the request refuses nothing', () => {
+    renderActions(makeRequest({ availableDecisions: ['accept', 'acceptForSession'] }), true)
+
+    expect(screen.getByTestId('control-deny-btn')).toHaveTextContent('Send feedback')
   })
 
   it('ignores malformed available decisions', () => {

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
@@ -1,211 +1,28 @@
 import type { Component } from 'solid-js'
 import type { ControlAllowChoicePill } from '../../controls/ControlPillGroups'
-import type { ActionsProps, ContentProps, ControlAnswerState, Question } from '../../controls/types'
+import type { ActionsProps, ContentProps } from '../../controls/types'
 import type { CodexDecision } from './controlResponse'
-import type { PillOptions } from '~/components/common/PillGroup'
 
 import { createMemo, Match, Show, Switch } from 'solid-js'
-import { isPillOptions, PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
-import { isObject, pickObject } from '~/lib/jsonPick'
 import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import * as styles from '../../ControlRequestBanner.css'
 import { CollapsibleText } from '../../controls/CollapsibleText'
 import { ControlDecisionFooter } from '../../controls/ControlDecisionFooter'
 import { buildSessionPermissionPill, createSessionPermissionPresetChoice, respondThenApplyPermissionPreset } from '../../controls/permissionPresets'
 import { createPlanApprovalState, planApprovalSwitches } from '../../controls/planApproval'
-import { CONTROL_ALLOW_CHOICE_ID, createControlChoice, sendJsonRpcResult, sendResponse } from '../../controls/types'
-import { codexDecisionKey, codexDecisionLabel, parseCodexDecision } from './controlResponse'
-
-/** Extract Codex approval params from the control request payload. */
-function getCodexParams(payload: Record<string, unknown>): Record<string, unknown> | undefined {
-  return pickObject(payload, 'params', undefined)
-}
-
-/**
- * Sends a Codex-native approval decision as a JSON-RPC response directly.
- */
-export function sendCodexDecision(
-  onRespond: (content: Uint8Array) => Promise<void>,
-  requestId: string,
-  decision: CodexDecision,
-): Promise<void> {
-  return sendJsonRpcResult(onRespond, requestId, { decision })
-}
-
-export function markCodexPlanPromptResponse(response: Record<string, unknown>): Record<string, unknown> {
-  return { ...response, codexPlanModePrompt: true }
-}
-
-function sendCodexPlanPromptResponse(
-  onRespond: (content: Uint8Array) => Promise<void>,
-  response: Record<string, unknown>,
-): Promise<void> {
-  return sendResponse(onRespond, markCodexPlanPromptResponse(response))
-}
-
-const CODEX_OTHER_OPTION_LABEL = 'None of the above'
-
-function hasCodexOtherOption(question: Question): boolean {
-  const raw = question as unknown as Record<string, unknown>
-  return raw.isOther === true && Array.isArray(question.options) && question.options.length > 0
-}
-
-function codexAnswerValues(question: Question, index: number, answerState: ControlAnswerState): string[] {
-  const selected = answerState.selections()[index] ?? []
-  const customText = answerState.customTexts()[index]?.trim()
-  const values = [...selected]
-
-  if (customText) {
-    if (values.length === 0 && hasCodexOtherOption(question)) {
-      // Codex marks its auto-added free-form option explicitly.
-      values.push(CODEX_OTHER_OPTION_LABEL)
-    }
-    // Codex's TUI appends free-form text as a user_note answer entry,
-    // even for questions without a selected option.
-    values.push(`user_note: ${customText}`)
-  }
-
-  return values
-}
-
-/**
- * Sends a Codex-native requestUserInput response as a JSON-RPC response directly.
- */
-export function sendCodexUserInputResponse(
-  onRespond: (content: Uint8Array) => Promise<void>,
-  requestId: string,
-  questions: Question[],
-  answerState: ControlAnswerState,
-): Promise<void> {
-  const answers: Record<string, { answers: string[] }> = {}
-  for (let i = 0; i < questions.length; i++) {
-    const values = codexAnswerValues(questions[i], i, answerState)
-    const key = questions[i].id || questions[i].header || `q${i}`
-    answers[key] = { answers: values }
-  }
-  return sendJsonRpcResult(onRespond, requestId, { answers })
-}
-
-export function sendCodexUserInputRejectResponse(
-  onRespond: (content: Uint8Array) => Promise<void>,
-  requestId: string,
-): Promise<void> {
-  return sendJsonRpcResult(onRespond, requestId, { answers: {} })
-}
-
-export function sendCodexPermissionsResponse(
-  onRespond: (content: Uint8Array) => Promise<void>,
-  requestId: string,
-  permissions: Record<string, unknown>,
-  scope: 'turn' | 'session',
-): Promise<void> {
-  return sendJsonRpcResult(onRespond, requestId, { permissions, scope })
-}
-
-function isNegativeDecision(decision: CodexDecision): boolean {
-  if (decision === 'decline' || decision === 'cancel')
-    return true
-  return typeof decision === 'object'
-    && 'applyNetworkPolicyAmendment' in decision
-    && decision.applyNetworkPolicyAmendment.network_policy_amendment.action === 'deny'
-}
-
-function remembersAllow(decision: CodexDecision): boolean {
-  if (decision === 'acceptForSession')
-    return true
-  if (typeof decision !== 'object')
-    return false
-  if ('acceptWithExecpolicyAmendment' in decision)
-    return true
-  return decision.applyNetworkPolicyAmendment.network_policy_amendment.action === 'allow'
-}
-
-interface CodexAllowChoice {
-  key: string
-  label: string
-  decision: CodexDecision
-}
-
-function codexAllowChoiceLabel(decision: CodexDecision): string {
-  if (decision === 'accept')
-    return 'Once'
-  if (decision === 'acceptForSession')
-    return 'Session'
-  if (typeof decision === 'object' && 'acceptWithExecpolicyAmendment' in decision)
-    return 'Command rule'
-  return 'Host rule'
-}
-
-function codexAllowChoicePriority(decision: CodexDecision): number {
-  if (decision === 'accept')
-    return 0
-  if (decision === 'acceptForSession')
-    return 1
-  if (typeof decision === 'object' && 'acceptWithExecpolicyAmendment' in decision)
-    return 2
-  return 3
-}
-
-/**
- * Builds the choices that qualify the shared Allow button. A group requires
- * Codex's one-turn `accept` decision, so its first and default pill is Once.
- */
-function codexAllowChoices(decisions: CodexDecision[]): CodexAllowChoice[] | undefined {
-  const candidates = decisions
-    .map((decision, sourceIndex) => ({ decision, sourceIndex }))
-    .filter(candidate => !isNegativeDecision(candidate.decision))
-    .sort((a, b) => codexAllowChoicePriority(a.decision) - codexAllowChoicePriority(b.decision))
-
-  if (candidates.length < 2 || candidates[0]?.decision !== 'accept')
-    return undefined
-
-  return candidates.slice(0, PILL_OPTION_LIMIT).map(({ decision, sourceIndex }) => ({
-    key: `codex-allow-${sourceIndex}`,
-    label: codexAllowChoiceLabel(decision),
-    decision,
-  }))
-}
-
-export interface ResolvedCodexDecisions {
-  negative: CodexDecision
-  positive: CodexDecision
-  /** Supports saved in-flight requests that used the former Remember switch. */
-  remembered?: CodexDecision
-  allowChoices?: CodexAllowChoice[]
-  additional: CodexDecision[]
-}
-
-export function resolveCodexDecisions(raw: unknown): ResolvedCodexDecisions {
-  const parsed = Array.isArray(raw)
-    ? raw.map(parseCodexDecision).filter((decision): decision is CodexDecision => decision !== null)
-    : []
-  const decisions: CodexDecision[] = parsed.length > 0 ? parsed : ['accept', 'cancel']
-  const negative = decisions.find(isNegativeDecision) ?? 'cancel'
-  const positive = decisions.find(decision => decision === 'accept')
-    ?? decisions.find(decision => !isNegativeDecision(decision))
-    ?? 'accept'
-  const remembered = positive === 'accept'
-    ? decisions.find(decision => typeof decision === 'object' && remembersAllow(decision))
-    ?? decisions.find(decision => decision === 'acceptForSession')
-    : undefined
-  const allowChoices = codexAllowChoices(decisions)
-  const consumed = new Set<CodexDecision>(allowChoices?.map(choice => choice.decision) ?? [positive])
-  consumed.add(negative)
-  const additional = decisions.filter(decision => !consumed.has(decision))
-  return { negative, positive, remembered, allowChoices, additional }
-}
-
-export function codexRequestedPermissions(payload: Record<string, unknown>): Record<string, unknown> {
-  const permissions = pickObject(getCodexParams(payload), 'permissions', undefined)
-  if (!permissions)
-    return {}
-  const granted: Record<string, unknown> = {}
-  if (isObject(permissions.network))
-    granted.network = permissions.network
-  if (isObject(permissions.fileSystem))
-    granted.fileSystem = permissions.fileSystem
-  return granted
-}
+import { CONTROL_ALLOW_CHOICE_ID, createControlChoice } from '../../controls/types'
+import {
+  ALLOW_AS_LABEL,
+  CODEX_PERMISSION_SCOPE_OPTIONS,
+  codexDecisionKey,
+  codexDecisionLabel,
+  codexRequestedPermissions,
+  getCodexParams,
+  resolveCodexDecisions,
+  sendCodexDecision,
+  sendCodexPermissionsResponse,
+  sendCodexPlanPromptResponse,
+} from './controlResponse'
 
 /** Codex-specific control request content. */
 export const CodexControlContent: Component<ContentProps> = (props) => {
@@ -260,18 +77,18 @@ export const CodexControlContent: Component<ContentProps> = (props) => {
 const CodexPermissionsActions: Component<ActionsProps> = (props) => {
   const allowChoice = createControlChoice(() => props.answerState, CONTROL_ALLOW_CHOICE_ID)
   const permissionChoice = createSessionPermissionPresetChoice(props)
-  const selectedScope = (): 'turn' | 'session' => {
-    const choice = allowChoice.choice()
-    if (choice === 'turn' || choice === 'session')
-      return choice
-    // Preserve a selection that an in-flight request saved before the switch
-    // changed to pills. A new request has neither value and defaults to Once.
-    return props.answerState.switches()['control-remember-checkbox'] ? 'session' : 'turn'
-  }
-  const scopeOptions = [
-    { key: 'turn', label: 'Once' },
-    { key: 'session', label: 'Session' },
-  ] as const satisfies PillOptions<string>
+  // A saved key the offered pair no longer holds clamps to Once, which is the
+  // narrowest grant. A wider one must be chosen, never inherited.
+  const selectedScope = (): 'turn' | 'session' =>
+    (allowChoice.choice() === 'session' ? 'session' : 'turn')
+  // A memo, like its sibling in `CodexControlActions`: the footer reads the
+  // accessor twice per pass (once for `leadingOptions`, once for the `Show`).
+  const allowChoicePill = createMemo<ControlAllowChoicePill>(() => ({
+    label: ALLOW_AS_LABEL,
+    options: CODEX_PERMISSION_SCOPE_OPTIONS,
+    selected: selectedScope(),
+    onSelect: allowChoice.setChoice,
+  }))
   const handleAllow = () => respondThenApplyPermissionPreset(
     sendCodexPermissionsResponse(
       props.onRespond,
@@ -292,12 +109,7 @@ const CodexPermissionsActions: Component<ActionsProps> = (props) => {
         onSelect: () => sendCodexPermissionsResponse(props.onRespond, props.request.requestId, {}, 'turn'),
       }}
       positiveAction={{ label: 'Allow', testId: 'control-allow-btn', onSelect: handleAllow }}
-      allowChoicePill={() => ({
-        label: 'Allow as',
-        options: scopeOptions,
-        selected: selectedScope(),
-        onSelect: allowChoice.setChoice,
-      })}
+      allowChoicePill={allowChoicePill}
       permissionPill={() => buildSessionPermissionPill(props.presets, permissionChoice)}
     />
   )
@@ -331,6 +143,21 @@ const CodexPlanModePromptActions: Component<ActionsProps> = (props) => {
   )
 }
 
+/**
+ * One decision as a footer action, or nothing when Codex offered that polarity
+ * no decision at all. The footer then draws no button, rather than one that
+ * sends a token the request never carried.
+ */
+function codexAction(
+  decision: CodexDecision | undefined,
+  testId: string,
+  onSelect: (decision: CodexDecision) => void,
+) {
+  if (!decision)
+    return undefined
+  return { label: codexDecisionLabel(decision), testId, onSelect: () => onSelect(decision) }
+}
+
 /** Codex-specific control request action buttons. */
 export const CodexControlActions: Component<ActionsProps> = (props) => {
   const toolName = () => getToolName(props.request.payload)
@@ -340,32 +167,24 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
   const allowChoice = createControlChoice(() => props.answerState, CONTROL_ALLOW_CHOICE_ID)
   const permissionChoice = createSessionPermissionPresetChoice(props)
 
-  const selectedAllowChoice = () => {
-    const choices = decisions().allowChoices
-    if (!choices)
+  // A saved key the live payload no longer offers clamps to the first pill,
+  // which `codexAllowChoices` guarantees is Codex's one-turn `accept`. Never to
+  // a remembering decision: a grant that outlives the turn must be chosen.
+  const selectedAllowChoice = createMemo(() => {
+    const allow = decisions().allowChoices
+    if (!allow)
       return undefined
-    const selected = choices.find(choice => choice.key === allowChoice.choice())
-    if (selected)
-      return selected
-    if (props.answerState.switches()['control-remember-checkbox']) {
-      const migrated = choices.find(choice => choice.decision === decisions().remembered)
-      if (migrated)
-        return migrated
-    }
-    return choices[0]
-  }
+    return allow.choices.find(choice => choice.key === allowChoice.choice()) ?? allow.choices[0]
+  })
 
   const allowChoicePill = createMemo<ControlAllowChoicePill | undefined>(() => {
-    const choices = decisions().allowChoices
-    if (!choices)
-      return undefined
-    const options = choices.map(choice => ({ key: choice.key, label: choice.label }))
-    if (!isPillOptions(options))
+    const allow = decisions().allowChoices
+    if (!allow)
       return undefined
     return {
-      label: 'Allow as',
-      options,
-      selected: selectedAllowChoice()?.key ?? options[0].key,
+      label: ALLOW_AS_LABEL,
+      options: allow.options,
+      selected: selectedAllowChoice()?.key ?? allow.options[0].key,
       onSelect: allowChoice.setChoice,
     }
   })
@@ -376,8 +195,11 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
     decision,
   )
 
-  const handleAllow = () => respondThenApplyPermissionPreset(
-    handleDecision(selectedAllowChoice()?.decision ?? decisions().positive),
+  // The pill's decision when a group renders, else the one allow decision the
+  // request carried -- which `codexAction` already proved present, because it
+  // draws no button without it.
+  const handleAllow = (positive: CodexDecision) => respondThenApplyPermissionPreset(
+    handleDecision(selectedAllowChoice()?.decision ?? positive),
     props.presets,
     permissionChoice.choice(),
   )
@@ -388,8 +210,8 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
         <ControlDecisionFooter
           hasEditorContent={props.hasEditorContent}
           onSendFeedback={props.onTriggerSend}
-          negativeAction={{ label: codexDecisionLabel(decisions().negative), testId: 'control-deny-btn', onSelect: () => handleDecision(decisions().negative) }}
-          positiveAction={{ label: codexDecisionLabel(decisions().positive), testId: 'control-allow-btn', onSelect: handleAllow }}
+          negativeAction={codexAction(decisions().negative, 'control-deny-btn', decision => handleDecision(decision))}
+          positiveAction={codexAction(decisions().positive, 'control-allow-btn', handleAllow)}
           allowChoicePill={allowChoicePill}
           permissionPill={() => buildSessionPermissionPill(props.presets, permissionChoice)}
           additionalActions={() => decisions().additional.map(decision => ({

--- a/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
+++ b/frontend/src/components/chat/providers/codex/CodexControlRequest.tsx
@@ -1,8 +1,11 @@
 import type { Component } from 'solid-js'
+import type { ControlAllowChoicePill } from '../../controls/ControlPillGroups'
 import type { ActionsProps, ContentProps, ControlAnswerState, Question } from '../../controls/types'
-
 import type { CodexDecision } from './controlResponse'
+import type { PillOptions } from '~/components/common/PillGroup'
+
 import { createMemo, Match, Show, Switch } from 'solid-js'
+import { isPillOptions, PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
 import { isObject, pickObject } from '~/lib/jsonPick'
 import { buildAllowResponse, buildDenyResponse, getToolInput, getToolName } from '~/utils/controlResponse'
 import * as styles from '../../ControlRequestBanner.css'
@@ -10,7 +13,7 @@ import { CollapsibleText } from '../../controls/CollapsibleText'
 import { ControlDecisionFooter } from '../../controls/ControlDecisionFooter'
 import { buildSessionPermissionPill, createSessionPermissionPresetChoice, respondThenApplyPermissionPreset } from '../../controls/permissionPresets'
 import { createPlanApprovalState, planApprovalSwitches } from '../../controls/planApproval'
-import { createControlSwitch, sendJsonRpcResult, sendResponse } from '../../controls/types'
+import { CONTROL_ALLOW_CHOICE_ID, createControlChoice, sendJsonRpcResult, sendResponse } from '../../controls/types'
 import { codexDecisionKey, codexDecisionLabel, parseCodexDecision } from './controlResponse'
 
 /** Extract Codex approval params from the control request payload. */
@@ -117,10 +120,58 @@ function remembersAllow(decision: CodexDecision): boolean {
   return decision.applyNetworkPolicyAmendment.network_policy_amendment.action === 'allow'
 }
 
+interface CodexAllowChoice {
+  key: string
+  label: string
+  decision: CodexDecision
+}
+
+function codexAllowChoiceLabel(decision: CodexDecision): string {
+  if (decision === 'accept')
+    return 'Once'
+  if (decision === 'acceptForSession')
+    return 'Session'
+  if (typeof decision === 'object' && 'acceptWithExecpolicyAmendment' in decision)
+    return 'Command rule'
+  return 'Host rule'
+}
+
+function codexAllowChoicePriority(decision: CodexDecision): number {
+  if (decision === 'accept')
+    return 0
+  if (decision === 'acceptForSession')
+    return 1
+  if (typeof decision === 'object' && 'acceptWithExecpolicyAmendment' in decision)
+    return 2
+  return 3
+}
+
+/**
+ * Builds the choices that qualify the shared Allow button. A group requires
+ * Codex's one-turn `accept` decision, so its first and default pill is Once.
+ */
+function codexAllowChoices(decisions: CodexDecision[]): CodexAllowChoice[] | undefined {
+  const candidates = decisions
+    .map((decision, sourceIndex) => ({ decision, sourceIndex }))
+    .filter(candidate => !isNegativeDecision(candidate.decision))
+    .sort((a, b) => codexAllowChoicePriority(a.decision) - codexAllowChoicePriority(b.decision))
+
+  if (candidates.length < 2 || candidates[0]?.decision !== 'accept')
+    return undefined
+
+  return candidates.slice(0, PILL_OPTION_LIMIT).map(({ decision, sourceIndex }) => ({
+    key: `codex-allow-${sourceIndex}`,
+    label: codexAllowChoiceLabel(decision),
+    decision,
+  }))
+}
+
 export interface ResolvedCodexDecisions {
   negative: CodexDecision
   positive: CodexDecision
+  /** Supports saved in-flight requests that used the former Remember switch. */
   remembered?: CodexDecision
+  allowChoices?: CodexAllowChoice[]
   additional: CodexDecision[]
 }
 
@@ -137,8 +188,11 @@ export function resolveCodexDecisions(raw: unknown): ResolvedCodexDecisions {
     ? decisions.find(decision => typeof decision === 'object' && remembersAllow(decision))
     ?? decisions.find(decision => decision === 'acceptForSession')
     : undefined
-  const additional = decisions.filter(decision => decision !== negative && decision !== positive && decision !== remembered)
-  return { negative, positive, remembered, additional }
+  const allowChoices = codexAllowChoices(decisions)
+  const consumed = new Set<CodexDecision>(allowChoices?.map(choice => choice.decision) ?? [positive])
+  consumed.add(negative)
+  const additional = decisions.filter(decision => !consumed.has(decision))
+  return { negative, positive, remembered, allowChoices, additional }
 }
 
 export function codexRequestedPermissions(payload: Record<string, unknown>): Record<string, unknown> {
@@ -204,14 +258,26 @@ export const CodexControlContent: Component<ContentProps> = (props) => {
 }
 
 const CodexPermissionsActions: Component<ActionsProps> = (props) => {
-  const rememberSwitch = createControlSwitch(() => props.answerState, 'control-remember-checkbox')
+  const allowChoice = createControlChoice(() => props.answerState, CONTROL_ALLOW_CHOICE_ID)
   const permissionChoice = createSessionPermissionPresetChoice(props)
+  const selectedScope = (): 'turn' | 'session' => {
+    const choice = allowChoice.choice()
+    if (choice === 'turn' || choice === 'session')
+      return choice
+    // Preserve a selection that an in-flight request saved before the switch
+    // changed to pills. A new request has neither value and defaults to Once.
+    return props.answerState.switches()['control-remember-checkbox'] ? 'session' : 'turn'
+  }
+  const scopeOptions = [
+    { key: 'turn', label: 'Once' },
+    { key: 'session', label: 'Session' },
+  ] as const satisfies PillOptions<string>
   const handleAllow = () => respondThenApplyPermissionPreset(
     sendCodexPermissionsResponse(
       props.onRespond,
       props.request.requestId,
       codexRequestedPermissions(props.request.payload),
-      rememberSwitch.checked() ? 'session' : 'turn',
+      selectedScope(),
     ),
     props.presets,
     permissionChoice.choice(),
@@ -226,9 +292,12 @@ const CodexPermissionsActions: Component<ActionsProps> = (props) => {
         onSelect: () => sendCodexPermissionsResponse(props.onRespond, props.request.requestId, {}, 'turn'),
       }}
       positiveAction={{ label: 'Allow', testId: 'control-allow-btn', onSelect: handleAllow }}
-      switches={() => [
-        { id: 'control-remember-checkbox', label: 'Remember', checked: rememberSwitch.checked(), onChange: rememberSwitch.set },
-      ]}
+      allowChoicePill={() => ({
+        label: 'Allow as',
+        options: scopeOptions,
+        selected: selectedScope(),
+        onSelect: allowChoice.setChoice,
+      })}
       permissionPill={() => buildSessionPermissionPill(props.presets, permissionChoice)}
     />
   )
@@ -268,8 +337,38 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
   const method = () => props.request.payload.method as string | undefined
   const params = () => getCodexParams(props.request.payload)
   const decisions = createMemo(() => resolveCodexDecisions(params()?.availableDecisions))
-  const rememberSwitch = createControlSwitch(() => props.answerState, 'control-remember-checkbox')
+  const allowChoice = createControlChoice(() => props.answerState, CONTROL_ALLOW_CHOICE_ID)
   const permissionChoice = createSessionPermissionPresetChoice(props)
+
+  const selectedAllowChoice = () => {
+    const choices = decisions().allowChoices
+    if (!choices)
+      return undefined
+    const selected = choices.find(choice => choice.key === allowChoice.choice())
+    if (selected)
+      return selected
+    if (props.answerState.switches()['control-remember-checkbox']) {
+      const migrated = choices.find(choice => choice.decision === decisions().remembered)
+      if (migrated)
+        return migrated
+    }
+    return choices[0]
+  }
+
+  const allowChoicePill = createMemo<ControlAllowChoicePill | undefined>(() => {
+    const choices = decisions().allowChoices
+    if (!choices)
+      return undefined
+    const options = choices.map(choice => ({ key: choice.key, label: choice.label }))
+    if (!isPillOptions(options))
+      return undefined
+    return {
+      label: 'Allow as',
+      options,
+      selected: selectedAllowChoice()?.key ?? options[0].key,
+      onSelect: allowChoice.setChoice,
+    }
+  })
 
   const handleDecision = (decision: CodexDecision) => sendCodexDecision(
     props.onRespond,
@@ -278,7 +377,7 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
   )
 
   const handleAllow = () => respondThenApplyPermissionPreset(
-    handleDecision(rememberSwitch.checked() ? (decisions().remembered ?? decisions().positive) : decisions().positive),
+    handleDecision(selectedAllowChoice()?.decision ?? decisions().positive),
     props.presets,
     permissionChoice.choice(),
   )
@@ -291,16 +390,7 @@ export const CodexControlActions: Component<ActionsProps> = (props) => {
           onSendFeedback={props.onTriggerSend}
           negativeAction={{ label: codexDecisionLabel(decisions().negative), testId: 'control-deny-btn', onSelect: () => handleDecision(decisions().negative) }}
           positiveAction={{ label: codexDecisionLabel(decisions().positive), testId: 'control-allow-btn', onSelect: handleAllow }}
-          switches={() => [
-            ...(decisions().remembered
-              ? [{
-                  id: 'control-remember-checkbox',
-                  label: 'Remember',
-                  checked: rememberSwitch.checked(),
-                  onChange: rememberSwitch.set,
-                }]
-              : []),
-          ]}
+          allowChoicePill={allowChoicePill}
           permissionPill={() => buildSessionPermissionPill(props.presets, permissionChoice)}
           additionalActions={() => decisions().additional.map(decision => ({
             label: codexDecisionLabel(decision),

--- a/frontend/src/components/chat/providers/codex/controlResponse.ts
+++ b/frontend/src/components/chat/providers/codex/controlResponse.ts
@@ -1,6 +1,10 @@
+import type { ControlAnswerState, Question } from '../../controls/types'
 import type { ControlResponseDisplay, PersistedControlResponse } from '../../persistedControlResponse'
+import type { PillOptions } from '~/components/common/PillGroup'
+import { disambiguateLabels, isPillOptions, PILL_OPTION_LIMIT } from '~/components/common/PillGroup'
 import { isObject, pickObject, pickString } from '~/lib/jsonPick'
 import { decodeControlBehaviorEnvelope } from '~/utils/controlResponse'
+import { sendJsonRpcResult, sendResponse } from '../../controls/types'
 import { feedback, firstNonEmpty, joinAnswerLines, label, labeledAnswerLine, labelOrNull } from '../../persistedControlResponse'
 
 export type CodexDecision
@@ -64,6 +68,265 @@ export function codexDecisionKey(value: unknown): string {
   if (typeof decision === 'string')
     return decision
   return Object.keys(decision)[0]
+}
+
+/** Extract Codex approval params from the control request payload. */
+export function getCodexParams(payload: Record<string, unknown>): Record<string, unknown> | undefined {
+  return pickObject(payload, 'params', undefined)
+}
+
+/**
+ * Sends a Codex-native approval decision as a JSON-RPC response directly.
+ */
+export function sendCodexDecision(
+  onRespond: (content: Uint8Array) => Promise<void>,
+  requestId: string,
+  decision: CodexDecision,
+): Promise<void> {
+  return sendJsonRpcResult(onRespond, requestId, { decision })
+}
+
+export function markCodexPlanPromptResponse(response: Record<string, unknown>): Record<string, unknown> {
+  return { ...response, codexPlanModePrompt: true }
+}
+
+export function sendCodexPlanPromptResponse(
+  onRespond: (content: Uint8Array) => Promise<void>,
+  response: Record<string, unknown>,
+): Promise<void> {
+  return sendResponse(onRespond, markCodexPlanPromptResponse(response))
+}
+
+const CODEX_OTHER_OPTION_LABEL = 'None of the above'
+
+function hasCodexOtherOption(question: Question): boolean {
+  const raw = question as unknown as Record<string, unknown>
+  return raw.isOther === true && Array.isArray(question.options) && question.options.length > 0
+}
+
+function codexAnswerValues(question: Question, index: number, answerState: ControlAnswerState): string[] {
+  const selected = answerState.selections()[index] ?? []
+  const customText = answerState.customTexts()[index]?.trim()
+  const values = [...selected]
+
+  if (customText) {
+    if (values.length === 0 && hasCodexOtherOption(question)) {
+      // Codex marks its auto-added free-form option explicitly.
+      values.push(CODEX_OTHER_OPTION_LABEL)
+    }
+    // Codex's TUI appends free-form text as a user_note answer entry,
+    // even for questions without a selected option.
+    values.push(`user_note: ${customText}`)
+  }
+
+  return values
+}
+
+/**
+ * Sends a Codex-native requestUserInput response as a JSON-RPC response directly.
+ */
+export function sendCodexUserInputResponse(
+  onRespond: (content: Uint8Array) => Promise<void>,
+  requestId: string,
+  questions: Question[],
+  answerState: ControlAnswerState,
+): Promise<void> {
+  const answers: Record<string, { answers: string[] }> = {}
+  for (let i = 0; i < questions.length; i++) {
+    const values = codexAnswerValues(questions[i], i, answerState)
+    const key = questions[i].id || questions[i].header || `q${i}`
+    answers[key] = { answers: values }
+  }
+  return sendJsonRpcResult(onRespond, requestId, { answers })
+}
+
+export function sendCodexUserInputRejectResponse(
+  onRespond: (content: Uint8Array) => Promise<void>,
+  requestId: string,
+): Promise<void> {
+  return sendJsonRpcResult(onRespond, requestId, { answers: {} })
+}
+
+export function sendCodexPermissionsResponse(
+  onRespond: (content: Uint8Array) => Promise<void>,
+  requestId: string,
+  permissions: Record<string, unknown>,
+  scope: 'turn' | 'session',
+): Promise<void> {
+  return sendJsonRpcResult(onRespond, requestId, { permissions, scope })
+}
+
+function isNegativeDecision(decision: CodexDecision): boolean {
+  if (decision === 'decline' || decision === 'cancel')
+    return true
+  return typeof decision === 'object'
+    && 'applyNetworkPolicyAmendment' in decision
+    && decision.applyNetworkPolicyAmendment.network_policy_amendment.action === 'deny'
+}
+
+interface CodexAllowChoice {
+  key: string
+  label: string
+  decision: CodexDecision
+}
+
+/**
+ * How each allow decision reads as a pill, strongest-lasting last.
+ *
+ * ONE ordered table, so a pill's label and its position come from one row. The
+ * two lived in separate cascades that a reader had to keep in step by hand, and
+ * neither was exhaustive: a decision that matched no branch still drew a pill,
+ * labelled as the branch that happened to be last. `detail` tells two decisions
+ * of the same row apart, because a payload may carry two host rules or two
+ * command rules.
+ */
+const CODEX_ALLOW_CHOICE_SPECS: ReadonlyArray<{
+  match: (decision: CodexDecision) => boolean
+  label: string
+  detail: (decision: CodexDecision) => string
+}> = [
+  { match: decision => decision === 'accept', label: 'Once', detail: () => 'Once' },
+  { match: decision => decision === 'acceptForSession', label: 'Session', detail: () => 'Session' },
+  {
+    match: decision => typeof decision === 'object' && 'acceptWithExecpolicyAmendment' in decision,
+    label: 'Command rule',
+    detail: decision => (typeof decision === 'object' && 'acceptWithExecpolicyAmendment' in decision
+      ? `Rule: ${decision.acceptWithExecpolicyAmendment.execpolicy_amendment.join(' ')}`
+      : 'Command rule'),
+  },
+  {
+    match: decision => typeof decision === 'object' && 'applyNetworkPolicyAmendment' in decision,
+    label: 'Host rule',
+    detail: decision => (typeof decision === 'object' && 'applyNetworkPolicyAmendment' in decision
+      ? `Host: ${decision.applyNetworkPolicyAmendment.network_policy_amendment.host}`
+      : 'Host rule'),
+  },
+]
+
+function codexAllowChoiceSpecIndex(decision: CodexDecision): number {
+  return CODEX_ALLOW_CHOICE_SPECS.findIndex(spec => spec.match(decision))
+}
+
+/**
+ * Builds the choices that qualify the shared Allow button. A group requires
+ * Codex's one-turn `accept` decision, so its first and default pill is Once.
+ *
+ * A decision that matches no row draws no pill. It stays in `additional`, where
+ * `codexDecisionLabel` gives it its own name on its own button.
+ */
+function codexAllowChoices(decisions: CodexDecision[]): PillChoices | undefined {
+  const candidates = decisions
+    .map((decision, sourceIndex) => ({ decision, sourceIndex, specIndex: codexAllowChoiceSpecIndex(decision) }))
+    // A repeated string decision draws two pills whose keys differ and whose
+    // names cannot: `detail` returns a constant for `accept` and
+    // `acceptForSession`, so `disambiguateLabels` has nothing to tell them
+    // apart. Answering either sends the same decision, so keep the first.
+    .filter((candidate, index, all) => typeof candidate.decision !== 'string'
+      || all.findIndex(other => other.decision === candidate.decision) === index)
+    .filter(candidate => candidate.specIndex >= 0 && !isNegativeDecision(candidate.decision))
+    .sort((a, b) => a.specIndex - b.specIndex)
+
+  if (candidates.length < 2 || candidates[0]?.decision !== 'accept')
+    return undefined
+
+  const drawn = candidates.slice(0, PILL_OPTION_LIMIT)
+  const labels = disambiguateLabels(
+    drawn,
+    candidate => CODEX_ALLOW_CHOICE_SPECS[candidate.specIndex]!.label,
+    candidate => CODEX_ALLOW_CHOICE_SPECS[candidate.specIndex]!.detail(candidate.decision),
+  )
+  const choices = drawn.map(({ decision, sourceIndex }, index) => ({
+    key: `codex-allow-${sourceIndex}`,
+    label: labels[index]!,
+    decision,
+  }))
+  // The slice already caps the count and the guard above sets the floor, so this
+  // narrows the tuple type rather than rejecting anything. Keeping the pills and
+  // the selection on ONE value is what matters: a group that vanished while
+  // `selectedAllowChoice` still answered would send a rule nothing offered.
+  const options = choices.map(choice => ({ key: choice.key, label: choice.label }))
+  return isPillOptions(options) ? { choices, options } : undefined
+}
+
+/** The allow choices and the exact pill options they draw, built together. */
+interface PillChoices {
+  choices: CodexAllowChoice[]
+  options: PillOptions<string>
+}
+
+/**
+ * The accessible name of the Codex allow-choice group.
+ *
+ * Both Codex action components draw the group, and the E2E specs and the
+ * `allowChoicePillGroup` test helper look it up by this name, so one spelling
+ * keeps a rename from reaching some of those and missing the rest.
+ */
+export const ALLOW_AS_LABEL = 'Allow as'
+
+/** How long a Codex permissions grant lasts. Fixed, unlike the decision pills. */
+export const CODEX_PERMISSION_SCOPE_OPTIONS = [
+  { key: 'turn', label: 'Once' },
+  { key: 'session', label: 'Session' },
+] as const satisfies PillOptions<string>
+
+export interface ResolvedCodexDecisions {
+  /** Absent when Codex offered no way to refuse. The banner then draws no Deny. */
+  negative?: CodexDecision
+  /** Absent when Codex offered no way to approve. The banner then draws no Allow. */
+  positive?: CodexDecision
+  allowChoices?: PillChoices
+  additional: CodexDecision[]
+}
+
+/**
+ * The decisions a Codex approval banner draws, from the request's own list.
+ *
+ * A polarity the list does not carry is ABSENT, and the banner draws no button
+ * for it. It must never be invented: a fabricated `accept` answers a request
+ * that offered no way to approve, and a fabricated `cancel` refuses one that
+ * offered no way to refuse. Codex then acts on a decision the user never had.
+ *
+ * One case does invent a token, and it is the opposite failure. `parseCodexDecision`
+ * DROPS a variant that this build does not know, so a list of one unknown allow
+ * decision beside a refusal parses to the refusal alone. Removing Allow there
+ * would leave the user unable to approve at all, for a request that Codex did
+ * offer an approval for. So a list the parser NARROWED keeps the canonical
+ * token of the missing polarity -- the same pair the empty-list branch below
+ * synthesizes -- and only a list that survived intact reports the polarity as
+ * genuinely absent.
+ */
+export function resolveCodexDecisions(raw: unknown): ResolvedCodexDecisions {
+  const offered = Array.isArray(raw) ? raw : []
+  const parsed = offered
+    .map(parseCodexDecision)
+    .filter((decision): decision is CodexDecision => decision !== null)
+  const narrowed = parsed.length < offered.length
+  const decisions: CodexDecision[] = parsed.length > 0 ? parsed : ['accept', 'cancel']
+  const offeredNegative = decisions.find(isNegativeDecision)
+  const offeredPositive = decisions.find(decision => decision === 'accept')
+    ?? decisions.find(decision => !isNegativeDecision(decision))
+  const negative = offeredNegative ?? (narrowed ? 'cancel' : undefined)
+  const positive = offeredPositive ?? (narrowed ? 'accept' : undefined)
+  const allowChoices = codexAllowChoices(decisions)
+  const consumed = new Set<CodexDecision>(
+    allowChoices?.choices.map(choice => choice.decision) ?? (positive ? [positive] : []),
+  )
+  if (negative)
+    consumed.add(negative)
+  const additional = decisions.filter(decision => !consumed.has(decision))
+  return { negative, positive, allowChoices, additional }
+}
+
+export function codexRequestedPermissions(payload: Record<string, unknown>): Record<string, unknown> {
+  const permissions = pickObject(getCodexParams(payload), 'permissions', undefined)
+  if (!permissions)
+    return {}
+  const granted: Record<string, unknown> = {}
+  if (isObject(permissions.network))
+    granted.network = permissions.network
+  if (isObject(permissions.fileSystem))
+    granted.fileSystem = permissions.fileSystem
+  return granted
 }
 
 /**

--- a/frontend/src/components/chat/providers/codex/plugin.test.ts
+++ b/frontend/src/components/chat/providers/codex/plugin.test.ts
@@ -6,9 +6,9 @@ import { createControlAnswerState } from '../../controls/types'
 import { renderDivider } from '../../messageRenderTestUtils'
 import { providerFor } from '../registry'
 import { input } from '../testUtils'
-import { sendCodexDecision, sendCodexUserInputResponse } from './CodexControlRequest'
-
 import { CODEX_OPTION_COLLABORATION_MODE, DEFAULT_CODEX_COLLABORATION_MODE } from './constants'
+
+import { sendCodexDecision, sendCodexUserInputResponse } from './controlResponse'
 // Side-effect import to register the Codex plugin.
 import './plugin'
 

--- a/frontend/src/components/chat/providers/codex/plugin.tsx
+++ b/frontend/src/components/chat/providers/codex/plugin.tsx
@@ -22,20 +22,19 @@ import { PlanExecutionMessage, UserContentMessage } from '../../messageRenderers
 import { isFinalCompactingStatus, isNotificationThreadWrapper } from '../../messageUtils'
 import { isJsonRpcResponseObject } from '../acp/classification'
 import { registerProvider } from '../registry'
+import { CodexControlActions, CodexControlContent } from './CodexControlRequest'
 import {
-  CodexControlActions,
-  CodexControlContent,
+  CODEX_OPTION_COLLABORATION_MODE,
+  DEFAULT_CODEX_COLLABORATION_MODE,
+} from './constants'
+import {
+  codexControlResponseDisplay,
   codexRequestedPermissions,
   markCodexPlanPromptResponse,
   resolveCodexDecisions,
   sendCodexUserInputRejectResponse,
   sendCodexUserInputResponse,
-} from './CodexControlRequest'
-import {
-  CODEX_OPTION_COLLABORATION_MODE,
-  DEFAULT_CODEX_COLLABORATION_MODE,
-} from './constants'
-import { codexControlResponseDisplay } from './controlResponse'
+} from './controlResponse'
 import { CODEX_RENDERERS } from './defineRenderer'
 import { codexToolResultImages } from './extractors/image'
 import { codexNotificationThreadEntry } from './notifications'
@@ -554,7 +553,16 @@ const codexPlugin: Provider = {
       })
     }
     const decisions = resolveCodexDecisions(pickObject(payload, 'params')?.availableDecisions)
-    return buildJsonRpcResult(requestId, { decision: content ? decisions.negative : decisions.positive })
+    // This path MUST answer: the user sent a message while the request was
+    // pending, and an unanswered request blocks the agent forever. So it falls
+    // back to the canonical token of a polarity the request offered none of,
+    // where the banner instead draws no button. The two differ on purpose --
+    // the banner can decline to offer a decision, and this cannot decline to
+    // send one.
+    const decision = content
+      ? decisions.negative ?? 'cancel'
+      : decisions.positive ?? 'accept'
+    return buildJsonRpcResult(requestId, { decision })
   },
   // The worker already forwards synthetic plan feedback as a user message.
   controlFeedbackAsFollowUpMessage: payload => getToolName(payload) !== 'CodexPlanModePrompt',

--- a/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
+++ b/frontend/src/components/chat/providers/opencode/OpenCodeControlRequest.test.ts
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
-import { allowScopePillGroup, permissionPillGroup } from '~/test-support/controlRequests'
+import { allowChoicePillGroup, permissionPillGroup } from '~/test-support/controlRequests'
 import { createControlAnswerState } from '../../controls/types'
 import { OpenCodeControlActions } from './OpenCodeControlRequest'
 
@@ -45,7 +45,7 @@ describe('openCodeControlActions', () => {
     expect(allow.textContent).toBe('Allow')
     expect(deny.compareDocumentPosition(allow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
-    const scope = allowScopePillGroup()
+    const scope = allowChoicePillGroup()
     expect(scope.getByRole('radio', { name: 'Once' })).toBeChecked()
     expect(scope.getByRole('radio', { name: 'Always' })).toBeInTheDocument()
     expect(screen.queryByTestId('control-decision-always')).not.toBeInTheDocument()
@@ -61,7 +61,7 @@ describe('openCodeControlActions', () => {
 
     fireEvent.click(permissionPillGroup().getByRole('radio', { name: 'Bypass' }))
 
-    fireEvent.click(allowScopePillGroup().getByRole('radio', { name: 'Always' }))
+    fireEvent.click(allowChoicePillGroup().getByRole('radio', { name: 'Always' }))
     await fireEvent.click(screen.getByTestId('control-allow-btn'))
     expect(decodeOptionId(onRespond.mock.calls[1][0])).toBe('always')
     expect(apply).toHaveBeenCalledWith({ sets: { permissionMode: 'yolo' } })

--- a/frontend/src/components/chat/providers/pi/controls.test.tsx
+++ b/frontend/src/components/chat/providers/pi/controls.test.tsx
@@ -1,6 +1,7 @@
 import type { ControlRequest } from '~/stores/control.store'
 import { fireEvent, render } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
+import { compactControl } from '~/components/common/CompactControl.css'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import { ControlRequestActions, ControlRequestContent } from '../../ControlRequestBanner'
 import { createControlAnswerState } from '../../controls/types'
@@ -183,8 +184,8 @@ describe('pi confirm control requests', () => {
     // The action surface produces the Approve / Deny buttons referenced by
     // the test name. queryByTestId-scoped to this render so the assertion
     // doesn't accidentally pick up the content render above.
-    expect(container.querySelector('[data-testid="control-allow-btn"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-testid="control-deny-btn"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-testid="control-allow-btn"]')).toHaveClass(compactControl)
+    expect(container.querySelector('[data-testid="control-deny-btn"]')).toHaveClass('outline', compactControl)
   })
 
   it('emits a confirm:true response on Approve', async () => {

--- a/frontend/src/components/chat/providers/pi/controls.test.tsx
+++ b/frontend/src/components/chat/providers/pi/controls.test.tsx
@@ -182,8 +182,9 @@ describe('pi confirm control requests', () => {
     expect(contentContainer.textContent ?? '').toContain('Continue?')
     expect(contentContainer.textContent ?? '').toContain('About to delete files.')
     // The action surface produces the Approve / Deny buttons referenced by
-    // the test name. queryByTestId-scoped to this render so the assertion
-    // doesn't accidentally pick up the content render above.
+    // the test name. Looked up through this render's own `container`, not
+    // through `screen`, so the assertion cannot pick up the content render
+    // above. A missing button then reads as `expected null to have class`.
     expect(container.querySelector('[data-testid="control-allow-btn"]')).toHaveClass(compactControl)
     expect(container.querySelector('[data-testid="control-deny-btn"]')).toHaveClass('outline', compactControl)
   })

--- a/frontend/src/components/chat/providers/stubs/cursor.test.ts
+++ b/frontend/src/components/chat/providers/stubs/cursor.test.ts
@@ -1,5 +1,8 @@
+import { render, screen } from '@solidjs/testing-library'
 import { describe, expect, it } from 'vitest'
+import { compactControl } from '~/components/common/CompactControl.css'
 import { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
+import { createControlAnswerState } from '../../controls/types'
 import { providerFor } from '../registry'
 import { describeACPStubBasics } from './stubBasics'
 
@@ -35,6 +38,24 @@ describe('cursor provider', () => {
 
   it('renders the permissionMode group as the trigger mode segment', () => {
     expect(plugin.triggerModeGroupKey).toBe('permissionMode')
+  })
+
+  it('uses Oat small metrics for create-plan decisions', () => {
+    render(() => plugin.ControlActions!({
+      request: {
+        requestId: 'cursor-plan-1',
+        agentId: 'cursor-1',
+        payload: { method: 'cursor/create_plan', params: {} },
+      },
+      answerState: createControlAnswerState(),
+      onRespond: async () => {},
+      hasEditorContent: false,
+      onTriggerSend: () => {},
+    }))
+
+    expect(screen.getByTestId('control-deny-btn')).toHaveClass('outline', compactControl)
+    expect(screen.getByTestId('control-allow-btn')).toHaveClass(compactControl)
+    expect(screen.getByTestId('control-allow-btn')).not.toHaveClass('outline')
   })
 
   // The neutral {isSynthetic, controlResponse} row -> control_response classification is provider-

--- a/frontend/src/components/common/CompactControl.css.ts
+++ b/frontend/src/components/common/CompactControl.css.ts
@@ -14,5 +14,27 @@ export const compactControlProperties = {
   fontSize: COMPACT_FONT_SIZE,
 } as const
 
-/** Shared typography and padding for compact buttons. */
-export const compactControl = style(compactControlProperties)
+/**
+ * Shared typography, padding, and HEIGHT for a compact button.
+ *
+ * The height is pinned because a button is `inline-flex` (Oat's rule), and a
+ * flex container has no line-box strut: its content height is the tallest ITEM.
+ * A button showing one line of text is as tall as that line box, and the same
+ * button showing a 14px icon alone is 4px shorter -- which is what the composer
+ * does below `sm`, where `hideInNarrowComposer` takes the word away from Pause
+ * Queue, Interrupt and Send. Those three then no longer matched the `[+]`
+ * button beside them, whose `--editor-btn-h` is this very value.
+ *
+ * `minHeight` rather than `height`, so a caller that does let a label wrap
+ * still grows.
+ *
+ * The pill options are NOT covered, and must not be: they spread
+ * `compactControlProperties` while their GROUP owns the border this height
+ * counts, so pinning them here would make every small pill group 2px taller.
+ * A group is `inline-flex` at the default `align-items: stretch`, so its
+ * options already match the tallest of them.
+ */
+export const compactControl = style({
+  ...compactControlProperties,
+  minHeight: compactControlHeight,
+})

--- a/frontend/src/components/common/CompactControl.css.ts
+++ b/frontend/src/components/common/CompactControl.css.ts
@@ -37,4 +37,8 @@ export const compactControlProperties = {
 export const compactControl = style({
   ...compactControlProperties,
   minHeight: compactControlHeight,
+  // Never compress. A decision button must stay readable at every width, so the
+  // row gives way somewhere else: the control request's options cluster scrolls,
+  // and the composer's own cluster wraps.
+  flexShrink: 0,
 })

--- a/frontend/src/components/common/IconButton.css.ts
+++ b/frontend/src/components/common/IconButton.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css'
+import { iconSize } from '~/styles/tokens'
 
 export const base = style({
   // Reset button defaults explicitly (avoid `all: unset` which breaks
@@ -62,9 +63,17 @@ export const active = style({
   },
 })
 
-// Size variants
+// Size variants, read from `iconSize.container` in `~/styles/tokens.ts`.
+//
+// That table is the scale, and other stylesheets already size against it, so a
+// literal here would let the two drift. `sharedTree.css.ts` reserves a sidebar
+// row's height from `container.md` to match the row-action button, which is the
+// pairing a second spelling would silently break.
+function square(size: string) {
+  return style({ width: size, height: size, minWidth: size })
+}
 
-export const sizeSm = style({ width: '20px', height: '20px', minWidth: '20px' })
-export const sizeMd = style({ width: '24px', height: '24px', minWidth: '24px' })
-export const sizeLg = style({ width: '28px', height: '28px', minWidth: '28px' })
-export const sizeXl = style({ width: '36px', height: '36px', minWidth: '36px' })
+export const sizeSm = square(iconSize.container.sm)
+export const sizeMd = square(iconSize.container.md)
+export const sizeLg = square(iconSize.container.lg)
+export const sizeXl = square(iconSize.container.xl)

--- a/frontend/src/components/common/PillGroup.test.tsx
+++ b/frontend/src/components/common/PillGroup.test.tsx
@@ -2,9 +2,10 @@ import type { PillOptions } from './PillGroup'
 import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { Minus } from 'lucide-solid'
 import { createSignal } from 'solid-js'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { hoverForTooltip, stubClipped, stubFitting } from '~/test-support/clipStub'
 import { installControllableResizeObserver, triggerResizeObserversSync } from '~/test-support/resizeObserverStub'
-import { PillGroup } from './PillGroup'
+import { disambiguateLabels, PillGroup } from './PillGroup'
 import * as styles from './PillGroup.css'
 
 /**
@@ -668,5 +669,108 @@ describe('pill group icon option', () => {
     expect(copies[0]).not.toHaveTextContent('Unchanged')
     expect(copies[1]!.querySelector('svg')).toBeNull()
     expect(copies[1]).toHaveTextContent('Smart')
+  })
+})
+
+/**
+ * A group is `overflow: hidden`, so a row too narrow for its options cuts the
+ * last ones off. A clipped text option used to state no name at all: it carried
+ * no tooltip, so neither a reader nor a screen reader could recover it. The
+ * groups most likely to run out of room are the ones whose labels carry a
+ * distinguishing detail, such as a host or a command.
+ */
+describe('pill group clipped option', () => {
+  const options = [
+    { key: 'once', label: 'Once' },
+    { key: 'host', label: 'Host: a.example.com' },
+  ] as const satisfies PillOptions<string>
+
+  beforeEach(() => {
+    installControllableResizeObserver()
+    vi.useFakeTimers()
+  })
+  afterEach(() => vi.useRealTimers())
+
+  function renderClipGroup() {
+    render(() => (
+      <PillGroup label="Allow as" options={options} selectedKey="once" onSelect={vi.fn()} />
+    ))
+    return screen.getByRole('radio', { name: 'Host: a.example.com' })
+  }
+
+  it('names a text option that the group cuts off', () => {
+    const radio = renderClipGroup()
+    stubClipped(radio)
+    expect(hoverForTooltip(radio)).toHaveTextContent('Host: a.example.com')
+  })
+
+  it('opens no tooltip while the label fits', () => {
+    const radio = renderClipGroup()
+    stubFitting(radio)
+    expect(hoverForTooltip(radio)).toBeNull()
+  })
+
+  // The option's own TEXT is its accessible name. An `aria-label` that repeats
+  // it would make the pill answer a second by-label lookup, which collides with
+  // a real field of the same name (`LoginPage` has a `Password` pill beside a
+  // `Password` input).
+  it('adds no aria-label to an option that spells its own name', () => {
+    const radio = renderClipGroup()
+    expect(radio).not.toHaveAttribute('aria-label')
+    expect(radio).toHaveAccessibleName('Host: a.example.com')
+  })
+})
+
+/**
+ * `optionMap` throws on two options that share a KEY, and nothing catches two
+ * that share a LABEL: the user cannot tell them apart, a screen reader
+ * announces one name twice, and a by-name lookup matches both.
+ */
+describe('disambiguateLabels', () => {
+  const label = (item: { label: string }) => item.label
+  const distinct = (item: { label: string, detail: string }) => item.detail
+
+  it('keeps a label that no other item shares', () => {
+    expect(disambiguateLabels(
+      [{ label: 'Once', detail: 'a' }, { label: 'Session', detail: 'b' }],
+      label,
+      distinct,
+    )).toEqual(['Once', 'Session'])
+  })
+
+  it('replaces every member of a collision, not the later ones alone', () => {
+    expect(disambiguateLabels(
+      [{ label: 'Host rule', detail: 'Host: a' }, { label: 'Host rule', detail: 'Host: b' }],
+      label,
+      distinct,
+    )).toEqual(['Host: a', 'Host: b'])
+  })
+
+  it('leaves an uncolliding neighbour alone while it replaces a collision', () => {
+    expect(disambiguateLabels(
+      [
+        { label: 'Once', detail: 'Once' },
+        { label: 'Host rule', detail: 'Host: a' },
+        { label: 'Host rule', detail: 'Host: b' },
+      ],
+      label,
+      distinct,
+    )).toEqual(['Once', 'Host: a', 'Host: b'])
+  })
+
+  it('replaces all three of a three-way collision', () => {
+    expect(disambiguateLabels(
+      [
+        { label: 'Host rule', detail: 'Host: a' },
+        { label: 'Host rule', detail: 'Host: b' },
+        { label: 'Host rule', detail: 'Host: c' },
+      ],
+      label,
+      distinct,
+    )).toEqual(['Host: a', 'Host: b', 'Host: c'])
+  })
+
+  it('gives an empty list back unchanged', () => {
+    expect(disambiguateLabels([], label, distinct)).toEqual([])
   })
 })

--- a/frontend/src/components/common/PillGroup.tsx
+++ b/frontend/src/components/common/PillGroup.tsx
@@ -47,6 +47,29 @@ export function isPillOptions<K extends string>(options: readonly PillOptionSpec
   return options.length > 0 && options.length <= PILL_OPTION_LIMIT
 }
 
+/**
+ * The label for each item, replaced by its distinct form wherever two items
+ * would otherwise read the same.
+ *
+ * `optionMap` refuses two options that share a KEY, and nothing refuses two that
+ * share a LABEL. Two pills with one name let the user pick the wrong answer, give
+ * a screen reader the same name twice, and make `getByRole('radio', { name })`
+ * match more than one element. A group derives its labels from a small
+ * vocabulary, so a collision is normal rather than exceptional, and each caller
+ * supplies the detail that tells its own two items apart.
+ */
+export function disambiguateLabels<T>(
+  items: readonly T[],
+  label: (item: T) => string,
+  distinct: (item: T) => string,
+): string[] {
+  const counts = new Map<string, number>()
+  const labels = items.map(label)
+  for (const one of labels)
+    counts.set(one, (counts.get(one) ?? 0) + 1)
+  return items.map((item, index) => ((counts.get(labels[index]!) ?? 0) > 1 ? distinct(item) : labels[index]!))
+}
+
 type PillOptionState
   = | { kind: 'enabled' }
     | { kind: 'option-refused', reason: string }
@@ -85,20 +108,31 @@ function PillOption(props: {
   const optionRefused = () => props.state.kind === 'option-refused'
   const groupRefused = () => props.state.kind === 'group-refused'
   /**
-   * What the tooltip says: the reason this option refuses selection, or the
-   * name an icon-only option does not spell out. A named option with no reason
-   * needs no tooltip, because its own text already says what it is.
+   * What the tooltip says: the reason this option refuses selection, else the
+   * option's own name.
    */
-  const tooltipText = () => {
-    if (props.state.kind === 'option-refused')
-      return props.state.reason
-    return props.icon === undefined ? undefined : props.label
-  }
+  const tooltipText = () => (props.state.kind === 'option-refused' ? props.state.reason : props.label)
+  /**
+   * When it opens. A refusal reason and an icon-only option's name are never on
+   * screen, so both open on every hover. A text option repeats a label the
+   * reader can already read, so it opens only where the group CUTS THE PILL OFF
+   * -- `pillGroup` is `overflow: hidden`, and a row too narrow for its options
+   * clips the last ones. Without this a clipped option states no name at all,
+   * and a group whose labels carry a distinguishing detail (a host, a command)
+   * is exactly the one that runs out of room.
+   */
+  const tooltipShowWhen = (): 'always' | 'clipped' =>
+    (props.state.kind === 'option-refused' || props.icon !== undefined ? 'always' : 'clipped')
   /**
    * The name an icon-only option carries. Passed as a STRING rather than
    * `true`, so it stays the name even when the tooltip states a refusal reason
    * instead; `Tooltip` then publishes the reason as a description, because the
    * two strings differ.
+   *
+   * A TEXT option passes nothing. Its own text is already the accessible name,
+   * and an `aria-label` that repeats it only makes the button answer a second
+   * by-label lookup -- `LoginPage` has a `Password` field beside a `Password`
+   * pill, and the two then collide.
    */
   const tooltipName = () => (props.icon === undefined ? undefined : props.label)
   const pill = () => (
@@ -130,7 +164,7 @@ function PillOption(props: {
 
   return (
     <Show when={tooltipText()} fallback={pill()}>
-      {text => <Tooltip text={text()} ariaLabel={tooltipName()}>{pill()}</Tooltip>}
+      {text => <Tooltip text={text()} ariaLabel={tooltipName()} showWhen={tooltipShowWhen()}>{pill()}</Tooltip>}
     </Show>
   )
 }

--- a/frontend/src/components/common/Spinner.tsx
+++ b/frontend/src/components/common/Spinner.tsx
@@ -5,7 +5,7 @@ import { spinner } from '~/styles/animations.css'
 import { Icon } from './Icon'
 
 export interface SpinnerProps {
-  /** Token-driven icon size. Defaults to `sm` (16px). */
+  /** Token-driven icon size. Defaults to `sm` (14px). */
   'size'?: IconSizeName
   /** Optional test id forwarded to the icon root. */
   'data-testid'?: string

--- a/frontend/src/components/common/moreHorizontalTrigger.test.tsx
+++ b/frontend/src/components/common/moreHorizontalTrigger.test.tsx
@@ -1,0 +1,26 @@
+import type { DropdownTriggerProps } from './DropdownMenu'
+import { render, screen } from '@solidjs/testing-library'
+import { describe, expect, it, vi } from 'vitest'
+import * as iconButtonStyles from './IconButton.css'
+import { moreHorizontalTrigger } from './moreHorizontalTrigger'
+
+const triggerProps: DropdownTriggerProps = {
+  'aria-expanded': false,
+  'ref': () => {},
+  'onPointerDown': vi.fn(),
+  'onClick': vi.fn(),
+}
+
+describe('moreHorizontalTrigger', () => {
+  it('uses a 24px button with a 14px icon', () => {
+    render(() => moreHorizontalTrigger({ title: 'More actions' })(triggerProps))
+
+    const button = screen.getByRole('button', { name: 'More actions' })
+    expect(button.classList).toContain(iconButtonStyles.sizeMd)
+    expect(button.classList).not.toContain(iconButtonStyles.sizeSm)
+
+    const icon = button.querySelector('svg')
+    expect(icon).toHaveAttribute('width', '14')
+    expect(icon).toHaveAttribute('height', '14')
+  })
+})

--- a/frontend/src/components/common/moreHorizontalTrigger.test.tsx
+++ b/frontend/src/components/common/moreHorizontalTrigger.test.tsx
@@ -1,19 +1,24 @@
 import type { DropdownTriggerProps } from './DropdownMenu'
-import { render, screen } from '@solidjs/testing-library'
+import { fireEvent, render, screen } from '@solidjs/testing-library'
 import { describe, expect, it, vi } from 'vitest'
 import * as iconButtonStyles from './IconButton.css'
-import { moreHorizontalTrigger } from './moreHorizontalTrigger'
+import { moreHorizontalTrigger, rowContextMenuTrigger } from './moreHorizontalTrigger'
 
-const triggerProps: DropdownTriggerProps = {
-  'aria-expanded': false,
-  'ref': () => {},
-  'onPointerDown': vi.fn(),
-  'onClick': vi.fn(),
+// Built per test. One shared object would carry its `vi.fn()` call counts from
+// the case before, so a forwarding assertion could pass on another test's click.
+function triggerProps(overrides: Partial<DropdownTriggerProps> = {}): DropdownTriggerProps {
+  return {
+    'aria-expanded': false,
+    'ref': () => {},
+    'onPointerDown': vi.fn(),
+    'onClick': vi.fn(),
+    ...overrides,
+  }
 }
 
 describe('moreHorizontalTrigger', () => {
   it('uses a 24px button with a 14px icon', () => {
-    render(() => moreHorizontalTrigger({ title: 'More actions' })(triggerProps))
+    render(() => moreHorizontalTrigger({ title: 'More actions' })(triggerProps()))
 
     const button = screen.getByRole('button', { name: 'More actions' })
     expect(button.classList).toContain(iconButtonStyles.sizeMd)
@@ -22,5 +27,52 @@ describe('moreHorizontalTrigger', () => {
     const icon = button.querySelector('svg')
     expect(icon).toHaveAttribute('width', '14')
     expect(icon).toHaveAttribute('height', '14')
+  })
+
+  // Forwarding is the helper's whole job. Dropping `onClick` makes every row
+  // menu refuse to open, and a size-only suite stays green through that.
+  it('forwards the menu handlers and the expanded state', () => {
+    let attached: HTMLElement | undefined
+    const props = triggerProps({ 'aria-expanded': true, 'ref': el => (attached = el) })
+    render(() => moreHorizontalTrigger({ title: 'More actions' })(props))
+
+    const button = screen.getByRole('button', { name: 'More actions' })
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.pointerDown(button)
+    expect(props.onPointerDown).toHaveBeenCalledOnce()
+
+    fireEvent.click(button)
+    expect(props.onClick).toHaveBeenCalledOnce()
+    expect(attached).toBe(button)
+  })
+
+  // The row owns the click that selects it, so the trigger must claim the event
+  // before it reaches the row, or opening a menu also selects the row under it.
+  it('keeps the row from seeing the press that opens the menu', () => {
+    const rowClick = vi.fn()
+    const rowPointerDown = vi.fn()
+    render(() => (
+      <div onPointerDown={rowPointerDown} onClick={rowClick}>
+        {moreHorizontalTrigger({ title: 'More actions' })(triggerProps())}
+      </div>
+    ))
+
+    const button = screen.getByRole('button', { name: 'More actions' })
+    fireEvent.pointerDown(button)
+    fireEvent.click(button)
+
+    expect(rowPointerDown).not.toHaveBeenCalled()
+    expect(rowClick).not.toHaveBeenCalled()
+  })
+})
+
+describe('rowContextMenuTrigger', () => {
+  it('carries the sidebar row-menu class and the caller test id', () => {
+    render(() => rowContextMenuTrigger({ 'data-testid': 'row-menu' })(triggerProps()))
+
+    const button = screen.getByTestId('row-menu')
+    expect(button.classList).toContain(iconButtonStyles.sizeMd)
+    expect(button.className).toMatch(/menuTrigger/)
   })
 })

--- a/frontend/src/components/common/moreHorizontalTrigger.tsx
+++ b/frontend/src/components/common/moreHorizontalTrigger.tsx
@@ -19,20 +19,19 @@ export interface MoreHorizontalTriggerOptions {
   'title'?: string
 }
 
-// Builds the DropdownMenu `trigger` render-prop for the standard
-// "three-dot" affordance: a small IconButton that swallows the row's
-// click/pointerdown so the popover opens without selecting the row.
-// The pointerdown/click toggle dance (capturing wasOpenOnPointerDown
-// before light-dismiss) lives in DropdownMenu's internal handlers —
-// see handleTriggerPointerDown / handleTriggerClick there — so this
-// helper just spreads the triggerProps it receives.
+// Creates the standard three-dot trigger for a DropdownMenu.
+// The trigger uses a 24px IconButton and keeps the default 14px icon.
+// It stops row events so the popover opens without selecting the row.
+// DropdownMenu owns the pointer-down and click state changes.
+// Its handlers capture the open state before light dismiss changes it.
+// This helper forwards the trigger properties to those handlers.
 export function moreHorizontalTrigger(
   opts: MoreHorizontalTriggerOptions = {},
 ): (triggerProps: DropdownTriggerProps) => JSX.Element {
   return triggerProps => (
     <IconButton
       icon={MoreHorizontal}
-      size="sm"
+      size="md"
       class={opts.class}
       title={opts.title}
       ref={triggerProps.ref}
@@ -50,16 +49,15 @@ export function moreHorizontalTrigger(
   )
 }
 
-// rowContextMenuTrigger is the standard "three-dot, styled with the
-// sidebar's row-menu CSS class" trigger used by every per-row context
-// menu (BranchContextMenu, WorkspaceContextMenu, WorkerContextMenu,
-// TunnelContextMenu). Bakes in `class: menuTrigger` so each call site
-// reduces to `<DropdownMenu trigger={rowContextMenuTrigger()}>` — when
-// the visual changes (kebab icon, different size, renamed CSS class),
-// every row menu picks it up uniformly instead of one of four
-// hand-written sites drifting. Callers that need a non-row trigger
-// (titlebar, dialog headers) still use `moreHorizontalTrigger` with
-// their own class.
+// Creates the standard three-dot trigger for each row context menu.
+// It supplies the sidebar's `menuTrigger` class to every row menu.
+// Thus, one visual change updates all row menus.
+// A trigger outside a row uses `moreHorizontalTrigger` with its own class.
+// These components use this trigger:
+// - BranchContextMenu
+// - WorkspaceContextMenu
+// - WorkerContextMenu
+// - TunnelContextMenu
 export function rowContextMenuTrigger(
   opts: { 'data-testid'?: string } = {},
 ): (triggerProps: DropdownTriggerProps) => JSX.Element {

--- a/frontend/src/components/common/moreHorizontalTrigger.tsx
+++ b/frontend/src/components/common/moreHorizontalTrigger.tsx
@@ -23,7 +23,8 @@ export interface MoreHorizontalTriggerOptions {
 // The trigger uses a 24px IconButton and keeps the default 14px icon.
 // It stops row events so the popover opens without selecting the row.
 // DropdownMenu owns the pointer-down and click state changes.
-// Its handlers capture the open state before light dismiss changes it.
+// Its `handleTriggerPointerDown` and `handleTriggerClick` capture the open
+// state before light dismiss changes it.
 // This helper forwards the trigger properties to those handlers.
 export function moreHorizontalTrigger(
   opts: MoreHorizontalTriggerOptions = {},
@@ -52,12 +53,12 @@ export function moreHorizontalTrigger(
 // Creates the standard three-dot trigger for each row context menu.
 // It supplies the sidebar's `menuTrigger` class to every row menu.
 // Thus, one visual change updates all row menus.
+// EVERY per-row context menu uses this trigger, and no other trigger belongs on
+// a sidebar row: the row height reserves this button's size, so a row menu that
+// picks a different one breaks the rhythm of the list.
 // A trigger outside a row uses `moreHorizontalTrigger` with its own class.
-// These components use this trigger:
-// - BranchContextMenu
-// - WorkspaceContextMenu
-// - WorkerContextMenu
-// - TunnelContextMenu
+// Run `rg 'rowContextMenuTrigger' frontend/src` for the current call sites,
+// rather than a list here that drifts as menus are added.
 export function rowContextMenuTrigger(
   opts: { 'data-testid'?: string } = {},
 ): (triggerProps: DropdownTriggerProps) => JSX.Element {

--- a/frontend/src/components/shell/TabBar.tsx
+++ b/frontend/src/components/shell/TabBar.tsx
@@ -4,7 +4,7 @@ import type { TabPopAction } from '~/components/common/TabContextMenu'
 import type { AgentProvider } from '~/generated/proto/leapmux/v1/agent_pb'
 import type { TerminalStatus } from '~/generated/proto/leapmux/v1/terminal_pb'
 import type { TabType } from '~/generated/proto/leapmux/v1/workspace_pb'
-import type { GuardedDragRow } from '~/lib/dragRow'
+import type { DragAxis, GuardedDragRow } from '~/lib/dragRow'
 import type { Tab } from '~/stores/tab.types'
 import { createDroppable, SortableProvider } from '@thisbeyond/solid-dnd'
 import Bot from 'lucide-solid/icons/bot'
@@ -390,13 +390,17 @@ export const TabBar: Component<TabBarProps> = (props) => {
     setRowEl: (el: HTMLElement) => void
   }
 
-  const setupTabRowDnd = (key: string): TabRowDnd => {
+  // ONE factory serves two surfaces of different axes: the desktop strip is a
+  // row and the mobile sheet is a column, so each passes its own. A row that
+  // travelled on both would reach past its container and raise the scrollbar of
+  // the other axis.
+  const setupTabRowDnd = (axis: DragAxis) => (key: string): TabRowDnd => {
     const [rowEl, setRowEl] = createContextMenuAnchor()
     // The key is the row's identity for the whole of its life now, so the
     // sortable id is fixed at creation rather than re-derived from a `Tab`
     // the row no longer owns. Created HERE, in the for-row owner, so it
     // outlives a tick where the lookup misses.
-    const row = createGuardedSortableRow(key)
+    const row = createGuardedSortableRow(key, undefined, axis)
     // Mouse-only activation on the row body; the grip carries the raw
     // handlers, so touch drags start there and nowhere else.
     attachDragActivators(rowEl, row.bodyActivators, { touch: 'block' })
@@ -655,7 +659,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
                 // No sortable: this fallback exists to render the strip when the drag
                 // machinery is what threw, so it must not touch it. The menu
                 // anchor survives — setupTabRowDnd creates it unconditionally.
-                <KeyedFor each={ids()} lookup={key => tabByKey().get(key)} rowSetup={setupTabRowDnd}>
+                <KeyedFor each={ids()} lookup={key => tabByKey().get(key)} rowSetup={setupTabRowDnd('x')}>
                   {(tab, _key, dnd) => renderStripRow(tab, dnd)}
                 </KeyedFor>
               )}
@@ -664,7 +668,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
                   <KeyedFor
                     each={ids()}
                     lookup={key => tabByKey().get(key)}
-                    rowSetup={setupTabRowDnd}
+                    rowSetup={setupTabRowDnd('x')}
                   >
                     {(tab, _key, dnd) => renderStripRow(tab, dnd)}
                   </KeyedFor>
@@ -880,7 +884,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
               fallback={<div class={styles.sheetEmpty}>No tabs</div>}
             >
               <ErrorBoundary fallback={(
-                <KeyedFor each={ids()} lookup={key => tabByKey().get(key)} rowSetup={setupTabRowDnd}>
+                <KeyedFor each={ids()} lookup={key => tabByKey().get(key)} rowSetup={setupTabRowDnd('y')}>
                   {(tab, _key, dnd) => renderSheetRow(tab, dnd)}
                 </KeyedFor>
               )}
@@ -889,7 +893,7 @@ export const TabBar: Component<TabBarProps> = (props) => {
                   <KeyedFor
                     each={ids()}
                     lookup={key => tabByKey().get(key)}
-                    rowSetup={setupTabRowDnd}
+                    rowSetup={setupTabRowDnd('y')}
                   >
                     {(tab, _key, dnd) => renderSheetRow(tab, dnd)}
                   </KeyedFor>

--- a/frontend/src/components/tree/sharedTree.css.ts
+++ b/frontend/src/components/tree/sharedTree.css.ts
@@ -1,10 +1,18 @@
 import { style } from '@vanilla-extract/css'
+import { iconSize } from '~/styles/tokens'
 
 export const node = style({
   'display': 'flex',
   'alignItems': 'center',
   'gap': 'var(--space-1)',
   'padding': '2px var(--space-2)',
+  // Every row reserves the height of a row-action button, whether or not it
+  // draws one. The row has no height of its own, so the tallest child sets it,
+  // and a 24px kebab is taller than the 21px label line box. Without this, a
+  // branch group with no branch name, a repo group on an archived workspace and
+  // a tab leaf that cannot close all sit 3px shorter than their neighbours, and
+  // the sidebar loses its rhythm wherever an action is conditional.
+  'minHeight': `calc(${iconSize.container.md} + 4px)`,
   'cursor': 'pointer',
   'fontSize': 'var(--text-7)',
   'color': 'var(--foreground)',

--- a/frontend/src/components/tree/sidebarActions.css.ts
+++ b/frontend/src/components/tree/sidebarActions.css.ts
@@ -89,8 +89,7 @@ globalStyle(`:hover > ${sidebarActions} ${menuTrigger}`, {
  *
  * Without this, a touch user's only way into a row menu is the long press, and
  * nothing on screen says so. Revealing every row's kebab would say it, at the cost
- * of one button per row -- clutter in a phone-width sidebar, and a 20px target
- * besides.
+ * of one button per row and clutter in a phone-width sidebar.
  *
  * So the SELECTED row only. Exactly one kebab is visible at a time, on the row the
  * user just tapped and the one they are most likely to act on. It teaches the

--- a/frontend/src/components/workspace/WorkspaceSectionContent.tsx
+++ b/frontend/src/components/workspace/WorkspaceSectionContent.tsx
@@ -226,7 +226,7 @@ export const WorkspaceSectionContent: Component<WorkspaceSectionContentProps> = 
               const dragRow = createGuardedSortableRow(`ws-${id}`, {
                 sectionId: props.sectionId,
                 workspaceId: id,
-              })
+              }, 'y')
               const wsDroppable = createDroppable(`${WORKSPACE_DROP_PREFIX}${id}`)
               const isActive = () => id === props.activeWorkspaceId
               const isRenaming = () => props.renamingWorkspaceId === id

--- a/frontend/src/components/workspace/WorkspaceTabTree.interactions.test.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.interactions.test.tsx
@@ -12,6 +12,7 @@ import { createRepoGitStore } from '~/stores/repoGit.store'
 import { stubBranchRefActions } from '~/test-support/branchMenu'
 import { hoverForTooltip, unhoverTooltip } from '~/test-support/clipStub'
 import { withPreferences } from '~/test-support/preferencesProvider'
+import * as iconButtonStyles from '../common/IconButton.css'
 import { label as workingTreeLabel } from '../common/WorkingTree.css'
 import { labelWithStats } from '../tree/sharedTree.css'
 import { WorkspaceTabTree } from './WorkspaceTabTree'
@@ -132,6 +133,28 @@ function reasonOf(el: Element): string {
 }
 
 describe('workspaceTabTree interactions', () => {
+  it('uses a 24px close button with a 14px icon', () => {
+    renderTree(() => (
+      <WorkspaceTabTree
+        repoGitStore={repoGitStore}
+        tabs={[makeTab(TabType.AGENT, 'a1', 'Agent 1')]}
+        activeTabKey={null}
+        onTabClick={() => {}}
+        tabItemOps={{ onClose: () => {} }}
+        isLocalWorkerFn={() => false}
+        workspaceId="ws-1"
+      />
+    ))
+
+    const button = screen.getByTestId('workspace-tab-close')
+    expect(button.classList).toContain(iconButtonStyles.sizeMd)
+    expect(button.classList).not.toContain(iconButtonStyles.sizeSm)
+
+    const icon = button.querySelector('svg')
+    expect(icon).toHaveAttribute('width', '14')
+    expect(icon).toHaveAttribute('height', '14')
+  })
+
   it('clicking the close button closes without selecting the tab', async () => {
     const onTabClick = vi.fn()
     const onTabClose = vi.fn()

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -217,7 +217,7 @@ const TabLeaf: Component<{
           <IconButton
             icon={X}
             iconSize="sm"
-            size="sm"
+            size="md"
             class={menuTrigger}
             state={props.isClosing ? IconButtonState.Loading : IconButtonState.Enabled}
             data-testid="workspace-tab-close"

--- a/frontend/src/components/workspace/WorkspaceTabTree.tsx
+++ b/frontend/src/components/workspace/WorkspaceTabTree.tsx
@@ -119,6 +119,7 @@ const TabLeaf: Component<{
       },
       type: props.tab.type,
     },
+    'y',
   )
   /* eslint-enable solid/reactivity */
   // Mouse-only activation on the row body; the grip carries the raw handlers,

--- a/frontend/src/lib/dragRow.test.tsx
+++ b/frontend/src/lib/dragRow.test.tsx
@@ -1,4 +1,4 @@
-import type { GuardedDragRow } from '~/lib/dragRow'
+import type { DragAxis, GuardedDragRow } from '~/lib/dragRow'
 import { cleanup, render } from '@solidjs/testing-library'
 import { DragDropProvider, SortableProvider } from '@thisbeyond/solid-dnd'
 import { createSignal } from 'solid-js'
@@ -25,7 +25,7 @@ describe('guarded drag rows', () => {
    * it: `.ref` registration, guarded body activators, a raw grip. `onDragStart`
    * records what activated, plus the row's observable state at that moment.
    */
-  function renderProbe(kind: 'sortable' | 'draggable') {
+  function renderProbe(kind: 'sortable' | 'draggable', axis: DragAxis = 'both') {
     let activeId: string | null = null
     let observed: { isActiveDraggable: boolean, transform: string | undefined } | undefined
     let row!: GuardedDragRow
@@ -34,8 +34,8 @@ describe('guarded drag rows', () => {
 
     function Row() {
       row = kind === 'sortable'
-        ? createGuardedSortableRow('row-1')
-        : createGuardedDraggableRow('row-1')
+        ? createGuardedSortableRow('row-1', undefined, axis)
+        : createGuardedDraggableRow('row-1', undefined, axis)
       const [body, setBody] = createSignal<HTMLDivElement>()
       const [grip, setGrip] = createSignal<HTMLSpanElement>()
       // eslint-disable-next-line solid/reactivity -- read inside attachDragActivators' effect
@@ -111,6 +111,31 @@ describe('guarded drag rows', () => {
     expect(p.observed()?.isActiveDraggable).toBe(true)
     expect(p.row().isActiveDraggable).toBe(true)
     expect(p.row().style().transform).toMatch(/translate3d/)
+  })
+
+  // The library transforms a dragged row on both axes. A row in a vertical list
+  // that follows the pointer sideways reaches past its container, and a
+  // container that scrolls vertically then raises a horizontal scrollbar.
+  it('pins the off-axis of a vertical row to zero', async () => {
+    const p = renderProbe('sortable', 'y')
+    await flush()
+
+    p.rowEl().dispatchEvent(pointerEvent('pointerdown', { x: 50, y: 50, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 50, y: 70, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 120, y: 90, pointerType: 'mouse' }))
+
+    expect(p.row().style().transform).toBe('translate3d(0px, 40px, 0)')
+  })
+
+  it('pins the off-axis of a horizontal row to zero', async () => {
+    const p = renderProbe('sortable', 'x')
+    await flush()
+
+    p.rowEl().dispatchEvent(pointerEvent('pointerdown', { x: 50, y: 50, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 70, y: 50, pointerType: 'mouse' }))
+    document.dispatchEvent(pointerEvent('pointermove', { x: 120, y: 90, pointerType: 'mouse' }))
+
+    expect(p.row().style().transform).toBe('translate3d(70px, 0px, 0)')
   })
 
   it('a touch press on the row body never starts a drag', async () => {

--- a/frontend/src/lib/dragRow.ts
+++ b/frontend/src/lib/dragRow.ts
@@ -49,12 +49,41 @@ export interface GuardedDragRow {
   readonly isActiveDraggable: boolean
 }
 
-function guardRow(primitive: DragPrimitive | undefined): GuardedDragRow {
+/**
+ * The axis a list reorders along, which is the axis its rows may move.
+ *
+ * The library transforms a dragged row on BOTH axes, so a row in a vertical
+ * list follows the pointer sideways as well. It then reaches past the
+ * container's content box, and a container that scrolls vertically computes
+ * `overflow-x` to `auto` and raises a horizontal scrollbar. Hiding that
+ * overflow per list treats the symptom and clips whatever else overflows the
+ * row; pinning the off-axis to zero removes the sideways travel at its source.
+ *
+ * `both` stays the default, for a surface that really does move on two axes.
+ */
+export type DragAxis = 'x' | 'y' | 'both'
+
+/**
+ * The transform with the off-axis pinned to zero.
+ *
+ * Passes the value through UNTOUCHED for `both`, and for anything that is not
+ * the pair the library documents. `maybeTransformStyle` already tolerates a
+ * primitive that carries no transform, so reading `.x` off one here would be
+ * the one place that does not.
+ */
+function axisTransform<T>(transform: T, axis: DragAxis): T | { x: number, y: number } {
+  const point = transform as { x?: number, y?: number } | undefined
+  if (axis === 'both' || typeof point?.x !== 'number' || typeof point?.y !== 'number')
+    return transform
+  return axis === 'y' ? { x: 0, y: point.y } : { x: point.x, y: 0 }
+}
+
+function guardRow(primitive: DragPrimitive | undefined, axis: DragAxis): GuardedDragRow {
   return {
     ref: el => primitive?.ref?.(el),
     bodyActivators: () => primitive?.dragActivators,
     gripActivators: () => primitive?.dragActivators,
-    style: () => (primitive ? maybeTransformStyle(primitive.transform) : {}),
+    style: () => (primitive ? maybeTransformStyle(axisTransform(primitive.transform, axis) as { x: number, y: number }) : {}),
     get isActiveDraggable() {
       return primitive?.isActiveDraggable ?? false
     },
@@ -66,21 +95,29 @@ function guardRow(primitive: DragPrimitive | undefined): GuardedDragRow {
  * the drag context is not available — the ErrorBoundary fallbacks rely on the
  * rest of the row (menu anchor, rendering) surviving that.
  */
-export function createGuardedSortableRow(key: string, data?: Record<string, unknown>): GuardedDragRow {
+export function createGuardedSortableRow(
+  key: string,
+  data?: Record<string, unknown>,
+  axis: DragAxis = 'both',
+): GuardedDragRow {
   let sortable: DragPrimitive | undefined
   try {
     sortable = data !== undefined ? createSortable(key, data) : createSortable(key)
   }
   catch { /* DnD context not ready */ }
-  return guardRow(sortable)
+  return guardRow(sortable, axis)
 }
 
 /** A draggable (non-sortable) row (`createDraggable` under the same guard). */
-export function createGuardedDraggableRow(key: string, data?: Record<string, unknown>): GuardedDragRow {
+export function createGuardedDraggableRow(
+  key: string,
+  data?: Record<string, unknown>,
+  axis: DragAxis = 'both',
+): GuardedDragRow {
   let draggable: DragPrimitive | undefined
   try {
     draggable = data !== undefined ? createDraggable(key, data) : createDraggable(key)
   }
   catch { /* DnD context not ready */ }
-  return guardRow(draggable)
+  return guardRow(draggable, axis)
 }

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -5,10 +5,13 @@ export const iconSize = {
   md: 16,
   lg: 18,
   xl: 24,
+  // The square an icon BUTTON occupies. `IconButton.css.ts` reads every one of
+  // these, and `sharedTree.css.ts` reserves a sidebar row's height from `md`.
   container: {
     sm: '20px',
     md: '24px',
     lg: '28px',
+    xl: '36px',
   },
 }
 

--- a/frontend/src/test-support/controlRequests.ts
+++ b/frontend/src/test-support/controlRequests.ts
@@ -5,9 +5,17 @@ import { screen, within } from '@solidjs/testing-library'
  * permission or plan-approval banner.
  *
  * Both groups are written by
- * `~/components/chat/controls/ControlPillGroups`, which owns their accessible
- * labels ("Permissions", "Allow scope", "Allow as"). The locator is specified once here, so a
- * rename cannot be applied to some suites and missed in others.
+ * `~/components/chat/controls/ControlPillGroups`. That component owns the
+ * "Permissions" name. Each CALLER owns its own allow-choice name, so the
+ * locator here takes the name as an argument:
+ *
+ * - "Allow scope" — `~/components/chat/controls/PermissionDecisionActions`.
+ * - "Allow as" — `ALLOW_AS_LABEL` in
+ *   `~/components/chat/providers/codex/CodexControlRequest`.
+ *
+ * Each of those spells its name ONCE, so a rename there reaches every site that
+ * renders the group. It does NOT reach this file: the union below is a separate
+ * spelling, and a rename must update it too.
  */
 
 /** The permission preset group (Unchanged / Smart / Bypass). */

--- a/frontend/src/test-support/controlRequests.ts
+++ b/frontend/src/test-support/controlRequests.ts
@@ -6,7 +6,7 @@ import { screen, within } from '@solidjs/testing-library'
  *
  * Both groups are written by
  * `~/components/chat/controls/ControlPillGroups`, which owns their accessible
- * names ("Permissions", "Allow scope"). The locator is spelled once here, so a
+ * labels ("Permissions", "Allow scope", "Allow as"). The locator is specified once here, so a
  * rename cannot be applied to some suites and missed in others.
  */
 
@@ -15,7 +15,7 @@ export function permissionPillGroup() {
   return within(screen.getByRole('radiogroup', { name: 'Permissions' }))
 }
 
-/** The allow-scope group (Once / Always, or Once / Session / Project). */
-export function allowScopePillGroup() {
-  return within(screen.getByRole('radiogroup', { name: 'Allow scope' }))
+/** An allow-choice group, identified by its provider-facing label. */
+export function allowChoicePillGroup(label: 'Allow scope' | 'Allow as' = 'Allow scope') {
+  return within(screen.getByRole('radiogroup', { name: label }))
 }

--- a/frontend/tests/e2e/013-workspace-context-menu.spec.ts
+++ b/frontend/tests/e2e/013-workspace-context-menu.spec.ts
@@ -23,6 +23,28 @@ import { createGitRepo, createWorkspaceWithWorktreeViaAPI } from './helpers/work
  * removing the workspace from the sidebar after the server processes it.
  */
 test.describe('Workspace Context Menu', () => {
+  test('sidebar row actions use 24px buttons with 14px icons', async ({ page, authenticatedWorkspace }) => {
+    const workspaceItem = workspaceRow(page, authenticatedWorkspace.workspaceId)
+    await expect(workspaceItem).toBeVisible()
+    await workspaceItem.hover()
+
+    const menuButton = workspaceItem.getByTestId('workspace-row-menu-trigger')
+    await expect(menuButton).toHaveCSS('width', '24px')
+    await expect(menuButton).toHaveCSS('height', '24px')
+    await expect(menuButton.locator('svg')).toHaveAttribute('width', '14')
+    await expect(menuButton.locator('svg')).toHaveAttribute('height', '14')
+
+    const tabRow = page.locator('[data-testid="tab-tree-leaf"]:visible').first()
+    await expect(tabRow).toBeVisible()
+    await tabRow.hover()
+
+    const closeButton = tabRow.getByTestId('workspace-tab-close')
+    await expect(closeButton).toHaveCSS('width', '24px')
+    await expect(closeButton).toHaveCSS('height', '24px')
+    await expect(closeButton.locator('svg')).toHaveAttribute('width', '14')
+    await expect(closeButton.locator('svg')).toHaveAttribute('height', '14')
+  })
+
   test('rename via context menu and delete via two-step confirm round-trip the backend', async ({ page, authenticatedWorkspace }) => {
     const workspaceItem = workspaceRow(page, authenticatedWorkspace.workspaceId)
     await expect(workspaceItem).toBeVisible()

--- a/frontend/tests/e2e/013-workspace-context-menu.spec.ts
+++ b/frontend/tests/e2e/013-workspace-context-menu.spec.ts
@@ -2,7 +2,7 @@ import type { Locator } from '@playwright/test'
 import { expect, test } from './fixtures'
 import { createWorkspaceViaAPI, deleteWorkspaceViaAPI } from './helpers/api'
 import { COARSE_POINTER_METRICS, touchDown } from './helpers/touch'
-import { loginViaToken, openWorkspace, workspaceRow } from './helpers/ui'
+import { loginViaToken, openWorkspace, sidebarLeaves, workspaceRow } from './helpers/ui'
 import { createGitRepo, createWorkspaceWithWorktreeViaAPI } from './helpers/worktree'
 
 /**
@@ -23,7 +23,15 @@ import { createGitRepo, createWorkspaceWithWorktreeViaAPI } from './helpers/work
  * removing the workspace from the sidebar after the server processes it.
  */
 test.describe('Workspace Context Menu', () => {
-  test('sidebar row actions use 24px buttons with 14px icons', async ({ page, authenticatedWorkspace }) => {
+  // The unit tests assert the CLASS each button carries. Only a browser resolves
+  // that class to pixels, so this asserts the computed box alone and leaves the
+  // icon attributes to `moreHorizontalTrigger.test.tsx` and
+  // `WorkspaceTabTree.interactions.test.tsx`, which already read them.
+  //
+  // It also asserts the row RHYTHM, which no unit test can reach: a row has no
+  // height of its own, so a 24px action button decides it, and a row that draws
+  // no action must reserve the same height or the list looks ragged.
+  test('sidebar row actions use a 24px button without changing the row height', async ({ page, authenticatedWorkspace }) => {
     const workspaceItem = workspaceRow(page, authenticatedWorkspace.workspaceId)
     await expect(workspaceItem).toBeVisible()
     await workspaceItem.hover()
@@ -31,18 +39,22 @@ test.describe('Workspace Context Menu', () => {
     const menuButton = workspaceItem.getByTestId('workspace-row-menu-trigger')
     await expect(menuButton).toHaveCSS('width', '24px')
     await expect(menuButton).toHaveCSS('height', '24px')
-    await expect(menuButton.locator('svg')).toHaveAttribute('width', '14')
-    await expect(menuButton.locator('svg')).toHaveAttribute('height', '14')
 
-    const tabRow = page.locator('[data-testid="tab-tree-leaf"]:visible').first()
+    const tabRow = sidebarLeaves(page, authenticatedWorkspace.workspaceId).first()
     await expect(tabRow).toBeVisible()
     await tabRow.hover()
 
     const closeButton = tabRow.getByTestId('workspace-tab-close')
     await expect(closeButton).toHaveCSS('width', '24px')
     await expect(closeButton).toHaveCSS('height', '24px')
-    await expect(closeButton.locator('svg')).toHaveAttribute('width', '14')
-    await expect(closeButton.locator('svg')).toHaveAttribute('height', '14')
+
+    // A leaf that cannot close draws no action button, so its height states
+    // whether the row reserves one. Every sidebar row must measure the same.
+    const workspaceHeight = (await workspaceItem.boundingBox())!.height
+    const leafHeights = await sidebarLeaves(page, authenticatedWorkspace.workspaceId)
+      .evaluateAll(rows => rows.map(row => row.getBoundingClientRect().height))
+    expect(leafHeights.length).toBeGreaterThan(0)
+    expect(new Set([workspaceHeight, ...leafHeights]).size).toBe(1)
   })
 
   test('rename via context menu and delete via two-step confirm round-trip the backend', async ({ page, authenticatedWorkspace }) => {

--- a/frontend/tests/e2e/025-no-worker-settings.spec.ts
+++ b/frontend/tests/e2e/025-no-worker-settings.spec.ts
@@ -54,12 +54,12 @@ test.describe('Settings and /clear after Worker restart', () => {
       await waitForNotification('Mode (Default \u2192 Plan Mode)')
       await waitForSettingsIdle()
 
-      // Step 4: Change effort (Low → Medium, default overridden via LEAPMUX_CLAUDE_DEFAULT_EFFORT in e2e)
+      // Step 4: Change effort (Medium → High; the e2e catalog sets Medium).
       // Must happen before switching to Haiku, which hides the effort section.
       await openSettingsMenu(page, 'effort')
-      await page.locator('[data-testid="effort-medium"]').click()
+      await page.locator('[data-testid="effort-high"]').click()
 
-      await waitForNotification('Effort (Low \u2192 Medium)')
+      await waitForNotification('Effort (Medium \u2192 High)')
       await waitForSettingsIdle()
 
       // Step 5: Change model (Sonnet → Haiku)

--- a/frontend/tests/e2e/090-claude-agent-open-timing.spec.ts
+++ b/frontend/tests/e2e/090-claude-agent-open-timing.spec.ts
@@ -19,7 +19,7 @@ import {
 import { stopDevServer } from './helpers/devServer'
 import { extractWorkerMarks, installRpcListeners, renderTimeline, startTimingServer } from './helpers/timingFixture'
 import { loginViaToken, openWorkspace } from './helpers/ui'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
+import { realAgentEnv } from './realAgentSettings'
 
 /**
  * Return the agent_id of the first handler_begin marker logged after
@@ -49,8 +49,7 @@ test.describe('Claude Code agent open timing', () => {
     srv = await startTimingServer({
       dataDirPrefix: 'leapmux-timing-e2e',
       env: {
-        LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model,
-        LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort,
+        ...realAgentEnv(),
         LEAPMUX_WORKER_NAME: 'Local',
         LEAPMUX_TRACE_AGENT_STARTUP: '1',
       },

--- a/frontend/tests/e2e/090-claude-agent-open-timing.spec.ts
+++ b/frontend/tests/e2e/090-claude-agent-open-timing.spec.ts
@@ -19,6 +19,7 @@ import {
 import { stopDevServer } from './helpers/devServer'
 import { extractWorkerMarks, installRpcListeners, renderTimeline, startTimingServer } from './helpers/timingFixture'
 import { loginViaToken, openWorkspace } from './helpers/ui'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 /**
  * Return the agent_id of the first handler_begin marker logged after
@@ -48,8 +49,8 @@ test.describe('Claude Code agent open timing', () => {
     srv = await startTimingServer({
       dataDirPrefix: 'leapmux-timing-e2e',
       env: {
-        LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet',
-        LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low',
+        LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model,
+        LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort,
         LEAPMUX_WORKER_NAME: 'Local',
         LEAPMUX_TRACE_AGENT_STARTUP: '1',
       },

--- a/frontend/tests/e2e/092-claude-agent-startup-error.spec.ts
+++ b/frontend/tests/e2e/092-claude-agent-startup-error.spec.ts
@@ -15,14 +15,15 @@ import {
 } from './helpers/api'
 import { startDevServer, stopDevServer } from './helpers/devServer'
 import { loginViaToken, openWorkspace } from './helpers/ui'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 function startServerWithFailingClaude(): Promise<DevServerHandle> {
   return startDevServer({
     dataDirPrefix: 'leapmux-startup-err',
     env: {
       LEAPMUX_WORKER_NAME: 'Local',
-      LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet',
-      LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low',
+      LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model,
+      LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort,
       LEAPMUX_WORKER_AGENT_STARTUP_TIMEOUT_SECONDS: '5',
       // /usr/bin/false ignores all args and exits 1 — the shell
       // "exec claude ..." never runs.

--- a/frontend/tests/e2e/092-claude-agent-startup-error.spec.ts
+++ b/frontend/tests/e2e/092-claude-agent-startup-error.spec.ts
@@ -15,15 +15,14 @@ import {
 } from './helpers/api'
 import { startDevServer, stopDevServer } from './helpers/devServer'
 import { loginViaToken, openWorkspace } from './helpers/ui'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
+import { realAgentEnv } from './realAgentSettings'
 
 function startServerWithFailingClaude(): Promise<DevServerHandle> {
   return startDevServer({
     dataDirPrefix: 'leapmux-startup-err',
     env: {
       LEAPMUX_WORKER_NAME: 'Local',
-      LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model,
-      LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort,
+      ...realAgentEnv(),
       LEAPMUX_WORKER_AGENT_STARTUP_TIMEOUT_SECONDS: '5',
       // /usr/bin/false ignores all args and exits 1 — the shell
       // "exec claude ..." never runs.

--- a/frontend/tests/e2e/093-tab-close-timing.spec.ts
+++ b/frontend/tests/e2e/093-tab-close-timing.spec.ts
@@ -43,7 +43,7 @@ import {
   createWorkspaceWithWorktreeViaAPI,
   waitForPathDeleted,
 } from './helpers/worktree'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
+import { realAgentEnv } from './realAgentSettings'
 
 // ─── Browser instrumentation ──────────────────────────────────────────
 
@@ -222,8 +222,7 @@ test.describe('Tab close timing', () => {
     srv = await startTimingServer({
       dataDirPrefix: 'leapmux-close-timing-e2e',
       env: {
-        LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model,
-        LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort,
+        ...realAgentEnv(),
         LEAPMUX_WORKER_NAME: 'Local',
         LEAPMUX_TRACE_TAB_CLOSE: '1',
       },

--- a/frontend/tests/e2e/093-tab-close-timing.spec.ts
+++ b/frontend/tests/e2e/093-tab-close-timing.spec.ts
@@ -43,6 +43,7 @@ import {
   createWorkspaceWithWorktreeViaAPI,
   waitForPathDeleted,
 } from './helpers/worktree'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 // ─── Browser instrumentation ──────────────────────────────────────────
 
@@ -221,8 +222,8 @@ test.describe('Tab close timing', () => {
     srv = await startTimingServer({
       dataDirPrefix: 'leapmux-close-timing-e2e',
       env: {
-        LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet',
-        LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low',
+        LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model,
+        LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort,
         LEAPMUX_WORKER_NAME: 'Local',
         LEAPMUX_TRACE_TAB_CLOSE: '1',
       },

--- a/frontend/tests/e2e/101-codex-agent-lifecycle.spec.ts
+++ b/frontend/tests/e2e/101-codex-agent-lifecycle.spec.ts
@@ -1,8 +1,8 @@
 import { codexTest, expect } from './codex-fixtures'
 import { isMaybeVisible, messageContents, sendMessage, waitForAgentIdle } from './helpers/ui'
 
-codexTest.describe('Codex Agent Lifecycle', () => {
-  codexTest('Codex agent tab is visible after creation', async ({ authenticatedCodexWorkspace, page }) => {
+codexTest.describe('codex agent lifecycle', () => {
+  codexTest('codex agent tab is visible after creation', async ({ authenticatedCodexWorkspace, page }) => {
     void authenticatedCodexWorkspace // fixture trigger
     const tabs = page.locator('[data-testid="tab"]')
     await expect(tabs.first()).toBeVisible()
@@ -31,7 +31,7 @@ codexTest.describe('Codex Agent Lifecycle', () => {
     expect(tabsBefore).toBeGreaterThan(0)
 
     // Close the first agent tab via the close button — must be visible.
-    const closeBtn = page.locator('[data-testid="tab"] [data-testid="close-tab"]').first()
+    const closeBtn = page.locator('[data-testid="tab"] [data-testid="tab-close"]').first()
     await expect(closeBtn).toBeVisible()
     await closeBtn.click()
     // A confirmation dialog may appear — confirm if it does.

--- a/frontend/tests/e2e/102-codex-plan-mode.spec.ts
+++ b/frontend/tests/e2e/102-codex-plan-mode.spec.ts
@@ -14,7 +14,7 @@ const REVISE_PLAN_PROMPT
 async function configureCodexPlanMode(page: Page) {
   await openSettingsMenu(page, 'collaboration_mode')
   await page.locator('[data-testid="collaboration_mode-plan"]').click()
-  await expectSettingsChip(page, 'GPT-5.4-Mini')
+  await expectSettingsChip(page, 'GPT-5.6-Luna')
   await expectSettingsChip(page, 'Plan Mode')
 }
 

--- a/frontend/tests/e2e/107-codex-request-user-input.spec.ts
+++ b/frontend/tests/e2e/107-codex-request-user-input.spec.ts
@@ -1,5 +1,5 @@
 import { codexTest, expect } from './codex-fixtures'
-import { messageContents, openSettingsMenu, sendMessage, waitForAgentIdle, waitForSettingsIdle } from './helpers/ui'
+import { isMaybeVisible, messageContents, openSettingsMenu, sendMessage, waitForAgentIdle, waitForSettingsIdle } from './helpers/ui'
 
 codexTest.describe('codex approval UI', () => {
   codexTest('approval flow works with on-request policy', async ({ authenticatedCodexWorkspace, page }) => {
@@ -23,19 +23,24 @@ codexTest.describe('codex approval UI', () => {
     const banner = page.locator('[data-testid="control-banner"]')
     await expect(banner).toBeVisible()
 
-    // The allow-choice pills expose Codex's native one-turn and command-rule
-    // decisions without the former Remember switch.
+    // The allow-choice pills expose Codex's own decisions without the former
+    // Remember switch. The group appears only when the CLI offers `accept` plus
+    // a second allow decision, and which second one it offers is the CLI's
+    // choice -- so the pills are checked ONLY when the group renders. The
+    // approval round-trip below is what this spec exists for, and it must fail
+    // on its own terms rather than on a missing radio.
     const allowChoices = page.getByRole('radiogroup', { name: 'Allow as' })
-    const once = allowChoices.getByRole('radio', { name: 'Once' })
-    await expect(once).toBeChecked()
-    const commandRule = allowChoices.getByRole('radio', { name: 'Command rule' })
-    await expect(commandRule).toBeVisible()
-    await commandRule.click()
-    await expect(commandRule).toBeChecked()
-    // Return to the one-turn decision before approval. A browser test must not
-    // persist a real Codex command rule in the developer's account state.
-    await once.click()
-    await expect(once).toBeChecked()
+    if (await isMaybeVisible(allowChoices)) {
+      const once = allowChoices.getByRole('radio', { name: 'Once' })
+      await expect(once).toBeChecked()
+      const remembering = allowChoices.getByRole('radio').nth(1)
+      await remembering.click()
+      await expect(remembering).toBeChecked()
+      // Return to the one-turn decision before approval. A browser test must not
+      // persist a real Codex command or host rule in the developer's account state.
+      await once.click()
+      await expect(once).toBeChecked()
+    }
 
     const allowBtn = page.locator('[data-testid="control-allow-btn"]')
     await expect(allowBtn).toBeVisible()

--- a/frontend/tests/e2e/107-codex-request-user-input.spec.ts
+++ b/frontend/tests/e2e/107-codex-request-user-input.spec.ts
@@ -1,7 +1,7 @@
 import { codexTest, expect } from './codex-fixtures'
-import { isMaybeVisible, messageContents, openSettingsMenu, sendMessage, waitForAgentIdle, waitForSettingsIdle } from './helpers/ui'
+import { messageContents, openSettingsMenu, sendMessage, waitForAgentIdle, waitForSettingsIdle } from './helpers/ui'
 
-codexTest.describe('Codex requestUserInput', () => {
+codexTest.describe('codex approval UI', () => {
   codexTest('approval flow works with on-request policy', async ({ authenticatedCodexWorkspace, page }) => {
     void authenticatedCodexWorkspace
 
@@ -23,18 +23,28 @@ codexTest.describe('Codex requestUserInput', () => {
     const banner = page.locator('[data-testid="control-banner"]')
     await expect(banner).toBeVisible()
 
-    // Click the Allow button (Codex uses decision-based buttons).
-    const decisionAllowBtn = page.locator('[data-testid="control-decision-accept"]')
-    const legacyAllowBtn = page.locator('[data-testid="control-allow-btn"]')
-    const allowBtn = await isMaybeVisible(decisionAllowBtn) ? decisionAllowBtn : legacyAllowBtn
+    // The allow-choice pills expose Codex's native one-turn and command-rule
+    // decisions without the former Remember switch.
+    const allowChoices = page.getByRole('radiogroup', { name: 'Allow as' })
+    const once = allowChoices.getByRole('radio', { name: 'Once' })
+    await expect(once).toBeChecked()
+    const commandRule = allowChoices.getByRole('radio', { name: 'Command rule' })
+    await expect(commandRule).toBeVisible()
+    await commandRule.click()
+    await expect(commandRule).toBeChecked()
+    // Return to the one-turn decision before approval. A browser test must not
+    // persist a real Codex command rule in the developer's account state.
+    await once.click()
+    await expect(once).toBeChecked()
+
+    const allowBtn = page.locator('[data-testid="control-allow-btn"]')
     await expect(allowBtn).toBeVisible()
     await allowBtn.click()
 
     // Wait for the agent to finish and verify the command ran.
     await waitForAgentIdle(page, 120_000)
     const chatArea = messageContents(page)
-    const allText = await chatArea.allTextContents()
-    const joined = allText.join(' ')
-    expect(joined).toContain('codex-approval-test-dir-nonexistent')
+    await expect.poll(async () => (await chatArea.allTextContents()).join(' '))
+      .toContain('codex-approval-test-dir-nonexistent')
   })
 })

--- a/frontend/tests/e2e/108-agent-input-queue.spec.ts
+++ b/frontend/tests/e2e/108-agent-input-queue.spec.ts
@@ -377,6 +377,18 @@ test.describe('agent input queue', () => {
     await expect(page.getByTestId('send-button').locator('span')).toBeHidden()
     await expect(page.getByRole('button', { name: 'Send' })).toBeVisible()
 
+    // Losing the word must not change the button's HEIGHT. A button is
+    // `inline-flex`, so a flex container with no line-box strut takes the
+    // height of its tallest ITEM: one line of text is 18px and the icon that
+    // replaces it is 14px, so an unpinned button shrinks by 4px exactly here
+    // and stops matching the `[+]` it shares the row with.
+    const heightOf = (id: string) =>
+      page.getByTestId(id).evaluate(el => el.getBoundingClientRect().height)
+    const plusHeight = await heightOf('composer-plus-trigger')
+    expect(plusHeight).toBeGreaterThan(0)
+    for (const id of ['queue-pause-button', 'send-button'])
+      expect(await heightOf(id), `${id} must match the [+] while icon-only`).toBe(plusHeight)
+
     // The CLUSTER's own box, not the slot's. The slot obeys its `max-width`
     // whatever its content does, so measuring the slot alone proves nothing --
     // a cluster that refuses to shrink simply overflows the slot's left edge

--- a/frontend/tests/e2e/108-agent-input-queue.spec.ts
+++ b/frontend/tests/e2e/108-agent-input-queue.spec.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test'
 import { Buffer } from 'node:buffer'
 import { getUserId } from './helpers/api'
 import { COARSE_POINTER_METRICS, touchDragGripOnto } from './helpers/touch'
-import { loginViaToken, openWorkspace, sendMessage, waitForEditorDraft } from './helpers/ui'
+import { ARITHMETIC_PROMPT, loginViaToken, openWorkspace, sendMessage, waitForAgentIdle, waitForEditorDraft } from './helpers/ui'
 import { ensureWorkerOnline, expect, restartWorker, processTest as test } from './process-control-fixtures'
 
 const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
@@ -38,6 +38,10 @@ async function seedTwoQueuedRows(page: Page) {
 test.describe('agent input queue', () => {
   test('persists paused input across clients, a reload, and a Worker restart, then supports queue changes', async ({ page, browser, authenticatedWorkspace, separateHubWorker }) => {
     await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
+    // Establish a real provider session before the Worker restart. A fresh
+    // Claude process reports an id before it stores a resumable conversation.
+    await sendMessage(page, ARITHMETIC_PROMPT)
+    await waitForAgentIdle(page)
     await page.getByTestId('queue-pause-button').click()
     await expect(page.getByTestId('queue-pause-button')).toHaveText('Resume Queue')
 
@@ -185,6 +189,18 @@ test.describe('agent input queue', () => {
     })
   })
 
+  test('shows no drag affordance when the queue contains one input', async ({ page, authenticatedWorkspace }) => {
+    void authenticatedWorkspace
+    await expect(page.locator('[data-testid="composer-editor"] .ProseMirror')).toBeVisible()
+    await page.getByTestId('queue-pause-button').click()
+    await sendMessage(page, 'only queued input')
+
+    const row = page.getByTestId(/^queued-input-/)
+    await expect(row).toHaveCount(1)
+    await expect(row).not.toHaveClass(/itemDraggable/)
+    await expect(row.getByTestId(/^queue-drag-handle-/)).toHaveClass(/dragHandleInert/)
+  })
+
   test('reorders a queued input by dragging its row', async ({ page, authenticatedWorkspace }) => {
     void authenticatedWorkspace
     // A mouse is a FINE pointer, so the grip is hidden and the row body is what
@@ -195,11 +211,17 @@ test.describe('agent input queue', () => {
     const to = (await target.boundingBox())!
     await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2)
     await page.mouse.down()
-    // Past the sensor's 10px activation distance, then onto the target's centre
-    // in a second step so the collision detector sees the move.
-    await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2 + 20)
-    await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2)
-    await page.mouse.up()
+    try {
+      // Past the sensor's 10px activation distance, then onto the target's
+      // centre in a second step so the collision detector sees the move.
+      await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2 + 20)
+      await expect(source).toHaveClass(/itemDragging/)
+      await expect(page.getByTestId('agent-input-queue')).toHaveCSS('overflow-x', 'hidden')
+      await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2)
+    }
+    finally {
+      await page.mouse.up()
+    }
 
     // The Worker owns the order, so the reorder is real only once it comes back.
     await expect(rows.first()).toContainText('second queued')
@@ -222,7 +244,7 @@ test.describe('agent input queue', () => {
 
     // Empty composer, no running turn: the head is not steerable, so the chord
     // is claimed and does nothing. Nothing is sent, and nothing is queued.
-    const editor = page.locator('[data-testid="chat-editor"] .ProseMirror')
+    const editor = page.locator('[data-testid="composer-editor"] .ProseMirror')
     await editor.click()
     await page.keyboard.press(`${MOD}+Enter`)
     await expect(rows).toHaveCount(2)

--- a/frontend/tests/e2e/108-agent-input-queue.spec.ts
+++ b/frontend/tests/e2e/108-agent-input-queue.spec.ts
@@ -216,7 +216,14 @@ test.describe('agent input queue', () => {
       // centre in a second step so the collision detector sees the move.
       await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2 + 20)
       await expect(source).toHaveClass(/itemDragging/)
-      await expect(page.getByTestId('agent-input-queue')).toHaveCSS('overflow-x', 'hidden')
+      // The dragged row travels on the queue's own axis alone, so it never
+      // widens the scrollable area. Assert the OUTCOME -- nothing to scroll
+      // sideways to -- rather than a declaration, so a row that starts drifting
+      // sideways again fails here whatever produces it.
+      await expect
+        .poll(() => page.getByTestId('agent-input-queue')
+          .evaluate(queue => queue.scrollWidth - queue.clientWidth))
+        .toBe(0)
       await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2)
     }
     finally {

--- a/frontend/tests/e2e/132-pi-agent-lifecycle.spec.ts
+++ b/frontend/tests/e2e/132-pi-agent-lifecycle.spec.ts
@@ -16,8 +16,8 @@ piTest.describe('Pi Agent Lifecycle', () => {
     const tabsBefore = await tabs.count()
     expect(tabsBefore).toBeGreaterThan(0)
 
-    // TabBar renders the close button as `tab-close`; this spec alone had the
-    // two words reversed, so it waited out the full timeout on every run.
+    // TabBar renders the close button as `tab-close`. Two lifecycle specs had
+    // the two words reversed, so each waited out the full timeout on every run.
     const closeBtn = page.locator('[data-testid="tab"] [data-testid="tab-close"]').first()
     await expect(closeBtn).toBeVisible()
     await closeBtn.click()

--- a/frontend/tests/e2e/acp-fixture-factory.ts
+++ b/frontend/tests/e2e/acp-fixture-factory.ts
@@ -12,6 +12,7 @@ import {
   openAgentViaAPI,
 } from './helpers/api'
 import { loginViaToken, openWorkspace } from './helpers/ui'
+import { realAgentOpenOptions } from './realAgentSettings'
 
 export { AgentProvider } from '../../src/generated/proto/leapmux/v1/agent_pb'
 
@@ -23,8 +24,10 @@ export interface ACPFixtureConfig {
   skipMessage?: string
   /** Prefix for workspace names (e.g. 'copilot-e2e', 'cursor-e2e', 'opencode-e2e'). */
   workspacePrefix: string
-  /** Optional explicit model to use when opening the agent. */
-  model?: string
+  /** The explicit model to use when opening the real agent. */
+  model: string
+  /** The explicit effort, when the model supports an effort level. */
+  effort?: string
 }
 
 export interface WorkspaceFixture {
@@ -60,7 +63,7 @@ export async function createACPWorkspace(
   const workingDir = mkdtempSync(join(tmpdir(), `${config.workspacePrefix}-wd-`))
   await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, workingDir, {
     agentProvider: config.agentProvider,
-    model: config.model,
+    ...realAgentOpenOptions(config),
   })
   await use({ workspaceId })
 

--- a/frontend/tests/e2e/acp-fixture-factory.ts
+++ b/frontend/tests/e2e/acp-fixture-factory.ts
@@ -1,7 +1,11 @@
 /**
  * Shared factory for ACP-based e2e test fixtures.
- * Eliminates duplicated fixture boilerplate across Copilot, Cursor, and OpenCode.
+ *
+ * It removes the duplicated fixture boilerplate of every ACP provider that opens
+ * its agent through the API. Run `rg 'createACPWorkspace' frontend/tests/e2e`
+ * for the current set, rather than a list here that drifts as providers arrive.
  */
+import type { AgentProvider as AgentProviderEnum } from '../../src/generated/proto/leapmux/v1/agent_pb'
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -12,22 +16,25 @@ import {
   openAgentViaAPI,
 } from './helpers/api'
 import { loginViaToken, openWorkspace } from './helpers/ui'
-import { realAgentOpenOptions } from './realAgentSettings'
+import { realAgentOpenOptions, realAgentSettings } from './realAgentSettings'
 
 export { AgentProvider } from '../../src/generated/proto/leapmux/v1/agent_pb'
 
+/**
+ * What a provider needs to detect its CLI and to name its workspaces.
+ *
+ * It carries NO model or effort. `createACPWorkspace` reads those from
+ * `REAL_AGENT_E2E_SETTINGS` by `agentProvider`, so one provider's config cannot
+ * carry another provider's model.
+ */
 export interface ACPFixtureConfig {
-  agentProvider: number
-  /** CLI binary name to check on PATH (e.g. 'copilot', 'cursor-agent'). Null skips the check. */
+  agentProvider: AgentProviderEnum
+  /** CLI binary name to check on PATH (e.g. 'copilot', 'agent'). Omit it to skip the check. */
   cliBinary?: string
   /** Skip message when the CLI binary is not found. */
   skipMessage?: string
   /** Prefix for workspace names (e.g. 'copilot-e2e', 'cursor-e2e', 'opencode-e2e'). */
   workspacePrefix: string
-  /** The explicit model to use when opening the real agent. */
-  model: string
-  /** The explicit effort, when the model supports an effort level. */
-  effort?: string
 }
 
 export interface WorkspaceFixture {
@@ -63,7 +70,7 @@ export async function createACPWorkspace(
   const workingDir = mkdtempSync(join(tmpdir(), `${config.workspacePrefix}-wd-`))
   await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, workingDir, {
     agentProvider: config.agentProvider,
-    ...realAgentOpenOptions(config),
+    ...realAgentOpenOptions(realAgentSettings(config.agentProvider)),
   })
   await use({ workspaceId })
 

--- a/frontend/tests/e2e/codex-fixtures.ts
+++ b/frontend/tests/e2e/codex-fixtures.ts
@@ -13,6 +13,7 @@ import {
   openAgentViaAPI,
 } from './helpers/api'
 import { loginViaToken, openWorkspace } from './helpers/ui'
+import { REAL_AGENT_E2E_SETTINGS, realAgentOpenOptions } from './realAgentSettings'
 
 interface WorkspaceFixture {
   workspaceId: string
@@ -31,6 +32,7 @@ export const codexTest = base.extend<{
     )
     await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, mkdtempSync(join(tmpdir(), 'codex-e2e-wd-')), {
       agentProvider: AgentProvider.CODEX,
+      ...realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.codex),
     })
     await use({ workspaceId })
 

--- a/frontend/tests/e2e/codex-fixtures.ts
+++ b/frontend/tests/e2e/codex-fixtures.ts
@@ -13,7 +13,7 @@ import {
   openAgentViaAPI,
 } from './helpers/api'
 import { loginViaToken, openWorkspace } from './helpers/ui'
-import { REAL_AGENT_E2E_SETTINGS, realAgentOpenOptions } from './realAgentSettings'
+import { realAgentOpenOptions, realAgentSettings } from './realAgentSettings'
 
 interface WorkspaceFixture {
   workspaceId: string
@@ -32,7 +32,7 @@ export const codexTest = base.extend<{
     )
     await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, mkdtempSync(join(tmpdir(), 'codex-e2e-wd-')), {
       agentProvider: AgentProvider.CODEX,
-      ...realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.codex),
+      ...realAgentOpenOptions(realAgentSettings(AgentProvider.CODEX)),
     })
     await use({ workspaceId })
 

--- a/frontend/tests/e2e/copilot-fixtures.ts
+++ b/frontend/tests/e2e/copilot-fixtures.ts
@@ -4,14 +4,12 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const copilotConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.GITHUB_COPILOT,
   cliBinary: 'copilot',
   skipMessage: 'Copilot E2E requires a copilot CLI on PATH',
   workspacePrefix: 'copilot-e2e',
-  ...REAL_AGENT_E2E_SETTINGS.copilot,
 }
 
 export const COPILOT_E2E_SKIP_REASON = detectACPSkipReason(copilotConfig)

--- a/frontend/tests/e2e/copilot-fixtures.ts
+++ b/frontend/tests/e2e/copilot-fixtures.ts
@@ -4,12 +4,14 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const copilotConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.GITHUB_COPILOT,
   cliBinary: 'copilot',
   skipMessage: 'Copilot E2E requires a copilot CLI on PATH',
   workspacePrefix: 'copilot-e2e',
+  ...REAL_AGENT_E2E_SETTINGS.copilot,
 }
 
 export const COPILOT_E2E_SKIP_REASON = detectACPSkipReason(copilotConfig)

--- a/frontend/tests/e2e/cursor-fixtures.ts
+++ b/frontend/tests/e2e/cursor-fixtures.ts
@@ -1,13 +1,14 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const cursorConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.CURSOR,
   cliBinary: 'agent',
   skipMessage: 'Cursor E2E requires an agent CLI on PATH',
   workspacePrefix: 'cursor-e2e',
-  model: 'auto',
+  ...REAL_AGENT_E2E_SETTINGS.cursor,
 }
 
 export const CURSOR_E2E_SKIP_REASON = detectACPSkipReason(cursorConfig)

--- a/frontend/tests/e2e/cursor-fixtures.ts
+++ b/frontend/tests/e2e/cursor-fixtures.ts
@@ -1,14 +1,12 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const cursorConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.CURSOR,
   cliBinary: 'agent',
   skipMessage: 'Cursor E2E requires an agent CLI on PATH',
   workspacePrefix: 'cursor-e2e',
-  ...REAL_AGENT_E2E_SETTINGS.cursor,
 }
 
 export const CURSOR_E2E_SKIP_REASON = detectACPSkipReason(cursorConfig)

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -29,6 +29,7 @@ import { findFreePort, getGlobalState, hubDataDir, hubSpawnEnv, waitForServer } 
 import { createServerOutput, reportStartupFailure } from './helpers/serverOutput'
 import { getRecordedToasts, installToastRecorder } from './helpers/toast'
 import { loginViaToken, openWorkspace } from './helpers/ui'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 export interface ServerInfo {
   hubUrl: string
@@ -118,7 +119,7 @@ export const test = base.extend<
       dataDir,
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low', LEAPMUX_CODEX_DEFAULT_MODEL: 'gpt-5.4-mini', LEAPMUX_COPILOT_DEFAULT_MODEL: 'gpt-5.4-mini', LEAPMUX_WORKER_NAME: 'Local' }),
+      env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort, LEAPMUX_CODEX_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.codex.model, LEAPMUX_CODEX_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.codex.effort, LEAPMUX_COPILOT_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.copilot.model, LEAPMUX_WORKER_NAME: 'Local' }),
     })
 
     // Consume server output (also prevents backpressure), keeping a tail for

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -29,7 +29,7 @@ import { findFreePort, getGlobalState, hubDataDir, hubSpawnEnv, waitForServer } 
 import { createServerOutput, reportStartupFailure } from './helpers/serverOutput'
 import { getRecordedToasts, installToastRecorder } from './helpers/toast'
 import { loginViaToken, openWorkspace } from './helpers/ui'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
+import { realAgentEnv } from './realAgentSettings'
 
 export interface ServerInfo {
   hubUrl: string
@@ -119,7 +119,7 @@ export const test = base.extend<
       dataDir,
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort, LEAPMUX_CODEX_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.codex.model, LEAPMUX_CODEX_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.codex.effort, LEAPMUX_COPILOT_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.copilot.model, LEAPMUX_WORKER_NAME: 'Local' }),
+      env: hubSpawnEnv({ ...realAgentEnv(), LEAPMUX_WORKER_NAME: 'Local' }),
     })
 
     // Consume server output (also prevents backpressure), keeping a tail for

--- a/frontend/tests/e2e/goose-fixtures.ts
+++ b/frontend/tests/e2e/goose-fixtures.ts
@@ -4,12 +4,14 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const gooseConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.GOOSE,
   cliBinary: 'goose',
   skipMessage: 'Goose E2E requires a goose CLI on PATH',
   workspacePrefix: 'goose-e2e',
+  ...REAL_AGENT_E2E_SETTINGS.goose,
 }
 
 export const GOOSE_E2E_SKIP_REASON = detectACPSkipReason(gooseConfig)

--- a/frontend/tests/e2e/goose-fixtures.ts
+++ b/frontend/tests/e2e/goose-fixtures.ts
@@ -4,14 +4,12 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const gooseConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.GOOSE,
   cliBinary: 'goose',
   skipMessage: 'Goose E2E requires a goose CLI on PATH',
   workspacePrefix: 'goose-e2e',
-  ...REAL_AGENT_E2E_SETTINGS.goose,
 }
 
 export const GOOSE_E2E_SKIP_REASON = detectACPSkipReason(gooseConfig)

--- a/frontend/tests/e2e/kilo-fixtures.ts
+++ b/frontend/tests/e2e/kilo-fixtures.ts
@@ -4,16 +4,12 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const kiloConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.KILO,
   cliBinary: 'kilo',
   skipMessage: 'Kilo E2E requires a kilo CLI on PATH',
   workspacePrefix: 'kilo-e2e',
-  // Kilo's default image model does not run agentic turns. Use a text-capable
-  // model so subagent spawns run.
-  ...REAL_AGENT_E2E_SETTINGS.kilo,
 }
 
 export const KILO_E2E_SKIP_REASON = detectACPSkipReason(kiloConfig)

--- a/frontend/tests/e2e/kilo-fixtures.ts
+++ b/frontend/tests/e2e/kilo-fixtures.ts
@@ -4,15 +4,16 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const kiloConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.KILO,
   cliBinary: 'kilo',
   skipMessage: 'Kilo E2E requires a kilo CLI on PATH',
   workspacePrefix: 'kilo-e2e',
-  // Kilo's default model is an image model that no-ops agentic turns; open the
-  // agent with an explicit text-capable model so subagent spawns actually run.
-  model: 'zai-coding-plan/glm-5.2',
+  // Kilo's default image model does not run agentic turns. Use a text-capable
+  // model so subagent spawns run.
+  ...REAL_AGENT_E2E_SETTINGS.kilo,
 }
 
 export const KILO_E2E_SKIP_REASON = detectACPSkipReason(kiloConfig)

--- a/frontend/tests/e2e/opencode-fixtures.ts
+++ b/frontend/tests/e2e/opencode-fixtures.ts
@@ -4,12 +4,14 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const opencodeConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.OPENCODE,
   cliBinary: 'opencode',
   skipMessage: 'OpenCode E2E requires opencode CLI on PATH',
   workspacePrefix: 'opencode-e2e',
+  ...REAL_AGENT_E2E_SETTINGS.opencode,
 }
 
 export const OPENCODE_E2E_SKIP_REASON = detectACPSkipReason(opencodeConfig)

--- a/frontend/tests/e2e/opencode-fixtures.ts
+++ b/frontend/tests/e2e/opencode-fixtures.ts
@@ -4,14 +4,12 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const opencodeConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.OPENCODE,
   cliBinary: 'opencode',
   skipMessage: 'OpenCode E2E requires opencode CLI on PATH',
   workspacePrefix: 'opencode-e2e',
-  ...REAL_AGENT_E2E_SETTINGS.opencode,
 }
 
 export const OPENCODE_E2E_SKIP_REASON = detectACPSkipReason(opencodeConfig)

--- a/frontend/tests/e2e/pi-fixtures.ts
+++ b/frontend/tests/e2e/pi-fixtures.ts
@@ -16,6 +16,7 @@ import {
   openAgentViaAPI,
 } from './helpers/api'
 import { loginViaToken, openWorkspace } from './helpers/ui'
+import { REAL_AGENT_E2E_SETTINGS, realAgentOpenOptions } from './realAgentSettings'
 
 interface WorkspaceFixture {
   workspaceId: string
@@ -49,6 +50,7 @@ export const piTest = base.extend<{
     )
     await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, mkdtempSync(join(tmpdir(), 'pi-e2e-wd-')), {
       agentProvider: AgentProvider.PI,
+      ...realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.pi),
     })
     await use({ workspaceId })
 

--- a/frontend/tests/e2e/pi-fixtures.ts
+++ b/frontend/tests/e2e/pi-fixtures.ts
@@ -16,7 +16,7 @@ import {
   openAgentViaAPI,
 } from './helpers/api'
 import { loginViaToken, openWorkspace } from './helpers/ui'
-import { REAL_AGENT_E2E_SETTINGS, realAgentOpenOptions } from './realAgentSettings'
+import { realAgentOpenOptions, realAgentSettings } from './realAgentSettings'
 
 interface WorkspaceFixture {
   workspaceId: string
@@ -50,7 +50,7 @@ export const piTest = base.extend<{
     )
     await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, mkdtempSync(join(tmpdir(), 'pi-e2e-wd-')), {
       agentProvider: AgentProvider.PI,
-      ...realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.pi),
+      ...realAgentOpenOptions(realAgentSettings(AgentProvider.PI)),
     })
     await use({ workspaceId })
 

--- a/frontend/tests/e2e/process-control-fixtures.ts
+++ b/frontend/tests/e2e/process-control-fixtures.ts
@@ -29,7 +29,7 @@ import { findFreePort, getGlobalState, hubSpawnEnv, waitForServer } from './help
 import { createServerOutput, reportStartupFailure } from './helpers/serverOutput'
 import { getRecordedToasts, installToastRecorder } from './helpers/toast'
 import { loginViaToken, openWorkspace } from './helpers/ui'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
+import { realAgentEnv } from './realAgentSettings'
 
 // Per-fixture PID registry written under `<dataDir>/pids.json`. The
 // global-teardown sweep reads this file and reaps any process that
@@ -173,7 +173,7 @@ export async function restartWorker(serverInfo: SeparateServerInfo) {
   ], {
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
-    env: { ...process.env, LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort, LEAPMUX_WORKER_NAME: 'test-worker' },
+    env: { ...process.env, ...realAgentEnv(), LEAPMUX_WORKER_NAME: 'test-worker' },
   })
   workerProc.unref()
   // Track immediately so the fixture teardown / global-teardown sweep still
@@ -252,7 +252,7 @@ export async function restartHub(serverInfo: SeparateServerInfo) {
   ], {
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
-    env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort }),
+    env: hubSpawnEnv(realAgentEnv()),
   })
   hubProc.unref()
   // Track immediately so the fixture teardown / global-teardown sweep still
@@ -336,7 +336,7 @@ export const processTest = base.extend<
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
-      env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort }),
+      env: hubSpawnEnv(realAgentEnv()),
     })
     hubProc.unref()
     trackSpawnedPid(dataDir, hubProc.pid!)
@@ -386,7 +386,7 @@ export const processTest = base.extend<
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
-      env: { ...process.env, LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort, LEAPMUX_WORKER_NAME: 'test-worker' },
+      env: { ...process.env, ...realAgentEnv(), LEAPMUX_WORKER_NAME: 'test-worker' },
     })
     workerProc.unref()
     trackSpawnedPid(dataDir, workerProc.pid!)

--- a/frontend/tests/e2e/process-control-fixtures.ts
+++ b/frontend/tests/e2e/process-control-fixtures.ts
@@ -29,6 +29,7 @@ import { findFreePort, getGlobalState, hubSpawnEnv, waitForServer } from './help
 import { createServerOutput, reportStartupFailure } from './helpers/serverOutput'
 import { getRecordedToasts, installToastRecorder } from './helpers/toast'
 import { loginViaToken, openWorkspace } from './helpers/ui'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 // Per-fixture PID registry written under `<dataDir>/pids.json`. The
 // global-teardown sweep reads this file and reaps any process that
@@ -172,7 +173,7 @@ export async function restartWorker(serverInfo: SeparateServerInfo) {
   ], {
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
-    env: { ...process.env, LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low', LEAPMUX_WORKER_NAME: 'test-worker' },
+    env: { ...process.env, LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort, LEAPMUX_WORKER_NAME: 'test-worker' },
   })
   workerProc.unref()
   // Track immediately so the fixture teardown / global-teardown sweep still
@@ -251,7 +252,7 @@ export async function restartHub(serverInfo: SeparateServerInfo) {
   ], {
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: true,
-    env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low' }),
+    env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort }),
   })
   hubProc.unref()
   // Track immediately so the fixture teardown / global-teardown sweep still
@@ -335,7 +336,7 @@ export const processTest = base.extend<
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
-      env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low' }),
+      env: hubSpawnEnv({ LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort }),
     })
     hubProc.unref()
     trackSpawnedPid(dataDir, hubProc.pid!)
@@ -385,7 +386,7 @@ export const processTest = base.extend<
     ], {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
-      env: { ...process.env, LEAPMUX_CLAUDE_DEFAULT_MODEL: 'sonnet', LEAPMUX_CLAUDE_DEFAULT_EFFORT: 'low', LEAPMUX_WORKER_NAME: 'test-worker' },
+      env: { ...process.env, LEAPMUX_CLAUDE_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS.claudeCode.model, LEAPMUX_CLAUDE_DEFAULT_EFFORT: REAL_AGENT_E2E_SETTINGS.claudeCode.effort, LEAPMUX_WORKER_NAME: 'test-worker' },
     })
     workerProc.unref()
     trackSpawnedPid(dataDir, workerProc.pid!)

--- a/frontend/tests/e2e/realAgentSettings.test.ts
+++ b/frontend/tests/e2e/realAgentSettings.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { REAL_AGENT_E2E_SETTINGS, realAgentOpenOptions } from './realAgentSettings'
+
+describe('real-agent end-to-end settings', () => {
+  it('pins each provider to the selected model and effort', () => {
+    expect(REAL_AGENT_E2E_SETTINGS).toEqual({
+      claudeCode: { model: 'sonnet', effort: 'medium' },
+      codex: { model: 'gpt-5.6-luna', effort: 'medium' },
+      copilot: { model: 'gpt-5.6-luna', effort: 'medium' },
+      cursor: { model: 'auto' },
+      goose: { model: 'glm-5.3-flash', effort: 'high' },
+      kilo: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
+      opencode: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
+      pi: { model: 'glm-5.3-flash', effort: 'high' },
+      reasonix: { model: 'deepseek-flash' },
+      zcode: { model: 'builtin:zai-coding-plan/GLM-5.3-Flash', effort: 'high' },
+    })
+  })
+
+  it('maps an effort into the worker option vocabulary', () => {
+    expect(realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.pi)).toEqual({
+      model: 'glm-5.3-flash',
+      optionValues: { effort: 'high' },
+    })
+  })
+
+  it('omits the effort option for a model without that setting', () => {
+    expect(realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.reasonix)).toEqual({
+      model: 'deepseek-flash',
+    })
+  })
+})

--- a/frontend/tests/e2e/realAgentSettings.test.ts
+++ b/frontend/tests/e2e/realAgentSettings.test.ts
@@ -1,32 +1,57 @@
 import { describe, expect, it } from 'vitest'
-import { REAL_AGENT_E2E_SETTINGS, realAgentOpenOptions } from './realAgentSettings'
+import { AgentProvider } from '../../src/generated/proto/leapmux/v1/agent_pb'
+import { REAL_AGENT_E2E_SETTINGS, realAgentEnv, realAgentOpenOptions, realAgentSettings } from './realAgentSettings'
 
+// The cases below assert the catalog's SHAPE and the two mappings that read it.
+// They never restate a model id: a second copy of the table would fail on every
+// model bump and catch nothing, because the copy and the source are one file
+// apart and change together.
 describe('real-agent end-to-end settings', () => {
-  it('pins each provider to the selected model and effort', () => {
-    expect(REAL_AGENT_E2E_SETTINGS).toEqual({
-      claudeCode: { model: 'sonnet', effort: 'medium' },
-      codex: { model: 'gpt-5.6-luna', effort: 'medium' },
-      copilot: { model: 'gpt-5.6-luna', effort: 'medium' },
-      cursor: { model: 'auto' },
-      goose: { model: 'glm-5.3-flash', effort: 'high' },
-      kilo: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
-      opencode: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
-      pi: { model: 'glm-5.3-flash', effort: 'high' },
-      reasonix: { model: 'deepseek-flash' },
-      zcode: { model: 'builtin:zai-coding-plan/GLM-5.3-Flash', effort: 'high' },
-    })
+  it('pins a usable model for every provider', () => {
+    for (const [provider, settings] of Object.entries(REAL_AGENT_E2E_SETTINGS)) {
+      expect(settings.model, `AgentProvider ${provider}`).not.toBe('')
+      expect(settings.model.trim(), `AgentProvider ${provider}`).toBe(settings.model)
+    }
+  })
+
+  // An empty string reaches the worker as a request to CLEAR the option, so it
+  // opens the agent at the account default -- the state this catalog exists to
+  // exclude. Omit the field instead.
+  it('never pins an empty effort', () => {
+    for (const [provider, settings] of Object.entries(REAL_AGENT_E2E_SETTINGS))
+      expect('effort' in settings ? settings.effort : 'high', `AgentProvider ${provider}`).not.toBe('')
+  })
+
+  it('covers every provider the enum offers', () => {
+    const missing = Object.values(AgentProvider)
+      .filter((value): value is AgentProvider => typeof value === 'number')
+      .filter(provider => provider !== AgentProvider.UNSPECIFIED)
+      .filter(provider => !(provider in REAL_AGENT_E2E_SETTINGS))
+    expect(missing).toEqual([])
+  })
+
+  it('refuses a provider it does not pin', () => {
+    expect(() => realAgentSettings(AgentProvider.UNSPECIFIED)).toThrow(/no pinned model/)
   })
 
   it('maps an effort into the worker option vocabulary', () => {
-    expect(realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.pi)).toEqual({
-      model: 'glm-5.3-flash',
+    expect(realAgentOpenOptions({ model: 'a-model', effort: 'high' })).toEqual({
+      model: 'a-model',
       optionValues: { effort: 'high' },
     })
   })
 
   it('omits the effort option for a model without that setting', () => {
-    expect(realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.reasonix)).toEqual({
-      model: 'deepseek-flash',
-    })
+    expect(realAgentOpenOptions({ model: 'a-model' })).toEqual({ model: 'a-model' })
+  })
+
+  it('builds the spawn environment from the catalog', () => {
+    const env = realAgentEnv()
+    expect(env.LEAPMUX_CLAUDE_DEFAULT_MODEL).toBe(REAL_AGENT_E2E_SETTINGS[AgentProvider.CLAUDE_CODE].model)
+    expect(env.LEAPMUX_CODEX_DEFAULT_EFFORT).toBe(REAL_AGENT_E2E_SETTINGS[AgentProvider.CODEX].effort)
+    expect(env.LEAPMUX_COPILOT_DEFAULT_MODEL).toBe(REAL_AGENT_E2E_SETTINGS[AgentProvider.GITHUB_COPILOT].model)
+    // Copilot registers no env effort key: its reasoning axis is the daemon's
+    // `reasoning_effort` config option, so the worker reads no such variable.
+    expect(env).not.toHaveProperty('LEAPMUX_COPILOT_DEFAULT_EFFORT')
   })
 })

--- a/frontend/tests/e2e/realAgentSettings.ts
+++ b/frontend/tests/e2e/realAgentSettings.ts
@@ -1,0 +1,29 @@
+import { OPTION_ID_EFFORT } from '../../src/components/chat/settingsGroups'
+
+/**
+ * Concrete settings for end-to-end tests that contact a real model provider.
+ * Keep this catalog explicit so account defaults cannot change test behavior.
+ */
+export const REAL_AGENT_E2E_SETTINGS = {
+  claudeCode: { model: 'sonnet', effort: 'medium' },
+  codex: { model: 'gpt-5.6-luna', effort: 'medium' },
+  copilot: { model: 'gpt-5.6-luna', effort: 'medium' },
+  cursor: { model: 'auto' },
+  goose: { model: 'glm-5.3-flash', effort: 'high' },
+  kilo: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
+  opencode: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
+  pi: { model: 'glm-5.3-flash', effort: 'high' },
+  reasonix: { model: 'deepseek-flash' },
+  // ZCode requires the configured model's exact case and provider-qualified id.
+  zcode: { model: 'builtin:zai-coding-plan/GLM-5.3-Flash', effort: 'high' },
+} as const
+
+/** Builds the initial option map for one real-agent test fixture. */
+export function realAgentOpenOptions(settings: { model: string, effort?: string }) {
+  return {
+    model: settings.model,
+    ...(settings.effort
+      ? { optionValues: { [OPTION_ID_EFFORT]: settings.effort } }
+      : {}),
+  }
+}

--- a/frontend/tests/e2e/realAgentSettings.ts
+++ b/frontend/tests/e2e/realAgentSettings.ts
@@ -1,29 +1,85 @@
+// A RELATIVE import, not `~/...`. `tsconfig.json` lists only
+// `tests/e2e/**/*.test.ts` under `include`, and vite's tsconfigPaths refuses the
+// `~` mapping for an importer outside `include` -- see that file's own comment.
+// This module is not a `.test.ts`, so `~/components/chat/settingsGroups` fails
+// to resolve here although a sibling spec may use it.
 import { OPTION_ID_EFFORT } from '../../src/components/chat/settingsGroups'
+import { AgentProvider } from '../../src/generated/proto/leapmux/v1/agent_pb'
+
+/** The model, and the reasoning effort where the provider has one. */
+export interface RealAgentSettings {
+  model: string
+  /** Omitted for a provider whose models expose no effort axis. */
+  effort?: string
+}
 
 /**
  * Concrete settings for end-to-end tests that contact a real model provider.
  * Keep this catalog explicit so account defaults cannot change test behavior.
+ *
+ * Keyed by `AgentProvider`, and `satisfies` makes a new provider a typecheck
+ * failure here rather than a test that silently takes the account default.
  */
 export const REAL_AGENT_E2E_SETTINGS = {
-  claudeCode: { model: 'sonnet', effort: 'medium' },
-  codex: { model: 'gpt-5.6-luna', effort: 'medium' },
-  copilot: { model: 'gpt-5.6-luna', effort: 'medium' },
-  cursor: { model: 'auto' },
-  goose: { model: 'glm-5.3-flash', effort: 'high' },
-  kilo: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
-  opencode: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
-  pi: { model: 'glm-5.3-flash', effort: 'high' },
-  reasonix: { model: 'deepseek-flash' },
+  [AgentProvider.CLAUDE_CODE]: { model: 'sonnet', effort: 'medium' },
+  [AgentProvider.CODEX]: { model: 'gpt-5.6-luna', effort: 'medium' },
+  [AgentProvider.GITHUB_COPILOT]: { model: 'gpt-5.6-luna', effort: 'medium' },
+  [AgentProvider.CURSOR]: { model: 'auto' },
+  [AgentProvider.GOOSE]: { model: 'glm-5.3-flash', effort: 'high' },
+  // Kilo's default image model does not run agentic turns. Keep a text-capable
+  // model so subagent spawns run.
+  [AgentProvider.KILO]: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
+  [AgentProvider.OPENCODE]: { model: 'zai-coding-plan/glm-5.3-flash', effort: 'high' },
+  [AgentProvider.PI]: { model: 'glm-5.3-flash', effort: 'high' },
+  [AgentProvider.REASONIX]: { model: 'deepseek-flash' },
   // ZCode requires the configured model's exact case and provider-qualified id.
-  zcode: { model: 'builtin:zai-coding-plan/GLM-5.3-Flash', effort: 'high' },
-} as const
+  [AgentProvider.ZCODE]: { model: 'builtin:zai-coding-plan/GLM-5.3-Flash', effort: 'high' },
+} as const satisfies Record<Exclude<AgentProvider, AgentProvider.UNSPECIFIED>, RealAgentSettings>
 
-/** Builds the initial option map for one real-agent test fixture. */
-export function realAgentOpenOptions(settings: { model: string, effort?: string }) {
+/** The pinned settings of one provider. */
+export function realAgentSettings(provider: AgentProvider): RealAgentSettings {
+  const settings = (REAL_AGENT_E2E_SETTINGS as Record<number, RealAgentSettings | undefined>)[provider]
+  if (!settings)
+    throw new Error(`realAgentSettings: no pinned model for AgentProvider ${provider}`)
+  return settings
+}
+
+/**
+ * Builds the initial option map for one real-agent test fixture.
+ *
+ * The effort travels under the well-known `effort` id whatever the provider's
+ * own axis is called: the worker maps it onto that axis at startup (see
+ * `applyStartupOptions` and `startupEffortConfigID` in the Go worker).
+ */
+export function realAgentOpenOptions(settings: RealAgentSettings) {
   return {
     model: settings.model,
     ...(settings.effort
       ? { optionValues: { [OPTION_ID_EFFORT]: settings.effort } }
       : {}),
+  }
+}
+
+/**
+ * The `LEAPMUX_*_DEFAULT_*` pairs a spawned hub or worker needs, so the catalog
+ * states the mapping once instead of at each `spawn` call.
+ *
+ * Claude Code and Codex own a static model catalog, so they read both a model
+ * and an effort. Copilot reads a model alone: its reasoning axis is the
+ * daemon's `reasoning_effort` config option, and it registers no env effort key
+ * (see `copilot.go`). The other ACP providers register neither, so their
+ * fixtures pin the settings through the open request (`realAgentOpenOptions`).
+ *
+ * `LEAPMUX_WORKER_NAME` stays at each call site, because it differs by site.
+ */
+export function realAgentEnv(): Record<string, string> {
+  const claude = REAL_AGENT_E2E_SETTINGS[AgentProvider.CLAUDE_CODE]
+  const codex = REAL_AGENT_E2E_SETTINGS[AgentProvider.CODEX]
+  return {
+    LEAPMUX_CLAUDE_DEFAULT_MODEL: claude.model,
+    LEAPMUX_CLAUDE_DEFAULT_EFFORT: claude.effort,
+    LEAPMUX_CODEX_DEFAULT_MODEL: codex.model,
+    LEAPMUX_CODEX_DEFAULT_EFFORT: codex.effort,
+    LEAPMUX_COPILOT_DEFAULT_MODEL: REAL_AGENT_E2E_SETTINGS[AgentProvider.GITHUB_COPILOT].model,
   }
 }

--- a/frontend/tests/e2e/reasonix-fixtures.ts
+++ b/frontend/tests/e2e/reasonix-fixtures.ts
@@ -4,14 +4,12 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
-import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const reasonixConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.REASONIX,
   cliBinary: 'reasonix',
   skipMessage: 'Reasonix E2E requires a reasonix CLI on PATH',
   workspacePrefix: 'reasonix-e2e',
-  ...REAL_AGENT_E2E_SETTINGS.reasonix,
 }
 
 export const REASONIX_E2E_SKIP_REASON = detectACPSkipReason(reasonixConfig)

--- a/frontend/tests/e2e/reasonix-fixtures.ts
+++ b/frontend/tests/e2e/reasonix-fixtures.ts
@@ -4,12 +4,14 @@
 import type { ACPFixtureConfig, WorkspaceFixture } from './acp-fixture-factory'
 import { AgentProvider, authenticateACPWorkspace, createACPWorkspace, detectACPSkipReason } from './acp-fixture-factory'
 import { test as base, expect } from './fixtures'
+import { REAL_AGENT_E2E_SETTINGS } from './realAgentSettings'
 
 const reasonixConfig: ACPFixtureConfig = {
   agentProvider: AgentProvider.REASONIX,
   cliBinary: 'reasonix',
   skipMessage: 'Reasonix E2E requires a reasonix CLI on PATH',
   workspacePrefix: 'reasonix-e2e',
+  ...REAL_AGENT_E2E_SETTINGS.reasonix,
 }
 
 export const REASONIX_E2E_SKIP_REASON = detectACPSkipReason(reasonixConfig)

--- a/frontend/tests/e2e/zcode-fixtures.ts
+++ b/frontend/tests/e2e/zcode-fixtures.ts
@@ -22,6 +22,7 @@ import {
   openAgentViaAPI,
 } from './helpers/api'
 import { loginViaToken, openWorkspace } from './helpers/ui'
+import { REAL_AGENT_E2E_SETTINGS, realAgentOpenOptions } from './realAgentSettings'
 import { computeZCodeE2ESkipReason } from './zcode-install'
 
 interface WorkspaceFixture {
@@ -63,6 +64,7 @@ export const zcodeTest = base.extend<{
     )
     await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, mkdtempSync(join(tmpdir(), 'zcode-e2e-wd-')), {
       agentProvider: AgentProvider.ZCODE,
+      ...realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.zcode),
     })
     await use({ workspaceId })
 

--- a/frontend/tests/e2e/zcode-fixtures.ts
+++ b/frontend/tests/e2e/zcode-fixtures.ts
@@ -22,7 +22,7 @@ import {
   openAgentViaAPI,
 } from './helpers/api'
 import { loginViaToken, openWorkspace } from './helpers/ui'
-import { REAL_AGENT_E2E_SETTINGS, realAgentOpenOptions } from './realAgentSettings'
+import { realAgentOpenOptions, realAgentSettings } from './realAgentSettings'
 import { computeZCodeE2ESkipReason } from './zcode-install'
 
 interface WorkspaceFixture {
@@ -64,7 +64,7 @@ export const zcodeTest = base.extend<{
     )
     await openAgentViaAPI(hubUrl, adminToken, workerId, workspaceId, mkdtempSync(join(tmpdir(), 'zcode-e2e-wd-')), {
       agentProvider: AgentProvider.ZCODE,
-      ...realAgentOpenOptions(REAL_AGENT_E2E_SETTINGS.zcode),
+      ...realAgentOpenOptions(realAgentSettings(AgentProvider.ZCODE)),
     })
     await use({ workspaceId })
 

--- a/site/content/docs/using/coding-agents.md
+++ b/site/content/docs/using/coding-agents.md
@@ -263,16 +263,18 @@ The exact buttons depend on the provider.
 
 ### Codex
 
-Codex approval banners are titled by the kind of request: **Command Execution**, **File Change**, **Permission Request**, or **Approval Required**, and show the reason, command (collapsible), and working directory. The buttons come from the request itself; depending on the request you may see:
+Codex approval banners are titled by the kind of request: **Command Execution**, **File Change**, **Permission Request**, or **Approval Required**, and show the reason, command (collapsible), and working directory. The decisions come from the request itself, so which ones you see depends on it.
 
-- **Allow** — approve this one request.
-- **Allow for Session** — approve and stop asking for the same kind of request for the rest of the session.
-- **Reject** — deny the request.
-- **Cancel** — dismiss the request without approving it.
-- **Allow & Remember** — approve and remember the amended execution policy for similar commands.
-- **Apply Network Policy** — approve and apply the proposed network-access amendment.
+One **Allow** button approves the request, and an **Allow as** control beside it chooses how long the approval lasts:
 
-An **& Bypass Permissions** option is also available (it switches Codex to Full Auto). Codex's plan-mode prompt is titled **Implement the proposed plan?** with **Stay in Plan Mode** / **Send Feedback** and **Implement Plan**.
+- **Once** — this one request only.
+- **Session** — the same kind of request for the rest of the session.
+- **Command rule** — remember the amended execution policy for similar commands.
+- **Host rule** — apply the proposed network-access amendment.
+
+**Once** is always selected first, so a wider grant is one you choose rather than one you inherit. When the request offers two rules of one kind, each option names the command or the host it covers. A request that offers more than four choices keeps the extra ones as their own buttons beside **Allow**.
+
+**Reject** denies the request and **Cancel** dismisses it without approving it. An **& Bypass Permissions** option is also available (it switches Codex to Full Auto). Codex's plan-mode prompt is titled **Implement the proposed plan?** with **Stay in Plan Mode** / **Send Feedback** and **Implement Plan**.
 
 ### Pi
 


### PR DESCRIPTION
## Motivation

- Control requests were inconsistent between providers. Codex used a
  **Remember** switch while every other provider used scope pills, so the
  same choice read differently depending on which agent asked.
- Composer actions, pill controls, and sidebar row targets used conflicting
  sizes, and a row menu target was small enough to be awkward on touch.
- A queue row offered a drag when no legal move existed. A queue of one
  dispatching row and one queued row has no destination the worker accepts,
  so the row lifted and snapped back with nothing saying why.
- A dragged row travelled on both axes in lists that reorder on one, which
  pushed the row past its container and raised a horizontal scrollbar.
- Real-agent end-to-end tests inherited whatever model and effort the
  account happened to have, so a settings change elsewhere altered what
  the suite exercised.

## Modifications

**Codex approval controls**

- Replace the Remember switch with provider-native **Allow as** pills, built
  from one ordered decision table. An unmatched decision now becomes its own
  button instead of a pill labelled as whichever branch happened to be last.
- Tell two allow decisions of one family apart by their host or command. Two
  radios previously carried the same accessible name, so the user could not
  see which rule they were about to apply permanently.
- Draw no decision button for a polarity the request offered nothing for,
  rather than sending an `accept` or `cancel` that Codex never named. A list
  this build's parser narrowed keeps its canonical token, so an unknown
  variant never removes the approval path.
- Move the decision algebra and the senders beside the `CodexDecision` type
  they switch on, leaving the component with its rendering.

**Sizing and the sidebar**

- Add shared small action and pill metrics, and enlarge row menu targets to
  24px. Every sidebar row now reserves that height, so a row that draws no
  action button matches its neighbours instead of sitting 3px shorter.
- Read the icon-button size scale from `iconSize.container` in one place.

**Input queue and drag**

- Withhold the drag affordance until a row has a legal destination, which is
  the question `resolveQueueMove` already answers for the two arrow buttons.
- Lock a guarded drag row's transform to its list's own axis. This removes
  the sideways drift at its source, so the queue keeps the sideways scroll
  that reaches an overflowing action cluster.

**Accessibility**

- Give a clipped pill a tooltip carrying its own label, which is the only way
  to read an option that a narrow row cut off.

**End-to-end settings**

- Pin every real-agent model and effort in one catalog, keyed by the
  `AgentProvider` enum, so a new provider fails the typecheck rather than
  silently taking an account default.
- Read those settings from the provider inside the ACP fixture factory, so
  one provider's config cannot carry another provider's model.
- State the `LEAPMUX_*_DEFAULT_*` mapping once, instead of at eight sites.

## Result

- Every provider now asks the same question the same way: one Allow button
  with pills that state how long the approval lasts.
- The banner can no longer send Codex a decision the request did not offer,
  and two rules of one kind can no longer look identical.
- A queue row offers a drag only when it can move, and dragging one no
  longer makes a horizontal scrollbar appear.
- Sidebar rows keep one rhythm whether or not they carry an action button.
- A test run exercises the models the catalog names, whatever the account
  is set to.
- `task lint` passes across frontend, backend and desktop. The frontend
  suite passes at 782 files and 14250 tests, 29 more than before this
  branch.
