### PR TITLE
fix(codex): Correct subagent lifecycle routing

### DIFF
--- a/backend/internal/worker/agent/agent.go
+++ b/backend/internal/worker/agent/agent.go
@@ -876,48 +876,52 @@ func (e *AgentBusyError) Unwrap() error {
 	return e.Err
 }
 
-// ChildSteerer lets a provider address a child conversation in its process.
-// Queue dispatch resolves the child registry row and drives the owner process.
-// Providers that cannot steer a child do not implement this interface.
+// ChildSteerer lets a provider send input to a child conversation in its
+// process. Queue dispatch resolves the child registry row and drives the owner.
+// Providers that cannot send direct child input do not implement this interface.
 type ChildSteerer interface {
 	// SendChildInput sends a user message to a child conversation identified by
 	// childKey (the provider linkage key stored in the registry row_key). Returns
-	// ErrChildSteeringUnsupported only via the Manager's type-assertion path.
+	// ErrChildOperationUnsupported only via the Manager's capability check.
 	SendChildInput(childKey, content string, attachments []*leapmuxv1.Attachment) error
 	// SteerChildInput adds input to the child's active turn.
 	SteerChildInput(childKey, content string, attachments []*leapmuxv1.Attachment) error
 	// ActiveChildTurnState classifies the child's current turn after
 	// SendChildInput returns ErrAgentBusy.
 	ActiveChildTurnState(childKey string) TurnState
-	// InterruptChild stops the child's current turn inside the owner process.
+}
+
+// ChildInterrupter lets a provider stop a child turn without claiming that the
+// provider can send direct input to that child.
+type ChildInterrupter interface {
 	InterruptChild(childKey string) error
 }
 
-// ErrChildSteeringUnsupported is returned by the Manager when a running Agent
-// does not implement ChildSteerer, which means that the provider cannot address
-// a subagent at all.
+// ErrChildOperationUnsupported is returned when a running agent lacks the
+// requested child capability. Input uses ChildSteerer. Interrupt uses
+// ChildInterrupter.
 //
 // Each caller maps it on its own, and the three mappings differ. The
 // InterruptChild handler maps it to FailedPrecondition, so the client shows the
 // reason. Queue steer maps it to inputqueue.ErrSteeringUnsupported, through
 // classifyQueueSteerError. Queue dispatch (SendChildInput) has no case for it
 // and passes it to classifyQueueDeliveryError with every other delivery error.
-var ErrChildSteeringUnsupported = errors.New("agent provider does not support steering a subagent")
+var ErrChildOperationUnsupported = errors.New("agent provider does not support this subagent operation")
 
-// ErrChildNotSteerableYet is returned by a ChildSteerer when the owner process
-// runs but does not yet know the child thread. A worker restart empties the
-// in-memory spawn index, so the registry row resolves before the provider
+// ErrChildRouteNotReady is returned by a child capability when the owner
+// process does not yet know the child thread. A worker restart empties the
+// in-memory child routes, so the registry row resolves before the provider
 // reports the spawn again. The condition is transient: the same call
 // succeeds after the owner process reports the spawn.
 //
-// ErrChildSteeringUnsupported is the opposite condition. That provider cannot
-// address a subagent at all. This provider does address one, but not yet.
+// ErrChildOperationUnsupported is the opposite condition. The provider lacks
+// the requested capability. This provider supports it, but its route is not ready.
 //
 // Each caller maps it on its own. The InterruptChild handler maps it to
 // UNAVAILABLE, so the client sends the interrupt again. Queue dispatch
 // (SendChildInput) passes it to classifyQueueDeliveryError, which decides how
 // the queue records the failed delivery.
-var ErrChildNotSteerableYet = errors.New("subagent not yet steerable in the running owner process; retry")
+var ErrChildRouteNotReady = errors.New("subagent route is not ready in the running owner process; retry")
 
 // turnSeqSource issues the ordering token that goes with a provider's turn
 // flag. Read the token in the SAME critical section that reads the flag: the

--- a/backend/internal/worker/agent/claude_subagent.go
+++ b/backend/internal/worker/agent/claude_subagent.go
@@ -715,8 +715,8 @@ func (a *ClaudeCodeAgent) routeSubagentMessage(content []byte, msgType string, e
 	//
 	// Inside the run loop the CLI forwards a message only when it holds a tool_use
 	// or a tool_result block, so every other forwarded user envelope is a
-	// tool_result; and a Claude subagent cannot be steered (only Codex implements
-	// ChildSteerer), so no TYPED user message reaches a child transcript either.
+	// tool_result. Claude does not implement ChildSteerer, so no typed user
+	// message reaches a child transcript either.
 	//
 	// A SendMessage the parent addresses to a subagent does not reach a child
 	// transcript this way either, and a live recipient is not an exception.

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -23,6 +23,7 @@ const (
 	CodexDefaultNetworkAccess     = "restricted"
 	CodexDefaultCollaborationMode = "default"
 	CodexDefaultServiceTier       = "default"
+	codexMultiAgentV2Feature      = "multi_agent_v2"
 )
 
 const (
@@ -128,14 +129,14 @@ type CodexAgent struct {
 	incompleteTools        map[string]*codexIncompleteTool
 	incompleteToolOrder    uint64
 	availableModels        []*ModelInfo
-	collabThreadSpans      map[string]string // child thread ID -> owning spawnAgent span ID (child index)
-	// collabChildAgents remembers the child AGENT id each thread resolved to.
-	// The span index above answers the same question, but it is torn down on a
-	// ClearContext and a registry write can fail, and a thread whose id cannot
-	// be resolved publishes no turn end -- which holds that child's own input
-	// queue with a turn that nothing will ever clear. The agent id does not
-	// change once assigned, so remembering it makes the clear survive both.
-	collabChildAgents map[string]string // child thread ID -> child agent ID
+	// collabChildren is the durable in-process route from each Codex child
+	// thread to its LeapMux transcript. The route survives completed runs, so
+	// a follow-up turn reuses the same transcript. ClearContext removes it,
+	// because the new root thread owns a different child tree.
+	collabChildren map[string]codexChildState
+	// collabThreadsByAgent is the reverse index for buffered output that records
+	// a LeapMux child agent ID but later needs the child's direct sink.
+	collabThreadsByAgent map[string]string
 	// collabChildItems records the child agent ID that owns an item
 	// (commandExecution/fileChange itemID -> childID). Populated when
 	// persistItemStartedChild routes the item/started to a child; consulted by
@@ -143,12 +144,9 @@ type CodexAgent struct {
 	// subagent's command output contributes to its own counter.
 	// Guarded by mu.
 	collabChildItems map[string]string
-	// collabChildTitles records the spawn prompt's first line per child thread
-	// (the registry + child tab title). Guarded by mu.
-	collabChildTitles map[string]string
 	// collabChildPrompts records the FULL spawn prompt per child thread (the
-	// title above keeps only its first line). Spent when the child transcript is
-	// created, so the subagent tab opens on the instruction it was given.
+	// child route keeps only its first line as the title). Spent when the child
+	// transcript is created, so the subagent tab opens on its instruction.
 	collabChildPrompts pendingPrompts
 	// childTurnIDs records the active turn id per child thread (for steering).
 	// Guarded by mu. Cleared on child turn/completed.
@@ -188,8 +186,11 @@ func StartCodex(ctx context.Context, opts Options, sink ProviderServices) (Agent
 		LoginShell:   opts.LoginShell,
 		Launch:       launch,
 		StripEnvKeys: []string{"CODEX_CI"},
-		BaseArgs:     []string{"app-server"},
-		WorkingDir:   opts.WorkingDir,
+		// Current models select Multi-Agent V2 from model metadata. Enable the
+		// stable feature explicitly too, so every supported model exposes one
+		// subagent protocol and LeapMux never falls back because metadata is absent.
+		BaseArgs:   codexBaseArgs(),
+		WorkingDir: opts.WorkingDir,
 	})
 
 	cmd.Env = envutil.FilterEnv(cmd.Environ(), "CODEX_CI", "CODEX_THREAD_ID")
@@ -318,6 +319,10 @@ func StartCodex(ctx context.Context, opts Options, sink ProviderServices) (Agent
 	a.publishSettings()
 
 	return a, nil
+}
+
+func codexBaseArgs() []string {
+	return []string{"--enable", codexMultiAgentV2Feature, "app-server"}
 }
 
 // startOrResumeThread sends thread/start, or thread/resume when the launch
@@ -655,11 +660,11 @@ func (a *CodexAgent) ClearContext() (string, bool) {
 	clear(a.reasoningSummaryIndex)
 	clear(a.reasoningSummarySeen)
 	clear(a.reasoningSummaryBreak)
-	// Clear the collab child index: a new thread means prior child threads are
-	// gone. Entries are otherwise only removed on a final collab status.
-	clear(a.collabThreadSpans)
+	// Clear the child routes: a new root thread owns a different child tree. A
+	// completed run keeps its route only while its root thread lives.
+	clear(a.collabChildren)
+	clear(a.collabThreadsByAgent)
 	clear(a.collabChildItems)
-	clear(a.collabChildTitles)
 	a.collabChildPrompts.clear()
 	clear(a.childTurnIDs)
 	clear(a.childTurnStartAcks)

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -24,6 +24,7 @@ const (
 	CodexDefaultNetworkAccess     = "restricted"
 	CodexDefaultCollaborationMode = "default"
 	CodexDefaultServiceTier       = "default"
+	codexMemoriesFeature          = "memories"
 	codexMultiAgentV2Feature      = "multi_agent_v2"
 )
 
@@ -173,9 +174,8 @@ func StartCodex(ctx context.Context, opts Options, sink ProviderServices) (Agent
 		LoginShell:   opts.LoginShell,
 		Launch:       launch,
 		StripEnvKeys: []string{"CODEX_CI"},
-		// Current models select Multi-Agent V2 from model metadata. Enable the
-		// stable feature explicitly too, so every supported model exposes one
-		// subagent protocol and LeapMux never falls back because metadata is absent.
+		// Codex leaves Multi-Agent V2 and memories off by default. Enable both
+		// stable features for every app-server process, independent of user config.
 		BaseArgs:   codexBaseArgs(),
 		WorkingDir: opts.WorkingDir,
 	})
@@ -309,7 +309,11 @@ func StartCodex(ctx context.Context, opts Options, sink ProviderServices) (Agent
 }
 
 func codexBaseArgs() []string {
-	return []string{"--enable", codexMultiAgentV2Feature, "app-server"}
+	return []string{
+		"--enable", codexMultiAgentV2Feature,
+		"--enable", codexMemoriesFeature,
+		"app-server",
+	}
 }
 
 // startOrResumeThread sends thread/start, or thread/resume when the launch

--- a/backend/internal/worker/agent/codex.go
+++ b/backend/internal/worker/agent/codex.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -78,6 +79,7 @@ func StringOrDefault(value, fallback string) string {
 // CodexAgent manages a single Codex app-server process.
 type CodexAgent struct {
 	jsonrpcBase // shared process lifecycle + JSON-RPC plumbing
+	outputMu    sync.Mutex
 
 	model      string
 	effort     string
@@ -118,42 +120,27 @@ type CodexAgent struct {
 	// SAME reasoning item (they are the same generation surfaced two ways), which
 	// would otherwise double-count. Locking onto whichever arrives first keeps the
 	// counter moving for models that stream only one of the two.
-	reasoningStreamKind    map[string]string
-	reasoningRetainedKind  map[string]string
-	reasoningSummaryIndex  map[string]int
-	reasoningSummarySeen   map[string]bool
-	reasoningSummaryBreak  map[string]bool
-	generationBuffer       GenerationBuffer
-	childGenerationBuffers map[string]*GenerationBuffer
-	unresolvedChildBuffers map[string]*GenerationBuffer
-	incompleteTools        map[string]*codexIncompleteTool
-	incompleteToolOrder    uint64
-	availableModels        []*ModelInfo
+	reasoningStreamKind   map[string]string
+	reasoningRetainedKind map[string]string
+	reasoningSummaryIndex map[string]int
+	reasoningSummarySeen  map[string]bool
+	reasoningSummaryBreak map[string]bool
+	generationBuffer      GenerationBuffer
+	incompleteTools       map[string]*codexIncompleteTool
+	incompleteToolOrder   uint64
+	availableModels       []*ModelInfo
 	// collabChildren is the durable in-process route from each Codex child
 	// thread to its LeapMux transcript. The route survives completed runs, so
 	// a follow-up turn reuses the same transcript. ClearContext removes it,
 	// because the new root thread owns a different child tree.
-	collabChildren map[string]codexChildState
-	// collabThreadsByAgent is the reverse index for buffered output that records
-	// a LeapMux child agent ID but later needs the child's direct sink.
-	collabThreadsByAgent map[string]string
-	// collabChildItems records the child agent ID that owns an item
-	// (commandExecution/fileChange itemID -> childID). Populated when
-	// persistItemStartedChild routes the item/started to a child; consulted by
-	// the output-delta handlers (which carry only an itemID, no threadID) so a
-	// subagent's command output contributes to its own counter.
+	collabChildren map[string]*codexChildState
+	// retiredCodexThreads prevents notifications from a replaced context from
+	// creating routes or transcript rows in the new context.
+	retiredCodexThreads map[string]struct{}
+	// collabChildItems records the child thread that owns a tool item. Output
+	// deltas carry only an item ID, so this index restores the transcript route.
 	// Guarded by mu.
 	collabChildItems map[string]string
-	// collabChildPrompts records the FULL spawn prompt per child thread (the
-	// child route keeps only its first line as the title). Spent when the child
-	// transcript is created, so the subagent tab opens on its instruction.
-	collabChildPrompts pendingPrompts
-	// childTurnIDs records the active turn id per child thread (for steering).
-	// Guarded by mu. Cleared on child turn/completed.
-	childTurnIDs map[string]string
-	// childTurnStartAcks records the turn/started notification that accepts a
-	// queued child input. Guarded by mu.
-	childTurnStartAcks map[string]chan struct{}
 	// interruptCalls coalesces concurrent interrupts for one Codex turn. A
 	// successful call stays cached until the turn ends, so a late retry cannot
 	// send another request for an already interrupted turn. Guarded by mu.
@@ -562,8 +549,10 @@ func (a *CodexAgent) Interrupt() error {
 // Stop retains unfinished model output before it stops the process.
 func (a *CodexAgent) Stop() {
 	a.processBase.Stop()
+	a.outputMu.Lock()
 	a.flushAllCodexGeneration(MessageCompletionInterrupted)
 	a.persistIncompleteCodexTools("", true, MessageCompletionInterrupted)
+	a.outputMu.Unlock()
 	a.sink.ReportProgress(ResetProgress())
 }
 
@@ -571,8 +560,10 @@ func (a *CodexAgent) Stop() {
 func (a *CodexAgent) Wait() error {
 	err := a.processBase.Wait()
 	completion := a.processExitCompletion()
+	a.outputMu.Lock()
 	a.flushAllCodexGeneration(completion)
 	a.persistIncompleteCodexTools("", true, completion)
+	a.outputMu.Unlock()
 	a.sink.ReportProgress(ResetProgress())
 	return err
 }
@@ -628,6 +619,7 @@ func (a *CodexAgent) clearInterruptCallsForThread(threadID string) {
 // replacing the current thread with a fresh one.
 func (a *CodexAgent) ClearContext() (string, bool) {
 	a.mu.Lock()
+	oldThreadID := a.threadID
 	approvalPolicy := a.approvalPolicy
 	sandboxPolicy := a.sandboxPolicy
 	serviceTier := a.serviceTier
@@ -645,10 +637,20 @@ func (a *CodexAgent) ClearContext() (string, bool) {
 		slog.Error("codex ClearContext: thread/start failed", "agent_id", a.agentID, "error", err)
 		return "", false
 	}
+	a.outputMu.Lock()
 	a.flushAllCodexGeneration(MessageCompletionInterrupted)
 	a.persistIncompleteCodexTools("", true, MessageCompletionInterrupted)
 
 	a.mu.Lock()
+	if a.retiredCodexThreads == nil {
+		a.retiredCodexThreads = make(map[string]struct{})
+	}
+	if oldThreadID != "" {
+		a.retiredCodexThreads[oldThreadID] = struct{}{}
+	}
+	for childThreadID := range a.collabChildren {
+		a.retiredCodexThreads[childThreadID] = struct{}{}
+	}
 	a.applyThreadResult(thread)
 	a.threadID = thread.ID
 	a.turnID = ""
@@ -663,19 +665,12 @@ func (a *CodexAgent) ClearContext() (string, bool) {
 	// Clear the child routes: a new root thread owns a different child tree. A
 	// completed run keeps its route only while its root thread lives.
 	clear(a.collabChildren)
-	clear(a.collabThreadsByAgent)
 	clear(a.collabChildItems)
-	a.collabChildPrompts.clear()
-	clear(a.childTurnIDs)
-	clear(a.childTurnStartAcks)
 	clear(a.incompleteTools)
 	a.incompleteToolOrder = 0
 	a.mu.Unlock()
 	a.generationBuffer.Reset()
-	a.mu.Lock()
-	clear(a.childGenerationBuffers)
-	clear(a.unresolvedChildBuffers)
-	a.mu.Unlock()
+	a.outputMu.Unlock()
 	a.PublishTurnActive()
 	a.sink.ReportProgress(ResetProgress())
 
@@ -704,9 +699,8 @@ func (a *CodexAgent) PublishTurnActive() TurnState {
 	active := a.turnID != ""
 	seq := a.nextTurnSeq()
 	a.mu.Unlock()
-	// Codex tracks collab child turns in childTurnIDs, deliberately not here: a
-	// child's own run is its background-task registry row, and the Worker reads
-	// that for the child tab. This is the MAIN thread's turn only.
+	// Each child route tracks its own turn. The background-task registry supplies
+	// that state to the child tab. This method reports the main thread only.
 	return publishSteerableTurnActiveTo(a.sink, active, seq)
 }
 

--- a/backend/internal/worker/agent/codex_launch_test.go
+++ b/backend/internal/worker/agent/codex_launch_test.go
@@ -1,0 +1,13 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCodexBaseArgsAlwaysEnableMultiAgentV2(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"--enable", "multi_agent_v2", "app-server"}, codexBaseArgs())
+}

--- a/backend/internal/worker/agent/codex_launch_test.go
+++ b/backend/internal/worker/agent/codex_launch_test.go
@@ -6,8 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCodexBaseArgsAlwaysEnableMultiAgentV2(t *testing.T) {
+func TestCodexBaseArgsAlwaysEnableRequiredFeatures(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, []string{"--enable", "multi_agent_v2", "app-server"}, codexBaseArgs())
+	assert.Equal(t, []string{
+		"--enable", "multi_agent_v2",
+		"--enable", "memories",
+		"app-server",
+	}, codexBaseArgs())
 }

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -35,6 +35,11 @@ var codexSystemMetadataMethods = map[string]struct{}{
 // handleCodexOutput processes a single parsed JSONL notification from the Codex app-server.
 // Codex messages are stored in their native JSON-RPC format.
 func handleCodexOutput(a *CodexAgent, line *parsedLine) {
+	a.outputMu.Lock()
+	defer a.outputMu.Unlock()
+	if a.isRetiredCodexOutput(line.Params) {
+		return
+	}
 	slog.Debug("codex HandleOutput", "agent_id", a.agentID, "method", line.Method, "len", len(line.Raw))
 
 	if _, ok := codexSystemMetadataMethods[line.Method]; ok {
@@ -133,60 +138,53 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 			ID string `json:"id"`
 		} `json:"turn"`
 	}
-	if json.Unmarshal(params, &notif) == nil && notif.Turn.ID != "" {
-		a.clearReasoningStateForThread(notif.ThreadID)
-		a.clearInterruptCallsForThread(notif.ThreadID)
-		// A collaboration subagent turn carries a child thread ID. It must not
-		// replace the primary turn ID used for interrupt and steering.
-		if !a.isMainThreadID(notif.ThreadID) {
-			// Record the child's active turn id (for steering) and upsert a
-			// running registry row so the child tab reflects activity.
-			a.activateCollabChild(notif.ThreadID)
-			a.setChildTurnID(notif.ThreadID, notif.Turn.ID)
-			childID := a.routeChildItemIfApplicable(notif.ThreadID)
-			if childID != "" {
-				a.flushCodexChildGeneration(childID, MessageCompletionInterrupted)
-				if childSink, ok := a.codexChildSinkForAgent(childID); ok {
-					childSink.ReportProgress(ResetModelProgress())
-				}
-			}
-			if a.knownCollabChild(notif.ThreadID) {
-				// upsertCollabChildRow reopens the row first when this child runs
-				// again after going final. The reopened row keeps a closer: the child
-				// turn or the parent's completion signal closes it.
-				logRegistryRefusal("codex", "upsert", a.upsertCollabChildRow(bgtask.Upsert{
-					RowKey:     notif.ThreadID,
-					Kind:       bgtask.KindSubagent,
-					Title:      a.collabChildTitle(notif.ThreadID),
-					ActiveForm: "working",
-					Status:     bgtask.StatusRunning,
-				}))
-			}
-			if childID != "" {
-				// The child's own turn. publishTurnActive covers the MAIN thread
-				// alone, so the child's flag is published against the child's
-				// sink -- which is what its own input queue follows.
-				if childSink, ok := a.codexChildSinkForAgent(childID); ok {
-					publishSteerableTurnActiveTo(childSink, true, a.childTurnSeq())
-				}
-			}
-			return
-		}
-		a.mu.Lock()
-		// Codex accepted the turn. sendTurnStart waits for this notification
-		// because response timing differs across Codex versions.
-		if a.turnStartAck != nil {
-			close(a.turnStartAck)
-			a.turnStartAck = nil
-		}
-		a.turnID = notif.Turn.ID
-		a.turnToolUses = 0
-		a.turnSawPlan = false
-		a.turnPlanText = ""
-		a.mu.Unlock()
-		a.PublishTurnActive()
-		a.sink.ReportProgress(ResetModelProgress())
+	if json.Unmarshal(params, &notif) != nil || notif.Turn.ID == "" {
+		return
 	}
+	a.clearReasoningStateForThread(notif.ThreadID)
+	a.clearInterruptCallsForThread(notif.ThreadID)
+	if a.isMainThreadID(notif.ThreadID) {
+		a.handleMainTurnStarted(notif.Turn.ID)
+		return
+	}
+	route, routed := a.ensureCodexChildRoute(notif.ThreadID)
+	if !routed {
+		a.enqueuePendingCodexChildEvent(notif.ThreadID, codexPendingChildEvent{
+			kind:   codexPendingTurnStarted,
+			params: append(json.RawMessage(nil), params...),
+		})
+		return
+	}
+	a.replayPendingCodexChildEvents(notif.ThreadID, route)
+	a.handleChildTurnStarted(notif.ThreadID, notif.Turn.ID, route)
+}
+
+func (a *CodexAgent) handleMainTurnStarted(turnID string) {
+	a.mu.Lock()
+	if a.turnStartAck != nil {
+		close(a.turnStartAck)
+		a.turnStartAck = nil
+	}
+	a.turnID = turnID
+	a.turnToolUses = 0
+	a.turnSawPlan = false
+	a.turnPlanText = ""
+	a.mu.Unlock()
+	a.PublishTurnActive()
+	a.sink.ReportProgress(ResetModelProgress())
+}
+
+func (a *CodexAgent) handleChildTurnStarted(threadID, turnID string, route codexChildRoute) {
+	a.activateCollabChild(threadID)
+	a.setChildTurnID(threadID, turnID)
+	a.flushCodexChildGeneration(threadID, MessageCompletionInterrupted)
+	route.childSink.ReportProgress(ResetModelProgress())
+	_, _, err := a.upsertCodexChildRegistryRow(threadID, codexChildTransition{
+		status:   bgtask.StatusRunning,
+		activity: "working",
+	})
+	logRegistryRefusal("codex", "upsert", err)
+	a.publishCodexChildTurnActive(route.childSink, true)
 }
 
 func (a *CodexAgent) clearReasoningStateForThread(threadID string) {
@@ -214,18 +212,15 @@ func (a *CodexAgent) bufferCodexModelText(
 	sink := a.sink
 	buffer := &a.generationBuffer
 	if !a.isMainThreadID(threadID) {
-		childID := a.routeChildItemIfApplicable(threadID)
-		if childID == "" {
-			a.unresolvedChildGenerationBuffer(threadID).Append(scopeID, kind, text, join)
+		route, routed := a.ensureCodexChildRoute(threadID)
+		buffer = a.codexChildGenerationBuffer(threadID)
+		if !routed {
+			a.appendPendingCodexChildGeneration(threadID, scopeID, kind, text, join)
 			return
 		}
-		childSink, ok := a.codexChildSinkForAgent(childID)
-		if !ok {
-			a.unresolvedChildGenerationBuffer(threadID).Append(scopeID, kind, text, join)
-			return
-		}
-		sink = childSink
-		buffer = a.childGenerationBuffer(childID)
+		a.replayPendingCodexChildEvents(threadID, route)
+		a.clearPendingCodexChildGenerationBytes(threadID)
+		sink = route.childSink
 	}
 	if reportProgress {
 		sink.ReportProgress(ModelTextProgress(scopeID, text))
@@ -236,15 +231,12 @@ func (a *CodexAgent) bufferCodexModelText(
 func (a *CodexAgent) reportCodexModelProgress(scopeID, threadID, text string) {
 	sink := a.sink
 	if !a.isMainThreadID(threadID) {
-		childID := a.routeChildItemIfApplicable(threadID)
-		if childID == "" {
+		route, routed := a.ensureCodexChildRoute(threadID)
+		if !routed {
 			return
 		}
-		childSink, ok := a.codexChildSinkForAgent(childID)
-		if !ok {
-			return
-		}
-		sink = childSink
+		a.replayPendingCodexChildEvents(threadID, route)
+		sink = route.childSink
 	}
 	sink.ReportProgress(ModelTextProgress(scopeID, text))
 }
@@ -254,67 +246,65 @@ func (a *CodexAgent) discardCodexModelText(scopeID, threadID string) {
 		a.generationBuffer.Discard(scopeID)
 		return
 	}
-	if childID := a.routeChildItemIfApplicable(threadID); childID != "" {
-		a.childGenerationBuffer(childID).Discard(scopeID)
+	a.codexChildGenerationBuffer(threadID).Discard(scopeID)
+}
+
+func (a *CodexAgent) codexChildGenerationBuffer(threadID string) *GenerationBuffer {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return &a.codexChildStateLocked(threadID).generationBuffer
+}
+
+func (a *CodexAgent) appendPendingCodexChildGeneration(
+	threadID, scopeID string,
+	kind AssembledMessageKind,
+	text string,
+	join textJoin,
+) {
+	a.mu.Lock()
+	state := a.codexChildStateLocked(threadID)
+	remaining := codexPendingChildGenerationLimit - state.pendingGenerationBytes
+	if remaining < len(text) {
+		firstDrop := !state.pendingOutputDropped
+		state.pendingOutputDropped = true
+		a.mu.Unlock()
+		if firstDrop {
+			slog.Warn("codex pending child generation limit reached", "thread", threadID)
+		}
 		return
 	}
-	a.unresolvedChildGenerationBuffer(threadID).Discard(scopeID)
-}
-
-func (a *CodexAgent) unresolvedChildGenerationBuffer(threadID string) *GenerationBuffer {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.unresolvedChildBuffers == nil {
-		a.unresolvedChildBuffers = make(map[string]*GenerationBuffer)
-	}
-	buffer := a.unresolvedChildBuffers[threadID]
-	if buffer == nil {
-		buffer = &GenerationBuffer{}
-		a.unresolvedChildBuffers[threadID] = buffer
-	}
-	return buffer
-}
-
-func (a *CodexAgent) adoptUnresolvedChildGeneration(threadID, childID string) {
-	a.mu.Lock()
-	buffer := a.unresolvedChildBuffers[threadID]
-	delete(a.unresolvedChildBuffers, threadID)
+	state.pendingGenerationBytes += len(text)
+	buffer := &state.generationBuffer
 	a.mu.Unlock()
-	if buffer != nil {
-		buffer.MoveAllTo(a.childGenerationBuffer(childID))
-	}
+	buffer.Append(scopeID, kind, text, join)
 }
 
-func (a *CodexAgent) childGenerationBuffer(childID string) *GenerationBuffer {
+func (a *CodexAgent) clearPendingCodexChildGenerationBytes(threadID string) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.childGenerationBuffers == nil {
-		a.childGenerationBuffers = make(map[string]*GenerationBuffer)
+	if state := a.collabChildren[threadID]; state != nil {
+		state.pendingGenerationBytes = 0
 	}
-	buffer := a.childGenerationBuffers[childID]
-	if buffer == nil {
-		buffer = &GenerationBuffer{}
-		a.childGenerationBuffers[childID] = buffer
-	}
-	return buffer
+	a.mu.Unlock()
 }
 
-// childSinkForItem resolves the child ProviderServices that owns an item
-// (commandExecution/fileChange), or nil when the item belongs to the parent.
-// Output-delta notifications carry only an itemID (no threadId), so this map --
-// populated by persistItemStartedChild -- is how those observations reach the child.
-func (a *CodexAgent) childSinkForItem(itemID string) ProviderServices {
+// childSinkForItem resolves the child services that own a tool item. Output
+// deltas carry only an item ID, so collabChildItems restores the thread route.
+func (a *CodexAgent) childSinkForItem(itemID string) (ProviderServices, bool) {
 	if itemID == "" {
-		return nil
+		return nil, false
 	}
 	a.mu.Lock()
-	childID := a.collabChildItems[itemID]
+	threadID := a.collabChildItems[itemID]
 	a.mu.Unlock()
-	if childID == "" {
-		return nil
+	if threadID == "" {
+		return nil, false
 	}
-	childSink, _ := a.codexChildSinkForAgent(childID)
-	return childSink
+	route, routed := a.ensureCodexChildRoute(threadID)
+	if !routed {
+		return nil, true
+	}
+	a.replayPendingCodexChildEvents(threadID, route)
+	return route.childSink, true
 }
 
 // Codex reasoning sub-stream kinds. A single reasoning item can surface as a
@@ -335,7 +325,7 @@ type codexToolOutputEvent struct {
 type codexIncompleteTool struct {
 	params          json.RawMessage
 	itemType        string
-	childID         string
+	childThreadID   string
 	outputEvents    []codexToolOutputEvent
 	outputBytes     int
 	outputTruncated bool
@@ -345,7 +335,7 @@ type codexIncompleteTool struct {
 type codexIncompleteToolSnapshot struct {
 	params          json.RawMessage
 	itemType        string
-	childID         string
+	childThreadID   string
 	output          string
 	outputTruncated bool
 	order           uint64
@@ -517,190 +507,216 @@ func (a *CodexAgent) handleCodexToolOutputDelta(params json.RawMessage) {
 	}
 	if json.Unmarshal(params, &notif) == nil && notif.ItemID != "" && notif.Delta != "" {
 		a.appendCodexToolOutput(notif.ItemID, notif.Delta)
-		sink := a.sink
-		if child := a.childSinkForItem(notif.ItemID); child != nil {
-			sink = child
+		if childSink, childOwned := a.childSinkForItem(notif.ItemID); childOwned {
+			if childSink != nil {
+				childSink.ReportProgress(OutputDeltaProgress(notif.ItemID, int64(len([]byte(notif.Delta)))))
+			}
+			return
 		}
-		sink.ReportProgress(OutputDeltaProgress(notif.ItemID, int64(len([]byte(notif.Delta)))))
+		a.sink.ReportProgress(OutputDeltaProgress(notif.ItemID, int64(len([]byte(notif.Delta)))))
 	}
+}
+
+type codexItemEvent struct {
+	raw      json.RawMessage
+	params   json.RawMessage
+	item     json.RawMessage
+	itemType string
+	itemID   string
+	threadID string
+}
+
+func newCodexItemEvent(raw []byte, params json.RawMessage) (codexItemEvent, bool) {
+	item, itemType, itemID, threadID := extractCodexItem(params)
+	if item == nil {
+		return codexItemEvent{}, false
+	}
+	return codexItemEvent{
+		raw:      raw,
+		params:   params,
+		item:     item,
+		itemType: itemType,
+		itemID:   itemID,
+		threadID: threadID,
+	}, true
 }
 
 // handleItemStarted processes item/started notifications.
 func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
-	item, itemType, itemID, threadID := extractCodexItem(params)
-	if item == nil {
+	event, ok := newCodexItemEvent(raw, params)
+	if !ok {
 		return
 	}
 	// subAgentActivity (v2) is registry-only: never persist. Consume it here
 	// before any transcript handling.
-	if itemType == "subAgentActivity" {
-		a.handleCodexSubAgentActivity(item, threadID)
+	if event.itemType == "subAgentActivity" {
+		a.handleCodexSubAgentActivity(event.item, event.threadID)
 		return
 	}
 
-	childID := a.routeChildItemIfApplicable(threadID)
-	if codexItemIsTool(itemType) {
-		a.rememberCodexIncompleteTool(itemID, itemType, childID, params)
-	}
-
-	// Route child-thread items to the child transcript. A non-empty threadID
-	// that is NOT the main thread identifies a collab child; resolve its child
-	// agent id (EnsureChildAgent, idempotent) and run the same per-type persist/
-	// span logic against the child sink.
-	if childID != "" {
-		a.persistItemStartedChild(threadID, childID, params, itemType, itemID)
-		return
-	}
-
-	switch itemType {
-	case "agentMessage":
-		// No-op for started — wait for completed to persist.
-	case "contextCompaction":
-		a.mu.Lock()
-		if a.compactionStartAck != nil {
-			close(a.compactionStartAck)
-			a.compactionStartAck = nil
+	if !a.isMainThreadID(event.threadID) {
+		if codexItemIsTool(event.itemType) {
+			a.rememberCodexIncompleteTool(event.itemID, event.itemType, event.threadID, event.params)
+			a.rememberCodexChildItemThread(event.itemID, event.threadID)
 		}
-		a.mu.Unlock()
-		// Persist the raw `item/started` JSON-RPC notification verbatim as
-		// AGENT. Preserves both `method:"item/started"` (so the
-		// notification consolidator and frontend classifier route by
-		// method) and Codex-specific fields under `params.item.*` that a
-		// synthesized `{type:"compacting"}` would discard.
-		if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
-			slog.Error("codex persist compacting notification", "agent_id", a.agentID, "error", err)
+		route, routed := a.ensureCodexChildRoute(event.threadID)
+		if !routed {
+			a.enqueuePendingCodexChildEvent(event.threadID, codexPendingChildEvent{
+				kind:   codexPendingItemStarted,
+				raw:    append(json.RawMessage(nil), event.raw...),
+				params: append(json.RawMessage(nil), event.params...),
+			})
+			return
+		}
+		a.replayPendingCodexChildEvents(event.threadID, route)
+		a.handleCodexItemStartedForSink(route.childSink, route.agentID, false, event)
+		return
+	}
+	a.handleCodexItemStartedForSink(a.sink, a.agentID, true, event)
+}
+
+func (a *CodexAgent) handleCodexItemStartedForSink(
+	sink ProviderServices,
+	agentID string,
+	mainThread bool,
+	event codexItemEvent,
+) {
+	if codexItemIsTool(event.itemType) {
+		ownerThreadID := event.threadID
+		if mainThread {
+			ownerThreadID = ""
+		}
+		a.rememberCodexIncompleteTool(event.itemID, event.itemType, ownerThreadID, event.params)
+	}
+	switch event.itemType {
+	case "agentMessage":
+		// Wait for the authoritative completed item.
+	case "contextCompaction":
+		if mainThread {
+			a.mu.Lock()
+			if a.compactionStartAck != nil {
+				close(a.compactionStartAck)
+				a.compactionStartAck = nil
+			}
+			a.mu.Unlock()
+		}
+		if _, err := sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, event.raw); err != nil {
+			slog.Error("codex persist compacting notification", "agent_id", agentID, "error", err)
 		}
 	case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall", "imageGeneration", "imageView", "reasoning":
-		persistSharedItemStarted(a.sink, params, itemType, itemID, a.agentID)
+		persistSharedItemStarted(sink, event.params, event.itemType, event.itemID, agentID)
 	case "collabAgentToolCall":
-		// Every collab tool_call stays in the parent transcript as a flat tool
-		// span (children no longer nest under it) -- EXCEPT spawnAgent, which
-		// owns no span at all. A spawn's output lives in the child transcript,
-		// so a rail held open for the whole subagent run only pushes every
-		// concurrent tool one column right. The other collab tools (wait,
-		// sendInput, resumeAgent, closeAgent) keep their span. Register receiver
-		// threads as child routes so later child-thread items reach their
-		// transcripts.
-		collab := parseCollabToolCall(item)
+		collab := parseCollabToolCall(event.item)
 		spawns := collab != nil && collab.Tool == codexCollabToolSpawnAgent
-		if err := openToolSpan(a.sink, params, itemID, itemType, spawns); err != nil {
-			slog.Error("codex persist collabAgentToolCall/started", "agent_id", a.agentID, "error", err)
+		if err := openToolSpan(sink, event.params, event.itemID, event.itemType, spawns); err != nil {
+			slog.Error("codex persist collabAgentToolCall/started", "agent_id", agentID, "error", err)
 		}
-		if collab != nil {
-			for _, receiverID := range collab.ReceiverThreadIds {
-				if collab.Tool == codexCollabToolSpawnAgent && collab.Prompt != "" {
-					a.recordCollabChildPromptTitle(receiverID, collab.Prompt)
-				}
-				a.registerCollabReceiver(receiverID, itemID, threadID)
-				a.collabChildPrompts.remember(receiverID, collab.Prompt)
-			}
-		}
+		a.registerCollabReceivers(collab, event.itemID, event.threadID)
 	}
 }
 
 // handleItemCompleted processes item/completed notifications.
 func (a *CodexAgent) handleItemCompleted(raw []byte, params json.RawMessage) {
-	item, itemType, itemID, threadID := extractCodexItem(params)
-	if item == nil {
+	event, ok := newCodexItemEvent(raw, params)
+	if !ok {
 		return
 	}
-	a.mu.Lock()
-	delete(a.incompleteTools, itemID)
-	a.mu.Unlock()
-	if a.isMainThreadID(threadID) {
-		discardCompletedCodexGeneration(&a.generationBuffer, itemType, itemID)
-	}
-
 	// subAgentActivity (v2) is registry-only: never persist. Consume it here
 	// before any transcript handling.
-	if itemType == "subAgentActivity" {
-		a.handleCodexSubAgentActivity(item, threadID)
+	if event.itemType == "subAgentActivity" {
+		a.handleCodexSubAgentActivity(event.item, event.threadID)
 		return
 	}
 
-	// Route child-thread items to the child transcript (mirrors
-	// handleItemStarted).
-	if childID := a.routeChildItemIfApplicable(threadID); childID != "" {
-		a.persistItemCompletedChild(threadID, childID, params, itemType, itemID)
+	if !a.isMainThreadID(event.threadID) {
+		route, routed := a.ensureCodexChildRoute(event.threadID)
+		if !routed {
+			a.enqueuePendingCodexChildEvent(event.threadID, codexPendingChildEvent{
+				kind:   codexPendingItemCompleted,
+				raw:    append(json.RawMessage(nil), event.raw...),
+				params: append(json.RawMessage(nil), event.params...),
+			})
+			return
+		}
+		a.replayPendingCodexChildEvents(event.threadID, route)
+		a.handleCodexItemCompletedForSink(route.childSink, route.agentID, false, event)
 		return
 	}
+	a.handleCodexItemCompletedForSink(a.sink, a.agentID, true, event)
+}
 
-	switch itemType {
+func (a *CodexAgent) handleCodexItemCompletedForSink(
+	sink ProviderServices,
+	agentID string,
+	mainThread bool,
+	event codexItemEvent,
+) {
+	a.mu.Lock()
+	delete(a.incompleteTools, event.itemID)
+	delete(a.collabChildItems, event.itemID)
+	a.mu.Unlock()
+	if mainThread {
+		discardCompletedCodexGeneration(&a.generationBuffer, event.itemType, event.itemID)
+	} else {
+		discardCompletedCodexGeneration(a.codexChildGenerationBuffer(event.threadID), event.itemType, event.itemID)
+	}
+
+	switch event.itemType {
 	case "agentMessage":
-		persistSharedItemCompleted(a.sink, params, itemType, itemID, a.agentID)
+		persistSharedItemCompleted(sink, event.params, event.itemType, event.itemID, agentID)
 	case "plan":
+		if !mainThread {
+			persistSharedItemCompleted(sink, event.params, event.itemType, event.itemID, agentID)
+			return
+		}
 		a.mu.Lock()
 		a.turnSawPlan = true
 		a.mu.Unlock()
-		a.sink.ReportProgress(CompleteModelProgress(itemID))
+		sink.ReportProgress(CompleteModelProgress(event.itemID))
 
 		var planItem struct {
 			Text string `json:"text"`
 		}
-		if json.Unmarshal(item, &planItem) == nil && planItem.Text != "" {
+		if json.Unmarshal(event.item, &planItem) == nil && planItem.Text != "" {
 			a.mu.Lock()
 			a.turnPlanText = planItem.Text
 			a.mu.Unlock()
 		}
-		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
-			SpanID: itemID, SpanType: itemType,
+		if err := sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, event.params, SpanInfo{
+			SpanID: event.itemID, SpanType: event.itemType,
 		}); err != nil {
-			slog.Error("codex persist plan", "agent_id", a.agentID, "error", err)
+			slog.Error("codex persist plan", "agent_id", agentID, "error", err)
 		}
 	case "commandExecution", "fileChange", "mcpToolCall", "dynamicToolCall", "imageGeneration", "imageView":
-		a.mu.Lock()
-		a.turnToolUses++
-		a.mu.Unlock()
-		persistSharedItemCompleted(a.sink, params, itemType, itemID, a.agentID)
-	case "collabAgentToolCall":
-		// wait, sendInput, resumeAgent and closeAgent are flat tool spans in the
-		// parent transcript that CLOSE at completion. Children no longer nest
-		// under the spawn span -- they route to their own transcripts -- so
-		// leaving any of these open leaks a span until the next turn's bulk
-		// ResetSpans. spawnAgent never opened one (item/started skips it), and
-		// the close below is a harmless no-op for it.
-		collab := parseCollabToolCall(item)
-		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
-			SpanID: itemID, SpanType: itemType, Closing: true,
-		}); err != nil {
-			slog.Error("codex persist collabAgentToolCall/completed", "agent_id", a.agentID, "error", err)
+		if mainThread {
+			a.mu.Lock()
+			a.turnToolUses++
+			a.mu.Unlock()
 		}
-		a.sink.CloseSpan(itemID)
-		// Register receiver threads on completion (late-binding, like the old
-		// code) and drive the registry from agentsStates.
+		persistSharedItemCompleted(sink, event.params, event.itemType, event.itemID, agentID)
+	case "collabAgentToolCall":
+		collab := parseCollabToolCall(event.item)
+		if err := sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, event.params, SpanInfo{
+			SpanID: event.itemID, SpanType: event.itemType, Closing: true,
+		}); err != nil {
+			slog.Error("codex persist collabAgentToolCall/completed", "agent_id", agentID, "error", err)
+		}
+		sink.CloseSpan(event.itemID)
 		if collab != nil {
-			for _, receiverID := range collab.ReceiverThreadIds {
-				a.registerCollabReceiver(receiverID, itemID, threadID)
-				a.collabChildPrompts.remember(receiverID, collab.Prompt)
-			}
-			if collab.Tool == codexCollabToolSpawnAgent {
-				if sp := collab.Prompt; sp != "" {
-					for _, rid := range collab.ReceiverThreadIds {
-						a.recordCollabChildPromptTitle(rid, sp)
-					}
-				}
-			}
+			a.registerCollabReceivers(collab, event.itemID, event.threadID)
 			a.collabAgentsStatesToRegistry(collab)
 		}
 	case "reasoning":
-		a.persistCompletedReasoningItem(a.sink, params, itemID, a.agentID)
+		a.persistCompletedReasoningItem(sink, event.params, event.itemID, agentID)
 	case "contextCompaction":
-		// Persist the raw `item/completed` JSON-RPC notification verbatim as
-		// AGENT, the same way the `item/started` case above does. It must join
-		// the notification thread that the start opened, because the
-		// consolidator drops the "Compacting context..." status only when the
-		// compaction boundary lands in that same thread. PersistMessage clears
-		// the thread instead, which leaves the status in place for the rest of
-		// the session. codexProvider.Classify gives this notification the
-		// compaction-boundary kind.
-		if _, err := a.sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw); err != nil {
-			slog.Error("codex persist contextCompaction/completed", "agent_id", a.agentID, "error", err)
+		if _, err := sink.PersistNotification(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, event.raw); err != nil {
+			slog.Error("codex persist contextCompaction/completed", "agent_id", agentID, "error", err)
 		}
 	default:
-		if err := a.sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, params, SpanInfo{
-			SpanID: itemID, SpanType: itemType,
+		if err := sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, event.params, SpanInfo{
+			SpanID: event.itemID, SpanType: event.itemType,
 		}); err != nil {
-			slog.Error("codex persist unknown item", "agent_id", a.agentID, "type", itemType, "error", err)
+			slog.Error("codex persist unknown item", "agent_id", agentID, "type", event.itemType, "error", err)
 		}
 	}
 }
@@ -711,29 +727,16 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 		ThreadID string `json:"threadId"`
 	}
 	if json.Unmarshal(params, &notif) == nil && !a.isMainThreadID(notif.ThreadID) {
-		// Child turn ended: persist a turn-end divider into the child
-		// transcript (mirrors the main-thread PersistTurnEnd below), then clear
-		// its active turn id (steering no longer possible until a new child
-		// turn starts). Falls through silently when the thread is unknown to
-		// the child routes (for example, a late receiver with no spawn event).
-		if route, ok := a.resolveCodexChild(notif.ThreadID); ok {
-			completion := codexTurnCompletion(params)
-			a.flushCodexChildGeneration(route.agentID, completion)
-			a.persistIncompleteCodexTools(route.agentID, false, completion)
-			if err := route.childSink.PersistTurnEnd(params, SpanInfo{}); err != nil {
-				slog.Warn("codex persist child turn/completed", "agent_id", a.agentID, "thread", notif.ThreadID, "error", err)
-			}
-			a.clearChildTurnID(notif.ThreadID)
-			publishSteerableTurnActiveTo(route.childSink, false, a.childTurnSeq())
-			if status, finished, activity := codexChildTurnRegistryStatus(params); finished {
-				a.completeCodexChildRun(notif.ThreadID, status, completion)
-			} else if activity != "" {
-				logRegistryRefusal("codex", "update status",
-					a.sink.UpdateBackgroundTaskStatus(notif.ThreadID, bgtask.StatusRunning, activity))
-			}
+		route, routed := a.ensureCodexChildRoute(notif.ThreadID)
+		if !routed {
+			a.enqueuePendingCodexChildEvent(notif.ThreadID, codexPendingChildEvent{
+				kind:   codexPendingTurnCompleted,
+				params: append(json.RawMessage(nil), params...),
+			})
 			return
 		}
-		a.clearChildTurnID(notif.ThreadID)
+		a.replayPendingCodexChildEvents(notif.ThreadID, route)
+		a.handleChildTurnCompleted(notif.ThreadID, params, route)
 		return
 	}
 
@@ -837,29 +840,52 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 	}
 }
 
+func (a *CodexAgent) handleChildTurnCompleted(threadID string, params json.RawMessage, route codexChildRoute) {
+	completion := codexTurnCompletion(params)
+	a.flushCodexChildGeneration(threadID, completion)
+	a.persistIncompleteCodexTools(threadID, false, completion)
+	if err := route.childSink.PersistTurnEnd(params, SpanInfo{}); err != nil {
+		slog.Warn("codex persist child turn/completed", "agent_id", a.agentID, "thread", threadID, "error", err)
+	}
+	hadTurn := a.childTurnID(threadID) != ""
+	a.clearChildTurnID(threadID)
+	if hadTurn {
+		a.publishCodexChildTurnActive(route.childSink, false)
+	}
+	transition := codexChildTurnTransition(params)
+	if transition.finished() {
+		a.completeCodexChildRun(threadID, transition)
+	} else if transition.activity != "" {
+		logRegistryRefusal("codex", "update status",
+			a.sink.UpdateBackgroundTaskStatus(threadID, bgtask.StatusRunning, transition.activity))
+	}
+}
+
 func (a *CodexAgent) flushCodexGeneration(completion MessageCompletion) {
 	a.persistCodexGeneration(&a.generationBuffer, a.sink, completion)
 }
 
-func (a *CodexAgent) flushCodexChildGeneration(childID string, completion MessageCompletion) {
-	childSink, ok := a.codexChildSinkForAgent(childID)
+func (a *CodexAgent) flushCodexChildGeneration(threadID string, completion MessageCompletion) {
+	route, ok := a.lookupCodexChildRoute(threadID)
 	if !ok {
 		return
 	}
-	a.persistCodexGeneration(a.childGenerationBuffer(childID), childSink, completion)
+	a.persistCodexGeneration(a.codexChildGenerationBuffer(threadID), route.childSink, completion)
 }
 
 func (a *CodexAgent) flushAllCodexGeneration(completion MessageCompletion) {
 	a.flushCodexGeneration(completion)
 	a.mu.Lock()
-	childIDs := make([]string, 0, len(a.childGenerationBuffers))
-	for childID := range a.childGenerationBuffers {
-		childIDs = append(childIDs, childID)
+	threadIDs := make([]string, 0, len(a.collabChildren))
+	for threadID, state := range a.collabChildren {
+		if state != nil && state.childAgentID != "" {
+			threadIDs = append(threadIDs, threadID)
+		}
 	}
 	a.mu.Unlock()
-	sort.Strings(childIDs)
-	for _, childID := range childIDs {
-		a.flushCodexChildGeneration(childID, completion)
+	sort.Strings(threadIDs)
+	for _, threadID := range threadIDs {
+		a.flushCodexChildGeneration(threadID, completion)
 	}
 }
 
@@ -895,7 +921,7 @@ func codexTurnCompletion(params json.RawMessage) MessageCompletion {
 	}
 }
 
-func (a *CodexAgent) rememberCodexIncompleteTool(itemID, itemType, childID string, params json.RawMessage) {
+func (a *CodexAgent) rememberCodexIncompleteTool(itemID, itemType, childThreadID string, params json.RawMessage) {
 	if itemID == "" {
 		return
 	}
@@ -903,11 +929,15 @@ func (a *CodexAgent) rememberCodexIncompleteTool(itemID, itemType, childID strin
 	if a.incompleteTools == nil {
 		a.incompleteTools = make(map[string]*codexIncompleteTool)
 	}
+	if a.incompleteTools[itemID] != nil {
+		a.mu.Unlock()
+		return
+	}
 	a.incompleteTools[itemID] = &codexIncompleteTool{
-		params:   append(json.RawMessage(nil), params...),
-		itemType: itemType,
-		childID:  childID,
-		order:    a.incompleteToolOrder,
+		params:        append(json.RawMessage(nil), params...),
+		itemType:      itemType,
+		childThreadID: childThreadID,
+		order:         a.incompleteToolOrder,
 	}
 	a.incompleteToolOrder++
 	a.mu.Unlock()
@@ -940,19 +970,19 @@ func (a *CodexAgent) appendCodexToolEventLocked(itemID, text string, stdin bool)
 	tool.outputBytes += len(text)
 }
 
-func (a *CodexAgent) persistIncompleteCodexTools(childID string, all bool, completion MessageCompletion) int {
+func (a *CodexAgent) persistIncompleteCodexTools(childThreadID string, all bool, completion MessageCompletion) int {
 	a.mu.Lock()
 	itemIDs := make([]string, 0, len(a.incompleteTools))
 	tools := make(map[string]codexIncompleteToolSnapshot)
 	for itemID, tool := range a.incompleteTools {
-		if tool == nil || (!all && tool.childID != childID) {
+		if tool == nil || (!all && tool.childThreadID != childThreadID) {
 			continue
 		}
 		itemIDs = append(itemIDs, itemID)
 		tools[itemID] = codexIncompleteToolSnapshot{
 			params:          append(json.RawMessage(nil), tool.params...),
 			itemType:        tool.itemType,
-			childID:         tool.childID,
+			childThreadID:   tool.childThreadID,
 			output:          renderCodexToolOutput(tool.outputEvents, tool.outputTruncated),
 			outputTruncated: tool.outputTruncated,
 			order:           tool.order,
@@ -983,13 +1013,13 @@ func (a *CodexAgent) persistIncompleteCodexTools(childID string, all bool, compl
 			continue
 		}
 		sink := a.sink
-		if tool.childID != "" {
-			childSink, ok := a.codexChildSinkForAgent(tool.childID)
+		if tool.childThreadID != "" {
+			route, ok := a.ensureCodexChildRoute(tool.childThreadID)
 			if !ok {
-				slog.Warn("persist incomplete codex child tool: route missing", "agent_id", a.agentID, "child", tool.childID)
+				slog.Warn("persist incomplete codex child tool: route missing", "agent_id", a.agentID, "thread", tool.childThreadID)
 				continue
 			}
-			sink = childSink
+			sink = route.childSink
 		}
 		if err := sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw, SpanInfo{
 			SpanID: itemID, SpanType: tool.itemType, Closing: true,
@@ -1105,6 +1135,23 @@ func (a *CodexAgent) isMainThreadID(threadID string) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return threadID == a.threadID
+}
+
+func (a *CodexAgent) isRetiredCodexOutput(params json.RawMessage) bool {
+	var value struct {
+		ThreadID string `json:"threadId"`
+	}
+	return json.Unmarshal(params, &value) == nil && a.isRetiredCodexThread(value.ThreadID)
+}
+
+func (a *CodexAgent) isRetiredCodexThread(threadID string) bool {
+	if threadID == "" {
+		return false
+	}
+	a.mu.Lock()
+	_, retired := a.retiredCodexThreads[threadID]
+	a.mu.Unlock()
+	return retired
 }
 
 // handleApprovalRequest processes server requests (approval requests from Codex).
@@ -1396,20 +1443,16 @@ func parseCollabToolCall(item json.RawMessage) *codexCollabAgentToolCall {
 	return &collab
 }
 
-// registerCollabReceiver records or reactivates one child route. The first
-// spawn ID and direct parent remain authoritative. A later wait, message, or
-// completion activity can identify the same child but must not change either.
+// registerCollabReceiver records one legacy spawn route. Multi-Agent V2 later
+// replaces these identity fields from its authoritative started activity.
 func (a *CodexAgent) registerCollabReceiver(threadID, spawnCorrelationID, parentThreadID string) bool {
 	if threadID == "" {
 		return false
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.collabChildren == nil {
-		a.collabChildren = make(map[string]codexChildState)
-	}
-	state := a.collabChildren[threadID]
-	changed := !state.active
+	state := a.codexChildStateLocked(threadID)
+	changed := state.phase != codexChildRunning
 	if state.spawnCorrelationID == "" && spawnCorrelationID != "" {
 		state.spawnCorrelationID = spawnCorrelationID
 		changed = true
@@ -1421,46 +1464,98 @@ func (a *CodexAgent) registerCollabReceiver(threadID, spawnCorrelationID, parent
 		state.parentThreadID = parentThreadID
 		changed = true
 	}
-	state.active = true
-	a.collabChildren[threadID] = state
+	if state.phase != codexChildClosing {
+		a.activateCodexChildStateLocked(state)
+	}
 	return changed
 }
 
-// routeChildItemIfApplicable returns the child agent id when the threadID is a
-// non-main collab child known to the index. EnsureChildAgent runs against the
-// direct parent's sink, which preserves nested subagent linkage.
-func (a *CodexAgent) routeChildItemIfApplicable(threadID string) string {
-	route, ok := a.resolveCodexChild(threadID)
-	if !ok {
-		return ""
+func (a *CodexAgent) registerCollabReceivers(
+	collab *codexCollabAgentToolCall,
+	spawnCorrelationID, parentThreadID string,
+) {
+	if collab == nil {
+		return
 	}
-	return route.agentID
+	for _, receiverID := range collab.ReceiverThreadIds {
+		if collab.Tool == codexCollabToolSpawnAgent {
+			a.recordCollabChildPromptTitle(receiverID, collab.Prompt)
+			a.rememberCollabChildPrompt(receiverID, collab.Prompt)
+			a.registerCollabReceiver(receiverID, spawnCorrelationID, parentThreadID)
+			continue
+		}
+		// A wait, message, resume, or close call proves activity only. Its call
+		// ID and sender do not identify the receiver's spawn or direct parent.
+		a.activateCollabChild(receiverID)
+	}
 }
 
-func (a *CodexAgent) resolveCodexChild(threadID string) (codexChildRoute, bool) {
+// lookupCodexChildRoute reads an existing route without creating transcript
+// state. Call ensureCodexChildRoute when the current lifecycle event permits
+// child creation.
+func (a *CodexAgent) lookupCodexChildRoute(threadID string) (codexChildRoute, bool) {
 	if threadID == "" || a.isMainThreadID(threadID) {
 		return codexChildRoute{}, false
 	}
 	a.mu.Lock()
 	state, ok := a.collabChildren[threadID]
-	a.mu.Unlock()
-	if !ok || state.spawnCorrelationID == "" && state.childAgentID == "" {
+	if !ok || state == nil || state.childAgentID == "" {
+		a.mu.Unlock()
 		return codexChildRoute{}, false
 	}
-	parentSink, parentAgentID, ok := a.codexServicesForThread(state.parentThreadID)
+	childAgentID := state.childAgentID
+	parentThreadID := state.parentThreadID
+	a.mu.Unlock()
+	parentSink, parentAgentID, ok := a.codexServicesForThread(parentThreadID)
 	if !ok {
 		return codexChildRoute{}, false
 	}
-	childID := state.childAgentID
-	if childID == "" {
-		var err error
-		childID, err = parentSink.EnsureChildAgent(state.spawnCorrelationID, threadID, state.displayTitle())
-		if err != nil {
-			slog.Warn("codex route child ensure failed", "thread", threadID, "error", err)
-			return codexChildRoute{}, false
-		}
-		a.rememberChildAgent(threadID, childID)
+	return codexChildRoute{
+		agentID:       childAgentID,
+		parentAgentID: parentAgentID,
+		parentSink:    parentSink,
+		childSink:     parentSink.ChildSink(childAgentID),
+	}, true
+}
+
+func (a *CodexAgent) ensureCodexChildRoute(threadID string) (codexChildRoute, bool) {
+	if route, ok := a.lookupCodexChildRoute(threadID); ok {
+		return route, true
 	}
+	if threadID == "" || a.isMainThreadID(threadID) {
+		return codexChildRoute{}, false
+	}
+	a.mu.Lock()
+	state := a.collabChildren[threadID]
+	if state == nil || state.spawnCorrelationID == "" {
+		a.mu.Unlock()
+		return codexChildRoute{}, false
+	}
+	spawnCorrelationID := state.spawnCorrelationID
+	parentThreadID := state.parentThreadID
+	title := state.displayTitle()
+	rootThreadID := a.threadID
+	a.mu.Unlock()
+	parentSink, parentAgentID, ok := a.codexServicesForThread(parentThreadID)
+	if !ok {
+		return codexChildRoute{}, false
+	}
+	childID, err := parentSink.EnsureChildAgent(spawnCorrelationID, threadID, title)
+	if err != nil {
+		slog.Warn("codex route child ensure failed", "thread", threadID, "error", err)
+		return codexChildRoute{}, false
+	}
+	a.mu.Lock()
+	if a.threadID != rootThreadID || a.collabChildren[threadID] != state {
+		a.mu.Unlock()
+		return codexChildRoute{}, false
+	}
+	if state.childAgentID == "" {
+		state.childAgentID = childID
+	} else {
+		childID = state.childAgentID
+	}
+	a.mu.Unlock()
 	return codexChildRoute{
 		agentID:       childID,
 		parentAgentID: parentAgentID,
@@ -1491,7 +1586,7 @@ func (a *CodexAgent) codexServicesForThread(threadID string) (ProviderServices, 
 		}
 		seen[threadID] = struct{}{}
 		state, ok := a.collabChildren[threadID]
-		if !ok || state.childAgentID == "" {
+		if !ok || state == nil || state.childAgentID == "" {
 			a.mu.Unlock()
 			return nil, "", false
 		}
@@ -1510,77 +1605,85 @@ func (a *CodexAgent) codexServicesForThread(threadID string) (ProviderServices, 
 	return sink, agentIDs[0], true
 }
 
-func (a *CodexAgent) codexChildSinkForAgent(childID string) (ProviderServices, bool) {
-	if childID == "" {
-		return nil, false
-	}
-	a.mu.Lock()
-	threadID := a.collabThreadsByAgent[childID]
-	a.mu.Unlock()
-	route, ok := a.resolveCodexChild(threadID)
-	if !ok || route.agentID != childID {
-		return nil, false
-	}
-	return route.childSink, true
-}
-
-// rememberChildAgent records both directions of the child route.
-func (a *CodexAgent) rememberChildAgent(threadID, childID string) {
-	if threadID == "" || childID == "" {
+func (a *CodexAgent) rememberCodexChildItemThread(itemID, threadID string) {
+	if itemID == "" || threadID == "" {
 		return
 	}
 	a.mu.Lock()
-	if a.collabChildren == nil {
-		a.collabChildren = make(map[string]codexChildState)
+	if a.collabChildItems == nil {
+		a.collabChildItems = make(map[string]string)
 	}
-	state := a.collabChildren[threadID]
-	state.childAgentID = childID
-	a.collabChildren[threadID] = state
-	if a.collabThreadsByAgent == nil {
-		a.collabThreadsByAgent = make(map[string]string)
-	}
-	a.collabThreadsByAgent[childID] = threadID
+	a.collabChildItems[itemID] = threadID
 	a.mu.Unlock()
-	a.adoptUnresolvedChildGeneration(threadID, childID)
 }
 
-// persistItemStartedChild applies item/started to the child transcript.
-func (a *CodexAgent) persistItemStartedChild(threadID, childID string, params json.RawMessage, itemType, itemID string) {
-	// Record the itemID -> childID mapping so output-delta handlers (which
-	// carry only an itemID) can route streaming chunks to the child.
-	if itemID != "" {
-		a.mu.Lock()
-		if a.collabChildItems == nil {
-			a.collabChildItems = make(map[string]string)
+func (a *CodexAgent) enqueuePendingCodexChildEvent(threadID string, event codexPendingChildEvent) {
+	if threadID == "" {
+		return
+	}
+	size := len(event.raw) + len(event.params)
+	a.mu.Lock()
+	state := a.codexChildStateLocked(threadID)
+	if len(state.pendingEvents) >= codexPendingChildEventLimit ||
+		state.pendingEventBytes+size > codexPendingChildEventBytesLimit {
+		firstDrop := !state.pendingOutputDropped
+		state.pendingOutputDropped = true
+		a.mu.Unlock()
+		if firstDrop {
+			slog.Warn("codex pending child event limit reached", "thread", threadID)
 		}
-		a.collabChildItems[itemID] = childID
-		a.mu.Unlock()
+		return
 	}
-	if route, ok := a.resolveCodexChild(threadID); ok {
-		persistSharedItemStarted(route.childSink, params, itemType, itemID, childID)
-	}
+	state.pendingEvents = append(state.pendingEvents, event)
+	state.pendingEventBytes += size
+	a.mu.Unlock()
 }
 
-// persistItemCompletedChild applies item/completed to the child transcript.
-func (a *CodexAgent) persistItemCompletedChild(threadID, childID string, params json.RawMessage, itemType, itemID string) {
-	// The item is done streaming; drop it from the itemID -> child index so the
-	// map doesn't grow unbounded across turns.
-	if itemID != "" {
-		a.mu.Lock()
-		delete(a.collabChildItems, itemID)
+func (a *CodexAgent) replayPendingCodexChildEvents(threadID string, route codexChildRoute) {
+	a.mu.Lock()
+	state := a.collabChildren[threadID]
+	if state == nil || len(state.pendingEvents) == 0 && !state.pendingOutputDropped {
 		a.mu.Unlock()
-	}
-	route, ok := a.resolveCodexChild(threadID)
-	if !ok {
 		return
 	}
-	childSink := route.childSink
-	discardCompletedCodexGeneration(a.childGenerationBuffer(childID), itemType, itemID)
-	if itemType == "reasoning" {
-		a.persistCompletedReasoningItem(childSink, params, itemID, childID)
-		return
+	events := state.pendingEvents
+	dropped := state.pendingOutputDropped
+	state.pendingEvents = nil
+	state.pendingEventBytes = 0
+	state.pendingOutputDropped = false
+	a.mu.Unlock()
+
+	if dropped {
+		route.childSink.PersistLeapMuxNotification(map[string]interface{}{
+			"type":  contracts.NotificationTypeAgentError,
+			"error": "Some Codex subagent events exceeded the pending-route limit.",
+		})
 	}
-	persistSharedItemCompleted(childSink, params, itemType, itemID, childID)
+	for _, event := range events {
+		switch event.kind {
+		case codexPendingItemStarted, codexPendingItemCompleted:
+			itemEvent, ok := newCodexItemEvent(event.raw, event.params)
+			if !ok {
+				continue
+			}
+			if event.kind == codexPendingItemStarted {
+				a.handleCodexItemStartedForSink(route.childSink, route.agentID, false, itemEvent)
+			} else {
+				a.handleCodexItemCompletedForSink(route.childSink, route.agentID, false, itemEvent)
+			}
+		case codexPendingTurnStarted:
+			var value struct {
+				Turn struct {
+					ID string `json:"id"`
+				} `json:"turn"`
+			}
+			if json.Unmarshal(event.params, &value) == nil && value.Turn.ID != "" {
+				a.handleChildTurnStarted(threadID, value.Turn.ID, route)
+			}
+		case codexPendingTurnCompleted:
+			a.handleChildTurnCompleted(threadID, event.params, route)
+		}
+	}
 }
 
 func discardCompletedCodexGeneration(buffer *GenerationBuffer, itemType, itemID string) {
@@ -1654,9 +1757,7 @@ func (a *CodexAgent) persistCompletedReasoningItem(sink generationServices, para
 	}
 }
 
-// extractCodexItem extracts the item type, ID, and threadId from item/started
-// or item/completed params. The threadId is returned alongside the item to
-// avoid a redundant unmarshal in codexParentSpanID.
+// extractCodexItem extracts the item and routing fields from one item event.
 func extractCodexItem(params json.RawMessage) (item json.RawMessage, itemType, itemID, threadID string) {
 	var wrapper struct {
 		Item     json.RawMessage `json:"item"`

--- a/backend/internal/worker/agent/codex_output.go
+++ b/backend/internal/worker/agent/codex_output.go
@@ -141,17 +141,19 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 		if !a.isMainThreadID(notif.ThreadID) {
 			// Record the child's active turn id (for steering) and upsert a
 			// running registry row so the child tab reflects activity.
+			a.activateCollabChild(notif.ThreadID)
 			a.setChildTurnID(notif.ThreadID, notif.Turn.ID)
 			childID := a.routeChildItemIfApplicable(notif.ThreadID)
 			if childID != "" {
 				a.flushCodexChildGeneration(childID, MessageCompletionInterrupted)
-				a.sink.ChildSink(childID).ReportProgress(ResetModelProgress())
+				if childSink, ok := a.codexChildSinkForAgent(childID); ok {
+					childSink.ReportProgress(ResetModelProgress())
+				}
 			}
 			if a.knownCollabChild(notif.ThreadID) {
 				// upsertCollabChildRow reopens the row first when this child runs
-				// again after going final. The reopened row keeps a closer: that
-				// collab call's own item/completed runs the states walk, which
-				// closes it.
+				// again after going final. The reopened row keeps a closer: the child
+				// turn or the parent's completion signal closes it.
 				logRegistryRefusal("codex", "upsert", a.upsertCollabChildRow(bgtask.Upsert{
 					RowKey:     notif.ThreadID,
 					Kind:       bgtask.KindSubagent,
@@ -164,7 +166,9 @@ func (a *CodexAgent) handleTurnStarted(params json.RawMessage) {
 				// The child's own turn. publishTurnActive covers the MAIN thread
 				// alone, so the child's flag is published against the child's
 				// sink -- which is what its own input queue follows.
-				publishSteerableTurnActiveTo(a.sink.ChildSink(childID), true, a.childTurnSeq())
+				if childSink, ok := a.codexChildSinkForAgent(childID); ok {
+					publishSteerableTurnActiveTo(childSink, true, a.childTurnSeq())
+				}
 			}
 			return
 		}
@@ -215,7 +219,12 @@ func (a *CodexAgent) bufferCodexModelText(
 			a.unresolvedChildGenerationBuffer(threadID).Append(scopeID, kind, text, join)
 			return
 		}
-		sink = a.sink.ChildSink(childID)
+		childSink, ok := a.codexChildSinkForAgent(childID)
+		if !ok {
+			a.unresolvedChildGenerationBuffer(threadID).Append(scopeID, kind, text, join)
+			return
+		}
+		sink = childSink
 		buffer = a.childGenerationBuffer(childID)
 	}
 	if reportProgress {
@@ -231,7 +240,11 @@ func (a *CodexAgent) reportCodexModelProgress(scopeID, threadID, text string) {
 		if childID == "" {
 			return
 		}
-		sink = a.sink.ChildSink(childID)
+		childSink, ok := a.codexChildSinkForAgent(childID)
+		if !ok {
+			return
+		}
+		sink = childSink
 	}
 	sink.ReportProgress(ModelTextProgress(scopeID, text))
 }
@@ -300,7 +313,8 @@ func (a *CodexAgent) childSinkForItem(itemID string) ProviderServices {
 	if childID == "" {
 		return nil
 	}
-	return a.sink.ChildSink(childID)
+	childSink, _ := a.codexChildSinkForAgent(childID)
+	return childSink
 }
 
 // Codex reasoning sub-stream kinds. A single reasoning item can surface as a
@@ -520,7 +534,7 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 	// subAgentActivity (v2) is registry-only: never persist. Consume it here
 	// before any transcript handling.
 	if itemType == "subAgentActivity" {
-		a.handleCodexSubAgentActivity(item)
+		a.handleCodexSubAgentActivity(item, threadID)
 		return
 	}
 
@@ -534,7 +548,7 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 	// agent id (EnsureChildAgent, idempotent) and run the same per-type persist/
 	// span logic against the child sink.
 	if childID != "" {
-		a.persistItemStartedChild(childID, params, itemType, itemID)
+		a.persistItemStartedChild(threadID, childID, params, itemType, itemID)
 		return
 	}
 
@@ -565,7 +579,7 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 		// so a rail held open for the whole subagent run only pushes every
 		// concurrent tool one column right. The other collab tools (wait,
 		// sendInput, resumeAgent, closeAgent) keep their span. Register receiver
-		// threads as the child index so later child-thread items route to child
+		// threads as child routes so later child-thread items reach their
 		// transcripts.
 		collab := parseCollabToolCall(item)
 		spawns := collab != nil && collab.Tool == codexCollabToolSpawnAgent
@@ -574,7 +588,10 @@ func (a *CodexAgent) handleItemStarted(raw []byte, params json.RawMessage) {
 		}
 		if collab != nil {
 			for _, receiverID := range collab.ReceiverThreadIds {
-				a.registerCollabReceiver(receiverID, itemID)
+				if collab.Tool == codexCollabToolSpawnAgent && collab.Prompt != "" {
+					a.recordCollabChildPromptTitle(receiverID, collab.Prompt)
+				}
+				a.registerCollabReceiver(receiverID, itemID, threadID)
 				a.collabChildPrompts.remember(receiverID, collab.Prompt)
 			}
 		}
@@ -597,14 +614,14 @@ func (a *CodexAgent) handleItemCompleted(raw []byte, params json.RawMessage) {
 	// subAgentActivity (v2) is registry-only: never persist. Consume it here
 	// before any transcript handling.
 	if itemType == "subAgentActivity" {
-		a.handleCodexSubAgentActivity(item)
+		a.handleCodexSubAgentActivity(item, threadID)
 		return
 	}
 
 	// Route child-thread items to the child transcript (mirrors
 	// handleItemStarted).
 	if childID := a.routeChildItemIfApplicable(threadID); childID != "" {
-		a.persistItemCompletedChild(childID, params, itemType, itemID)
+		a.persistItemCompletedChild(threadID, childID, params, itemType, itemID)
 		return
 	}
 
@@ -653,13 +670,13 @@ func (a *CodexAgent) handleItemCompleted(raw []byte, params json.RawMessage) {
 		// code) and drive the registry from agentsStates.
 		if collab != nil {
 			for _, receiverID := range collab.ReceiverThreadIds {
-				a.registerCollabReceiver(receiverID, itemID)
+				a.registerCollabReceiver(receiverID, itemID, threadID)
 				a.collabChildPrompts.remember(receiverID, collab.Prompt)
 			}
 			if collab.Tool == codexCollabToolSpawnAgent {
 				if sp := collab.Prompt; sp != "" {
 					for _, rid := range collab.ReceiverThreadIds {
-						a.recordCollabChildTitle(rid, sp)
+						a.recordCollabChildPromptTitle(rid, sp)
 					}
 				}
 			}
@@ -669,7 +686,7 @@ func (a *CodexAgent) handleItemCompleted(raw []byte, params json.RawMessage) {
 		a.persistCompletedReasoningItem(a.sink, params, itemID, a.agentID)
 	case "contextCompaction":
 		// Persist the raw `item/completed` JSON-RPC notification verbatim as
-		// AGENT, the same way the `item/started` arm above does. It must join
+		// AGENT, the same way the `item/started` case above does. It must join
 		// the notification thread that the start opened, because the
 		// consolidator drops the "Compacting context..." status only when the
 		// compaction boundary lands in that same thread. PersistMessage clears
@@ -698,15 +715,22 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 		// transcript (mirrors the main-thread PersistTurnEnd below), then clear
 		// its active turn id (steering no longer possible until a new child
 		// turn starts). Falls through silently when the thread is unknown to
-		// the child index (e.g. a late receiver the spawn never registered).
-		if childID := a.routeChildItemIfApplicable(notif.ThreadID); childID != "" {
-			a.flushCodexChildGeneration(childID, codexTurnCompletion(params))
-			a.persistIncompleteCodexTools(childID, false, codexTurnCompletion(params))
-			if err := a.sink.PersistChildTurnEnd(childID, params, SpanInfo{}); err != nil {
+		// the child routes (for example, a late receiver with no spawn event).
+		if route, ok := a.resolveCodexChild(notif.ThreadID); ok {
+			completion := codexTurnCompletion(params)
+			a.flushCodexChildGeneration(route.agentID, completion)
+			a.persistIncompleteCodexTools(route.agentID, false, completion)
+			if err := route.childSink.PersistTurnEnd(params, SpanInfo{}); err != nil {
 				slog.Warn("codex persist child turn/completed", "agent_id", a.agentID, "thread", notif.ThreadID, "error", err)
 			}
 			a.clearChildTurnID(notif.ThreadID)
-			publishSteerableTurnActiveTo(a.sink.ChildSink(childID), false, a.childTurnSeq())
+			publishSteerableTurnActiveTo(route.childSink, false, a.childTurnSeq())
+			if status, finished, activity := codexChildTurnRegistryStatus(params); finished {
+				a.completeCodexChildRun(notif.ThreadID, status, completion)
+			} else if activity != "" {
+				logRegistryRefusal("codex", "update status",
+					a.sink.UpdateBackgroundTaskStatus(notif.ThreadID, bgtask.StatusRunning, activity))
+			}
 			return
 		}
 		a.clearChildTurnID(notif.ThreadID)
@@ -783,10 +807,9 @@ func (a *CodexAgent) handleTurnCompleted(params json.RawMessage) {
 	}
 
 	// Reset all span tracking at turn-end so the next turn starts clean.
-	// The collab child index is NOT cleared here: background tasks outlive
-	// turns, and the child-index entries are removed only on a final collab
-	// status (collabAgentsStatesToRegistry). Clearing on ClearContext/restart
-	// stays.
+	// The child routes stay here because background tasks outlive root turns.
+	// A completed child run keeps its route for later input. ClearContext or a
+	// process restart removes the routes for the old child tree.
 	a.sink.ResetSpans()
 
 	if turnStatus != "" {
@@ -819,7 +842,11 @@ func (a *CodexAgent) flushCodexGeneration(completion MessageCompletion) {
 }
 
 func (a *CodexAgent) flushCodexChildGeneration(childID string, completion MessageCompletion) {
-	a.persistCodexGeneration(a.childGenerationBuffer(childID), a.sink.ChildSink(childID), completion)
+	childSink, ok := a.codexChildSinkForAgent(childID)
+	if !ok {
+		return
+	}
+	a.persistCodexGeneration(a.childGenerationBuffer(childID), childSink, completion)
 }
 
 func (a *CodexAgent) flushAllCodexGeneration(completion MessageCompletion) {
@@ -931,6 +958,7 @@ func (a *CodexAgent) persistIncompleteCodexTools(childID string, all bool, compl
 			order:           tool.order,
 		}
 		delete(a.incompleteTools, itemID)
+		delete(a.collabChildItems, itemID)
 	}
 	a.mu.Unlock()
 	if a.isDiscardingOutput() {
@@ -956,7 +984,12 @@ func (a *CodexAgent) persistIncompleteCodexTools(childID string, all bool, compl
 		}
 		sink := a.sink
 		if tool.childID != "" {
-			sink = a.sink.ChildSink(tool.childID)
+			childSink, ok := a.codexChildSinkForAgent(tool.childID)
+			if !ok {
+				slog.Warn("persist incomplete codex child tool: route missing", "agent_id", a.agentID, "child", tool.childID)
+				continue
+			}
+			sink = childSink
 		}
 		if err := sink.PersistMessage(leapmuxv1.MessageSource_MESSAGE_SOURCE_AGENT, raw, SpanInfo{
 			SpanID: itemID, SpanType: tool.itemType, Closing: true,
@@ -1363,82 +1396,156 @@ func parseCollabToolCall(item json.RawMessage) *codexCollabAgentToolCall {
 	return &collab
 }
 
-// registerCollabReceiver records a child thread -> spawnSpanID mapping (the
-// child index). Idempotent. The index is NOT cleared at turn end (background
-// tasks outlive turns); entries are removed on a final collab status by
-// collabAgentsStatesToRegistry -> removeCollabChildIndex.
-func (a *CodexAgent) registerCollabReceiver(threadID, spanID string) bool {
-	if threadID == "" || spanID == "" {
+// registerCollabReceiver records or reactivates one child route. The first
+// spawn ID and direct parent remain authoritative. A later wait, message, or
+// completion activity can identify the same child but must not change either.
+func (a *CodexAgent) registerCollabReceiver(threadID, spawnCorrelationID, parentThreadID string) bool {
+	if threadID == "" {
 		return false
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.collabThreadSpans == nil {
-		a.collabThreadSpans = make(map[string]string)
+	if a.collabChildren == nil {
+		a.collabChildren = make(map[string]codexChildState)
 	}
-	if a.collabThreadSpans[threadID] == spanID {
-		return false
+	state := a.collabChildren[threadID]
+	changed := !state.active
+	if state.spawnCorrelationID == "" && spawnCorrelationID != "" {
+		state.spawnCorrelationID = spawnCorrelationID
+		changed = true
 	}
-	a.collabThreadSpans[threadID] = spanID
-	return true
+	if state.parentThreadID == "" {
+		if parentThreadID == "" {
+			parentThreadID = a.threadID
+		}
+		state.parentThreadID = parentThreadID
+		changed = true
+	}
+	state.active = true
+	a.collabChildren[threadID] = state
+	return changed
 }
 
 // routeChildItemIfApplicable returns the child agent id when the threadID is a
-// non-main collab child known to the index, resolving it via EnsureChildAgent
-// (idempotent). Returns "" for the main thread, an empty thread, or an unknown
-// child (which falls through to the parent handler; the index may learn the
-// mapping later via registerCollabReceiver).
+// non-main collab child known to the index. EnsureChildAgent runs against the
+// direct parent's sink, which preserves nested subagent linkage.
 func (a *CodexAgent) routeChildItemIfApplicable(threadID string) string {
-	if threadID == "" {
+	route, ok := a.resolveCodexChild(threadID)
+	if !ok {
 		return ""
 	}
-	a.mu.Lock()
-	mainThreadID := a.threadID
-	spanID := a.collabThreadSpans[threadID]
-	a.mu.Unlock()
-	if threadID == mainThreadID {
-		return ""
-	}
-	if spanID == "" {
-		// The span index is gone (a ClearContext wiped it, or the spawn was
-		// never registered). A thread that resolved before still has to resolve
-		// now: its turn end is the only thing that clears the child's own input
-		// queue, and nothing else ever will.
-		return a.rememberedChildAgent(threadID)
-	}
-	childID, err := a.sink.EnsureChildAgent(spanID, threadID, a.collabChildTitle(threadID))
-	if err != nil {
-		slog.Warn("codex route child ensure failed", "thread", threadID, "error", err)
-		return a.rememberedChildAgent(threadID)
-	}
-	a.rememberChildAgent(threadID, childID)
-	return childID
+	return route.agentID
 }
 
-// rememberChildAgent records the agent id a child thread resolved to, and
-// rememberedChildAgent reads it back. removeCollabChildIndex drops both together
-// when the child reaches a final status.
+func (a *CodexAgent) resolveCodexChild(threadID string) (codexChildRoute, bool) {
+	if threadID == "" || a.isMainThreadID(threadID) {
+		return codexChildRoute{}, false
+	}
+	a.mu.Lock()
+	state, ok := a.collabChildren[threadID]
+	a.mu.Unlock()
+	if !ok || state.spawnCorrelationID == "" && state.childAgentID == "" {
+		return codexChildRoute{}, false
+	}
+	parentSink, parentAgentID, ok := a.codexServicesForThread(state.parentThreadID)
+	if !ok {
+		return codexChildRoute{}, false
+	}
+	childID := state.childAgentID
+	if childID == "" {
+		var err error
+		childID, err = parentSink.EnsureChildAgent(state.spawnCorrelationID, threadID, state.displayTitle())
+		if err != nil {
+			slog.Warn("codex route child ensure failed", "thread", threadID, "error", err)
+			return codexChildRoute{}, false
+		}
+		a.rememberChildAgent(threadID, childID)
+	}
+	return codexChildRoute{
+		agentID:       childID,
+		parentAgentID: parentAgentID,
+		parentSink:    parentSink,
+		childSink:     parentSink.ChildSink(childID),
+	}, true
+}
+
+// codexServicesForThread resolves a thread's transcript sink. It walks the
+// recorded parent chain before it touches sink caches, so malformed cycles or
+// incomplete nested routes fail without creating a sink under the wrong parent.
+func (a *CodexAgent) codexServicesForThread(threadID string) (ProviderServices, string, bool) {
+	a.mu.Lock()
+	mainThreadID := a.threadID
+	if threadID == "" {
+		threadID = mainThreadID
+	}
+	if threadID == mainThreadID {
+		a.mu.Unlock()
+		return a.sink, a.agentID, true
+	}
+	var agentIDs []string
+	seen := make(map[string]struct{})
+	for threadID != "" && threadID != mainThreadID {
+		if _, duplicate := seen[threadID]; duplicate {
+			a.mu.Unlock()
+			return nil, "", false
+		}
+		seen[threadID] = struct{}{}
+		state, ok := a.collabChildren[threadID]
+		if !ok || state.childAgentID == "" {
+			a.mu.Unlock()
+			return nil, "", false
+		}
+		agentIDs = append(agentIDs, state.childAgentID)
+		threadID = state.parentThreadID
+		if threadID == "" {
+			threadID = mainThreadID
+		}
+	}
+	a.mu.Unlock()
+
+	sink := a.sink
+	for i := len(agentIDs) - 1; i >= 0; i-- {
+		sink = sink.ChildSink(agentIDs[i])
+	}
+	return sink, agentIDs[0], true
+}
+
+func (a *CodexAgent) codexChildSinkForAgent(childID string) (ProviderServices, bool) {
+	if childID == "" {
+		return nil, false
+	}
+	a.mu.Lock()
+	threadID := a.collabThreadsByAgent[childID]
+	a.mu.Unlock()
+	route, ok := a.resolveCodexChild(threadID)
+	if !ok || route.agentID != childID {
+		return nil, false
+	}
+	return route.childSink, true
+}
+
+// rememberChildAgent records both directions of the child route.
 func (a *CodexAgent) rememberChildAgent(threadID, childID string) {
 	if threadID == "" || childID == "" {
 		return
 	}
 	a.mu.Lock()
-	if a.collabChildAgents == nil {
-		a.collabChildAgents = make(map[string]string)
+	if a.collabChildren == nil {
+		a.collabChildren = make(map[string]codexChildState)
 	}
-	a.collabChildAgents[threadID] = childID
+	state := a.collabChildren[threadID]
+	state.childAgentID = childID
+	a.collabChildren[threadID] = state
+	if a.collabThreadsByAgent == nil {
+		a.collabThreadsByAgent = make(map[string]string)
+	}
+	a.collabThreadsByAgent[childID] = threadID
 	a.mu.Unlock()
 	a.adoptUnresolvedChildGeneration(threadID, childID)
 }
 
-func (a *CodexAgent) rememberedChildAgent(threadID string) string {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.collabChildAgents[threadID]
-}
-
 // persistItemStartedChild applies item/started to the child transcript.
-func (a *CodexAgent) persistItemStartedChild(childID string, params json.RawMessage, itemType, itemID string) {
+func (a *CodexAgent) persistItemStartedChild(threadID, childID string, params json.RawMessage, itemType, itemID string) {
 	// Record the itemID -> childID mapping so output-delta handlers (which
 	// carry only an itemID) can route streaming chunks to the child.
 	if itemID != "" {
@@ -1449,12 +1556,13 @@ func (a *CodexAgent) persistItemStartedChild(childID string, params json.RawMess
 		a.collabChildItems[itemID] = childID
 		a.mu.Unlock()
 	}
-	childSink := a.sink.ChildSink(childID)
-	persistSharedItemStarted(childSink, params, itemType, itemID, childID)
+	if route, ok := a.resolveCodexChild(threadID); ok {
+		persistSharedItemStarted(route.childSink, params, itemType, itemID, childID)
+	}
 }
 
 // persistItemCompletedChild applies item/completed to the child transcript.
-func (a *CodexAgent) persistItemCompletedChild(childID string, params json.RawMessage, itemType, itemID string) {
+func (a *CodexAgent) persistItemCompletedChild(threadID, childID string, params json.RawMessage, itemType, itemID string) {
 	// The item is done streaming; drop it from the itemID -> child index so the
 	// map doesn't grow unbounded across turns.
 	if itemID != "" {
@@ -1462,7 +1570,11 @@ func (a *CodexAgent) persistItemCompletedChild(childID string, params json.RawMe
 		delete(a.collabChildItems, itemID)
 		a.mu.Unlock()
 	}
-	childSink := a.sink.ChildSink(childID)
+	route, ok := a.resolveCodexChild(threadID)
+	if !ok {
+		return
+	}
+	childSink := route.childSink
 	discardCompletedCodexGeneration(a.childGenerationBuffer(childID), itemType, itemID)
 	if itemType == "reasoning" {
 		a.persistCompletedReasoningItem(childSink, params, itemID, childID)

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +24,17 @@ type transientCodexCloseFailureSink struct {
 	*testSink
 	closeFailures int
 	closeAttempts int
+}
+
+type transientCodexEnsureFailureSink struct {
+	*testSink
+	ensureFailures int
+}
+
+type blockingCodexEnsureSink struct {
+	*testSink
+	started chan struct{}
+	release chan struct{}
 }
 
 type codexEnsureCall struct {
@@ -52,6 +64,20 @@ func (s *transientCodexCloseFailureSink) CloseBackgroundTask(rowKey string, stat
 		return fmt.Errorf("transient registry close failure")
 	}
 	return s.testSink.CloseBackgroundTask(rowKey, status)
+}
+
+func (s *transientCodexEnsureFailureSink) EnsureChildAgent(spawnSpanID, providerChildKey, title string) (string, error) {
+	if s.ensureFailures > 0 {
+		s.ensureFailures--
+		return "", fmt.Errorf("transient child creation failure")
+	}
+	return s.testSink.EnsureChildAgent(spawnSpanID, providerChildKey, title)
+}
+
+func (s *blockingCodexEnsureSink) EnsureChildAgent(spawnSpanID, providerChildKey, title string) (string, error) {
+	close(s.started)
+	<-s.release
+	return s.testSink.EnsureChildAgent(spawnSpanID, providerChildKey, title)
 }
 
 func (s *startupStatusGuardSink) PersistMessage(source leapmuxv1.MessageSource, content []byte, span SpanInfo) error {
@@ -206,7 +232,7 @@ func TestHandleCodexOutput_ContextCompactionStartPersistsRawAsAgent(t *testing.T
 	sink := &testSink{}
 	agent := newCodexAgentWithSink(sink)
 
-	input := `{"method":"item/started","params":{"item":{"type":"contextCompaction","id":"compact-1"},"threadId":"t1","turnId":"turn1"}}`
+	input := `{"method":"item/started","params":{"item":{"type":"contextCompaction","id":"compact-1"},"threadId":"main-thread","turnId":"turn1"}}`
 	handleCodexOutput(agent, parseLine([]byte(input)))
 
 	require.Equal(t, 1, sink.NotificationCount())
@@ -655,6 +681,17 @@ func TestHandleCodexOutput_MultiAgentV2LifecycleOwnsTheChildTranscript(t *testin
 	assert.Equal(t, bgtask.StatusCompleted, rows[0].Status)
 }
 
+func TestHandleCodexOutput_MultiAgentV2DoesNotRegisterTheRootPath(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"root-call","kind":"started","agentThreadId":"main-thread","agentPath":"/root"}}}`)))
+
+	assert.Empty(t, sink.BackgroundTasks(), "the canonical root path is the primary agent, not a subagent")
+	assert.Empty(t, agent.collabChildren)
+}
+
 func TestHandleCodexOutput_MultiAgentV2FailedTurnClosesWithoutAnActivity(t *testing.T) {
 	t.Parallel()
 
@@ -714,6 +751,169 @@ func TestHandleCodexOutput_MultiAgentV2DuplicateCompletionRetriesARegistryFailur
 	require.True(t, found)
 	assert.Equal(t, bgtask.StatusCompleted, status, "the duplicate completion retries the close")
 	assert.Equal(t, 2, sink.closeAttempts)
+}
+
+func TestHandleCodexOutput_MultiAgentV2LateDuplicateStartDoesNotReviveCompletedRun(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	started := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"spawn-call","kind":"started","agentThreadId":"child-thread","agentPath":"/root/idempotent_child"}}}`
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"child-thread","turn":{"id":"child-turn","status":"completed","items":[],"error":null}}}`)))
+
+	handleCodexOutput(agent, parseLine([]byte(started)))
+
+	_, status, found, err := sink.LookupBackgroundTask("child-thread")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, bgtask.StatusCompleted, status)
+	assert.Empty(t, sink.RevivedTasks(), "a duplicate spawn activity cannot start a second run")
+}
+
+func TestHandleCodexOutput_MultiAgentV2ReplaysChildItemsAfterRouteRecovery(t *testing.T) {
+	t.Parallel()
+
+	sink := &transientCodexEnsureFailureSink{
+		testSink:       &testSink{},
+		ensureFailures: 2,
+	}
+	agent := newCodexAgentWithSink(sink)
+	started := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"call-spawn","kind":"started","agentThreadId":"child-thread","agentPath":"/root/recovered_child"}}}`
+	childAnswer := `{"method":"item/completed","params":{"threadId":"child-thread","turnId":"child-turn","item":{"type":"agentMessage","id":"child-message","text":"RECOVERED_CHILD_DONE","phase":"final_answer"}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(childAnswer)))
+	assert.Empty(t, sink.Messages(), "a child item must never fall through to the root after a route error")
+
+	// The duplicate activity retries child creation. The retained child item
+	// must then replay into the child transcript in provider order.
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	child := sink.ChildSink("child-of-call-spawn").(*testSink)
+	require.Len(t, child.Messages(), 1)
+	assert.Contains(t, string(child.Messages()[0].Content), "RECOVERED_CHILD_DONE")
+}
+
+func TestHandleCodexOutput_MultiAgentV2CompletionBeforeStartStillClosesTheRun(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	completed := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"completion-call","kind":"completed","agentThreadId":"child-thread","agentPath":"/root/reordered_child"}}}`
+	started := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"spawn-call","kind":"started","agentThreadId":"child-thread","agentPath":"/root/reordered_child"}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(completed)))
+	handleCodexOutput(agent, parseLine([]byte(started)))
+
+	rows := sink.BackgroundTasks()
+	require.Len(t, rows, 1)
+	assert.Equal(t, bgtask.StatusCompleted, rows[0].Status,
+		"the authoritative start must apply a completion that arrived first")
+	assert.Equal(t, "child-of-spawn-call", rows[0].ChildAgentID)
+}
+
+func TestHandleCodexOutput_MultiAgentV2StartOwnsIdentityAfterEarlierInteraction(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	interacted := `{"method":"item/completed","params":{"threadId":"unrelated-thread","turnId":"other-turn","item":{"type":"subAgentActivity","id":"interaction-call","kind":"interacted","agentThreadId":"child-thread","agentPath":"/root/identity_child"}}}`
+	started := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"spawn-call","kind":"started","agentThreadId":"child-thread","agentPath":"/root/identity_child"}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(interacted)))
+	handleCodexOutput(agent, parseLine([]byte(started)))
+
+	agent.mu.Lock()
+	state := agent.collabChildren["child-thread"]
+	agent.mu.Unlock()
+	assert.Equal(t, "spawn-call", state.spawnCorrelationID)
+	assert.Equal(t, "main-thread", state.parentThreadID)
+	rows := sink.BackgroundTasks()
+	require.Len(t, rows, 1)
+	assert.Equal(t, "child-of-spawn-call", rows[0].ChildAgentID)
+	assert.Equal(t, "test-agent", rows[0].ParentAgentID)
+}
+
+func TestHandleCodexOutput_MultiAgentV2CompletionClearsTurnWhenRouteRecoveryFails(t *testing.T) {
+	t.Parallel()
+
+	sink := &transientCodexEnsureFailureSink{
+		testSink:       &testSink{},
+		ensureFailures: 3,
+	}
+	agent := newCodexAgentWithSink(sink)
+	started := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"spawn-call","kind":"started","agentThreadId":"child-thread","agentPath":"/root/failing_route"}}}`
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"child-thread","turn":{"id":"child-turn"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"completion-call","kind":"completed","agentThreadId":"child-thread","agentPath":"/root/failing_route"}}}`)))
+
+	assert.Empty(t, agent.childTurnID("child-thread"),
+		"a final activity must release child input even when child creation still fails")
+}
+
+func TestHandleCodexOutput_NestedV2CollaborationToolUsesTheChildTranscript(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"spawn-parent","kind":"started","agentThreadId":"parent-thread","agentPath":"/root/parent"}}}`)))
+	waitStarted := `{"method":"item/started","params":{"threadId":"parent-thread","turnId":"parent-turn","item":{"type":"collabAgentToolCall","id":"wait-call","tool":"wait","status":"inProgress","senderThreadId":"parent-thread","receiverThreadIds":[],"prompt":null,"agentsStates":{}}}}`
+	waitCompleted := `{"method":"item/completed","params":{"threadId":"parent-thread","turnId":"parent-turn","item":{"type":"collabAgentToolCall","id":"wait-call","tool":"wait","status":"completed","senderThreadId":"parent-thread","receiverThreadIds":[],"prompt":null,"agentsStates":{}}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(waitStarted)))
+	handleCodexOutput(agent, parseLine([]byte(waitCompleted)))
+
+	assert.Empty(t, sink.Messages())
+	parent := sink.ChildSink("child-of-spawn-parent").(*testSink)
+	require.Len(t, parent.Messages(), 2, "the child transcript retains both collaboration tool boundaries")
+	assert.Equal(t, []string{"wait-call"}, parent.ClosedSpans())
+}
+
+func TestHandleCodexOutput_UnresolvedChildGenerationHasAMemoryCap(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	chunk := strings.Repeat("x", 768<<10)
+	for range 2 {
+		raw, err := json.Marshal(map[string]any{
+			"method": "item/agentMessage/delta",
+			"params": map[string]any{
+				"threadId": "unknown-child",
+				"itemId":   "message-1",
+				"delta":    chunk,
+			},
+		})
+		require.NoError(t, err)
+		handleCodexOutput(agent, parseLine(raw))
+	}
+
+	buffer := agent.codexChildGenerationBuffer("unknown-child")
+	buffer.mu.Lock()
+	retained := buffer.segments["message-1"].text.Len()
+	buffer.mu.Unlock()
+	assert.LessOrEqual(t, retained, 1<<20,
+		"an unresolved child cannot retain model output without a fixed limit")
+}
+
+func TestCodex_ReplayReportsAFullPendingQueueWithNoRetainedEvent(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"spawn-call","kind":"started","agentThreadId":"child-thread","agentPath":"/root/limited_child"}}}`)))
+	route, routed := agent.lookupCodexChildRoute("child-thread")
+	require.True(t, routed)
+	agent.mu.Lock()
+	agent.collabChildren["child-thread"].pendingOutputDropped = true
+	agent.mu.Unlock()
+
+	agent.replayPendingCodexChildEvents("child-thread", route)
+
+	agent.mu.Lock()
+	dropped := agent.collabChildren["child-thread"].pendingOutputDropped
+	agent.mu.Unlock()
+	assert.False(t, dropped, "the route recovery must consume the overflow signal")
 }
 
 func TestHandleCodexOutput_MultiAgentV2ReusesTheChildTranscript(t *testing.T) {
@@ -1166,14 +1366,14 @@ func TestHandleCodexOutput_ImageItemsOpenAndCloseASpan(t *testing.T) {
 		{
 			itemType:  "imageGeneration",
 			id:        "img-1",
-			started:   `{"method":"item/started","params":{"threadId":"t1","item":{"type":"imageGeneration","id":"img-1","status":"inProgress","prompt":"a cat"}}}`,
-			completed: `{"method":"item/completed","params":{"threadId":"t1","item":{"type":"imageGeneration","id":"img-1","status":"completed","result":"aVZ","revisedPrompt":"a cat, photoreal"}}}`,
+			started:   `{"method":"item/started","params":{"threadId":"main-thread","item":{"type":"imageGeneration","id":"img-1","status":"inProgress","prompt":"a cat"}}}`,
+			completed: `{"method":"item/completed","params":{"threadId":"main-thread","item":{"type":"imageGeneration","id":"img-1","status":"completed","result":"aVZ","revisedPrompt":"a cat, photoreal"}}}`,
 		},
 		{
 			itemType:  "imageView",
 			id:        "view-1",
-			started:   `{"method":"item/started","params":{"threadId":"t1","item":{"type":"imageView","id":"view-1","status":"inProgress","path":"/tmp/a.png"}}}`,
-			completed: `{"method":"item/completed","params":{"threadId":"t1","item":{"type":"imageView","id":"view-1","status":"completed","path":"/tmp/a.png"}}}`,
+			started:   `{"method":"item/started","params":{"threadId":"main-thread","item":{"type":"imageView","id":"view-1","status":"inProgress","path":"/tmp/a.png"}}}`,
+			completed: `{"method":"item/completed","params":{"threadId":"main-thread","item":{"type":"imageView","id":"view-1","status":"completed","path":"/tmp/a.png"}}}`,
 		},
 	}
 
@@ -1301,7 +1501,7 @@ func TestHandleCodexOutput_TurnCompletedIgnoresSubagentThreads(t *testing.T) {
 // registered child thread's turn/completed persists a turn-end divider into the
 // CHILD transcript (mirrors the main-thread PersistTurnEnd), rather than being
 // a silent no-op. The child must be registered first via a spawnAgent
-// item/started so routeChildItemIfApplicable can resolve the child agent id.
+// item/started so the route can resolve the child agent ID.
 func TestHandleCodexOutput_TurnCompletedChildPersistsChildTurnEnd(t *testing.T) {
 	t.Parallel()
 
@@ -1333,9 +1533,9 @@ func TestHandleCodexOutput_TurnCompletedChildPersistsChildTurnEnd(t *testing.T) 
 	assert.Equal(t, []bool{true, false}, child.TurnActives(),
 		"the child's own turn opens and releases the child input queue")
 	assert.Equal(t, []leapmuxv1.AgentInputKind{
-		leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_USER_MESSAGE,
 		leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_UNSPECIFIED,
-	}, child.TurnKinds(), "a Codex child turn accepts steering until it ends")
+		leapmuxv1.AgentInputKind_AGENT_INPUT_KIND_UNSPECIFIED,
+	}, child.TurnKinds(), "a Multi-Agent V2 child reports activity without direct-input steering")
 }
 
 func TestHandleCodexOutput_InterruptedChildTurnPersistsBufferedText(t *testing.T) {
@@ -1353,12 +1553,20 @@ func TestHandleCodexOutput_InterruptedChildTurnPersistsBufferedText(t *testing.T
 
 	child := sink.ChildSink("child-of-call-1").(*testSink)
 	require.NotEmpty(t, child.Messages())
+	var bufferedMessage []byte
+	for _, message := range child.Messages() {
+		if strings.Contains(string(message.Content), "partial child answer") {
+			bufferedMessage = message.Content
+			break
+		}
+	}
+	require.NotEmpty(t, bufferedMessage)
 	assert.JSONEq(t, `{
 		"type":"assembled_message",
 		"kind":"text",
 		"text":"partial child answer",
 		"completion":"interrupted"
-	}`, string(child.Messages()[0].Content))
+	}`, string(bufferedMessage))
 	assert.Equal(t, ProgressSnapshot{}, child.progressCount.Snapshot(),
 		"the completed child turn must not replay an active token count")
 }
@@ -1977,15 +2185,15 @@ func TestCodexCollabStatusToRegistry_ResumableInterrupted(t *testing.T) {
 		tc := tc
 		t.Run(tc.status, func(t *testing.T) {
 			t.Parallel()
-			gotStatus, gotFinal, gotActivity := codexCollabStatusToRegistry(tc.status)
-			assert.Equal(t, tc.wantStatus, gotStatus)
-			assert.Equal(t, tc.wantFinal, gotFinal)
+			transition := codexCollabTransition(tc.status)
+			assert.Equal(t, tc.wantStatus, transition.status)
+			assert.Equal(t, tc.wantFinal, transition.finished())
 			if tc.wantNonBlank {
-				assert.NotEmpty(t, gotActivity, "resumable interrupted carries a paused activity line")
+				assert.NotEmpty(t, transition.activity, "resumable interrupted carries a paused activity line")
 			}
 			// The mapped status must NOT be final for a resumable interrupt.
 			if !tc.wantFinal {
-				assert.False(t, gotStatus.IsFinished(), "%s must not map to a final status", tc.status)
+				assert.False(t, transition.status.IsFinished(), "%s must not map to a final status", tc.status)
 			}
 		})
 	}
@@ -2013,17 +2221,17 @@ func TestCodexChildTurnRegistryStatus(t *testing.T) {
 		t.Run(test.providerStatus, func(t *testing.T) {
 			t.Parallel()
 			params := json.RawMessage(`{"turn":{"status":"` + test.providerStatus + `"}}`)
-			status, finished, activity := codexChildTurnRegistryStatus(params)
-			assert.Equal(t, test.wantStatus, status)
-			assert.Equal(t, test.wantFinished, finished)
-			assert.Equal(t, test.wantActivity, activity)
+			transition := codexChildTurnTransition(params)
+			assert.Equal(t, test.wantStatus, transition.status)
+			assert.Equal(t, test.wantFinished, transition.finished())
+			assert.Equal(t, test.wantActivity, transition.activity)
 		})
 	}
 
-	status, finished, activity := codexChildTurnRegistryStatus(json.RawMessage(`{"turn":`))
-	assert.Equal(t, bgtask.StatusRunning, status)
-	assert.False(t, finished)
-	assert.Empty(t, activity)
+	transition := codexChildTurnTransition(json.RawMessage(`{"turn":`))
+	assert.Equal(t, bgtask.StatusRunning, transition.status)
+	assert.False(t, transition.finished())
+	assert.Empty(t, transition.activity)
 }
 
 // TestCodexSubAgentActivity_InterruptedStaysRunning verifies the
@@ -2125,7 +2333,6 @@ func TestHandleCodexOutput_ChildTurnEndSurvivesALostSpanIndex(t *testing.T) {
 	agent.mu.Lock()
 	state := agent.collabChildren["child-1"]
 	state.spawnCorrelationID = ""
-	agent.collabChildren["child-1"] = state
 	agent.mu.Unlock()
 
 	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"child-1","turn":{"id":"turn-1","status":"completed","items":[],"error":null}}}`)))

--- a/backend/internal/worker/agent/codex_output_test.go
+++ b/backend/internal/worker/agent/codex_output_test.go
@@ -19,6 +19,41 @@ type startupStatusGuardSink struct {
 	t *testing.T
 }
 
+type transientCodexCloseFailureSink struct {
+	*testSink
+	closeFailures int
+	closeAttempts int
+}
+
+type codexEnsureCall struct {
+	spawnSpanID      string
+	providerChildKey string
+	title            string
+}
+
+type recordingCodexEnsureSink struct {
+	*testSink
+	ensureCalls []codexEnsureCall
+}
+
+func (s *recordingCodexEnsureSink) EnsureChildAgent(spawnSpanID, providerChildKey, title string) (string, error) {
+	s.ensureCalls = append(s.ensureCalls, codexEnsureCall{
+		spawnSpanID:      spawnSpanID,
+		providerChildKey: providerChildKey,
+		title:            title,
+	})
+	return s.testSink.EnsureChildAgent(spawnSpanID, providerChildKey, title)
+}
+
+func (s *transientCodexCloseFailureSink) CloseBackgroundTask(rowKey string, status bgtask.Status) error {
+	s.closeAttempts++
+	if s.closeFailures > 0 {
+		s.closeFailures--
+		return fmt.Errorf("transient registry close failure")
+	}
+	return s.testSink.CloseBackgroundTask(rowKey, status)
+}
+
 func (s *startupStatusGuardSink) PersistMessage(source leapmuxv1.MessageSource, content []byte, span SpanInfo) error {
 	s.t.Fatalf("startup status notification must not be persisted as a regular message: source=%v content=%s", source, string(content))
 	return nil
@@ -562,6 +597,188 @@ func TestHandleCodexOutput_TurnCompletedSuccessCancelsAPIError(t *testing.T) {
 	require.Equal(t, AutoContinueReasonAPIError, sink.LastAutoCancel())
 }
 
+// Current Codex models select Multi-Agent V2. That protocol does not emit a
+// spawnAgent collab item. The parent receives a subAgentActivity pair first,
+// then the child thread's own lifecycle, then a completed activity pair.
+// Replaying that exact order must create one readable child, keep its output
+// out of the parent transcript, and close its registry row.
+func TestHandleCodexOutput_MultiAgentV2LifecycleOwnsTheChildTranscript(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingCodexEnsureSink{testSink: &testSink{}}
+	agent := newCodexAgentWithSink(sink)
+
+	activityStarted := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"call-spawn","kind":"started","agentThreadId":"child-thread","agentPath":"/root/probe_child"}}}`
+	activityStartedCompleted := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"call-spawn","kind":"started","agentThreadId":"child-thread","agentPath":"/root/probe_child"}}}`
+	handleCodexOutput(agent, parseLine([]byte(activityStarted)))
+	handleCodexOutput(agent, parseLine([]byte(activityStartedCompleted)))
+
+	rows := sink.BackgroundTasks()
+	require.Len(t, rows, 1, "one activity pair creates one registry row")
+	assert.Equal(t, "child-thread", rows[0].RowKey)
+	assert.Equal(t, "probe_child", rows[0].Title, "the task path supplies the readable title")
+	assert.Equal(t, "child-of-call-spawn", rows[0].ChildAgentID, "the row links to a transcript")
+	assert.Equal(t, "test-agent", rows[0].ParentAgentID)
+	assert.Equal(t, bgtask.StatusRunning, rows[0].Status)
+	require.Len(t, sink.ensureCalls, 1)
+	assert.Equal(t, codexEnsureCall{
+		spawnSpanID:      "call-spawn",
+		providerChildKey: "child-thread",
+		title:            "probe_child",
+	}, sink.ensureCalls[0], "child creation receives the same readable title")
+	agent.mu.Lock()
+	childState := agent.collabChildren["child-thread"]
+	agent.mu.Unlock()
+	assert.Equal(t, "call-spawn", childState.spawnCorrelationID)
+	assert.Equal(t, "main-thread", childState.parentThreadID)
+	assert.Equal(t, "/root/probe_child", childState.agentPath)
+
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"child-thread","turn":{"id":"child-turn"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/started","params":{"threadId":"child-thread","turnId":"child-turn","item":{"type":"agentMessage","id":"child-message","text":"","phase":"final_answer"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"child-thread","turnId":"child-turn","item":{"type":"agentMessage","id":"child-message","text":"CHILD_DONE","phase":"final_answer"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"child-thread","turn":{"id":"child-turn","status":"completed","items":[],"error":null}}}`)))
+
+	activityCompleted := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"subagent-completed-child-turn","kind":"completed","agentThreadId":"child-thread","agentPath":"/root/probe_child"}}}`
+	activityCompletedCompleted := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"subagent-completed-child-turn","kind":"completed","agentThreadId":"child-thread","agentPath":"/root/probe_child"}}}`
+	handleCodexOutput(agent, parseLine([]byte(activityCompleted)))
+	handleCodexOutput(agent, parseLine([]byte(activityCompletedCompleted)))
+
+	assert.Empty(t, sink.Messages(), "the parent transcript receives no child output")
+	child := sink.ChildSink("child-of-call-spawn").(*testSink)
+	childMessages := child.Messages()
+	require.Len(t, childMessages, 2, "the child receives its answer and turn end")
+	assert.Contains(t, string(childMessages[0].Content), "CHILD_DONE")
+	assert.True(t, childMessages[1].TurnEnd)
+
+	rows = sink.BackgroundTasks()
+	require.Len(t, rows, 1)
+	assert.Equal(t, bgtask.StatusCompleted, rows[0].Status)
+}
+
+func TestHandleCodexOutput_MultiAgentV2FailedTurnClosesWithoutAnActivity(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"call-spawn","kind":"started","agentThreadId":"child-thread","agentPath":"/root/failing_child"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"child-thread","turn":{"id":"child-turn"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"child-thread","turn":{"id":"child-turn","status":"failed","items":[],"error":{"message":"child failed"}}}}`)))
+
+	rows := sink.BackgroundTasks()
+	require.Len(t, rows, 1)
+	assert.Equal(t, bgtask.StatusFailed, rows[0].Status,
+		"V2 sends no failed activity, so the child turn closes the row")
+	child := sink.ChildSink("child-of-call-spawn").(*testSink)
+	require.Len(t, child.Messages(), 1)
+	assert.True(t, child.Messages()[0].TurnEnd)
+}
+
+func TestHandleCodexOutput_MultiAgentV2CompletedActivityClosesWithoutATurnEnd(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"call-spawn","kind":"started","agentThreadId":"child-thread","agentPath":"/root/completing_child"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"child-thread","turn":{"id":"child-turn"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"subagent-completed-child-turn","kind":"completed","agentThreadId":"child-thread","agentPath":"/root/completing_child"}}}`)))
+
+	rows := sink.BackgroundTasks()
+	require.Len(t, rows, 1)
+	assert.Equal(t, bgtask.StatusCompleted, rows[0].Status)
+	assert.Empty(t, agent.childTurnID("child-thread"), "the final activity clears steering state")
+	child := sink.ChildSink("child-of-call-spawn").(*testSink)
+	assert.Equal(t, []bool{true, false}, child.TurnActives())
+}
+
+func TestHandleCodexOutput_MultiAgentV2DuplicateCompletionRetriesARegistryFailure(t *testing.T) {
+	t.Parallel()
+
+	sink := &transientCodexCloseFailureSink{
+		testSink:      &testSink{},
+		closeFailures: 1,
+	}
+	agent := newCodexAgentWithSink(sink)
+	started := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"call-spawn","kind":"started","agentThreadId":"child-thread","agentPath":"/root/retry_child"}}}`
+	completed := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"child-completed","kind":"completed","agentThreadId":"child-thread","agentPath":"/root/retry_child"}}}`
+
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(completed)))
+	_, status, found, err := sink.LookupBackgroundTask("child-thread")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, bgtask.StatusRunning, status, "the failed close leaves the row active")
+
+	handleCodexOutput(agent, parseLine([]byte(completed)))
+	_, status, found, err = sink.LookupBackgroundTask("child-thread")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, bgtask.StatusCompleted, status, "the duplicate completion retries the close")
+	assert.Equal(t, 2, sink.closeAttempts)
+}
+
+func TestHandleCodexOutput_MultiAgentV2ReusesTheChildTranscript(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	started := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"call-spawn","kind":"started","agentThreadId":"child-thread","agentPath":"/root/reuse_child"}}}`
+	handleCodexOutput(agent, parseLine([]byte(started)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"child-thread","turn":{"id":"child-turn-1"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"child-thread","turnId":"child-turn-1","item":{"type":"agentMessage","id":"child-message-1","text":"FIRST_DONE","phase":"final_answer"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"child-thread","turn":{"id":"child-turn-1","status":"completed","items":[],"error":null}}}`)))
+
+	interacted := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"child-input","kind":"interacted","agentThreadId":"child-thread","agentPath":"/root/reuse_child"}}}`
+	handleCodexOutput(agent, parseLine([]byte(interacted)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"child-thread","turn":{"id":"child-turn-2"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"child-thread","turnId":"child-turn-2","item":{"type":"agentMessage","id":"child-message-2","text":"SECOND_DONE","phase":"final_answer"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"child-thread","turn":{"id":"child-turn-2","status":"completed","items":[],"error":null}}}`)))
+
+	assert.Empty(t, sink.Messages())
+	child := sink.ChildSink("child-of-call-spawn").(*testSink)
+	messages := child.Messages()
+	require.Len(t, messages, 4, "both turns use one child transcript")
+	assert.Contains(t, string(messages[0].Content), "FIRST_DONE")
+	assert.True(t, messages[1].TurnEnd)
+	assert.Contains(t, string(messages[2].Content), "SECOND_DONE")
+	assert.True(t, messages[3].TurnEnd)
+	rows := sink.BackgroundTasks()
+	require.Len(t, rows, 1)
+	assert.Equal(t, "child-of-call-spawn", rows[0].ChildAgentID)
+	assert.Equal(t, bgtask.StatusCompleted, rows[0].Status)
+}
+
+func TestHandleCodexOutput_MultiAgentV2NestedChildUsesItsDirectParent(t *testing.T) {
+	t.Parallel()
+
+	sink := &testSink{}
+	agent := newCodexAgentWithSink(sink)
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/started","params":{"threadId":"main-thread","turnId":"root-turn","item":{"type":"subAgentActivity","id":"call-parent","kind":"started","agentThreadId":"parent-thread","agentPath":"/root/parent_child"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/started","params":{"threadId":"parent-thread","turnId":"parent-turn","item":{"type":"subAgentActivity","id":"call-grandchild","kind":"started","agentThreadId":"grandchild-thread","agentPath":"/root/parent_child/grandchild"}}}`)))
+	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"grandchild-thread","turnId":"grandchild-turn","item":{"type":"agentMessage","id":"grandchild-message","text":"NESTED_DONE","phase":"final_answer"}}}`)))
+
+	rows := sink.BackgroundTasks()
+	require.Len(t, rows, 2)
+	var grandchildRow bgtask.Item
+	foundGrandchild := false
+	for _, row := range rows {
+		if row.RowKey == "grandchild-thread" {
+			grandchildRow = row
+			foundGrandchild = true
+		}
+	}
+	require.True(t, foundGrandchild)
+	assert.Equal(t, "grandchild", grandchildRow.Title)
+	assert.Equal(t, "child-of-call-parent", grandchildRow.ParentAgentID)
+	assert.Equal(t, "child-of-call-grandchild", grandchildRow.ChildAgentID)
+	assert.Empty(t, sink.Messages(), "nested output does not reach the root")
+
+	parent := sink.ChildSink("child-of-call-parent").(*testSink)
+	assert.Empty(t, parent.Messages(), "nested output does not reach the direct parent transcript")
+	grandchild := parent.ChildSink("child-of-call-grandchild").(*testSink)
+	require.Len(t, grandchild.Messages(), 1)
+	assert.Contains(t, string(grandchild.Messages()[0].Content), "NESTED_DONE")
+}
+
 // A spawnAgent tool call owns NO span: the subagent's output lives in its own
 // child transcript, so a rail held open for the whole run would only push every
 // concurrent tool one column right. The row still carries the span id (the
@@ -640,10 +857,9 @@ func TestHandleCodexOutput_ARerunCollabChildReopensItsRow(t *testing.T) {
 	assert.Equal(t, bgtask.StatusRunning, status)
 }
 
-// A replayed snapshot that still calls an old child running must NOT resurrect
-// it. The close dropped the child index, and nothing re-registered it, so the
-// row stays final and keeps its closer.
-func TestHandleCodexOutput_AReplayedRunningStateDoesNotReopenARow(t *testing.T) {
+// A replayed snapshot that still calls an old child running must not reopen it.
+// A later child turn is live evidence and must reopen the same transcript.
+func TestHandleCodexOutput_AReplayedRunningStateWaitsForALiveChildTurn(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -655,19 +871,21 @@ func TestHandleCodexOutput_AReplayedRunningStateDoesNotReopenARow(t *testing.T) 
 	// old child as running.
 	stale := `{"method":"item/completed","params":{"threadId":"main-thread","turnId":"turn2","item":{"type":"collabAgentToolCall","id":"call-2","tool":"spawnAgent","status":"completed","senderThreadId":"main-thread","receiverThreadIds":["child-2"],"prompt":"other","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{"child-1":{"status":"running"},"child-2":{"status":"completed"}}}}}`
 
-	// A child turn/started for the closed child, with no re-registration before
-	// it: knownCollabChild is false, so nothing reopens the row.
-	orphanTurn := `{"method":"turn/started","params":{"threadId":"child-1","turn":{"id":"turn-c9"}}}`
-
 	handleCodexOutput(agent, parseLine([]byte(started)))
 	handleCodexOutput(agent, parseLine([]byte(completed)))
 	handleCodexOutput(agent, parseLine([]byte(stale)))
-	handleCodexOutput(agent, parseLine([]byte(orphanTurn)))
 
 	assert.Empty(t, sink.RevivedTasks(), "a snapshot alone cannot prove a restart")
 	_, status, ok, _ := sink.LookupBackgroundTask("child-1")
 	require.True(t, ok)
 	assert.Equal(t, bgtask.StatusCompleted, status, "the row keeps its final status")
+
+	liveTurn := `{"method":"turn/started","params":{"threadId":"child-1","turn":{"id":"turn-c9"}}}`
+	handleCodexOutput(agent, parseLine([]byte(liveTurn)))
+	assert.Equal(t, []string{"child-1"}, sink.RevivedTasks(), "a live child turn reopens the row")
+	_, status, ok, _ = sink.LookupBackgroundTask("child-1")
+	require.True(t, ok)
+	assert.Equal(t, bgtask.StatusRunning, status)
 }
 
 // A subagent spawn that starts while an unrelated command is running draws that
@@ -783,7 +1001,7 @@ func TestHandleCodexOutput_SpawnAgentCompletedRegistersLateReceiverThreads(t *te
 	handleCodexOutput(agent, parseLine([]byte(cmdStarted)))
 
 	// The child's command routed to the child transcript (late receiver
-	// registration at spawn completion made the child index resolve).
+	// registration at spawn completion made the child route resolve).
 	parentMessages := sink.Messages()
 	require.Len(t, parentMessages, 2, "parent keeps spawn started + completed")
 	child := sink.ChildSink("child-of-call-1").(*testSink)
@@ -808,7 +1026,7 @@ func TestHandleCodexOutput_WaitCompletedClosesFinalSubagentSpan(t *testing.T) {
 	handleCodexOutput(agent, parseLine([]byte(completed)))
 
 	// wait is a flat tool span that CLOSES at completion (like every other collab
-	// tool). The old code gated CloseSpan behind `collab.Tool == "spawnAgent"`,
+	// tool). The old code ran CloseSpan only for `collab.Tool == "spawnAgent"`,
 	// leaving wait/sendInput/resumeAgent/closeAgent spans open until turn reset.
 	require.Contains(t, sink.ClosedSpans(), "call-2", "wait span closes at completion")
 }
@@ -1091,7 +1309,7 @@ func TestHandleCodexOutput_TurnCompletedChildPersistsChildTurnEnd(t *testing.T) 
 	agent := newCodexAgentWithSink(sink)
 	agent.threadID = "main-thread"
 
-	// Register child-1 -> call-1 in the child index (spawnAgent item/started).
+	// Register child-1 -> call-1 in the child route (spawnAgent item/started).
 	spawnStarted := `{"method":"item/started","params":{"threadId":"main-thread","turnId":"turn1","item":{"type":"collabAgentToolCall","id":"call-1","tool":"spawnAgent","status":"inProgress","senderThreadId":"main-thread","receiverThreadIds":["child-1"],"prompt":"do work","model":"gpt-5.4","reasoningEffort":"medium","agentsStates":{}}}}`
 	handleCodexOutput(agent, parseLine([]byte(spawnStarted)))
 	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/started","params":{"threadId":"child-1","turn":{"id":"turn-1"}}}`)))
@@ -1548,7 +1766,7 @@ func TestHandleCodexOutput_ReasoningItemCompletedReleasesStreamLock(t *testing.T
 	require.Equal(t, int64(2), lastThinkingTokens(sink))
 
 	// Completing the reasoning item resets the estimate (a main-scope AGENT commit)
-	// AND releases r1's stream-kind lock so the map stays bounded.
+	// AND releases r1's stream-kind lock so the map does not grow.
 	handleCodexOutput(agent, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"main-thread","item":{"type":"reasoning","id":"r1","summary":[{"text":"done"}]}}}`)))
 	agent.mu.Lock()
 	_, stillLocked := agent.reasoningStreamKind[codexReasoningKey("main-thread", "r1")]
@@ -1773,6 +1991,41 @@ func TestCodexCollabStatusToRegistry_ResumableInterrupted(t *testing.T) {
 	}
 }
 
+func TestCodexChildTurnRegistryStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		providerStatus string
+		wantStatus     bgtask.Status
+		wantFinished   bool
+		wantActivity   string
+	}{
+		{providerStatus: "completed", wantStatus: bgtask.StatusCompleted, wantFinished: true},
+		{providerStatus: "failed", wantStatus: bgtask.StatusFailed, wantFinished: true},
+		{providerStatus: "cancelled", wantStatus: bgtask.StatusRunning, wantActivity: "paused"},
+		{providerStatus: "canceled", wantStatus: bgtask.StatusRunning, wantActivity: "paused"},
+		{providerStatus: "interrupted", wantStatus: bgtask.StatusRunning, wantActivity: "paused"},
+		{providerStatus: "aborted", wantStatus: bgtask.StatusRunning, wantActivity: "paused"},
+		{providerStatus: "futureStatus", wantStatus: bgtask.StatusRunning},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.providerStatus, func(t *testing.T) {
+			t.Parallel()
+			params := json.RawMessage(`{"turn":{"status":"` + test.providerStatus + `"}}`)
+			status, finished, activity := codexChildTurnRegistryStatus(params)
+			assert.Equal(t, test.wantStatus, status)
+			assert.Equal(t, test.wantFinished, finished)
+			assert.Equal(t, test.wantActivity, activity)
+		})
+	}
+
+	status, finished, activity := codexChildTurnRegistryStatus(json.RawMessage(`{"turn":`))
+	assert.Equal(t, bgtask.StatusRunning, status)
+	assert.False(t, finished)
+	assert.Empty(t, activity)
+}
+
 // TestCodexSubAgentActivity_InterruptedStaysRunning verifies the
 // subAgentActivity "interrupted" kind upserts a Running row (not final
 // StatusInterrupted), so a later "started" activity can resume it.
@@ -1782,7 +2035,7 @@ func TestCodexSubAgentActivity_InterruptedStaysRunning(t *testing.T) {
 	sink := &testSink{}
 	a := newCodexAgentWithSink(sink)
 	item := json.RawMessage(`{"type":"subAgentActivity","agentThreadId":"thr-1","kind":"interrupted"}`)
-	assert.True(t, a.handleCodexSubAgentActivity(item), "consumed the activity item")
+	assert.True(t, a.handleCodexSubAgentActivity(item, "main-thread"), "consumed the activity item")
 	rows := sink.BackgroundTasks()
 	require.Len(t, rows, 1, "interrupted activity upserts one row")
 	assert.Equal(t, bgtask.StatusRunning, rows[0].Status, "interrupted stays Running (resumable)")
@@ -1791,7 +2044,7 @@ func TestCodexSubAgentActivity_InterruptedStaysRunning(t *testing.T) {
 
 	// A subsequent started activity must update the SAME row (not be absorbed).
 	started := json.RawMessage(`{"type":"subAgentActivity","agentThreadId":"thr-1","kind":"started"}`)
-	assert.True(t, a.handleCodexSubAgentActivity(started))
+	assert.True(t, a.handleCodexSubAgentActivity(started, "main-thread"))
 	rows = sink.BackgroundTasks()
 	require.Len(t, rows, 1)
 	assert.Equal(t, bgtask.StatusRunning, rows[0].Status)
@@ -1829,9 +2082,9 @@ func TestHandleCodexOutput_ASubAgentActivityReopensAFinishedChild(t *testing.T) 
 	assert.Equal(t, bgtask.StatusRunning, status)
 }
 
-// The negative half: an activity for a child nothing re-registered must NOT
-// reopen the row. The close dropped the child index, so the proof is absent.
-func TestHandleCodexOutput_ASubAgentActivityAloneDoesNotReopenARow(t *testing.T) {
+// A V2 interaction is itself live restart evidence. It does not need a legacy
+// resumeAgent collab item before it can reopen the durable child route.
+func TestHandleCodexOutput_ASubAgentActivityReopensWithoutALegacyCollabItem(t *testing.T) {
 	t.Parallel()
 
 	sink := &testSink{}
@@ -1845,20 +2098,18 @@ func TestHandleCodexOutput_ASubAgentActivityAloneDoesNotReopenARow(t *testing.T)
 	handleCodexOutput(agent, parseLine([]byte(completed)))
 	handleCodexOutput(agent, parseLine([]byte(interacted)))
 
-	assert.Empty(t, sink.RevivedTasks(), "an activity with no re-registration is not proof of a restart")
+	assert.Equal(t, []string{"child-1"}, sink.RevivedTasks(), "the activity reopens the child")
 	_, status, ok, _ := sink.LookupBackgroundTask("child-1")
 	require.True(t, ok)
-	assert.True(t, status.IsFinished(), "the row keeps its final status")
+	assert.Equal(t, bgtask.StatusRunning, status)
 }
 
 func TestHandleCodexOutput_ChildTurnEndSurvivesALostSpanIndex(t *testing.T) {
 	t.Parallel()
 
-	// The child's turn end is the ONLY thing that clears the child's own input
-	// queue. It resolves the child agent id through the span index, and a
-	// ClearContext wipes that index -- so a turn that ends after one left the
-	// child holding every later message with a turn nothing would clear. The
-	// agent id does not change once assigned, so it is remembered.
+	// The child's turn end is the only event that clears its input queue. The
+	// durable child ID must still route that event when the spawn correlation is
+	// missing. Otherwise, the child holds all later input behind a stale turn.
 	sink := &testSink{}
 	agent := newCodexAgentWithSink(sink)
 	agent.threadID = "main-thread"
@@ -1869,9 +2120,12 @@ func TestHandleCodexOutput_ChildTurnEndSurvivesALostSpanIndex(t *testing.T) {
 	child := sink.ChildSink("child-of-call-1").(*testSink)
 	require.Equal(t, []bool{true}, child.TurnActives(), "the child's turn opened")
 
-	// The span index goes away, the way ClearContext wipes it.
+	// Lose only the spawn correlation. The durable child ID still routes the
+	// turn end, which is the split state this regression covers.
 	agent.mu.Lock()
-	clear(agent.collabThreadSpans)
+	state := agent.collabChildren["child-1"]
+	state.spawnCorrelationID = ""
+	agent.collabChildren["child-1"] = state
 	agent.mu.Unlock()
 
 	handleCodexOutput(agent, parseLine([]byte(`{"method":"turn/completed","params":{"threadId":"child-1","turn":{"id":"turn-1","status":"completed","items":[],"error":null}}}`)))

--- a/backend/internal/worker/agent/codex_resume_test.go
+++ b/backend/internal/worker/agent/codex_resume_test.go
@@ -207,6 +207,70 @@ func TestCodexClearContextStartsFreshThread(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{"model_reasoning_summary": "detailed"}, sent[0].Params["config"])
 }
 
+func TestCodexClearContextDoesNotRouteLateChildOutputToTheNewRoot(t *testing.T) {
+	t.Parallel()
+
+	a, sink, _ := newCodexAgentForRPC(t, func(string) json.RawMessage {
+		return json.RawMessage(`{
+			"thread":{"id":"thread-new"},
+			"model":"gpt-5.4",
+			"reasoningEffort":"high",
+			"approvalPolicy":"on-request",
+			"sandbox":{"type":"workspaceWrite"}
+		}`)
+	})
+	a.threadID = "thread-old"
+	handleCodexOutput(a, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"thread-old","turnId":"root-turn","item":{"type":"subAgentActivity","id":"spawn-call","kind":"started","agentThreadId":"old-child","agentPath":"/root/old_child"}}}`)))
+
+	_, ok := a.ClearContext()
+	require.True(t, ok)
+	handleCodexOutput(a, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"old-child","turnId":"child-turn","item":{"type":"agentMessage","id":"late-message","text":"LATE_OLD_CHILD_OUTPUT","phase":"final_answer"}}}`)))
+
+	assert.Empty(t, sink.Messages(), "an old child item must not enter the new root transcript")
+}
+
+func TestCodexClearContextRejectsAChildRouteThatFinishesLate(t *testing.T) {
+	t.Parallel()
+
+	a, baseSink, _ := newCodexAgentForRPC(t, func(string) json.RawMessage {
+		return json.RawMessage(`{
+			"thread":{"id":"thread-new"},
+			"model":"gpt-5.4",
+			"reasoningEffort":"high",
+			"approvalPolicy":"on-request",
+			"sandbox":{"type":"workspaceWrite"}
+		}`)
+	})
+	a.threadID = "thread-old"
+	blockingSink := &blockingCodexEnsureSink{
+		testSink: baseSink,
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	a.sink = blockingSink
+	done := make(chan struct{})
+	go func() {
+		handleCodexOutput(a, parseLine([]byte(`{"method":"item/completed","params":{"threadId":"thread-old","turnId":"root-turn","item":{"type":"subAgentActivity","id":"spawn-call","kind":"started","agentThreadId":"old-child","agentPath":"/root/old_child"}}}`)))
+		close(done)
+	}()
+	<-blockingSink.started
+
+	clearDone := make(chan bool, 1)
+	go func() {
+		_, ok := a.ClearContext()
+		clearDone <- ok
+	}()
+	close(blockingSink.release)
+	ok := <-clearDone
+	require.True(t, ok)
+	<-done
+
+	a.mu.Lock()
+	_, oldRouteReturned := a.collabChildren["old-child"]
+	a.mu.Unlock()
+	assert.False(t, oldRouteReturned, "a completed old-thread write cannot repopulate the new context")
+}
+
 func testCodexThreadResponse(id, model string, effort, serviceTier, approvalPolicy, sandbox json.RawMessage) codexThreadResponse {
 	response := codexThreadResponse{
 		Model:          model,

--- a/backend/internal/worker/agent/codex_subagent.go
+++ b/backend/internal/worker/agent/codex_subagent.go
@@ -4,17 +4,43 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
 )
 
-// This file holds the Codex subagent integration (Part 4b): the background-task
-// registry drive from collab agentsStates + subAgentActivity, the child index
-// repurposed as EnsureChildAgent backing, child-thread routing, and the
-// ChildSteerer implementation. It keeps codex_output.go focused on the main-
-// thread item handlers; the collab-specific translation lives here.
+// codexChildState is one child thread's routing and lifecycle state. Identity
+// fields survive a completed run, so a follow-up turn reuses the same virtual
+// agent. A live event sets active and proves that the row can reopen. A stale
+// agentsStates snapshot does not supply that proof.
+type codexChildState struct {
+	spawnCorrelationID string
+	parentThreadID     string
+	childAgentID       string
+	agentPath          string
+	promptTitle        string
+	active             bool
+}
+
+func (s codexChildState) displayTitle() string {
+	if s.agentPath != "" {
+		return bgtask.CleanTitleRunes(codexAgentPathTitle(s.agentPath), 80)
+	}
+	return s.promptTitle
+}
+
+type codexChildRoute struct {
+	agentID       string
+	parentAgentID string
+	parentSink    ProviderServices
+	childSink     ProviderServices
+}
+
+// This file holds the Codex subagent integration: the legacy collab registry
+// adapter, the V2 activity lifecycle, direct-parent transcript routing, and the
+// ChildSteerer implementation. It keeps codex_output.go focused on item output.
 
 // codexCollabStatusToRegistry maps a collab agentsStates status to the registry
 // status. interrupted does NOT close the row (a child can be resumed via
@@ -48,12 +74,36 @@ func codexCollabStatusToRegistry(s string) (status bgtask.Status, finished bool,
 	}
 }
 
+// codexChildTurnRegistryStatus interprets a child turn boundary. V2 emits no
+// failed activity item, so a failed turn is the only final failure signal.
+// An interrupted turn remains resumable and keeps a paused row.
+func codexChildTurnRegistryStatus(params json.RawMessage) (status bgtask.Status, finished bool, activity string) {
+	var value struct {
+		Turn struct {
+			Status string `json:"status"`
+		} `json:"turn"`
+	}
+	if json.Unmarshal(params, &value) != nil {
+		return bgtask.StatusRunning, false, ""
+	}
+	switch strings.ToLower(value.Turn.Status) {
+	case "completed":
+		return bgtask.StatusCompleted, true, ""
+	case "failed":
+		return bgtask.StatusFailed, true, ""
+	case "cancelled", "canceled", "interrupted", "aborted":
+		return bgtask.StatusRunning, false, "paused"
+	default:
+		return bgtask.StatusRunning, false, ""
+	}
+}
+
 // collabAgentsStatesToRegistry walks a collab item's agentsStates and upserts/
 // closes the registry rows for each child thread. The child threadId is the
-// registry row_key; when the thread is known to the child index it is also the
+// registry row_key. When the child route knows the thread, the ID is also the
 // EnsureChildAgent providerChildKey (linking the row to a transcript). Final
-// states close the row AND remove the child-index entry; interrupted updates
-// without closing (resumable).
+// states close the row; interrupted updates without closing (resumable). The
+// durable route stays so a later run can reuse the same transcript.
 func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCall) {
 	if collab == nil || a.sink == nil {
 		return
@@ -64,18 +114,16 @@ func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCa
 		}
 		status, finished, activity := codexCollabStatusToRegistry(st.Status)
 		title := a.collabChildTitle(threadID)
-		// Link the registry row to a child transcript when the index knows the
-		// thread (EnsureChildAgent is idempotent).
+		route, routed := a.resolveCodexChild(threadID)
 		childAgentID := ""
-		spawnSpan := a.collabSpanForThread(threadID)
-		if spawnSpan != "" {
-			var err error
-			childAgentID, err = a.sink.EnsureChildAgent(spawnSpan, threadID, title)
-			if err != nil {
-				slog.Warn("codex collab ensure child failed", "thread", threadID, "error", err)
-			} else if prompt := a.collabChildPrompts.take(threadID); prompt != "" {
-				// The transcript exists now, so open it on the spawn prompt.
-				if err := a.sink.PersistChildPrompt(childAgentID, prompt); err != nil {
+		parentAgentID := ""
+		if routed {
+			childAgentID = route.agentID
+			parentAgentID = route.parentAgentID
+			if prompt := a.collabChildPrompts.take(threadID); prompt != "" {
+				// Multi-Agent V1 supplies a prompt. Multi-Agent V2 supplies only
+				// the canonical task path, so its transcript starts with output.
+				if err := route.parentSink.PersistChildPrompt(childAgentID, prompt); err != nil {
 					slog.Warn("codex collab persist prompt failed", "thread", threadID, "error", err)
 				}
 			}
@@ -87,7 +135,7 @@ func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCa
 			RowKey:        threadID,
 			Kind:          bgtask.KindSubagent,
 			ChildAgentID:  childAgentID,
-			ParentAgentID: a.agentID,
+			ParentAgentID: parentAgentID,
 			Title:         title,
 			ActiveForm:    activity,
 			Status:        status,
@@ -95,33 +143,16 @@ func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCa
 			slog.Warn("codex collab registry upsert failed", "thread", threadID, "error", err)
 		}
 		if finished {
-			if childAgentID == "" {
-				childAgentID = a.rememberedChildAgent(threadID)
+			completion := MessageCompletionError
+			switch status {
+			case bgtask.StatusCompleted:
+				completion = MessageCompletionComplete
+			case bgtask.StatusStopped, bgtask.StatusInterrupted:
+				completion = MessageCompletionInterrupted
+			default:
+				// Failed and unexpected active states keep the error completion.
 			}
-			if childAgentID != "" {
-				completion := MessageCompletionError
-				switch status {
-				case bgtask.StatusCompleted:
-					completion = MessageCompletionComplete
-				case bgtask.StatusStopped, bgtask.StatusInterrupted:
-					completion = MessageCompletionInterrupted
-				default:
-					// Failed and unexpected active states keep the error completion.
-				}
-				a.flushCodexChildGeneration(childAgentID, completion)
-				a.persistIncompleteCodexTools(childAgentID, false, completion)
-			}
-			if err := a.sink.CloseBackgroundTask(threadID, status); err != nil {
-				slog.Warn("codex collab registry close failed", "thread", threadID, "error", err)
-			}
-			a.removeCollabChildIndex(threadID)
-			// Release the child's per-agent service state (span tracker, todos,
-			// cached child sink) so a long-running root that cycles many collab
-			// children does not accumulate a stale entry per closed child until
-			// the root itself closes. The transcript row survives.
-			if childAgentID != "" {
-				a.sink.CleanupChildAgent(childAgentID)
-			}
+			a.completeCodexChildRun(threadID, status, completion)
 		}
 	}
 }
@@ -156,25 +187,25 @@ func (a *CodexAgent) reviveFinishedCollabChild(threadID string) {
 // child turn/started, a collab agentsStates walk, a subAgentActivity), and each
 // carried its own hand-placed copy of the same pair.
 //
-// The child INDEX is the proof: removeCollabChildIndex drops the entry at the
-// close, so a thread that is still known was re-registered by a later collab
-// call, which a replayed snapshot never does.
+// The active field is the proof. The durable route survives a close, so a
+// later direct child turn can reuse it. A replayed snapshot cannot set active.
 func (a *CodexAgent) upsertCollabChildRow(up bgtask.Upsert) error {
-	if !up.Status.IsFinished() && a.knownCollabChild(up.RowKey) {
+	if !up.Status.IsFinished() && a.activeCollabChild(up.RowKey) {
 		a.reviveFinishedCollabChild(up.RowKey)
 	}
 	return a.sink.UpsertBackgroundTask(up)
 }
 
 // handleCodexSubAgentActivity handles a v2 subAgentActivity item (registry
-// only; never persisted): {kind: started|interacted|interrupted, agentThreadId}.
-// started→Running, interacted→activity "received input", interrupted→Running
-// with activity "paused" (resumable; see codexCollabStatusToRegistry for why a
-// resumable interrupt must not use the final StatusInterrupted).
-func (a *CodexAgent) handleCodexSubAgentActivity(item json.RawMessage) bool {
+// only; never persisted). The started item is the V2 spawn authority: it
+// supplies the spawn call ID, child thread ID, and canonical task path. The
+// completed item closes the run. Interacted and interrupted remain resumable.
+func (a *CodexAgent) handleCodexSubAgentActivity(item json.RawMessage, parentThreadID string) bool {
 	var act struct {
 		Type          string `json:"type"`
+		ID            string `json:"id"`
 		AgentThreadID string `json:"agentThreadId"`
+		AgentPath     string `json:"agentPath"`
 		Kind          string `json:"kind"`
 	}
 	if json.Unmarshal(item, &act) != nil || act.Type != "subAgentActivity" {
@@ -183,29 +214,47 @@ func (a *CodexAgent) handleCodexSubAgentActivity(item json.RawMessage) bool {
 	if act.AgentThreadID == "" {
 		return true
 	}
-	var status bgtask.Status
+	if act.AgentPath != "" {
+		a.recordCollabChildAgentPath(act.AgentThreadID, act.AgentPath)
+	}
+	if act.Kind == "completed" {
+		a.completeCodexChildRun(act.AgentThreadID, bgtask.StatusCompleted, MessageCompletionComplete)
+		return true
+	}
+
 	var activity string
 	switch act.Kind {
 	case "started":
-		status = bgtask.StatusRunning
 	case "interacted":
-		status = bgtask.StatusRunning
 		activity = "received input"
 	case "interrupted":
-		status = bgtask.StatusRunning
 		activity = "paused"
 	default:
-		status = bgtask.StatusRunning
+		return true
+	}
+
+	// A started activity always comes from the direct parent. Later activity can
+	// come from another initiator, so registerCollabReceiver never replaces a
+	// parent that the start already recorded.
+	a.registerCollabReceiver(act.AgentThreadID, act.ID, parentThreadID)
+	route, routed := a.resolveCodexChild(act.AgentThreadID)
+	childAgentID := ""
+	parentAgentID := ""
+	if routed {
+		childAgentID = route.agentID
+		parentAgentID = route.parentAgentID
 	}
 	// upsertCollabChildRow reopens the row first. Without it an activity that
 	// follows a close lands its ActiveForm ("received input") on a row that still
 	// reads "completed" -- a finished subagent that just took a message.
 	if err := a.upsertCollabChildRow(bgtask.Upsert{
-		RowKey:     act.AgentThreadID,
-		Kind:       bgtask.KindSubagent,
-		Title:      a.collabChildTitle(act.AgentThreadID),
-		ActiveForm: activity,
-		Status:     status,
+		RowKey:        act.AgentThreadID,
+		Kind:          bgtask.KindSubagent,
+		ChildAgentID:  childAgentID,
+		ParentAgentID: parentAgentID,
+		Title:         a.collabChildTitle(act.AgentThreadID),
+		ActiveForm:    activity,
+		Status:        bgtask.StatusRunning,
 	}); err != nil {
 		slog.Warn("codex subAgentActivity upsert failed", "thread", act.AgentThreadID, "error", err)
 		return true
@@ -216,77 +265,131 @@ func (a *CodexAgent) handleCodexSubAgentActivity(item json.RawMessage) bool {
 	// it unconditionally. Same monotonic guard, so this cannot resurrect a row
 	// that already ended.
 	if activity == "" {
-		if err := a.sink.UpdateBackgroundTaskStatus(act.AgentThreadID, status, ""); err != nil {
+		if err := a.sink.UpdateBackgroundTaskStatus(act.AgentThreadID, bgtask.StatusRunning, ""); err != nil {
 			slog.Warn("codex subAgentActivity clear activity failed", "thread", act.AgentThreadID, "error", err)
 		}
 	}
 	return true
 }
 
-// --- Child index (collabThreadSpans repurposed as EnsureChildAgent backing) ---
-
-// collabSpanForThread returns the owning spawnAgent span id for a child thread,
-// or "" when the thread is unknown to the index.
-func (a *CodexAgent) collabSpanForThread(threadID string) string {
-	if threadID == "" {
-		return ""
+func codexAgentPathTitle(agentPath string) string {
+	agentPath = strings.TrimRight(strings.TrimSpace(agentPath), "/")
+	if i := strings.LastIndexByte(agentPath, '/'); i >= 0 {
+		agentPath = agentPath[i+1:]
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.collabThreadSpans == nil {
-		return ""
-	}
-	return a.collabThreadSpans[threadID]
+	return agentPath
 }
 
-// removeCollabChildIndex drops a child thread from the index (it reached a final status).
-// Both the thread->span mapping and the thread->title cache are cleared so a
-// long-lived session that repeatedly spawns and closes subagents does not
-// accumulate stale title entries (collabChildTitles is otherwise only cleared
-// on ClearContext).
-func (a *CodexAgent) removeCollabChildIndex(threadID string) {
+// --- Child index ---
+
+// finishCollabChildRun marks the current run final but keeps its durable route.
+// A follow-up turn can then reuse the same transcript and direct-parent sink.
+func (a *CodexAgent) finishCollabChildRun(threadID string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	childID := a.collabChildAgents[threadID]
-	if a.collabThreadSpans != nil {
-		delete(a.collabThreadSpans, threadID)
-	}
-	if a.collabChildAgents != nil {
-		delete(a.collabChildAgents, threadID)
-	}
-	if a.collabChildTitles != nil {
-		delete(a.collabChildTitles, threadID)
-	}
-	if childID != "" {
-		delete(a.childGenerationBuffers, childID)
+	state, ok := a.collabChildren[threadID]
+	if ok {
+		state.active = false
+		a.collabChildren[threadID] = state
+		if state.childAgentID != "" {
+			delete(a.childGenerationBuffers, state.childAgentID)
+		}
 	}
 	a.collabChildPrompts.forget(threadID)
 }
 
-// collabChildTitle returns a best-effort title for a child thread (the first
-// line of the spawn prompt). Empty when no spawn item has been seen yet.
+func (a *CodexAgent) activeCollabChild(threadID string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.collabChildren[threadID].active
+}
+
+func (a *CodexAgent) activateCollabChild(threadID string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	state, ok := a.collabChildren[threadID]
+	if !ok {
+		return false
+	}
+	state.active = true
+	a.collabChildren[threadID] = state
+	return true
+}
+
+// completeCodexChildRun closes one active run. Both child turn/completed and
+// the parent's completed activity can report the same run, so Active makes the
+// operation idempotent without deleting the route that a follow-up needs.
+func (a *CodexAgent) completeCodexChildRun(
+	threadID string,
+	status bgtask.Status,
+	completion MessageCompletion,
+) {
+	if !a.activeCollabChild(threadID) {
+		return
+	}
+	route, routed := a.resolveCodexChild(threadID)
+	if routed {
+		a.flushCodexChildGeneration(route.agentID, completion)
+		a.persistIncompleteCodexTools(route.agentID, false, completion)
+		if a.childTurnID(threadID) != "" {
+			a.clearChildTurnID(threadID)
+			publishSteerableTurnActiveTo(route.childSink, false, a.childTurnSeq())
+		}
+	}
+	if err := a.sink.CloseBackgroundTask(threadID, status); err != nil {
+		slog.Warn("codex child registry close failed", "thread", threadID, "error", err)
+		// Keep the run active. Codex sends duplicate lifecycle notifications,
+		// and the next one can retry this registry write.
+		return
+	}
+	a.finishCollabChildRun(threadID)
+	if routed {
+		route.parentSink.CleanupChildAgent(route.agentID)
+	}
+}
+
+// collabChildTitle returns the V2 path segment or the first V1 prompt line.
+// It returns an empty string when neither spawn form supplied a title.
 func (a *CodexAgent) collabChildTitle(threadID string) string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.collabChildTitles == nil {
-		return ""
-	}
-	return a.collabChildTitles[threadID]
+	return a.collabChildren[threadID].displayTitle()
 }
 
-// recordCollabChildTitle records the spawn prompt's first line as the title for
-// a child thread, for the registry + the child tab.
-func (a *CodexAgent) recordCollabChildTitle(threadID, prompt string) {
+// recordCollabChildPromptTitle records the first V1 prompt line as the title.
+func (a *CodexAgent) recordCollabChildPromptTitle(threadID, prompt string) {
 	if threadID == "" {
 		return
 	}
 	title := bgtask.CleanTitleRunes(bgtask.FirstLine(prompt), 80)
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.collabChildTitles == nil {
-		a.collabChildTitles = make(map[string]string)
+	if a.collabChildren == nil {
+		a.collabChildren = make(map[string]codexChildState)
 	}
-	a.collabChildTitles[threadID] = title
+	state := a.collabChildren[threadID]
+	state.promptTitle = title
+	a.collabChildren[threadID] = state
+}
+
+// recordCollabChildAgentPath records the canonical V2 path. The title remains
+// derived from this source, and the path stays available after the run.
+func (a *CodexAgent) recordCollabChildAgentPath(threadID, agentPath string) {
+	if threadID == "" {
+		return
+	}
+	agentPath = strings.TrimRight(strings.TrimSpace(agentPath), "/")
+	if agentPath == "" {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.collabChildren == nil {
+		a.collabChildren = make(map[string]codexChildState)
+	}
+	state := a.collabChildren[threadID]
+	state.agentPath = agentPath
+	a.collabChildren[threadID] = state
 }
 
 // --- ChildSteerer implementation ---
@@ -304,9 +407,9 @@ func (a *CodexAgent) recordCollabChildTitle(threadID, prompt string) {
 func (a *CodexAgent) SendChildInput(childKey, content string, attachments []*leapmuxv1.Attachment) error {
 	threadID := childKey
 	if !a.knownCollabChild(threadID) {
-		// The owner process runs, but its in-memory spawn index does not know
-		// this thread. The worker rebuilds that index only when the live collab
-		// spawn reports the thread again, so the index is empty after a worker
+		// The owner process runs, but its in-memory child route does not know
+		// this thread. The worker rebuilds that route only when a live spawn
+		// reports the thread again, so the route is empty after a worker
 		// restart. The persisted registry row resolves, so the child IS
 		// steerable in principle. ErrChildNotSteerableYet states exactly that
 		// condition; its declaration lists the caller that maps it and where.
@@ -416,8 +519,8 @@ func (a *CodexAgent) sendTurnStartChild(threadID, input string) error {
 func (a *CodexAgent) knownCollabChild(threadID string) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	_, ok := a.collabThreadSpans[threadID]
-	return ok
+	state, ok := a.collabChildren[threadID]
+	return ok && (state.spawnCorrelationID != "" || state.childAgentID != "")
 }
 
 // childTurnID returns the active turn id for a child thread ("" if none).

--- a/backend/internal/worker/agent/codex_subagent.go
+++ b/backend/internal/worker/agent/codex_subagent.go
@@ -5,28 +5,75 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
-	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 	"github.com/leapmux/leapmux/internal/worker/bgtask"
 )
 
-// codexChildState is one child thread's routing and lifecycle state. Identity
-// fields survive a completed run, so a follow-up turn reuses the same virtual
-// agent. A live event sets active and proves that the row can reopen. A stale
-// agentsStates snapshot does not supply that proof.
-type codexChildState struct {
-	spawnCorrelationID string
-	parentThreadID     string
-	childAgentID       string
-	agentPath          string
-	promptTitle        string
-	active             bool
+const (
+	codexPendingChildGenerationLimit = 1 << 20
+	codexPendingChildEventLimit      = 256
+	codexPendingChildEventBytesLimit = 4 << 20
+)
+
+type codexChildPhase uint8
+
+const (
+	codexChildPending codexChildPhase = iota
+	codexChildRunning
+	codexChildClosing
+	codexChildInactive
+)
+
+type codexChildTransition struct {
+	status     bgtask.Status
+	completion MessageCompletion
+	activity   string
 }
 
-func (s codexChildState) displayTitle() string {
+func (t codexChildTransition) finished() bool {
+	return t.status.IsFinished()
+}
+
+type codexPendingChildEventKind uint8
+
+const (
+	codexPendingItemStarted codexPendingChildEventKind = iota
+	codexPendingItemCompleted
+	codexPendingTurnStarted
+	codexPendingTurnCompleted
+)
+
+type codexPendingChildEvent struct {
+	kind   codexPendingChildEventKind
+	raw    json.RawMessage
+	params json.RawMessage
+}
+
+// codexChildState owns one child thread's route, output, and run lifecycle.
+// Route identity survives a completed run so a later turn reuses the same
+// transcript. Pending events stay capped until the authoritative start event
+// supplies the route.
+type codexChildState struct {
+	spawnCorrelationID     string
+	parentThreadID         string
+	childAgentID           string
+	agentPath              string
+	promptTitle            string
+	prompt                 string
+	phase                  codexChildPhase
+	finalTransition        codexChildTransition
+	transcriptFinalized    bool
+	generationBuffer       GenerationBuffer
+	pendingGenerationBytes int
+	pendingEvents          []codexPendingChildEvent
+	pendingEventBytes      int
+	pendingOutputDropped   bool
+	turnID                 string
+}
+
+func (s *codexChildState) displayTitle() string {
 	if s.agentPath != "" {
-		return bgtask.CleanTitleRunes(codexAgentPathTitle(s.agentPath), 80)
+		return codexAgentPathTitle(s.agentPath)
 	}
 	return s.promptTitle
 }
@@ -40,11 +87,10 @@ type codexChildRoute struct {
 
 // This file holds the Codex subagent integration: the legacy collab registry
 // adapter, the V2 activity lifecycle, direct-parent transcript routing, and the
-// ChildSteerer implementation. It keeps codex_output.go focused on item output.
+// child interruption. It keeps codex_output.go focused on item output.
 
-// codexCollabStatusToRegistry maps a collab agentsStates status to the registry
-// status. interrupted does NOT close the row (a child can be resumed via
-// resumeAgent), so the caller distinguishes close-vs-update separately.
+// codexCollabTransition maps a collab agentsStates status to one child
+// transition. An interrupted child remains resumable.
 //
 // A resumable "interrupted" child stays Running in the registry (with a paused
 // activity line). This is an IN-SESSION Codex collab pause, not a worker
@@ -57,44 +103,44 @@ type codexChildRoute struct {
 // at Interrupted forever. StatusInterrupted is reserved for the boot sweep that
 // marks tasks left active by a crashed worker (a genuine ending: a background
 // task never survives a worker restart).
-func codexCollabStatusToRegistry(s string) (status bgtask.Status, finished bool, activity string) {
+func codexCollabTransition(s string) codexChildTransition {
 	switch s {
 	case "pendingInit", "running":
-		return bgtask.StatusRunning, false, ""
+		return codexChildTransition{status: bgtask.StatusRunning}
 	case "completed":
-		return bgtask.StatusCompleted, true, ""
+		return codexChildTransition{status: bgtask.StatusCompleted, completion: MessageCompletionComplete}
 	case "errored", "notFound":
-		return bgtask.StatusFailed, true, ""
+		return codexChildTransition{status: bgtask.StatusFailed, completion: MessageCompletionError}
 	case "shutdown":
-		return bgtask.StatusStopped, true, ""
+		return codexChildTransition{status: bgtask.StatusStopped, completion: MessageCompletionInterrupted}
 	case "interrupted":
-		return bgtask.StatusRunning, false, "paused"
+		return codexChildTransition{status: bgtask.StatusRunning, activity: "paused"}
 	default:
-		return bgtask.StatusRunning, false, ""
+		return codexChildTransition{status: bgtask.StatusRunning}
 	}
 }
 
-// codexChildTurnRegistryStatus interprets a child turn boundary. V2 emits no
+// codexChildTurnTransition interprets a child turn boundary. V2 emits no
 // failed activity item, so a failed turn is the only final failure signal.
 // An interrupted turn remains resumable and keeps a paused row.
-func codexChildTurnRegistryStatus(params json.RawMessage) (status bgtask.Status, finished bool, activity string) {
+func codexChildTurnTransition(params json.RawMessage) codexChildTransition {
 	var value struct {
 		Turn struct {
 			Status string `json:"status"`
 		} `json:"turn"`
 	}
 	if json.Unmarshal(params, &value) != nil {
-		return bgtask.StatusRunning, false, ""
+		return codexChildTransition{status: bgtask.StatusRunning}
 	}
 	switch strings.ToLower(value.Turn.Status) {
 	case "completed":
-		return bgtask.StatusCompleted, true, ""
+		return codexChildTransition{status: bgtask.StatusCompleted, completion: MessageCompletionComplete}
 	case "failed":
-		return bgtask.StatusFailed, true, ""
+		return codexChildTransition{status: bgtask.StatusFailed, completion: MessageCompletionError}
 	case "cancelled", "canceled", "interrupted", "aborted":
-		return bgtask.StatusRunning, false, "paused"
+		return codexChildTransition{status: bgtask.StatusRunning, activity: "paused"}
 	default:
-		return bgtask.StatusRunning, false, ""
+		return codexChildTransition{status: bgtask.StatusRunning}
 	}
 }
 
@@ -112,49 +158,44 @@ func (a *CodexAgent) collabAgentsStatesToRegistry(collab *codexCollabAgentToolCa
 		if threadID == "" {
 			continue
 		}
-		status, finished, activity := codexCollabStatusToRegistry(st.Status)
-		title := a.collabChildTitle(threadID)
-		route, routed := a.resolveCodexChild(threadID)
-		childAgentID := ""
-		parentAgentID := ""
-		if routed {
-			childAgentID = route.agentID
-			parentAgentID = route.parentAgentID
-			if prompt := a.collabChildPrompts.take(threadID); prompt != "" {
-				// Multi-Agent V1 supplies a prompt. Multi-Agent V2 supplies only
-				// the canonical task path, so its transcript starts with output.
-				if err := route.parentSink.PersistChildPrompt(childAgentID, prompt); err != nil {
-					slog.Warn("codex collab persist prompt failed", "thread", threadID, "error", err)
-				}
-			}
-		}
-		// upsertCollabChildRow reopens the row first when this walk reports the
-		// child still running after its row went final. The reopened row keeps a
-		// closer: this same walk closes it when the state goes final again.
-		if err := a.upsertCollabChildRow(bgtask.Upsert{
-			RowKey:        threadID,
-			Kind:          bgtask.KindSubagent,
-			ChildAgentID:  childAgentID,
-			ParentAgentID: parentAgentID,
-			Title:         title,
-			ActiveForm:    activity,
-			Status:        status,
-		}); err != nil {
+		transition := codexCollabTransition(st.Status)
+		if _, _, err := a.upsertCodexChildRegistryRow(threadID, transition); err != nil {
 			slog.Warn("codex collab registry upsert failed", "thread", threadID, "error", err)
 		}
-		if finished {
-			completion := MessageCompletionError
-			switch status {
-			case bgtask.StatusCompleted:
-				completion = MessageCompletionComplete
-			case bgtask.StatusStopped, bgtask.StatusInterrupted:
-				completion = MessageCompletionInterrupted
-			default:
-				// Failed and unexpected active states keep the error completion.
-			}
-			a.completeCodexChildRun(threadID, status, completion)
+		if transition.finished() {
+			a.completeCodexChildRun(threadID, transition)
 		}
 	}
+}
+
+// upsertCodexChildRegistryRow builds the registry row from the child route.
+// Route creation is explicit here because this write can link a transcript.
+func (a *CodexAgent) upsertCodexChildRegistryRow(
+	threadID string,
+	transition codexChildTransition,
+) (codexChildRoute, bool, error) {
+	route, routed := a.ensureCodexChildRoute(threadID)
+	childAgentID := ""
+	parentAgentID := ""
+	if routed {
+		childAgentID = route.agentID
+		parentAgentID = route.parentAgentID
+		if prompt := a.takeCollabChildPrompt(threadID); prompt != "" {
+			if err := route.parentSink.PersistChildPrompt(childAgentID, prompt); err != nil {
+				slog.Warn("codex collab persist prompt failed", "thread", threadID, "error", err)
+			}
+		}
+	}
+	err := a.upsertCollabChildRow(bgtask.Upsert{
+		RowKey:        threadID,
+		Kind:          bgtask.KindSubagent,
+		ChildAgentID:  childAgentID,
+		ParentAgentID: parentAgentID,
+		Title:         a.collabChildTitle(threadID),
+		ActiveForm:    transition.activity,
+		Status:        transition.status,
+	})
+	return route, routed, err
 }
 
 // reviveFinishedCollabChild returns a collab child's row to Running when the
@@ -214,57 +255,55 @@ func (a *CodexAgent) handleCodexSubAgentActivity(item json.RawMessage, parentThr
 	if act.AgentThreadID == "" {
 		return true
 	}
+	if codexAgentPathIsRoot(act.AgentPath) || a.isMainThreadID(act.AgentThreadID) ||
+		a.isRetiredCodexThread(act.AgentThreadID) {
+		return true
+	}
 	if act.AgentPath != "" {
 		a.recordCollabChildAgentPath(act.AgentThreadID, act.AgentPath)
 	}
 	if act.Kind == "completed" {
-		a.completeCodexChildRun(act.AgentThreadID, bgtask.StatusCompleted, MessageCompletionComplete)
+		a.completeCodexChildRun(act.AgentThreadID, codexChildTransition{
+			status:     bgtask.StatusCompleted,
+			completion: MessageCompletionComplete,
+		})
 		return true
 	}
 
-	var activity string
+	transition := codexChildTransition{status: bgtask.StatusRunning}
 	switch act.Kind {
 	case "started":
+		if !a.registerCodexV2ChildStart(act.AgentThreadID, act.ID, parentThreadID) {
+			return true
+		}
 	case "interacted":
-		activity = "received input"
+		transition.activity = "received input"
+		a.activateCollabChild(act.AgentThreadID)
 	case "interrupted":
-		activity = "paused"
+		transition.activity = "paused"
+		a.activateCollabChild(act.AgentThreadID)
 	default:
-		return true
+		// An unknown activity still proves that the child exists. Do not infer
+		// route identity from its call ID; only started supplies that authority.
+		transition.activity = "working"
+		a.activateCollabChild(act.AgentThreadID)
 	}
 
-	// A started activity always comes from the direct parent. Later activity can
-	// come from another initiator, so registerCollabReceiver never replaces a
-	// parent that the start already recorded.
-	a.registerCollabReceiver(act.AgentThreadID, act.ID, parentThreadID)
-	route, routed := a.resolveCodexChild(act.AgentThreadID)
-	childAgentID := ""
-	parentAgentID := ""
-	if routed {
-		childAgentID = route.agentID
-		parentAgentID = route.parentAgentID
-	}
-	// upsertCollabChildRow reopens the row first. Without it an activity that
-	// follows a close lands its ActiveForm ("received input") on a row that still
-	// reads "completed" -- a finished subagent that just took a message.
-	if err := a.upsertCollabChildRow(bgtask.Upsert{
-		RowKey:        act.AgentThreadID,
-		Kind:          bgtask.KindSubagent,
-		ChildAgentID:  childAgentID,
-		ParentAgentID: parentAgentID,
-		Title:         a.collabChildTitle(act.AgentThreadID),
-		ActiveForm:    activity,
-		Status:        bgtask.StatusRunning,
-	}); err != nil {
+	route, routed, err := a.upsertCodexChildRegistryRow(act.AgentThreadID, transition)
+	if err != nil {
 		slog.Warn("codex subAgentActivity upsert failed", "thread", act.AgentThreadID, "error", err)
 		return true
+	}
+	if routed {
+		a.replayPendingCodexChildEvents(act.AgentThreadID, route)
+		a.retryCodexChildCompletion(act.AgentThreadID)
 	}
 	// An upsert cannot CLEAR a field: a blank one means "keep", so the row would
 	// still read "paused" after the subagent resumed. `started` is exactly that
 	// transition, so the activity line is set through the primitive that writes
 	// it unconditionally. Same monotonic guard, so this cannot resurrect a row
 	// that already ended.
-	if activity == "" {
+	if transition.activity == "" {
 		if err := a.sink.UpdateBackgroundTaskStatus(act.AgentThreadID, bgtask.StatusRunning, ""); err != nil {
 			slog.Warn("codex subAgentActivity clear activity failed", "thread", act.AgentThreadID, "error", err)
 		}
@@ -280,72 +319,152 @@ func codexAgentPathTitle(agentPath string) string {
 	return agentPath
 }
 
+func codexAgentPathIsRoot(agentPath string) bool {
+	return strings.TrimRight(strings.TrimSpace(agentPath), "/") == "/root"
+}
+
 // --- Child index ---
 
-// finishCollabChildRun marks the current run final but keeps its durable route.
-// A follow-up turn can then reuse the same transcript and direct-parent sink.
-func (a *CodexAgent) finishCollabChildRun(threadID string) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	state, ok := a.collabChildren[threadID]
-	if ok {
-		state.active = false
-		a.collabChildren[threadID] = state
-		if state.childAgentID != "" {
-			delete(a.childGenerationBuffers, state.childAgentID)
-		}
+func (a *CodexAgent) codexChildStateLocked(threadID string) *codexChildState {
+	if threadID == "" {
+		return nil
 	}
-	a.collabChildPrompts.forget(threadID)
+	if a.collabChildren == nil {
+		a.collabChildren = make(map[string]*codexChildState)
+	}
+	state := a.collabChildren[threadID]
+	if state == nil {
+		state = &codexChildState{}
+		a.collabChildren[threadID] = state
+	}
+	return state
+}
+
+func (a *CodexAgent) registerCodexV2ChildStart(threadID, spawnCorrelationID, parentThreadID string) bool {
+	if threadID == "" {
+		return false
+	}
+	a.mu.Lock()
+	state := a.codexChildStateLocked(threadID)
+	if state.phase == codexChildInactive && state.spawnCorrelationID == spawnCorrelationID {
+		a.mu.Unlock()
+		return false
+	}
+	state.spawnCorrelationID = spawnCorrelationID
+	if parentThreadID == "" {
+		parentThreadID = a.threadID
+	}
+	state.parentThreadID = parentThreadID
+	if state.phase != codexChildClosing {
+		a.activateCodexChildStateLocked(state)
+	}
+	a.mu.Unlock()
+	return true
+}
+
+func (a *CodexAgent) activateCodexChildStateLocked(state *codexChildState) {
+	if state.phase == codexChildInactive || state.phase == codexChildPending {
+		state.finalTransition = codexChildTransition{}
+		state.transcriptFinalized = false
+	}
+	state.phase = codexChildRunning
 }
 
 func (a *CodexAgent) activeCollabChild(threadID string) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.collabChildren[threadID].active
+	state := a.collabChildren[threadID]
+	return state != nil && state.phase == codexChildRunning
 }
 
 func (a *CodexAgent) activateCollabChild(threadID string) bool {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	state, ok := a.collabChildren[threadID]
-	if !ok {
+	if threadID == "" {
 		return false
 	}
-	state.active = true
-	a.collabChildren[threadID] = state
-	return true
+	a.mu.Lock()
+	state := a.codexChildStateLocked(threadID)
+	if state.phase != codexChildClosing {
+		a.activateCodexChildStateLocked(state)
+	}
+	known := state.spawnCorrelationID != "" || state.childAgentID != ""
+	a.mu.Unlock()
+	return known
 }
 
-// completeCodexChildRun closes one active run. Both child turn/completed and
-// the parent's completed activity can report the same run, so Active makes the
-// operation idempotent without deleting the route that a follow-up needs.
-func (a *CodexAgent) completeCodexChildRun(
-	threadID string,
-	status bgtask.Status,
-	completion MessageCompletion,
-) {
-	if !a.activeCollabChild(threadID) {
+// completeCodexChildRun moves one run through closing to inactive. Transcript
+// finalization runs once. A duplicate completion retries only the registry
+// close that failed.
+func (a *CodexAgent) completeCodexChildRun(threadID string, transition codexChildTransition) {
+	if threadID == "" || !transition.finished() {
 		return
 	}
-	route, routed := a.resolveCodexChild(threadID)
-	if routed {
-		a.flushCodexChildGeneration(route.agentID, completion)
-		a.persistIncompleteCodexTools(route.agentID, false, completion)
-		if a.childTurnID(threadID) != "" {
-			a.clearChildTurnID(threadID)
-			publishSteerableTurnActiveTo(route.childSink, false, a.childTurnSeq())
-		}
+	a.mu.Lock()
+	state := a.codexChildStateLocked(threadID)
+	if state.phase == codexChildInactive {
+		a.mu.Unlock()
+		return
 	}
-	if err := a.sink.CloseBackgroundTask(threadID, status); err != nil {
+	if state.phase != codexChildClosing || transition.status == bgtask.StatusFailed {
+		state.finalTransition = transition
+	}
+	state.phase = codexChildClosing
+	hadTurn := state.turnID != ""
+	state.turnID = ""
+	finalized := state.transcriptFinalized
+	a.mu.Unlock()
+
+	route, routed := a.ensureCodexChildRoute(threadID)
+	if !routed {
+		return
+	}
+	if !finalized {
+		a.flushCodexChildGeneration(threadID, transition.completion)
+		a.persistIncompleteCodexTools(threadID, false, transition.completion)
+		if hadTurn {
+			a.publishCodexChildTurnActive(route.childSink, false)
+		}
+		a.mu.Lock()
+		if current := a.collabChildren[threadID]; current != nil && current.phase == codexChildClosing {
+			current.transcriptFinalized = true
+		}
+		a.mu.Unlock()
+	}
+	if err := a.sink.CloseBackgroundTask(threadID, transition.status); err != nil {
 		slog.Warn("codex child registry close failed", "thread", threadID, "error", err)
-		// Keep the run active. Codex sends duplicate lifecycle notifications,
-		// and the next one can retry this registry write.
 		return
 	}
 	a.finishCollabChildRun(threadID)
-	if routed {
-		route.parentSink.CleanupChildAgent(route.agentID)
+	route.parentSink.CleanupChildAgent(route.agentID)
+}
+
+func (a *CodexAgent) retryCodexChildCompletion(threadID string) {
+	a.mu.Lock()
+	state := a.collabChildren[threadID]
+	if state == nil || state.phase != codexChildClosing {
+		a.mu.Unlock()
+		return
 	}
+	transition := state.finalTransition
+	a.mu.Unlock()
+	a.completeCodexChildRun(threadID, transition)
+}
+
+// finishCollabChildRun keeps route identity and releases per-run state.
+func (a *CodexAgent) finishCollabChildRun(threadID string) {
+	a.mu.Lock()
+	state := a.collabChildren[threadID]
+	if state != nil {
+		state.phase = codexChildInactive
+		state.finalTransition = codexChildTransition{}
+		state.transcriptFinalized = false
+		state.prompt = ""
+		state.pendingEvents = nil
+		state.pendingEventBytes = 0
+		state.pendingOutputDropped = false
+		state.pendingGenerationBytes = 0
+		state.generationBuffer.Reset()
+	}
+	a.mu.Unlock()
 }
 
 // collabChildTitle returns the V2 path segment or the first V1 prompt line.
@@ -353,7 +472,11 @@ func (a *CodexAgent) completeCodexChildRun(
 func (a *CodexAgent) collabChildTitle(threadID string) string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	return a.collabChildren[threadID].displayTitle()
+	state := a.collabChildren[threadID]
+	if state == nil {
+		return ""
+	}
+	return state.displayTitle()
 }
 
 // recordCollabChildPromptTitle records the first V1 prompt line as the title.
@@ -361,15 +484,11 @@ func (a *CodexAgent) recordCollabChildPromptTitle(threadID, prompt string) {
 	if threadID == "" {
 		return
 	}
-	title := bgtask.CleanTitleRunes(bgtask.FirstLine(prompt), 80)
+	title := bgtask.FirstLine(prompt)
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.collabChildren == nil {
-		a.collabChildren = make(map[string]codexChildState)
-	}
-	state := a.collabChildren[threadID]
+	state := a.codexChildStateLocked(threadID)
 	state.promptTitle = title
-	a.collabChildren[threadID] = state
 }
 
 // recordCollabChildAgentPath records the canonical V2 path. The title remains
@@ -384,135 +503,50 @@ func (a *CodexAgent) recordCollabChildAgentPath(threadID, agentPath string) {
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.collabChildren == nil {
-		a.collabChildren = make(map[string]codexChildState)
-	}
-	state := a.collabChildren[threadID]
+	state := a.codexChildStateLocked(threadID)
 	state.agentPath = agentPath
-	a.collabChildren[threadID] = state
 }
 
-// --- ChildSteerer implementation ---
-
-// SendChildInput starts a new turn on a child conversation (childKey = child
-// threadId). It never steers. SteerChildInput is the one method that adds input
-// to an active child turn.
-//
-// turn/steer and turn/start are not safely composable, so this method must not
-// try one and then the other. A transport failure after the host applies the
-// steer starts a DUPLICATE concurrent turn on the same thread, which
-// interleaves the output and leaves an orphaned turn that nothing can steer.
-// So this method refuses an active child turn and returns ErrNoActiveTurn. The
-// Worker queue then holds the input until that turn ends.
-func (a *CodexAgent) SendChildInput(childKey, content string, attachments []*leapmuxv1.Attachment) error {
-	threadID := childKey
-	if !a.knownCollabChild(threadID) {
-		// The owner process runs, but its in-memory child route does not know
-		// this thread. The worker rebuilds that route only when a live spawn
-		// reports the thread again, so the route is empty after a worker
-		// restart. The persisted registry row resolves, so the child IS
-		// steerable in principle. ErrChildNotSteerableYet states exactly that
-		// condition; its declaration lists the caller that maps it and where.
-		return fmt.Errorf("%w: unknown codex subagent thread %q", ErrChildNotSteerableYet, childKey)
+func (a *CodexAgent) rememberCollabChildPrompt(threadID, prompt string) {
+	if threadID == "" || prompt == "" {
+		return
 	}
-	// The child already runs a turn, so it cannot take a NEW turn now. That is
-	// the busy condition, not the absent-turn condition: ErrNoActiveTurn here
-	// would tell the queue to store a permanent failure whose text says the
-	// child has no turn, while the child is visibly working.
-	if a.childTurnID(threadID) != "" {
-		// No publish here, unlike the main-thread refusals. A child's activity
-		// state comes from its background-task registry row rather than from a
-		// turn flag, and the child's own queue already holds the turn that its
-		// dispatch opened -- so the publish would need a registry write to
-		// resolve the child agent id, and would then tell nobody anything new.
-		return ErrAgentBusy
+	a.mu.Lock()
+	state := a.codexChildStateLocked(threadID)
+	if state.prompt == "" {
+		state.prompt = prompt
 	}
-	return a.sendTurnStartChild(threadID, codexChildInput(content, attachments))
+	a.mu.Unlock()
 }
 
-func (a *CodexAgent) SteerChildInput(childKey, content string, attachments []*leapmuxv1.Attachment) error {
-	if !a.knownCollabChild(childKey) {
-		return fmt.Errorf("%w: unknown codex subagent thread %q", ErrChildNotSteerableYet, childKey)
+func (a *CodexAgent) takeCollabChildPrompt(threadID string) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	state := a.collabChildren[threadID]
+	if state == nil {
+		return ""
 	}
-	turnID := a.childTurnID(childKey)
-	if turnID == "" {
-		return ErrNoActiveTurn
-	}
-	if err := a.sendTurnSteer(childKey, turnID, []map[string]interface{}{{"type": "text", "text": codexChildInput(content, attachments)}}); err != nil {
-		return err
-	}
-	if a.childTurnID(childKey) != turnID {
-		return ErrNoActiveTurn
-	}
-	return nil
-}
-
-func (a *CodexAgent) ActiveChildTurnState(childKey string) TurnState {
-	active := a.childTurnID(childKey) != ""
-	return TurnState{Active: active, Steerable: active}
-}
-
-func codexChildInput(content string, attachments []*leapmuxv1.Attachment) string {
-	// Codex child turns accept only string input. Preserve each attachment name
-	// so the child can ask the user for content that it cannot receive directly.
-	for _, attachment := range attachments {
-		if attachment.GetFilename() != "" {
-			content += "\n\n[attachment: " + attachment.GetFilename() + "]"
-		}
-	}
-	return content
+	prompt := state.prompt
+	state.prompt = ""
+	return prompt
 }
 
 // InterruptChild aborts a child's current turn inside the owner process.
 func (a *CodexAgent) InterruptChild(childKey string) error {
 	threadID := childKey
 	if !a.knownCollabChild(threadID) {
-		// See SendChildInput: the live index may be empty after a restart even
-		// though the registry row resolves. Retry, not a permanent failure.
-		return fmt.Errorf("%w: unknown codex subagent thread %q", ErrChildNotSteerableYet, childKey)
+		// The live route can be empty after a restart while the registry row
+		// still resolves. Report a retryable failure.
+		return fmt.Errorf("%w: unknown codex subagent thread %q", ErrChildRouteNotReady, childKey)
 	}
 	turnID := a.childTurnID(threadID)
 	return a.interruptCodexTurn(threadID, turnID)
 }
 
-// sendTurnStartChild starts a new turn on a child thread. The turn/started
-// notification is the acceptance signal across Codex versions.
-func (a *CodexAgent) sendTurnStartChild(threadID, input string) error {
-	params := map[string]any{
-		"threadId": threadID,
-		"input":    input,
-	}
-	paramsJSON, err := json.Marshal(params)
-	if err != nil {
-		return fmt.Errorf("marshal turn/start params: %w", err)
-	}
-	ack := make(chan struct{})
-	a.mu.Lock()
-	if a.childTurnStartAcks == nil {
-		a.childTurnStartAcks = make(map[string]chan struct{})
-	}
-	a.childTurnStartAcks[threadID] = ack
-	a.mu.Unlock()
-	requestErr := make(chan error, 1)
-	go func() {
-		if _, err := a.sendRequest("turn/start", paramsJSON, 0); err != nil {
-			requestErr <- err
-		}
-	}()
-
-	select {
-	case <-ack:
-		return nil
-	case err := <-requestErr:
-		a.clearChildTurnStartAck(threadID, ack)
-		return classifyCodexTurnStartRequestError("turn/start child", err)
-	case <-a.processDone:
-		a.clearChildTurnStartAck(threadID, ack)
-		return classifyCodexTurnStartRequestError("turn/start child", a.processExitError())
-	case <-time.After(turnStartAckTimeout):
-		a.clearChildTurnStartAck(threadID, ack)
-		return fmt.Errorf("%w: child turn/start received no turn/started within %s", ErrDeliveryUncertain, turnStartAckTimeout)
-	}
+// publishCodexChildTurnActive reports activity without a steering capability.
+// Multi-Agent V2 rejects direct app-server input for spawned child threads.
+func (a *CodexAgent) publishCodexChildTurnActive(sink TurnServices, active bool) {
+	publishTurnStateTo(sink, TurnState{Active: active}, a.childTurnSeq())
 }
 
 // knownCollabChild reports whether the thread is a registered collab child.
@@ -520,44 +554,31 @@ func (a *CodexAgent) knownCollabChild(threadID string) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	state, ok := a.collabChildren[threadID]
-	return ok && (state.spawnCorrelationID != "" || state.childAgentID != "")
+	return ok && state != nil && (state.spawnCorrelationID != "" || state.childAgentID != "")
 }
 
 // childTurnID returns the active turn id for a child thread ("" if none).
 func (a *CodexAgent) childTurnID(threadID string) string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if a.childTurnIDs == nil {
+	state := a.collabChildren[threadID]
+	if state == nil {
 		return ""
 	}
-	return a.childTurnIDs[threadID]
+	return state.turnID
 }
 
 func (a *CodexAgent) setChildTurnID(threadID, turnID string) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.childTurnIDs == nil {
-		a.childTurnIDs = make(map[string]string)
-	}
-	a.childTurnIDs[threadID] = turnID
-	if ack := a.childTurnStartAcks[threadID]; ack != nil {
-		close(ack)
-		delete(a.childTurnStartAcks, threadID)
-	}
-}
-
-func (a *CodexAgent) clearChildTurnStartAck(threadID string, expected chan struct{}) {
-	a.mu.Lock()
-	if a.childTurnStartAcks[threadID] == expected {
-		delete(a.childTurnStartAcks, threadID)
-	}
+	state := a.codexChildStateLocked(threadID)
+	state.turnID = turnID
 	a.mu.Unlock()
 }
 
 func (a *CodexAgent) clearChildTurnID(threadID string) {
 	a.mu.Lock()
-	if a.childTurnIDs != nil {
-		delete(a.childTurnIDs, threadID)
+	if state := a.collabChildren[threadID]; state != nil {
+		state.turnID = ""
 	}
 	a.mu.Unlock()
 	a.clearInterruptCallsForThread(threadID)

--- a/backend/internal/worker/agent/codex_subagent_test.go
+++ b/backend/internal/worker/agent/codex_subagent_test.go
@@ -3,12 +3,9 @@ package agent
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	leapmuxv1 "github.com/leapmux/leapmux/generated/proto/leapmux/v1"
 )
 
 // The `turn/started` notification confirms that Codex accepted a turn.
@@ -50,75 +47,15 @@ func TestCodex_AChildTurnStartedDoesNotReleaseTheSend(t *testing.T) {
 	assert.NotNil(t, a.turnStartAck, "the main send is still waiting")
 }
 
-// TestCodex_SendChildInputUnknownThreadReturnsRetryable verifies that when the
-// owner process is running but its in-memory collab index does not know the
-// thread (empty after a worker restart), SendChildInput wraps the failure in
-// ErrChildNotSteerableYet. The service maps that to UNAVAILABLE so the client
-// keeps the queue item retryable instead of storing a permanent failure.
-func TestCodex_SendChildInputUnknownThreadReturnsRetryable(t *testing.T) {
-	t.Parallel()
-	// A fresh CodexAgent has an empty child route index (the post-restart
-	// state until the live spawn re-fires).
-	a := &CodexAgent{}
-	err := a.SendChildInput("unknown-thread", "hello", []*leapmuxv1.Attachment{})
-	assert.ErrorIs(t, err, ErrChildNotSteerableYet,
-		"an unknown thread on a running owner must be retryable, not a hard failure")
-}
-
-func TestCodex_SendChildInputReturnsAfterTurnStarted(t *testing.T) {
+func TestCodex_MultiAgentV2ChildDoesNotAdvertiseDirectInput(t *testing.T) {
 	t.Parallel()
 
-	agent, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-	agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
-	done := make(chan error, 1)
-	go func() {
-		done <- agent.SendChildInput("child-thread", "hello", nil)
-	}()
-	require.Eventually(t, func() bool { return len(requests()) == 1 }, time.Second, time.Millisecond)
-	select {
-	case err := <-done:
-		t.Fatalf("child input returned before turn/started: %v", err)
-	default:
-	}
-	agent.setChildTurnID("child-thread", "turn-1")
-	require.NoError(t, <-done)
-}
-
-func TestCodex_SendChildInputDoesNotAutomaticallySteer(t *testing.T) {
-	t.Parallel()
-
-	agent, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-	agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
-	agent.setChildTurnID("child-thread", "turn-1")
-
-	// A child that already runs a turn is busy. The queue holds the item and
-	// dispatches it when the turn ends; ErrNoActiveTurn would fail it instead.
-	assert.ErrorIs(t, agent.SendChildInput("child-thread", "later turn", nil), ErrAgentBusy)
-	assert.NotErrorIs(t, agent.SendChildInput("child-thread", "later turn", nil), ErrNoActiveTurn)
-	assert.Empty(t, requests())
-}
-
-func TestCodex_SteerChildInputUsesActiveTurn(t *testing.T) {
-	t.Parallel()
-
-	agent, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-	agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
-	agent.setChildTurnID("child-thread", "turn-1")
-
-	require.NoError(t, agent.SteerChildInput("child-thread", "guide", nil))
-	require.Len(t, requests(), 1)
-	assert.Equal(t, "turn/steer", requests()[0].Method)
-	assert.Equal(t, "turn-1", requests()[0].Params["expectedTurnId"])
-}
-
-func TestCodex_SendChildInputProcessExitIsDeliveryUncertain(t *testing.T) {
-	t.Parallel()
-
-	agent, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-	agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
-	close(agent.processDone)
-
-	assert.ErrorIs(t, agent.SendChildInput("child-thread", "hello", nil), ErrDeliveryUncertain)
+	assert.False(t, codexProvider{}.SupportsChildSteering(),
+		"Codex rejects direct app-server input for Multi-Agent V2 children")
+	_, sendsDirectInput := any(&CodexAgent{}).(ChildSteerer)
+	assert.False(t, sendsDirectInput)
+	_, interruptsChild := any(&CodexAgent{}).(ChildInterrupter)
+	assert.True(t, interruptsChild, "the app server still permits direct child interruption")
 }
 
 // TestCodex_InterruptChildUnknownThreadReturnsRetryable mirrors the send path
@@ -128,7 +65,7 @@ func TestCodex_InterruptChildUnknownThreadReturnsRetryable(t *testing.T) {
 	t.Parallel()
 	a := &CodexAgent{}
 	err := a.InterruptChild("unknown-thread")
-	assert.ErrorIs(t, err, ErrChildNotSteerableYet)
+	assert.ErrorIs(t, err, ErrChildRouteNotReady)
 }
 
 // Codex declares `prompt` on the collabAgentToolCall thread item
@@ -139,12 +76,11 @@ func TestCodex_CollabPromptHeldUntilTheChildExists(t *testing.T) {
 	t.Parallel()
 
 	a := &CodexAgent{}
-	a.collabChildPrompts.remember("thread-1", "Write the essay.")
-	assert.Equal(t, "Write the essay.", a.collabChildPrompts.peek("thread-1"))
+	a.rememberCollabChildPrompt("thread-1", "Write the essay.")
 
 	// Spent once, so a second child creation cannot repeat it.
-	assert.Equal(t, "Write the essay.", a.collabChildPrompts.take("thread-1"))
-	assert.Empty(t, a.collabChildPrompts.take("thread-1"))
+	assert.Equal(t, "Write the essay.", a.takeCollabChildPrompt("thread-1"))
+	assert.Empty(t, a.takeCollabChildPrompt("thread-1"))
 }
 
 // The spawn's own prompt wins; the later collab tools (send/wait) on the same
@@ -153,19 +89,19 @@ func TestCodex_CollabPromptFirstWriteWins(t *testing.T) {
 	t.Parallel()
 
 	a := &CodexAgent{}
-	a.collabChildPrompts.remember("thread-1", "first")
-	a.collabChildPrompts.remember("thread-1", "second")
-	a.collabChildPrompts.remember("thread-1", "")
-	assert.Equal(t, "first", a.collabChildPrompts.peek("thread-1"))
+	a.rememberCollabChildPrompt("thread-1", "first")
+	a.rememberCollabChildPrompt("thread-1", "second")
+	a.rememberCollabChildPrompt("thread-1", "")
+	assert.Equal(t, "first", a.takeCollabChildPrompt("thread-1"))
 }
 
 func TestCodex_CollabPromptIgnoresEmptyInput(t *testing.T) {
 	t.Parallel()
 
 	a := &CodexAgent{}
-	a.collabChildPrompts.remember("", "x")
-	a.collabChildPrompts.remember("thread-1", "")
-	assert.Zero(t, a.collabChildPrompts.count())
+	a.rememberCollabChildPrompt("", "x")
+	a.rememberCollabChildPrompt("thread-1", "")
+	assert.Empty(t, a.collabChildren)
 }
 
 // A completed run drops its spent prompt but keeps the route that a follow-up
@@ -174,9 +110,9 @@ func TestCodex_CollabPromptDroppedOnFinalChild(t *testing.T) {
 	t.Parallel()
 
 	a := &CodexAgent{}
-	a.collabChildPrompts.remember("thread-1", "Write the essay.")
+	a.rememberCollabChildPrompt("thread-1", "Write the essay.")
 	a.finishCollabChildRun("thread-1")
-	assert.Zero(t, a.collabChildPrompts.count())
+	assert.Empty(t, a.takeCollabChildPrompt("thread-1"))
 }
 
 // The spawn item's prompt reaches the index through the parse.
@@ -209,4 +145,14 @@ func TestCodex_AgentPathTitleUsesTheLastNonEmptySegment(t *testing.T) {
 	assert.Equal(t, "probe_child", codexAgentPathTitle("probe_child"))
 	assert.Empty(t, codexAgentPathTitle("///"))
 	assert.Empty(t, codexAgentPathTitle(""))
+}
+
+func TestCodex_RootPathClassificationUsesTheCompleteCanonicalPath(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, codexAgentPathIsRoot("/root"))
+	assert.True(t, codexAgentPathIsRoot(" /root/// "))
+	assert.False(t, codexAgentPathIsRoot("/root/root"), "a child can use root as its task name")
+	assert.False(t, codexAgentPathIsRoot("root"))
+	assert.False(t, codexAgentPathIsRoot(""))
 }

--- a/backend/internal/worker/agent/codex_subagent_test.go
+++ b/backend/internal/worker/agent/codex_subagent_test.go
@@ -57,7 +57,7 @@ func TestCodex_AChildTurnStartedDoesNotReleaseTheSend(t *testing.T) {
 // keeps the queue item retryable instead of storing a permanent failure.
 func TestCodex_SendChildInputUnknownThreadReturnsRetryable(t *testing.T) {
 	t.Parallel()
-	// A fresh CodexAgent has an empty collabThreadSpans (the post-restart
+	// A fresh CodexAgent has an empty child route index (the post-restart
 	// state until the live spawn re-fires).
 	a := &CodexAgent{}
 	err := a.SendChildInput("unknown-thread", "hello", []*leapmuxv1.Attachment{})
@@ -69,7 +69,7 @@ func TestCodex_SendChildInputReturnsAfterTurnStarted(t *testing.T) {
 	t.Parallel()
 
 	agent, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-	agent.collabThreadSpans = map[string]string{"child-thread": "spawn-1"}
+	agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
 	done := make(chan error, 1)
 	go func() {
 		done <- agent.SendChildInput("child-thread", "hello", nil)
@@ -88,7 +88,7 @@ func TestCodex_SendChildInputDoesNotAutomaticallySteer(t *testing.T) {
 	t.Parallel()
 
 	agent, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-	agent.collabThreadSpans = map[string]string{"child-thread": "spawn-1"}
+	agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
 	agent.setChildTurnID("child-thread", "turn-1")
 
 	// A child that already runs a turn is busy. The queue holds the item and
@@ -102,7 +102,7 @@ func TestCodex_SteerChildInputUsesActiveTurn(t *testing.T) {
 	t.Parallel()
 
 	agent, _, requests := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-	agent.collabThreadSpans = map[string]string{"child-thread": "spawn-1"}
+	agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
 	agent.setChildTurnID("child-thread", "turn-1")
 
 	require.NoError(t, agent.SteerChildInput("child-thread", "guide", nil))
@@ -115,7 +115,7 @@ func TestCodex_SendChildInputProcessExitIsDeliveryUncertain(t *testing.T) {
 	t.Parallel()
 
 	agent, _, _ := newCodexAgentForRPC(t, func(string) json.RawMessage { return json.RawMessage(`{}`) })
-	agent.collabThreadSpans = map[string]string{"child-thread": "spawn-1"}
+	agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
 	close(agent.processDone)
 
 	assert.ErrorIs(t, agent.SendChildInput("child-thread", "hello", nil), ErrDeliveryUncertain)
@@ -168,14 +168,14 @@ func TestCodex_CollabPromptIgnoresEmptyInput(t *testing.T) {
 	assert.Zero(t, a.collabChildPrompts.count())
 }
 
-// A terminal child drops its remembered prompt along with the rest of its index
-// entries, so a long session that cycles subagents cannot accumulate them.
+// A completed run drops its spent prompt but keeps the route that a follow-up
+// turn needs.
 func TestCodex_CollabPromptDroppedOnFinalChild(t *testing.T) {
 	t.Parallel()
 
 	a := &CodexAgent{}
 	a.collabChildPrompts.remember("thread-1", "Write the essay.")
-	a.removeCollabChildIndex("thread-1")
+	a.finishCollabChildRun("thread-1")
 	assert.Zero(t, a.collabChildPrompts.count())
 }
 
@@ -199,4 +199,14 @@ func TestCodex_ParseCollabToolCallToleratesNullPrompt(t *testing.T) {
 		`{"type":"collabAgentToolCall","tool":"waitForAgent","receiverThreadIds":["thread-1"],"prompt":null}`))
 	require.NotNil(t, collab)
 	assert.Empty(t, collab.Prompt)
+}
+
+func TestCodex_AgentPathTitleUsesTheLastNonEmptySegment(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "probe_child", codexAgentPathTitle("/root/probe_child"))
+	assert.Equal(t, "probe_child", codexAgentPathTitle(" /root/probe_child/// "))
+	assert.Equal(t, "probe_child", codexAgentPathTitle("probe_child"))
+	assert.Empty(t, codexAgentPathTitle("///"))
+	assert.Empty(t, codexAgentPathTitle(""))
 }

--- a/backend/internal/worker/agent/interrupt_test.go
+++ b/backend/internal/worker/agent/interrupt_test.go
@@ -350,7 +350,7 @@ func TestCodexAgent_InterruptChild_SendsTurnInterruptRequest(t *testing.T) {
 	t.Parallel()
 
 	rig := newCodexInterruptRig(t)
-	rig.agent.collabThreadSpans = map[string]string{"child-thread": "spawn-1"}
+	rig.agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
 	rig.agent.childTurnIDs = map[string]string{"child-thread": "child-turn"}
 
 	interruptDone := make(chan error, 1)
@@ -378,7 +378,7 @@ func TestCodexAgent_InterruptChild_NoActiveTurnIsNoop(t *testing.T) {
 	t.Parallel()
 
 	rig := newCodexInterruptRig(t)
-	rig.agent.collabThreadSpans = map[string]string{"child-thread": "spawn-1"}
+	rig.agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
 
 	require.NoError(t, rig.agent.InterruptChild("child-thread"))
 	time.Sleep(50 * time.Millisecond)

--- a/backend/internal/worker/agent/interrupt_test.go
+++ b/backend/internal/worker/agent/interrupt_test.go
@@ -350,8 +350,7 @@ func TestCodexAgent_InterruptChild_SendsTurnInterruptRequest(t *testing.T) {
 	t.Parallel()
 
 	rig := newCodexInterruptRig(t)
-	rig.agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
-	rig.agent.childTurnIDs = map[string]string{"child-thread": "child-turn"}
+	rig.agent.collabChildren = map[string]*codexChildState{"child-thread": {spawnCorrelationID: "spawn-1", turnID: "child-turn"}}
 
 	interruptDone := make(chan error, 1)
 	go func() {
@@ -378,7 +377,7 @@ func TestCodexAgent_InterruptChild_NoActiveTurnIsNoop(t *testing.T) {
 	t.Parallel()
 
 	rig := newCodexInterruptRig(t)
-	rig.agent.collabChildren = map[string]codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
+	rig.agent.collabChildren = map[string]*codexChildState{"child-thread": {spawnCorrelationID: "spawn-1"}}
 
 	require.NoError(t, rig.agent.InterruptChild("child-thread"))
 	time.Sleep(50 * time.Millisecond)

--- a/backend/internal/worker/agent/manager.go
+++ b/backend/internal/worker/agent/manager.go
@@ -537,7 +537,7 @@ func (m *Manager) Interrupt(agentID string) error {
 // by childKey, the provider linkage key stored in the registry row_key) inside
 // the owner process rootAgentID. It type-asserts the running Agent to
 // ChildSteerer; providers that cannot steer a subagent return
-// ErrChildSteeringUnsupported. The service resolves childKey from the registry
+// ErrChildOperationUnsupported. The service resolves childKey from the registry
 // before calling here.
 // Like SendInput, it waits for an active lifecycle operation on the owner.
 // The lock covers only provider resolution because child steering can block.
@@ -548,7 +548,7 @@ func (m *Manager) SendChildInput(rootAgentID, childKey, content string, attachme
 	}
 	steerer, ok := p.(ChildSteerer)
 	if !ok {
-		return ErrChildSteeringUnsupported
+		return ErrChildOperationUnsupported
 	}
 	err = steerer.SendChildInput(childKey, content, attachments)
 	if errors.Is(err, ErrAgentBusy) {
@@ -564,14 +564,14 @@ func (m *Manager) SteerChildInput(rootAgentID, childKey, content string, attachm
 	}
 	steerer, ok := p.(ChildSteerer)
 	if !ok {
-		return ErrChildSteeringUnsupported
+		return ErrChildOperationUnsupported
 	}
 	return steerer.SteerChildInput(childKey, content, attachments)
 }
 
-// InterruptChild aborts a subagent's current turn inside the owner process,
-// mirroring SendChildInput. Same resolution + ErrChildSteeringUnsupported
-// disposition for a non-steering provider.
+// InterruptChild aborts a subagent's current turn inside the owner process.
+// Input and interrupt capabilities stay separate because Codex Multi-Agent V2
+// permits direct interruption but rejects direct input.
 func (m *Manager) InterruptChild(rootAgentID, childKey string) error {
 	m.mu.RLock()
 	p, ok := m.agents[rootAgentID]
@@ -579,11 +579,11 @@ func (m *Manager) InterruptChild(rootAgentID, childKey string) error {
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrAgentNotFound, rootAgentID)
 	}
-	steerer, ok := p.(ChildSteerer)
+	interrupter, ok := p.(ChildInterrupter)
 	if !ok {
-		return ErrChildSteeringUnsupported
+		return ErrChildOperationUnsupported
 	}
-	return steerer.InterruptChild(childKey)
+	return interrupter.InterruptChild(childKey)
 }
 
 // SupportedGoalActions reports the session-goal actions the RUNNING agent can
@@ -597,9 +597,8 @@ func (m *Manager) InterruptChild(rootAgentID, childKey string) error {
 // /goal in 2.1.139, ZCode in 3.10.2), so a table would offer a button that does
 // nothing against an older CLI.
 //
-// Same shape as the AgentInfo.accepts_messages decision, which type-asserts
-// ChildSteerer for the same reason: the capability cannot drift from the code
-// that implements it.
+// Same shape as the AgentInfo.accepts_messages decision, which reads the
+// provider capability that owns direct child input.
 // It reads the agent map DIRECTLY rather than through providerAfterLifecycle,
 // and that is deliberate: StartAgent publishes the capabilities while a
 // lifecycle caller holds LockAgent, and the ExitHandler broadcasts them while

--- a/backend/internal/worker/agent/manager_child_test.go
+++ b/backend/internal/worker/agent/manager_child_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// steerableStub implements both the Agent provider surface (via stubProvider)
-// and ChildSteerer, so Manager.SendChildInput/InterruptChild can reach it.
+// steerableStub implements the Agent provider surface, ChildSteerer, and
+// ChildInterrupter.
 type steerableStub struct {
 	stubProvider
 	sendInputErr        error
@@ -59,6 +59,7 @@ func (s *steerableStub) ActiveChildTurnState(string) TurnState {
 // compile time). steerableStub embeds stubProvider; adding ChildSteerer makes
 // it satisfy the type-assert in Manager.SendChildInput.
 var _ ChildSteerer = (*steerableStub)(nil)
+var _ ChildInterrupter = (*steerableStub)(nil)
 var _ Agent = (*steerableStub)(nil)
 
 func TestManager_SendChildInputNotRunning(t *testing.T) {
@@ -75,7 +76,7 @@ func TestManager_SendChildInputUnsupportedProvider(t *testing.T) {
 	m.agents["root"] = &stubProvider{}
 	m.mu.Unlock()
 	err := m.SendChildInput("root", "child-1", "hello", nil)
-	assert.ErrorIs(t, err, ErrChildSteeringUnsupported)
+	assert.ErrorIs(t, err, ErrChildOperationUnsupported)
 }
 
 func TestManager_SendChildInputDispatch(t *testing.T) {
@@ -146,5 +147,5 @@ func TestManager_InterruptChildUnsupportedProvider(t *testing.T) {
 	m.agents["root"] = &stubProvider{}
 	m.mu.Unlock()
 	err := m.InterruptChild("root", "child-1")
-	assert.ErrorIs(t, err, ErrChildSteeringUnsupported)
+	assert.ErrorIs(t, err, ErrChildOperationUnsupported)
 }

--- a/backend/internal/worker/agent/manager_test.go
+++ b/backend/internal/worker/agent/manager_test.go
@@ -290,7 +290,7 @@ func TestManager_SendChildInputWaitsForRestartToFinish(t *testing.T) {
 		// The mock provider steers no child, so the ERROR is expected. What
 		// matters is that the call got past the lock to a live process at all,
 		// rather than resolving against the one the restart was destroying.
-		assert.ErrorIs(t, err, ErrChildSteeringUnsupported)
+		assert.ErrorIs(t, err, ErrChildOperationUnsupported)
 	case <-time.After(5 * time.Second):
 		t.Fatal("child send never completed after the restart finished")
 	}

--- a/backend/internal/worker/agent/provider.go
+++ b/backend/internal/worker/agent/provider.go
@@ -159,9 +159,9 @@ type Provider interface {
 	// simply stops return false and get the neutral divider.
 	//
 	// The question is "does this close the SUBAGENT", NOT "is this a turn-end
-	// envelope". The two differ for a steerable child: a Codex collab thread
-	// draws a turn-end divider at the end of EVERY turn and then accepts
-	// another, so answering the turn-end question would suppress the divider
+	// envelope". The two differ for a resumable child: a Codex collab thread
+	// draws a turn-end divider after each turn, and its parent can resume it.
+	// Answering the turn-end question would suppress the divider
 	// for exactly the stopped-mid-life child that needs it. Codex therefore
 	// keeps the false default although it does forward a turn end.
 	//
@@ -170,11 +170,10 @@ type Provider interface {
 	// is stopped mid-flight, and only the stopped one needs the neutral divider.
 	EndsSubagentTranscript(content []byte) bool
 	// SupportsChildSteering reports whether a running agent of this provider
-	// can address a subagent conversation inside the same process (Codex's
-	// collab child threads). Drives AgentInfo.accepts_messages for child tabs:
+	// can address a subagent conversation inside the same process. It drives
+	// AgentInfo.accepts_messages for child tabs:
 	// a child of a steering provider keeps an enabled composer; every other
-	// child tab is read-only. Defaults to false (noopProvider); only Codex
-	// overrides it to true.
+	// child tab is read-only. The default is false.
 	SupportsChildSteering() bool
 	// ReportsDefaultModelSentinel reports whether this provider's own model
 	// catalog lists DefaultModelSentinel as a selectable entry meaning "the
@@ -337,14 +336,13 @@ func (noopProvider) TurnEndToolUses(content []byte) (int32, bool) {
 // it.
 //
 // Codex keeps this default deliberately although it DOES forward a divider:
-// its per-turn `turn/completed` ends a turn, not the subagent, and a collab
-// child accepts another turn afterwards. Answering true there would suppress
+// its per-turn `turn/completed` ends a turn, not the subagent, and the parent
+// can send the child another turn. Answering true there would suppress
 // the closing divider for every stopped child.
 func (noopProvider) EndsSubagentTranscript([]byte) bool { return false }
 
-// SupportsChildSteering defaults to false: a provider whose running agents
-// cannot steer a subagent conversation inside their own process. Only Codex
-// overrides it to true (its collab child threads accept host-initiated turns).
+// SupportsChildSteering defaults to false for a provider whose running agents
+// cannot send direct input to a child conversation.
 func (noopProvider) SupportsChildSteering() bool { return false }
 
 // ReportsDefaultModelSentinel defaults to false: a provider whose CLI reports
@@ -561,8 +559,8 @@ func (codexProvider) SyntheticInterruptNotice() string { return "[Request interr
 // PermissionModeFromRawInput: Codex has no set_permission_mode raw control frame.
 func (codexProvider) PermissionModeFromRawInput(string) (string, bool) { return "", false }
 
-// SupportsChildSteering reports whether Codex accepts input for a child thread.
-func (codexProvider) SupportsChildSteering() bool { return true }
+// Multi-Agent V2 rejects direct app-server input for spawned child threads.
+func (codexProvider) SupportsChildSteering() bool { return false }
 
 // ReportsDefaultModelSentinel is false: Codex stores the sentinel until the
 // thread/start lifecycle response reports a concrete model, and model/list never

--- a/backend/internal/worker/service/agent.go
+++ b/backend/internal/worker/service/agent.go
@@ -814,7 +814,7 @@ func registerAgentHandlers(d registrar, svc *Service) {
 				slog.Warn("failed to pause agent input queue before interrupt", "agent_id", agentID, "error", err)
 			}
 			// A child agent: resolve its registry row, then interrupt the child
-			// conversation inside the owner process via ChildSteerer.
+			// conversation inside the owner process via ChildInterrupter.
 			dbAgent, err := svc.Queries.GetAgentByID(bgCtx(), agentID)
 			if err != nil {
 				sendNotFoundError(sender, "agent not found")
@@ -834,14 +834,13 @@ func registerAgentHandlers(d registrar, svc *Service) {
 				}
 				svc.Output.NoteAgentInterrupted(agentID, row.OwnerAgentID)
 				if err := svc.Agents.InterruptChild(row.OwnerAgentID, row.RowKey); err != nil {
-					if errors.Is(err, agent.ErrChildSteeringUnsupported) {
+					if errors.Is(err, agent.ErrChildOperationUnsupported) {
 						sendFailedPrecondition(sender, "this subagent cannot be interrupted")
 						return
 					}
-					if errors.Is(err, agent.ErrChildNotSteerableYet) {
-						// Owner running but the spawn index is empty (a restart);
-						// nothing to interrupt yet. Tell the client to retry.
-						sendUnavailable(sender, "subagent not yet steerable in the running owner process; retry")
+					if errors.Is(err, agent.ErrChildRouteNotReady) {
+						// The child route can be empty after an owner restart. Tell the client to retry.
+						sendUnavailable(sender, "subagent route is not ready in the running owner process; retry")
 						return
 					}
 					slog.Warn("interrupt child failed", "agent_id", agentID, "error", err)
@@ -1555,9 +1554,8 @@ func (svc *Service) agentToProto(a *db.Agent, isRunning bool, gs *leapmuxv1.GitR
 	if a.ParentAgentID.Valid {
 		info.ParentAgentId = a.ParentAgentID.String
 		info.SpawnSpanId = a.SpawnSpanID
-		// A child accepts messages only when its feeding provider can steer a
-		// subagent conversation inside the same process (Codex). Roots always
-		// accept; non-steering children are read-only transcripts.
+		// A child accepts messages only when its feeding provider permits direct
+		// subagent input. Roots always accept. Other children are read-only.
 		info.AcceptsMessages = agent.ProviderFor(a.AgentProvider).SupportsChildSteering()
 		// Resolve the root owner once here so the frontend reads the registry
 		// owner and its NOTIFY subscription from the wire, instead of walking a

--- a/backend/internal/worker/service/agent_child_routing_test.go
+++ b/backend/internal/worker/service/agent_child_routing_test.go
@@ -27,7 +27,7 @@ func setupChildAgentTest(t *testing.T) (*Service, *channel.Dispatcher, string, s
 	ctx := context.Background()
 	svc, d, _ := setupTestService(t)
 
-	// Root agent (Codex supports child steering).
+	// Codex supports direct child interruption.
 	require.NoError(t, svc.Queries.CreateAgent(ctx, db.CreateAgentParams{
 		ID:            "root-1",
 		WorkingDir:    t.TempDir(),
@@ -230,13 +230,13 @@ func TestListAgentMessagesChildReturnsEmptyTasks(t *testing.T) {
 		"child LATEST page must report loaded=true (empty-but-loaded)")
 }
 
-// TestInterruptAgentOnChildRoutesViaChildSteerer verifies InterruptAgent on a
+// TestInterruptAgentOnChildRoutesViaChildInterrupter verifies InterruptAgent on a
 // child agent routes through the child-steering path (Agents.InterruptChild on
 // the owner) rather than interrupting the child id directly. The strongest
 // feasible service-level assertion uses the rejection disposition unique to
-// that path: a RUNNING owner that does NOT implement ChildSteerer (the mock
+// that path: a RUNNING owner that does NOT implement ChildInterrupter (the mock
 // owner here is a ClaudeCodeAgent, which never steers) makes InterruptChild
-// return ErrChildSteeringUnsupported, which the handler maps to
+// return ErrChildOperationUnsupported, which the handler maps to
 // FailedPrecondition "this subagent cannot be interrupted". That arm is ONLY
 // reachable through InterruptChild -- the direct-interrupt arm (owner not
 // running, or a non-child target) produces NotFound instead -- so observing it
@@ -246,18 +246,18 @@ func TestListAgentMessagesChildReturnsEmptyTasks(t *testing.T) {
 // registered, InterruptChild returns ErrAgentNotFound and the handler reports
 // NotFound "agent not found or not running" (still via the child path, not a
 // direct Interrupt on the child id).
-func TestInterruptAgentOnChildRoutesViaChildSteerer(t *testing.T) {
+func TestInterruptAgentOnChildRoutesViaChildInterrupter(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 
-	t.Run("runningOwnerWithoutChildSteererReportsFailedPrecondition", func(t *testing.T) {
+	t.Run("runningOwnerWithoutChildInterrupterReportsFailedPrecondition", func(t *testing.T) {
 		t.Parallel()
 		svc, d, childID, rootID := setupChildAgentTest(t)
 
 		// Start a mock owner process. MockStartAgent wraps it as a
-		// ClaudeCodeAgent, which does NOT implement ChildSteerer -- so
-		// InterruptChild returns ErrChildSteeringUnsupported, the unique
+		// ClaudeCodeAgent, which does NOT implement ChildInterrupter -- so
+		// InterruptChild returns ErrChildOperationUnsupported, the unique
 		// FailedPrecondition disposition that proves the child-steering path
 		// was taken (rather than Agents.Interrupt on the child id).
 		_, err := svc.Agents.MockStartAgent(ctx, agent.Options{
@@ -276,7 +276,7 @@ func TestInterruptAgentOnChildRoutesViaChildSteerer(t *testing.T) {
 		rejs := w.rejections()
 		require.Len(t, rejs, 1, "the child-steering-unsupported path must reject")
 		assert.Equal(t, int32(codes.FailedPrecondition), rejs[0].code,
-			"ErrChildSteeringUnsupported maps to FailedPrecondition, proving InterruptChild routing")
+			"ErrChildOperationUnsupported maps to FailedPrecondition, proving InterruptChild routing")
 		assert.Contains(t, rejs[0].message, "cannot be interrupted")
 		snapshot, snapshotErr := svc.InputQueue.Snapshot(ctx, childID)
 		require.NoError(t, snapshotErr)

--- a/backend/internal/worker/service/agent_input_queue.go
+++ b/backend/internal/worker/service/agent_input_queue.go
@@ -98,7 +98,7 @@ func (a *agentInputQueueAdapter) Dispatch(item inputqueue.DispatchItem) (inputqu
 			return inputqueue.DispatchResult{}, &inputqueue.DeliveryError{Err: agent.ErrAgentNotFound, Outcome: inputqueue.DispatchNotReady}
 		}
 		if err := svc.Agents.SendChildInput(row.OwnerAgentID, row.RowKey, item.Text, attachments); err != nil {
-			if errors.Is(err, agent.ErrChildSteeringUnsupported) {
+			if errors.Is(err, agent.ErrChildOperationUnsupported) {
 				return inputqueue.DispatchResult{}, inputqueue.ErrSteeringUnsupported
 			}
 			return inputqueue.DispatchResult{}, classifyQueueDeliveryError(err)
@@ -182,8 +182,8 @@ func (a *agentInputQueueAdapter) Dispatch(item inputqueue.DispatchItem) (inputqu
 // Two of them need the agent to change state first, so the queue pauses and
 // waits for the cause that changes it (DispatchNotReady):
 //
-//   - ErrChildNotSteerableYet: the owner process runs, but it did not re-fire
-//     the child spawn yet. Every Worker restart produces this condition.
+//   - ErrChildRouteNotReady: the owner process runs, but it did not rebuild
+//     the child route yet. Every Worker restart produces this condition.
 //   - ErrAgentNotFound: the process exited between the readiness test and the
 //     write. Manager returns it from providerAfterLifecycle, which resolves the
 //     provider BEFORE any write, so nothing reached the agent.
@@ -208,7 +208,7 @@ func queueDispatchOutcome(err error) inputqueue.DispatchOutcome {
 	switch {
 	case errors.Is(err, agent.ErrAgentBusy):
 		return inputqueue.DispatchBusy
-	case errors.Is(err, agent.ErrChildNotSteerableYet), errors.Is(err, agent.ErrAgentNotFound):
+	case errors.Is(err, agent.ErrChildRouteNotReady), errors.Is(err, agent.ErrAgentNotFound):
 		return inputqueue.DispatchNotReady
 	case errors.Is(err, agent.ErrDeliveryUncertain):
 		return inputqueue.DispatchUncertain
@@ -223,7 +223,7 @@ func classifyQueueSteerError(err error) error {
 		return nil
 	case errors.Is(err, agent.ErrNoActiveTurn):
 		return inputqueue.ErrTurnEnded
-	case errors.Is(err, agent.ErrSteeringUnsupported), errors.Is(err, agent.ErrChildSteeringUnsupported):
+	case errors.Is(err, agent.ErrSteeringUnsupported), errors.Is(err, agent.ErrChildOperationUnsupported):
 		return inputqueue.ErrSteeringUnsupported
 	default:
 		return classifyQueueDeliveryError(err)

--- a/frontend/src/components/chat/controlResponseHandling.test.ts
+++ b/frontend/src/components/chat/controlResponseHandling.test.ts
@@ -745,8 +745,8 @@ describe('handleControlSend', () => {
 /**
  * The Interrupt button is offered only when the click can actually land. A
  * subagent tab whose provider cannot interrupt one subagent gets no button:
- * the worker routes a child interrupt through the same ChildSteerer as a child
- * message, so the request would come back FailedPrecondition.
+ * the worker routes a child interrupt through a separate child capability.
+ * A provider without that capability returns FailedPrecondition.
  */
 describe('showInterrupt', () => {
   it('shows the button while the agent works and nothing is being asked', async () => {

--- a/frontend/src/components/chat/providers/codex/plugin.tsx
+++ b/frontend/src/components/chat/providers/codex/plugin.tsx
@@ -317,10 +317,10 @@ const codexPlugin: Provider = {
   // Codex accepts an option selection AND a free-text note together, so the
   // AskUserQuestion UI keeps both instead of treating them as mutually exclusive.
   preservesSelectionNotes: true,
-  // Codex collab child threads accept host-initiated turns inside the same
-  // process, so a child tab keeps an enabled composer. AgentInfo.accepts_messages
-  // (the backend-authoritative field) wins when present; this is the fallback.
-  supportsSubagentSend: true,
+  // Multi-Agent V2 rejects direct app-server input for spawned child threads.
+  // The child tab is a read-only transcript.
+  supportsSubagentSend: false,
+  supportsSubagentInterrupt: true,
   attachments: {
     text: true,
     image: true,

--- a/frontend/src/components/chat/providers/registry.ts
+++ b/frontend/src/components/chat/providers/registry.ts
@@ -425,14 +425,15 @@ export interface Provider {
   attachments?: AttachmentCapabilities
 
   /**
-   * True when a running agent of this provider can address a subagent
-   * conversation inside the same process (Codex's collab child threads).
+   * True when a running agent of this provider permits direct child input.
    * Drives the composer gate for child tabs together with
    * `AgentInfo.accepts_messages`: the proto field WINS when present on the
-   * tab; this is the fallback for optimistic/legacy state. Omit (false) for
-   * every provider but Codex.
+   * tab; this is the fallback for optimistic state. Omit it for false.
    */
   supportsSubagentSend?: boolean
+
+  /** True when the provider permits direct interruption of a child turn. */
+  supportsSubagentInterrupt?: boolean
 }
 
 const registry = new Map<number, Provider>()

--- a/frontend/src/components/shell/TileRenderer.tsx
+++ b/frontend/src/components/shell/TileRenderer.tsx
@@ -51,7 +51,7 @@ import { formatFileMention, formatFileQuote } from '~/lib/quoteUtils'
 import { hasGoalSurface } from '~/stores/chatGoal'
 import { insertIntoAgentEditor, insertIntoMruAgentEditor } from '~/stores/editorRef.store'
 import { buildTilePredicateMap, CLOSE_MODE_NONE } from '~/stores/layout.store'
-import { agentTabSupportsSessionGoal, agentTabToInfo, isSteerableAgentTab, isSubagentTab } from '~/stores/tab.helpers'
+import { agentTabSupportsInterrupt, agentTabSupportsSessionGoal, agentTabToInfo, isSteerableAgentTab, isSubagentTab } from '~/stores/tab.helpers'
 import { emitMergeTabsIntoTile, emitReassignTabsToTile } from '~/stores/tabOps'
 import { workerInfoStore } from '~/stores/workerInfo.store'
 import { warningText } from '~/styles/shared.css'
@@ -219,17 +219,13 @@ export function createTileRenderer(opts: TileRendererOpts) {
   const confirmLink = opts.confirmLink
   const mruEditorDeps = opts.mruEditorDeps
 
-  // A child (subagent) tab whose provider cannot steer a subagent conversation
-  // is a READ-ONLY transcript: the worker routes both a child message
-  // (SendChildInput) and a child interrupt (InterruptChild) through the same
-  // ChildSteerer, so a provider that implements neither can do neither. Roots
-  // and steerable children stay fully interactive. isSteerableAgentTab resolves
-  // acceptsMessages (backend-authoritative) with a supportsSubagentSend fallback
-  // for optimistic state.
+  // A child tab whose provider rejects direct input is a read-only transcript.
+  // Roots and writable children stay interactive. isSteerableAgentTab resolves
+  // acceptsMessages with a supportsSubagentSend fallback before hydration.
   //
-  // One predicate feeds the composer gate, its hint, the Interrupt button, and
-  // where a quote goes, so those cannot disagree about what a tab can do. It
-  // takes an agent id rather than reading the focused one, because the quote
+  // One predicate feeds the composer gate, its hint, and quote routing. The
+  // separate interrupt capability can remain available on a read-only child.
+  // This predicate takes an agent ID because the quote
   // handlers run per TAB inside the tile loop while the composer is built for
   // the focused tab alone.
   const isSubagentReadOnly = (agentId: string): boolean => {
@@ -1271,7 +1267,7 @@ export function createTileRenderer(opts: TileRendererOpts) {
         onControlResponse={agentOps.handleControlResponse}
         onSettingChange={change => agentOps.handleAgentSettingChange(agentId(), change)}
         onInterrupt={() => agentOps.handleInterrupt(agentId())}
-        canInterrupt={!subagentReadOnly()}
+        canInterrupt={agentTabSupportsInterrupt(focusedAgentTab())}
         settingsLoading={settingsLoading.loading()}
         agentSessionInfo={agentSessionStore.getInfo(agentId())}
         agentWorking={agentThinking(agentId())}

--- a/frontend/src/stores/editorRef.store.test.ts
+++ b/frontend/src/stores/editorRef.store.test.ts
@@ -104,7 +104,7 @@ describe('insertIntoMruAgentEditor', () => {
   it('skips a non-steerable child agent and reaches the steerable root behind it', () => {
     const setRoot = vi.fn()
     const activate = vi.fn()
-    // A non-steerable child: parentAgentId set, acceptsMessages false, non-Codex
+    // A non-steerable child has a parent and an explicit read-only capability.
     // provider. Its composer is disabled and it must never receive an inserted
     // mention or quote.
     const nonSteerableChild: Tab = {
@@ -134,10 +134,10 @@ describe('insertIntoMruAgentEditor', () => {
     }
   })
 
-  it('targets a steerable child (Codex, accepts messages) directly', () => {
+  it('targets a child that accepts messages directly', () => {
     const setChild = vi.fn()
     const activate = vi.fn()
-    // A steerable child: Codex child that accepts messages.
+    // The backend-authoritative field permits direct child input.
     const steerableChild: Tab = {
       type: TabType.AGENT,
       id: 'c1',
@@ -160,12 +160,11 @@ describe('insertIntoMruAgentEditor', () => {
     }
   })
 
-  it('optimistically targets a Codex child before hydration (acceptsMessages undefined)', () => {
+  it('uses the provider fallback before child hydration', () => {
     const setChild = vi.fn()
     const activate = vi.fn()
-    // A Codex child whose acceptsMessages is not yet known (before listAgents
-    // hydration). isSteerableAgentTab routes the pre-hydration fallback through
-    // the provider plugin's supportsSubagentSend, so register Codex's capability.
+    // acceptsMessages is unknown before listAgents hydration. Register a
+    // synthetic provider capability to exercise the fallback.
     registerProvider(AgentProvider.CODEX, { classify: () => ({} as never), supportsSubagentSend: true })
     const codexChildUnhydrated: Tab = {
       type: TabType.AGENT,
@@ -180,7 +179,7 @@ describe('insertIntoMruAgentEditor', () => {
         { mruTabs: () => [codexChildUnhydrated], activate },
         'hello',
       )
-      expect(setChild, 'a Codex child is optimistically steerable pre-hydration').toHaveBeenCalled()
+      expect(setChild, 'the provider fallback permits the pre-hydration child').toHaveBeenCalled()
     }
     finally {
       unregisterEditorRef('c1')

--- a/frontend/src/stores/tab.helpers.test.ts
+++ b/frontend/src/stores/tab.helpers.test.ts
@@ -15,7 +15,7 @@ import { repoKey } from './repoGit'
 // failed a 5s test on a cold Vite cache. `./tab.helpers` already pulls
 // `./repoGit` into the static graph, so nothing here forces the dynamic form.
 import { createRepoGitStore } from './repoGit.store'
-import { agentTabSupportsSessionGoal, agentTabToInfo, canCloseTab, canRenameTab, deriveOptionGroupTabFields, descendantAgentTabs, isSameRepo, isSteerableAgentTab, isSubagentTab, isTabReadyForGitStatus, mruSteerableAgentTab, openedAgentTabFields, openedTerminalMetadata, planOptimisticRepoGit, protoToAgentTabFields, resolveOptimisticGitInfo, rootAgentIdFor, setOptionValue, tabDisplayLabel, tabTooltipShowWhen, tabTooltipText, terminalMetadata, terminalProgressBarProps } from './tab.helpers'
+import { agentTabSupportsInterrupt, agentTabSupportsSessionGoal, agentTabToInfo, canCloseTab, canRenameTab, deriveOptionGroupTabFields, descendantAgentTabs, isSameRepo, isSteerableAgentTab, isSubagentTab, isTabReadyForGitStatus, mruSteerableAgentTab, openedAgentTabFields, openedTerminalMetadata, planOptimisticRepoGit, protoToAgentTabFields, resolveOptimisticGitInfo, rootAgentIdFor, setOptionValue, tabDisplayLabel, tabTooltipShowWhen, tabTooltipText, terminalMetadata, terminalProgressBarProps } from './tab.helpers'
 import { createTabMetadataStore } from './tabMetadata.store'
 
 // `tabDisplayLabel` is the shared "what should we render in the tab strip
@@ -1007,7 +1007,7 @@ describe('isSteerableAgentTab', () => {
   it('falls back to the provider for an unhydrated child: a provider with supportsSubagentSend is optimistically steerable', () => {
     // acceptsMessages is unset (optimistic state before hydration). The fallback
     // routes through the provider plugin's supportsSubagentSend so the single
-    // source of truth is the plugin (Codex sets it true), not a hardcoded name.
+    // source of truth is the plugin, not a hardcoded provider check.
     registerProvider(AgentProvider.CODEX, { classify: () => ({} as never), supportsSubagentSend: true })
     expect(
       isSteerableAgentTab({ type: TabType.AGENT, parentAgentId: 'root', agentProvider: AgentProvider.CODEX }),
@@ -1032,6 +1032,32 @@ describe('isSteerableAgentTab', () => {
     expect(
       isSteerableAgentTab({ type: TabType.AGENT, parentAgentId: 'root', acceptsMessages: false, agentProvider: AgentProvider.CODEX }),
     ).toBe(false)
+  })
+})
+
+describe('agentTabSupportsInterrupt', () => {
+  it('keeps roots interruptible and rejects a non-agent tab', () => {
+    expect(agentTabSupportsInterrupt({ type: TabType.AGENT })).toBe(true)
+    expect(agentTabSupportsInterrupt({ type: TabType.FILE })).toBe(false)
+    expect(agentTabSupportsInterrupt(undefined)).toBe(false)
+  })
+
+  it('uses the child provider interrupt capability independently of input', () => {
+    registerProvider(AgentProvider.CODEX, {
+      classify: () => ({} as never),
+      supportsSubagentSend: false,
+      supportsSubagentInterrupt: true,
+    })
+    expect(agentTabSupportsInterrupt({
+      type: TabType.AGENT,
+      parentAgentId: 'root',
+      agentProvider: AgentProvider.CODEX,
+    })).toBe(true)
+    expect(agentTabSupportsInterrupt({
+      type: TabType.AGENT,
+      parentAgentId: 'root',
+      agentProvider: AgentProvider.CLAUDE_CODE,
+    })).toBe(false)
   })
 })
 

--- a/frontend/src/stores/tab.helpers.ts
+++ b/frontend/src/stores/tab.helpers.ts
@@ -340,12 +340,19 @@ export function isSteerableAgentTab(tab: { type: TabType, parentAgentId?: string
     return true
   // acceptsMessages (backend-authoritative) wins when present. Before
   // hydration, fall back to the provider plugin's supportsSubagentSend so
-  // "which providers can steer a subagent" has a single source of truth (the
-  // Codex plugin sets it true; all others omit it). Adding a second steerable
-  // provider then needs no edit here.
+  // "which providers can steer a subagent" has a single source of truth.
   if (tab.acceptsMessages !== undefined)
     return tab.acceptsMessages
   return pluginFor(tab.agentProvider)?.supportsSubagentSend ?? false
+}
+
+/** Whether an agent tab can send a direct interrupt to its process owner. */
+export function agentTabSupportsInterrupt(tab: { type: TabType, parentAgentId?: string, agentProvider?: AgentProvider } | undefined): boolean {
+  if (tab?.type !== TabType.AGENT)
+    return false
+  if (!tab.parentAgentId)
+    return true
+  return pluginFor(tab.agentProvider)?.supportsSubagentInterrupt ?? false
 }
 
 /**

--- a/frontend/tests/e2e/171-codex-subagent-lifecycle.spec.ts
+++ b/frontend/tests/e2e/171-codex-subagent-lifecycle.spec.ts
@@ -1,8 +1,8 @@
 /**
- * 171 — Codex collab subagent steering.
+ * 171 — Codex subagent lifecycle and transcript routing.
  *
  * Covers: the V2 activity-based registry row, its readable title, a child tab
- * with an isolated transcript, an enabled composer, and exact completion.
+ * with an isolated read-only transcript and exact completion.
  */
 import { codexTest, expect } from './codex-fixtures'
 import {
@@ -13,7 +13,7 @@ import {
 } from './helpers/subagentRegistry'
 import { assistantBubbles, sendMessage } from './helpers/ui'
 
-codexTest.describe('codex subagent steering', () => {
+codexTest.describe('codex subagent lifecycle', () => {
   codexTest('opens and isolates a V2 subagent transcript', async ({
     authenticatedCodexWorkspace,
     page,
@@ -45,27 +45,26 @@ codexTest.describe('codex subagent steering', () => {
     await expect(page.locator(`[data-testid="tab"][data-tab-id="${childTabId}"]`)).toContainText(taskName)
 
     // The child answer belongs only to the child transcript.
-    const childAnswer = assistantBubbles(page).filter({ hasText: 'CHILD_DONE' })
+    const childAnswer = assistantBubbles(page).filter({ hasText: /^CHILD_DONE$/ })
     await expect(childAnswer).toBeVisible()
 
-    // 5. Composer: enabled (Codex is steerable), so the box carries its normal
-    //    placeholder rather than any disabled reason.
-    await expect(page.locator('[data-placeholder="Send a message..."]:visible')).toBeVisible()
+    // 5. Multi-Agent V2 rejects direct app-server input for spawned children.
+    await expect(page.locator('[data-placeholder="This subagent doesn\'t accept messages."]:visible')).toBeVisible()
 
-    // 6. Worker-backed: the child exists with parent linkage and accepts
-    //    messages. Query the worker directly for the child tab id read above
+    // 6. Worker-backed: the child exists with parent linkage and reports the
+    //    read-only capability. Query the worker directly for the child tab ID
     //    (the child tab propagates to the hub's ListTabs async).
     await expect.poll(async () => {
       const agents = await listAgents(hubUrl, adminToken, workerId, [childTabId])
       if (!agents)
         return null
       const child = agents.find(a => a.id === childTabId)
-      return child && child.acceptsMessages ? 'steerable' : null
-    }).toBe('steerable')
+      return child && !child.acceptsMessages ? 'read-only' : null
+    }).toBe('read-only')
 
     // 7. Select the parent and prove the child answer did not leak into it.
     await page.locator(`[data-testid="tab"][data-tab-id="${parentTabId}"]`).click()
-    await expect(assistantBubbles(page).filter({ hasText: 'CHILD_DONE' })).toHaveCount(0)
+    await expect(assistantBubbles(page).filter({ hasText: /^CHILD_DONE$/ })).toHaveCount(0)
 
     // 8. The completed child turn is an exact final signal. A generic final
     // status would let a failed child pass this happy-path regression.

--- a/frontend/tests/e2e/171-codex-subagent-steering.spec.ts
+++ b/frontend/tests/e2e/171-codex-subagent-steering.spec.ts
@@ -1,23 +1,20 @@
 /**
  * 171 — Codex collab subagent steering.
  *
- * Covers: registry row on spawn, child tab with a live transcript, an ENABLED
- * composer (Codex is the only provider with SupportsChildSteering), and a
- * steering message delivered to the child conversation. Parent isolation: the
- * parent shows the flat spawnAgent card with no nested child rows.
+ * Covers: the V2 activity-based registry row, its readable title, a child tab
+ * with an isolated transcript, an enabled composer, and exact completion.
  */
 import { codexTest, expect } from './codex-fixtures'
 import {
   expectNoRegistryRows,
-  expectRowBecomesFinal,
   listAgents,
   openChildTabFromRow,
-  requireRegistryRow,
+  waitForRegistryRow,
 } from './helpers/subagentRegistry'
-import { sendMessage } from './helpers/ui'
+import { assistantBubbles, sendMessage } from './helpers/ui'
 
-codexTest.describe('Codex subagent steering', () => {
-  codexTest('spawn a collab subagent, open its tab, and steer it', async ({
+codexTest.describe('codex subagent steering', () => {
+  codexTest('opens and isolates a V2 subagent transcript', async ({
     authenticatedCodexWorkspace,
     page,
     leapmuxServer,
@@ -28,19 +25,28 @@ codexTest.describe('Codex subagent steering', () => {
     // 1. Precondition.
     await expectNoRegistryRows(page)
 
-    // 2. Spawn a collab subagent with a long-enough task to stay running.
-    await sendMessage(page, 'Use your spawnAgent/subagent tool to spawn a subagent that writes a 500-word essay about the ocean. Wait for it to start.')
+    // 2. Spawn one V2 subagent with a fixed canonical task name. Spell the
+    // output marker as parts so it is absent from the root's user bubble.
+    const taskName = 'codex_probe_child'
+    await sendMessage(page, `You MUST use spawn_agent exactly once with task_name "${taskName}". Tell the child to reply with the string formed by joining CHILD, an underscore, and DONE. Use wait_agent until it finishes. Do not quote the child's answer. Then reply with exactly ROOT_DONE.`)
 
-    // 3. Registry row (subagent, running). Wait for the row directly (not
-    //    waitForAgentIdle -- the indicator stays up while a task is active).
-    // The model may choose not to spawn; skip the spawn-dependent assertions
-    // rather than fail on a real LLM's discretion.
-    const row = await requireRegistryRow(codexTest, page)
+    // 3. This request is explicit, so a missing row is a failure. The canonical
+    // task path supplies the row and tab title before child output starts.
+    const parentTab = page.locator('[data-testid="tab"][data-tab-type="agent"]').first()
+    const parentTabId = await parentTab.getAttribute('data-tab-id') ?? ''
+    expect(parentTabId).not.toBe('')
+    const row = await waitForRegistryRow(page)
+    await expect(row).toContainText(taskName)
 
     // 4. Wait for the row to link to a child transcript, then click -> child
     //    tab opens adjacent to the parent.
     await expect.poll(async () => await row.getAttribute('data-child-agent-id')).not.toBe('')
     const childTabId = await openChildTabFromRow(page, row)
+    await expect(page.locator(`[data-testid="tab"][data-tab-id="${childTabId}"]`)).toContainText(taskName)
+
+    // The child answer belongs only to the child transcript.
+    const childAnswer = assistantBubbles(page).filter({ hasText: 'CHILD_DONE' })
+    await expect(childAnswer).toBeVisible()
 
     // 5. Composer: enabled (Codex is steerable), so the box carries its normal
     //    placeholder rather than any disabled reason.
@@ -57,10 +63,12 @@ codexTest.describe('Codex subagent steering', () => {
       return child && child.acceptsMessages ? 'steerable' : null
     }).toBe('steerable')
 
-    // 7. Terminal (best-effort): after the parent's wait/closeAgent completes,
-    //    the row becomes terminal. A long-running subagent may not finish within
-    //    the poll window; the core assertions (registry + steerable child tab)
-    //    already passed, so this is a soft check.
-    await expectRowBecomesFinal(page, row)
+    // 7. Select the parent and prove the child answer did not leak into it.
+    await page.locator(`[data-testid="tab"][data-tab-id="${parentTabId}"]`).click()
+    await expect(assistantBubbles(page).filter({ hasText: 'CHILD_DONE' })).toHaveCount(0)
+
+    // 8. The completed child turn is an exact final signal. A generic final
+    // status would let a failed child pass this happy-path regression.
+    await expect(row).toHaveAttribute('data-status', 'completed')
   })
 })

--- a/proto/leapmux/v1/agent.proto
+++ b/proto/leapmux/v1/agent.proto
@@ -257,10 +257,10 @@ message AgentInfo {
   string parent_agent_id = 16;
   string spawn_span_id = 17;
   // Whether this agent accepts a user message sent directly to it. Roots:
-  // always true. Children: true only when the feeding provider supports
-  // steering a subagent conversation inside the same process (Codex); false
-  // for read-only transcripts (Claude, ACP, Pi). The frontend gates the
-  // composer on this.
+  // always true. Children: true only when the feeding provider supports direct
+  // input to a subagent conversation. Codex Multi-Agent V2 rejects that input,
+  // so its child transcripts are read-only. The frontend gates the composer on
+  // this field.
   bool accepts_messages = 18;
   // The ROOT owner agent id (the top of the parent_agent_id chain). For a root
   // agent this equals its own id. The background-task registry and the root's


### PR DESCRIPTION
## Motivation

- Codex Multi-Agent V2 events can arrive before child identity and routing state. This produced unreadable titles and misplaced output.
- Codex rejects direct input to spawned children but permits interruption. One shared capability cannot model this API.
- Codex leaves its stable memories feature disabled by default.

## Modifications

- Enable `multi_agent_v2` and `memories` for every Codex app-server launch.
- Add durable per-thread child state with direct-parent transcript routing, limited pending buffers, and idempotent lifecycle transitions.
- Use the canonical task path for child titles. Ignore the `/root` primary path and events from replaced contexts.
- Separate child interruption from child input. Make Codex child transcripts read-only while keeping the Interrupt button available.
- Add backend, frontend, race, and end-to-end regression coverage.

## Result

- Background tasks open readable child tabs with isolated transcripts.
- Child runs reach the correct completed state, and nested output stays with its direct parent.
- The Worker never reports `/root` as a subagent.
- Users can interrupt an active Codex child without an unsupported message composer.
- Every Codex session starts with persistent memory support enabled.
